### PR TITLE
Sanitize facts in project fact updates

### DIFF
--- a/imbi/common.py
+++ b/imbi/common.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import datetime
 import decimal
 import typing
-from distutils import util
 
 import dateutil.parser
 
@@ -29,10 +28,13 @@ def coerce_project_fact(
     if not value and value != 0:
         value = None
     elif data_type == 'boolean':
-        if value is None:
+        value = 'false' if value is None else str(value).lower()
+        if value in ('y', 'yes', 't', 'true', 'on', '1'):
+            value = True
+        elif value in ('n', 'no', 'f', 'false', 'off', '0'):
             value = False
         else:
-            value = bool(util.strtobool(str(value)))
+            raise ValueError(f'{value!r} is not a valid Boolean')
     elif data_type == 'decimal':
         try:
             value = decimal.Decimal(value)

--- a/imbi/common.py
+++ b/imbi/common.py
@@ -51,6 +51,8 @@ def coerce_project_fact(
         if value.tzinfo is None:
             value = value.replace(tzinfo=datetime.timezone.utc)
         value = value.isoformat()
+    elif data_type == 'string':
+        value = str(value)
     else:
         raise ValueError(f'{data_type!r} is not a known fact type')
 

--- a/imbi/common.py
+++ b/imbi/common.py
@@ -1,6 +1,9 @@
+import datetime
 import decimal
 import typing
 from distutils import util
+
+import dateutil.parser
 
 
 def coerce_project_fact_values(rows: typing.List[typing.Dict]) -> typing.List:
@@ -9,11 +12,38 @@ def coerce_project_fact_values(rows: typing.List[typing.Dict]) -> typing.List:
 
     """
     for row in rows:
+        if not row['value'] and row['value'] != 0:
+            row['value'] = None
+            continue
+
         if row['data_type'] == 'boolean':
-            row['value'] = bool(util.strtobool(row['value']))
+            if row['value'] is None:
+                row['value'] = False
+            else:
+                row['value'] = bool(util.strtobool(str(row['value'])))
         elif row['data_type'] == 'decimal':
-            row['value'] = decimal.Decimal(row['value'])
+            try:
+                row['value'] = decimal.Decimal(row['value'])
+            except decimal.InvalidOperation as error:
+                raise ValueError(
+                    f'{row["value"]!r} is not a valid decimal: {error}')
         elif row['data_type'] == 'integer':
-            row['value'] = int(row['value'])
+            try:
+                row['value'] = int(row['value'])
+            except TypeError as error:
+                raise ValueError(
+                    f'{row["value"]!r} is not a valid integer: {error}')
+        elif row['data_type'] == 'date':
+            value = dateutil.parser.parse(str(row['value']))
+            row['value'] = value.date().isoformat()
+        elif row['data_type'] == 'timestamp':
+            value = dateutil.parser.parse(str(row['value']))
+            if value.tzinfo is None:
+                value = value.replace(tzinfo=datetime.timezone.utc)
+            row['value'] = value.isoformat()
+        else:
+            raise ValueError(f'{row["data_type"]!r} is not a known fact type')
+
         del row['data_type']
+
     return rows

--- a/imbi/mappings.py
+++ b/imbi/mappings.py
@@ -4,6 +4,7 @@ OpenSearch Mapping Management
 """
 FACT_DATA_TYPES = {
     'boolean': 'boolean',
+    'date': 'date',
     'decimal': 'float',
     'integer': 'integer',
     'string': 'text',

--- a/imbi/models.py
+++ b/imbi/models.py
@@ -5,9 +5,8 @@ import decimal
 import logging
 import re
 import typing
-from distutils import util
 
-from imbi import errors
+from imbi import common, errors
 if typing.TYPE_CHECKING:
     from imbi import app
 
@@ -109,16 +108,12 @@ class ProjectFact:
       ORDER BY a.name""")
 
     def __post_init__(self):
-        if self.value is None:
-            return
-        if self.data_type == 'boolean':
-            self.__setattr__(
-                'value', bool(util.strtobool(self.value)))
-        elif self.data_type == 'decimal':
-            if self.value:
-                self.__setattr__('value', decimal.Decimal(self.value))
-        elif self.data_type == 'integer':
-            self.__setattr__('value', int(self.value if self.value else 0))
+        try:
+            value = common.coerce_project_fact(self.data_type, self.value)
+        except ValueError:
+            pass
+        else:
+            self.__setattr__('value', value)
 
 
 @dataclasses.dataclass

--- a/imbi/opensearch.py
+++ b/imbi/opensearch.py
@@ -75,8 +75,8 @@ class OpenSearch:
         try:
             await self.client.indices.create('projects')
         except opensearchpy.exceptions.RequestError as err:
-            if err.error != 'resource_already_exists_exception':
-                LOGGER.debug('Index creation error: %r', err)
+            if 'resource_already_exists_exception' not in err.error:
+                LOGGER.warning('Index creation error: %r', err)
 
         try:
             await self.client.indices.put_mapping(

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,10 +5,11 @@ description = Imbi is a DevOps Service Management Platform designed to provide a
 author = Gavin M. Roy
 author_email = gavinr@aweber.com
 license = BSD 3-Clause License
-license-file = LICENSE
+license_files =
+	LICENSE
 long_description = file: README.rst
 long_description_content_type = text/x-rst; charset=UTF-8
-home-page = https://github.com/aweber/imbi
+home_page = https://github.com/aweber/imbi
 project_urls =
     Bug Tracker = https://github.com/aweber/imbi/issues
     Documentation = https://imbi.readthedocs.io
@@ -35,7 +36,6 @@ classifiers =
     Topic :: System :: Monitoring
     Topic :: System :: Systems Administration
     Topic :: Utilities
-requires-dist = setuptools
 keywords =
     devops
     python3
@@ -43,6 +43,7 @@ keywords =
     operations
 
 [options]
+python_requires = >=3.7
 include_package_data = True
 install_requires =
     aioredis>=1.2.0,<2

--- a/tests/base.py
+++ b/tests/base.py
@@ -122,6 +122,8 @@ class TestCaseWithReset(TestCase):
         super().tearDown()
 
     def create_project(self) -> dict:
+        if not self.environments:
+            self.environments = self.create_environments()
         if not self.namespace:
             self.namespace = self.create_namespace()
         if not self.project_type:
@@ -166,19 +168,21 @@ class TestCaseWithReset(TestCase):
         self.assertEqual(result.code, 200)
         return json.loads(result.body.decode('utf-8'))
 
-    def create_project_fact_type(self) -> dict:
+    def create_project_fact_type(self, **overrides) -> dict:
         if not self.project_type:
             self.project_type = self.create_project_type()
-        print(self.project_type['id'])
+        project_fact = {
+            'project_type_ids': [self.project_type['id']],
+            'name': str(uuid.uuid4()),
+            'fact_type': 'free-form',
+            'data_type': 'string',
+            'weight': 100
+        }
+        project_fact.update(overrides)
+
         result = self.fetch(
             '/project-fact-types', method='POST', headers=self.headers,
-            body=json.dumps({
-                'project_type_ids': [self.project_type['id']],
-                'name': str(uuid.uuid4()),
-                'fact_type': 'free-form',
-                'data_type': 'string',
-                'weight': 100
-            }).encode('utf-8'))
+            body=json.dumps(project_fact).encode('utf-8'))
         self.assertEqual(result.code, 200)
         return json.loads(result.body.decode('utf-8'))
 

--- a/tests/endpoints/test_project_facts.py
+++ b/tests/endpoints/test_project_facts.py
@@ -1,0 +1,169 @@
+import datetime
+import json
+import math
+import time
+
+from tests import base
+
+
+class ProjectFactTests(base.TestCaseWithReset):
+    TRUNCATE_TABLES = ['v1.projects', 'v1.project_fact_types']
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.project = self.create_project()
+
+    def test_valid_fact_values(self):
+        now = datetime.datetime.now(datetime.timezone.utc)
+        boolean_fact = self.create_project_fact_type(data_type='boolean')
+        date_fact = self.create_project_fact_type(data_type='date')
+        decimal_fact = self.create_project_fact_type(data_type='decimal')
+        integer_fact = self.create_project_fact_type(data_type='integer')
+        timestamp_fact = self.create_project_fact_type(data_type='timestamp')
+        facts = [
+            {'fact_type_id': boolean_fact['id'], 'value': 'yes'},
+            {'fact_type_id': date_fact['id'], 'value': now.date().isoformat()},
+            {'fact_type_id': decimal_fact['id'], 'value': math.pi},
+            {'fact_type_id': integer_fact['id'], 'value': 42},
+            {'fact_type_id': timestamp_fact['id'], 'value': now.isoformat()},
+        ]
+        result = self.fetch(
+            f'/projects/{self.project["id"]}/facts',
+            method='POST',
+            body=json.dumps(facts).encode('utf-8'),
+            headers=self.headers)
+        self.assertEqual(204, result.code)
+
+        result = self.fetch(f'/projects/{self.project["id"]}/facts',
+                            headers=self.headers)
+        self.assertEqual(200, result.code)
+
+        data = json.loads(result.body)
+        self.assertDictEqual(
+            {
+                boolean_fact['id']: True,
+                date_fact['id']: now.date().isoformat(),
+                decimal_fact['id']: float(math.pi),
+                integer_fact['id']: 42,
+                timestamp_fact['id']: now.isoformat(),
+            },
+            {fact['fact_type_id']: fact['value'] for fact in data})
+
+    def verify_expectations(self, data_type: str, values: dict) -> None:
+        fact_type = self.create_project_fact_type(data_type=data_type)
+        body = [{'fact_type_id': fact_type['id']}]
+        for input_value, expected_value in values.items():
+            body[0]['value'] = input_value
+            result = self.fetch(
+                f'/projects/{self.project["id"]}/facts',
+                method='POST', body=json.dumps(body).encode('utf-8'),
+                headers=self.headers)
+            self.assertEqual(204, result.code, f'Failure for {input_value!r}')
+
+            result = self.fetch(f'/projects/{self.project["id"]}/facts',
+                                headers=self.headers)
+            self.assertEqual(200, result.code)
+            data = json.loads(result.body)
+            self.assertEqual(expected_value, data[0]['value'])
+
+    def test_supported_boolean_formats(self):
+        self.verify_expectations('boolean', {
+            'y': True,
+            'yes': True,
+            't': True,
+            'TRUE': True,
+            'on': True,
+            '1': True,
+
+            'n': False,
+            'no': False,
+            'f': False,
+            'FALSE': False,
+            'off': False,
+            '0': False,
+            '': None,
+        })
+
+    def test_supported_timestamp_formats(self):
+        now = datetime.datetime.now(datetime.timezone.utc)
+        truncated = now.replace(microsecond=0)
+        self.verify_expectations('timestamp', {
+            now.isoformat(): now.isoformat(),
+            now.isoformat(sep=' '): now.isoformat(),
+            now.strftime('%Y-%m-%dT%H:%M:%SZ'): truncated.isoformat(),
+            now.strftime('%Y-%m-%d %H:%M:%S'): truncated.isoformat(),
+            now.strftime('%c'): truncated.isoformat(),  # no TZ means UTC!
+            now.strftime('%b %d, %Y %I:%M:%S%p %Z'): truncated.isoformat(),
+            now.strftime('%m/%d/%Y %H:%M:%S.%f %Z'): now.isoformat(),
+            '': None,
+        })
+
+    def test_supported_date_formats(self):
+        self.verify_expectations('date', {
+            '08/15/22': '2022-08-15',
+            '08/15/2022': '2022-08-15',
+            '20220815': '2022-08-15',
+            '2022-08-15': '2022-08-15',
+            '08-15-2022': '2022-08-15',
+            'aug-15-2022': '2022-08-15',
+            '': None,
+        })
+
+    def test_integer_representations(self):
+        self.verify_expectations('integer', {
+            '1': 1,
+            10: 10,
+            '-5': -5,
+            0: 0,
+            '': None,
+        })
+
+    def test_decimal_representations(self):
+        self.verify_expectations('decimal', {
+            '1': 1,
+            '1.5': 1.5,
+            1.5: 1.5,
+            -12.34: -12.34,
+            '+12.23': 12.23,
+            0.0: 0.0,
+            '0': 0.0,
+            '': None,
+        })
+
+    def test_invalid_fact_values(self):
+        boolean_fact = self.create_project_fact_type(data_type='boolean')
+        date_fact = self.create_project_fact_type(data_type='date')
+        decimal_fact = self.create_project_fact_type(data_type='decimal')
+        integer_fact = self.create_project_fact_type(data_type='integer')
+        timestamp_fact = self.create_project_fact_type(data_type='timestamp')
+
+        invalid_facts = [
+            {'fact_type_id': boolean_fact['id'], 'value': -1},
+            {'fact_type_id': boolean_fact['id'], 'value': '42'},
+            {'fact_type_id': boolean_fact['id'], 'value': 'nope'},
+            {'fact_type_id': date_fact['id'], 'value': time.time()},
+            {'fact_type_id': timestamp_fact['id'], 'value': '2002-55-66'},
+            {'fact_type_id': timestamp_fact['id'],
+             'value': '2002-12-31 24:00'},
+            {'fact_type_id': integer_fact['id'], 'value': '1.5'},
+            {'fact_type_id': integer_fact['id'], 'value': 'inf'},
+            {'fact_type_id': integer_fact['id'], 'value': 'not a number'},
+            {'fact_type_id': integer_fact['id'], 'value': {}},
+            {'fact_type_id': decimal_fact['id'], 'value': 'not a number'},
+        ]
+        for invalid_fact in invalid_facts:
+            result = self.fetch(
+                f'/projects/{self.project["id"]}/facts',
+                method='POST',
+                body=json.dumps([invalid_fact]).encode('utf-8'),
+                headers=self.headers)
+            self.assertEqual(
+                400, result.code,
+                f'Unexpected response for {invalid_fact["value"]}')
+
+    def test_unknown_fact_id(self):
+        result = self.fetch(f'/projects/{self.project["id"]}/facts',
+                            method='POST',
+                            body=b'[{"fact_type_id":-1,"value":""}]',
+                            headers=self.headers)
+        self.assertEqual(400, result.code)

--- a/tests/endpoints/test_project_facts.py
+++ b/tests/endpoints/test_project_facts.py
@@ -19,12 +19,14 @@ class ProjectFactTests(base.TestCaseWithReset):
         date_fact = self.create_project_fact_type(data_type='date')
         decimal_fact = self.create_project_fact_type(data_type='decimal')
         integer_fact = self.create_project_fact_type(data_type='integer')
+        string_fact = self.create_project_fact_type(data_type='string')
         timestamp_fact = self.create_project_fact_type(data_type='timestamp')
         facts = [
             {'fact_type_id': boolean_fact['id'], 'value': 'yes'},
             {'fact_type_id': date_fact['id'], 'value': now.date().isoformat()},
             {'fact_type_id': decimal_fact['id'], 'value': math.pi},
             {'fact_type_id': integer_fact['id'], 'value': 42},
+            {'fact_type_id': string_fact['id'], 'value': 'hello world'},
             {'fact_type_id': timestamp_fact['id'], 'value': now.isoformat()},
         ]
         result = self.fetch(
@@ -45,6 +47,7 @@ class ProjectFactTests(base.TestCaseWithReset):
                 date_fact['id']: now.date().isoformat(),
                 decimal_fact['id']: float(math.pi),
                 integer_fact['id']: 42,
+                string_fact['id']: 'hello world',
                 timestamp_fact['id']: now.isoformat(),
             },
             {fact['fact_type_id']: fact['value'] for fact in data})


### PR DESCRIPTION
We noticed that we were getting questionably correct values in some of our timestamp facts today.  This PR validates the incoming request body to `POST /projects/{id}/facts` against the actual configured fact types in addition to the Open API specification.  I was in the middle of some unrelated cleanup (using sprockets.http.testing and some setup.cfg stuff) so that is in here too.  Sorry for the slightly muddled PR.