### PR TITLE
Move /metrics to be a Prometheus Exporter

### DIFF
--- a/imbi/endpoints/authentication_tokens.py
+++ b/imbi/endpoints/authentication_tokens.py
@@ -9,7 +9,7 @@ from . import base
 
 class RequestHandler(base.ValidatingRequestHandler):
 
-    ENDPOINT = 'authentication-tokens'
+    NAME = 'authentication-tokens'
 
     CREATE_SQL = re.sub(r'\s+', ' ', """
         INSERT INTO v1.authentication_tokens (token, "name", username)

--- a/imbi/endpoints/default.py
+++ b/imbi/endpoints/default.py
@@ -9,7 +9,7 @@ from imbi.endpoints import base
 
 class RequestHandler(base.RequestHandler):
 
-    ENDPOINT = 'not-found'
+    NAME = 'not-found'
 
     def get(self, *args, **kwargs):
         raise web.HTTPError(404)

--- a/imbi/endpoints/integrations/gitlab.py
+++ b/imbi/endpoints/integrations/gitlab.py
@@ -21,6 +21,8 @@ class RedirectHandler(sprockets.mixins.http.HTTPClientMixin,
                       base.RequestHandler):
     integration: 'oauth2.OAuth2Integration'
 
+    NAME = 'gitlab-redirect'
+
     async def prepare(self) -> None:
         await super().prepare()
         if not self._finished:
@@ -100,6 +102,8 @@ class RedirectHandler(sprockets.mixins.http.HTTPClientMixin,
 
 
 class GitLabIntegratedHandler(base.AuthenticatedRequestHandler):
+
+    NAME = 'gitlab-integrated'
     client: gitlab.GitLabClient
 
     async def prepare(self) -> None:
@@ -119,6 +123,9 @@ class GitLabIntegratedHandler(base.AuthenticatedRequestHandler):
 
 
 class UserNamespacesHandler(GitLabIntegratedHandler):
+
+    NAME = 'gitlab-user-namespace'
+
     async def get(self):
         entries = await self.client.fetch_all_pages(
             'groups', min_access_level=30)
@@ -129,6 +136,9 @@ class UserNamespacesHandler(GitLabIntegratedHandler):
 
 
 class ProjectsHandler(GitLabIntegratedHandler):
+
+    NAME = 'gitlab-projects'
+
     async def get(self):
         group_arg = self.get_query_argument('group_id')
         try:

--- a/imbi/endpoints/integrations/oauth2.py
+++ b/imbi/endpoints/integrations/oauth2.py
@@ -4,6 +4,7 @@ from imbi.endpoints import base
 
 
 class CollectionRequestHandler(base.CollectionRequestHandler):
+
     NAME = 'integrations'
     ITEM_NAME = 'integration'
     ID_KEY = 'name'
@@ -36,6 +37,7 @@ class CollectionRequestHandler(base.CollectionRequestHandler):
 
 
 class RecordRequestHandler(base.CRUDRequestHandler):
+
     NAME = 'integration'
     ID_KEY = 'name'
 

--- a/imbi/endpoints/metrics.py
+++ b/imbi/endpoints/metrics.py
@@ -2,30 +2,114 @@
 Application Metrics
 
 """
-import datetime
+import collections
+import logging
+import re
+import socket
+import typing
 
-import isodate
-from sprockets.mixins import mediatype
-from tornado import web
+from . import base
+
+LOGGER = logging.getLogger(__name__)
+INF = float('inf')
+TAGS = re.compile(r'(([\w_-]+)=([\w_\+\.-]+))')
 
 
-class RequestHandler(mediatype.ContentMixin,
-                     web.RequestHandler):
-    """Returns internal metrics"""
-    ENDPOINT = 'metrics'
+class RequestHandler(base.RequestHandler):
+    """Returns internal metrics in Prometheus line format"""
+    BUCKETS = (.005, .01, .025, .05, .075, .1, .25, .5, .75, 1.0, 2.5,
+               5.0, 7.5, 10.0, INF)
+    NAME = 'metrics'
+
+    @staticmethod
+    def _build_key_dict(key_in: str) -> dict:
+        tags = {}
+        for match in TAGS.finditer(key_in):
+            tags[match.group(2)] = match.group(3)
+        return tags
+
+    def _build_output_key(self, key_in: str, suffix: str) -> str:
+        tags = self._build_key_dict(key_in)
+        key = tags.pop('key')
+        tag_repr = ','.join(f'{k}="{v}"' for k, v in tags.items())
+        return f'{key}_{suffix}{{{tag_repr}}}'
 
     async def get(self):
         """Tornado RequestHandler GET request endpoint for reporting status"""
-        prune = self.get_argument('flush', 'false') == 'true'
-        self.send_response({
-            'counters': await self.application.stats.counters(prune),
-            'durations': await self.application.stats.durations(prune),
-            'postgres': await self.application.postgres_status(),
-            'uptime': isodate.duration_isoformat(
-                datetime.datetime.now(datetime.timezone.utc) -
-                self.application.started_at)})
+        all_hosts = self.get_argument('all_hosts', 'false').lower() == 'true'
+        flush = self.get_argument('flush', 'true').lower() == 'true'
 
-    def set_default_headers(self) -> None:
-        """Override the default headers, setting the Server response header"""
-        super().set_default_headers()
-        self.set_header('Server', self.settings['server_header'])
+        self.set_header('Content-Type', 'text/plain; version=0.0.4')
+        self.write('# Prometheus line format\n')
+        self.write(
+            f'# Generated on {socket.gethostname()}, all_hosts={all_hosts},'
+            f' flush={flush}\n\n')
+
+        counters = await self.application.stats.counters(all_hosts, flush)
+        chunks = {}
+        for counter in sorted(counters.keys()):
+            key = self._build_output_key(counter, 'total')
+            chunk_key = key.split('{')[0]
+            if chunk_key not in chunks:
+                chunks[chunk_key] = []
+            chunks[chunk_key].append(f'{key} {counters[counter]}\n')
+        for key in chunks:
+            self.write(f'# TYPE {key} counter\n')
+            for item in chunks[key]:
+                self.write(item)
+            self.write('\n')
+
+        timers = await self.application.stats.durations(all_hosts, flush)
+        values: typing.Dict[str, typing.List[str]] = {}
+        for timer in sorted(timers.keys()):
+            chunk_key = self._build_output_key(timer, 'seconds').split('{')[0]
+            if chunk_key not in values:
+                values[chunk_key] = []
+            buckets = collections.Counter()
+            counts = collections.Counter()
+            sums = collections.Counter()
+            while timers[timer]:
+                value = timers[timer].pop(0)
+                counts[timer] += 1
+                sums[timer] += value
+                for bucket in self.BUCKETS:
+                    if bucket not in buckets:
+                        buckets[bucket] = 0
+                    if value <= bucket:
+                        buckets[bucket] += 1
+            for bucket in self.BUCKETS:
+                if bucket == INF:
+                    continue
+                key = self._build_output_key(
+                    f'{timer}:le={bucket}', 'seconds_bucket')
+                values[chunk_key].append(f'{key} {buckets[bucket]}\n')
+
+            key = self._build_output_key(f'{timer}:le=Inf+', 'seconds_bucket')
+            values[chunk_key].append(f'{key} {counts[timer]}\n')
+
+            key = self._build_output_key(f'{timer}', 'seconds_count')
+            values[chunk_key].append(f'{key} {counts[timer]}\n')
+            key = self._build_output_key(f'{timer}', 'seconds_sum')
+            values[chunk_key].append(f'{key} {sums[timer]}\n')
+
+        for chunk_key in sorted(values):
+            self.write(f'# TYPE {chunk_key} histogram\n')
+            for metric in values[chunk_key]:
+                self.write(metric)
+            self.write('\n')
+
+        postgres = await self.application.postgres_status()
+        self.write(
+            '# HELP postgres_pool_size The number of open connections '
+            'in the pool\n')
+        self.write(f'# TYPE postgres_pool_size gauge\n')
+        self.write(
+            f'postgres_pool_size{{host="{socket.gethostname()}"}} '
+            f'{postgres["pool_size"]}\n\n')
+        self.write(
+            '# HELP postgres_pool_free The number of free connections '
+            'in the pool\n')
+        self.write(f'# TYPE postgres_pool_free gauge\n')
+        self.write(
+            f'postgres_pool_free{{host="{socket.gethostname()}"}} '
+            f'{postgres["pool_free"]}\n\n')

--- a/imbi/endpoints/openapi.py
+++ b/imbi/endpoints/openapi.py
@@ -12,7 +12,7 @@ class RequestHandler(base.RequestHandler):
     system.
 
     """
-    ENDPOINT = 'OpenAPI'
+    NAME = 'openapi'
     TTL = 300
 
     def get(self, *args):

--- a/imbi/endpoints/status.py
+++ b/imbi/endpoints/status.py
@@ -17,7 +17,7 @@ OK = 'ok'
 class RequestHandler(mediatype.ContentMixin,
                      web.RequestHandler):
     """Returns the current status"""
-    ENDPOINT = 'Status'
+    NAME = 'status'
 
     SYSTEM = {
         'language': {

--- a/imbi/endpoints/ui/authentication.py
+++ b/imbi/endpoints/ui/authentication.py
@@ -3,7 +3,7 @@ from imbi.endpoints import base
 
 class LoginRequestHandler(base.RequestHandler):
 
-    ENDPOINT = 'ui-login'
+    NAME = 'ui-login'
 
     async def post(self, *args, **kwargs):
         body = self.get_request_body()
@@ -20,7 +20,7 @@ class LoginRequestHandler(base.RequestHandler):
 
 class LogoutRequestHandler(base.RequestHandler):
 
-    ENDPOINT = 'ui-logout'
+    NAME = 'ui-logout'
 
     async def get(self, *args, **kwargs):
         await self.session.clear()

--- a/imbi/endpoints/ui/automations/gitlab.py
+++ b/imbi/endpoints/ui/automations/gitlab.py
@@ -10,8 +10,7 @@ from imbi.endpoints.ui.automations import mixins
 class GitLabAutomationRequestHandler(mixins.PrepareFailureMixin,
                                      base.AuthenticatedRequestHandler):
 
-    NAME = 'GitLabAutomationRequestHandler'
-    ENDPOINT = 'ui-gitlab'
+    NAME = 'ui-gitlab'
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -36,8 +35,8 @@ class GitLabAutomationRequestHandler(mixins.PrepareFailureMixin,
 
 class CreationRequestHandler(GitLabAutomationRequestHandler,
                              base.ValidatingRequestHandler):
-    NAME = 'CreationRequestHandler'
-    ENDPOINT = 'ui-gitlab-create'
+
+    NAME = 'ui-gitlab-create'
 
     async def post(self):
         request = self.get_request_body()
@@ -59,8 +58,8 @@ class CreationRequestHandler(GitLabAutomationRequestHandler,
 
 
 class InitialCommitRequestHandler(GitLabAutomationRequestHandler):
-    NAME = 'InitialCommitRequestHandler'
-    ENDPOINT = 'ui-gitlab-commit'
+
+    NAME = 'ui-gitlab-commit'
 
     async def post(self):
         request = self.get_request_body()

--- a/imbi/endpoints/ui/automations/sonarqube.py
+++ b/imbi/endpoints/ui/automations/sonarqube.py
@@ -13,8 +13,7 @@ from imbi.endpoints.ui.automations import mixins
 class CreationRequestHandler(mixins.PrepareFailureMixin,
                              base.AuthenticatedRequestHandler):
 
-    NAME = 'CreationRequestHandler'
-    ENDPOINT = 'ui-sonarqube-create'
+    NAME = 'ui-sonarqube-create'
 
     async def post(self):
         request = self.get_request_body()

--- a/imbi/endpoints/ui/groups.py
+++ b/imbi/endpoints/ui/groups.py
@@ -3,7 +3,7 @@ from imbi.endpoints import base
 
 class GroupsRequestHandler(base.CRUDRequestHandler):
 
-    ENDPOINT = 'ui-groups'
+    NAME = 'ui-groups'
 
     GET_SQL = 'SELECT name FROM v1.groups ORDER BY name ASC;'
     TTL = 300

--- a/imbi/endpoints/ui/index.py
+++ b/imbi/endpoints/ui/index.py
@@ -3,7 +3,7 @@ from imbi.endpoints import base
 
 class IndexRequestHandler(base.RequestHandler):
 
-    ENDPOINT = 'ui-index'
+    NAME = 'ui-index'
 
     def get(self, *args, **kwargs):
         if self.request.path == '/':

--- a/imbi/endpoints/ui/settings.py
+++ b/imbi/endpoints/ui/settings.py
@@ -3,7 +3,7 @@ from imbi.endpoints import base
 
 class SettingsRequestHandler(base.RequestHandler):
 
-    ENDPOINT = 'ui-settings'
+    NAME = 'ui-settings'
 
     async def get(self, *args, **kwargs):
         settings = self.settings['automations']

--- a/imbi/endpoints/ui/user.py
+++ b/imbi/endpoints/ui/user.py
@@ -3,7 +3,7 @@ from imbi.endpoints import base
 
 class UserRequestHandler(base.AuthenticatedRequestHandler):
 
-    ENDPOINT = 'ui-user'
+    NAME = 'ui-user'
 
     def get(self, *args, **kwargs):
         user = self.current_user.as_dict()

--- a/imbi/stats.py
+++ b/imbi/stats.py
@@ -100,7 +100,7 @@ class Stats:
             'd:*' if all_hosts else f'd:*hostname={self._hostname}*')
         for key in keys:
             durations[key[2:].decode('utf-8')] = sorted(
-                [float(v) for v in await self._client.lrange(key, 0, -1)])
+                float(v) for v in await self._client.lrange(key, 0, -1))
             if flush:
                 await self._client.delete(key)
         return durations

--- a/imbi/stats.py
+++ b/imbi/stats.py
@@ -4,15 +4,12 @@ polling.
 
 """
 import contextlib
-import logging
 import os
+import socket
 import time
+import typing
 
 import aioredis
-
-from imbi import timestamp
-
-LOGGER = logging.getLogger(__name__)
 
 DEFAULT_POOL_SIZE = 10
 
@@ -25,86 +22,102 @@ class Stats:
     def __init__(self, client: aioredis.Redis):
         """Create a new instance of the Stats class"""
         self._client = client
+        self._hostname = socket.gethostname()
 
-    async def decr(self, key, value=1):
+    async def decr(self, tags: dict, value: int = 1) -> None:
         """Decrement a counter
 
-        :param str key: The key to decrement
-        :param int value: The value to decrement by
+        :param tags: The key tags to decrement
+        :param value: The value to decrement by
 
         """
-        await self._client.decrby('c:{}'.format(key), value)
+        await self._client.decrby(self._compose_key('c', tags), value)
 
-    async def incr(self, key, value=1):
+    async def incr(self, tags: dict, value: int = 1) -> None:
         """Increment a counter
 
-        :param str key: The key to increment
-        :param int value: The value to increment by
+        :param tags: The key tags to increment
+        :param value: The value to increment by
 
         """
-        await self._client.incrby('c:{}'.format(key), value)
+        await self._client.incrby(self._compose_key('c', tags), value)
 
-    async def add_duration(self, key, value):
+    async def add_duration(self, tags: dict, value: float) -> None:
         """Add a duration for the specified key
 
-        :param str key: The value name
-        :param float value: The value
+        :param tags: The key tags to record the timing for
+        :param value: The value of the duration
 
         """
-        await self._client.lpush(
-            'd:{}'.format(key), '{},{}'.format(
-                timestamp.isoformat(), value))
+        await self._client.lpush(self._compose_key('d', tags), value)
 
     @contextlib.asynccontextmanager
-    async def track_duration(self, key):
+    async def track_duration(self, tags: dict) -> typing.AsyncContextManager:
         """Context manager that sets a value with the duration of time that it
         takes to execute whatever it is wrapping.
 
-        :param str key: The timing name
+        :param tags: The key tags to track the duration of
 
         """
         start_time = time.time()
         try:
             yield
         finally:
-            await self.add_duration(key, time.time() - start_time)
+            await self.add_duration(tags, time.time() - start_time)
 
-    async def counters(self, flush=False):
+    async def counters(self,
+                       all_hosts: bool = False,
+                       flush: bool = False) -> typing.Dict[str, int]:
         """Return a dict of counters and their values
 
-        :param bool flush: Flush existing values
-        :rtype: dict
+        :param all_hosts: Process counters for all hosts
+        :param flush: Flush existing values
 
         """
         counters = {}
-        keys = await self._client.keys('c:*')
-        LOGGER.debug('Counters: %r', keys)
+        keys = await self._client.keys(
+            'c:*' if all_hosts else f'c:*hostname={self._hostname}*')
         if keys:
             values = await self._client.mget(*keys)
             for offset, key in enumerate(keys):
                 counters[key[2:].decode('utf-8')] = int(values[offset])
             if flush:
-                self._client.delete(*keys)
+                await self._client.delete(*keys)
         return counters
 
-    async def durations(self, flush=False):
+    async def durations(self,
+                        all_hosts: bool = False,
+                        flush: bool = False) \
+            -> typing.Dict[str, typing.List[float]]:
         """Return a dict of durations and their values
 
-        :param bool flush: Flush existing values
-        :rtype: dict
+        :param all_hosts: Process durations for all hosts
+        :param flush: Flush existing values
 
         """
         durations = {}
-        keys = await self._client.keys('d:*')
-        LOGGER.debug('Durations: %r', keys)
+        keys = await self._client.keys(
+            'd:*' if all_hosts else f'd:*hostname={self._hostname}*')
         for key in keys:
-            values = await self._client.lrange(key, 0, -1)
-            values = [v.decode('utf-8') for v in values]
-            durations[key[2:].decode('utf-8')] = \
-                [(r.split(',')[0], float(r.split(',')[1])) for r in values]
+            durations[key[2:].decode('utf-8')] = sorted(
+                [float(v) for v in await self._client.lrange(key, 0, -1)])
             if flush:
                 await self._client.delete(key)
         return durations
+
+    def _compose_key(self, prefix: str, tags: dict) -> str:
+        """Create the deterministically sorted compound key that is used
+        to ensure we're always incrementing or adding to the same set for
+        the same set of values.
+
+        :param prefix: The key prefix
+        :param tags: The key tags that will be used to compose the key
+
+        """
+        parts = [f'hostname={self._hostname}']
+        for key, value in tags.items():
+            parts.append(f'{key}={value}')
+        return f'{prefix}:' + ':'.join(value for value in sorted(parts))
 
 
 async def create(redis_url):

--- a/imbi/templates/openapi.yaml
+++ b/imbi/templates/openapi.yaml
@@ -1274,16 +1274,27 @@ paths:
   /metrics:
     get:
       security: []
-      description: Returns runtime metrics including counters and durations.
+      description: |-
+        Returns runtime metrics including counters and durations in Prometheus
+        text-based exposition format.
       summary: Service metrics
       operationId: metrics
       parameters:
+        - in: query
+          name: all_hosts
+          description: Return metrics from all hosts
+          schema:
+            type: string
+            default: 'false'
+            enum:
+              - 'true'
+              - 'false'
         - in: query
           name: flush
           description: Flush the stats / metrics database of recorded values
           schema:
             type: string
-            default: 'false'
+            default: 'true'
             enum:
               - 'true'
               - 'false'
@@ -1293,68 +1304,31 @@ paths:
         '200':
           description: OK
           content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  counters:
-                    type: object
-                    additionalProperties:
-                      type: number
-                    description: A key-value pair of internal counters
-                  durations:
-                    type: object
-                    description: |-
-                      A key-value pair of recorded durations where the value is an array
-                      of timestamp and duration in seconds
-                    additionalProperties:
-                      type: array
-                      items:
-                        type: array
-                        items:
-                          oneOf:
-                            - type: string
-                              format: iso8601-timestamp
-                            - type: number
-                              format: float
-                        minItems: 2
-                        maxItems: 2
-                  postgres:
-                    type: object
-                    description: PostgreSQL pool information
-                    properties:
-                      pool_free:
-                        type: number
-                        description: |-
-                          Indicates the current number of idle connections available to
-                          process queries
-                      pool_size:
-                        type: number
-                        description: Indicates the current quantity of open connections to Postgres
-                  uptime:
-                    type: string
-                    description: ISO-8601 formatted duration indicating how long the service has been running
-              example:
-                counters:
-                  response.Base.GET.200: 10
-                durations:
-                  request.Base.GET.200:
-                    - - '2018-12-03 23:46:54+00:00'
-                      - 0.2566049098968506
-                    - - '2018-12-03 23:31:50+00:00'
-                      - 0.33482813835144043
-                    - - '2018-12-03 23:00:39+00:00'
-                      - 0.25607776641845703
-                postgres:
-                  available: true
-                  pool_size: 10
-                  pool_free: 9
-                uptime: PT6M9.053148S
-            application/msgpack:
-              schema:
-                $ref: '#/paths/~1metrics/get/responses/200/content/application~1json/schema'
-              example:
-                $ref: '#/paths/~1metrics/get/responses/200/content/application~1json/example'
+            text/plain; version=0.0.4:
+              example: |-
+                # TYPE http_requests_total counter
+                http_requests_total{endpoint="dashboard",hostname="example",method="GET",status="200"} 1
+                http_requests_total{endpoint="environments",hostname="example",method="GET",status="200"} 2
+                http_requests_total{endpoint="metrics",hostname="example",method="GET",status="200"} 5
+
+                # TYPE http_request_duration_seconds histogram
+                http_request_duration_seconds_bucket{endpoint="dashboard",hostname="example",method="GET",status="200",le="0.005"} 0
+                http_request_duration_seconds_bucket{endpoint="dashboard",hostname="example",method="GET",status="200",le="0.01"} 0
+                http_request_duration_seconds_bucket{endpoint="dashboard",hostname="example",method="GET",status="200",le="0.025"} 0
+                http_request_duration_seconds_bucket{endpoint="dashboard",hostname="example",method="GET",status="200",le="0.05"} 0
+                http_request_duration_seconds_bucket{endpoint="dashboard",hostname="example",method="GET",status="200",le="0.075"} 0
+                http_request_duration_seconds_bucket{endpoint="dashboard",hostname="example",method="GET",status="200",le="0.1"} 0
+                http_request_duration_seconds_bucket{endpoint="dashboard",hostname="example",method="GET",status="200",le="0.25"} 0
+                http_request_duration_seconds_bucket{endpoint="dashboard",hostname="example",method="GET",status="200",le="0.5"} 0
+                http_request_duration_seconds_bucket{endpoint="dashboard",hostname="example",method="GET",status="200",le="0.75"} 0
+                http_request_duration_seconds_bucket{endpoint="dashboard",hostname="example",method="GET",status="200",le="1.0"} 0
+                http_request_duration_seconds_bucket{endpoint="dashboard",hostname="example",method="GET",status="200",le="2.5"} 1
+                http_request_duration_seconds_bucket{endpoint="dashboard",hostname="example",method="GET",status="200",le="5.0"} 1
+                http_request_duration_seconds_bucket{endpoint="dashboard",hostname="example",method="GET",status="200",le="7.5"} 1
+                http_request_duration_seconds_bucket{endpoint="dashboard",hostname="example",method="GET",status="200",le="10.0"} 1
+                http_request_duration_seconds_bucket{endpoint="dashboard",hostname="example",method="GET",status="200",le="Inf+"} 1
+                http_request_duration_seconds_count{endpoint="dashboard",hostname="example",method="GET",status="200"} 1
+                http_request_duration_seconds_sum{endpoint="dashboard",hostname="example",method="GET",status="200"} 2.2017457485198975
   /namespaces:
     get:
       description: Retrieve the collection of namespaces

--- a/tests/endpoints/test_metrics.py
+++ b/tests/endpoints/test_metrics.py
@@ -6,4 +6,7 @@ class AsyncHTTPTestCase(base.TestCase):
     def test_status_ok(self):
         response = self.fetch('/metrics', headers=self.headers)
         self.assertEqual(response.code, 200)
-        self.validate_response(response)
+        self.assertIn(
+            '# TYPE postgres_pool_free gauge', response.body.decode('utf-8'))
+        self.assertIn(
+            'postgres_pool_size{host=', response.body.decode('utf-8'))


### PR DESCRIPTION
This change alters the `/metrics` endpoint to return the Prometheus text-based exposition format, including returning a histogram of request duration by endpoint, http method, status, and host.

The `Stats` class needed to change to allow for more complex key structures that can be easily decomposed.

In addition, endpoints with the wrong class attribute name were updated to use the proper attribute name for stats collection.

Testing of the format was performed against the latest Prometheus and included querying to ensure the behaviors matched the desired end result.