### PR TITLE
Fix fact score for booleans

### DIFF
--- a/imbi/endpoints/project_facts.py
+++ b/imbi/endpoints/project_facts.py
@@ -36,6 +36,8 @@ class CollectionRequestHandler(projects.OpensearchMixin,
                                            WHERE fact_type_id = b.fact_type_id
                                              AND b.value::NUMERIC(9,2)
                                          BETWEEN min_value AND max_value)
+                              WHEN a.data_type = 'boolean' AND b.value = 'true'
+                              THEN 100
                               ELSE 0
                           END
                 END AS score,

--- a/imbi/endpoints/projects.py
+++ b/imbi/endpoints/projects.py
@@ -250,6 +250,8 @@ class RecordRequestHandler(OpensearchMixin,
                                            WHERE fact_type_id = b.fact_type_id
                                              AND b.value::NUMERIC(9,2)
                                          BETWEEN min_value AND max_value)
+                              WHEN a.data_type = 'boolean' AND b.value = 'true'
+                              THEN 100
                               ELSE 0
                           END
                 END AS score,

--- a/tests/endpoints/test_project_facts.py
+++ b/tests/endpoints/test_project_facts.py
@@ -184,6 +184,13 @@ class ProjectFactTests(base.TestCaseWithReset):
         fact = json.loads(result.body)[0]
         self.assertEqual(fact['score'], 100)
 
+        result = self.fetch(f'/projects/{self.project["id"]}?full=true',
+                            headers=self.headers)
+        self.assertEqual(200, result.code)
+        project = json.loads(result.body)
+        fact = project['facts'][0]
+        self.assertEqual(fact['score'], 100)
+
     def test_false_boolean_fact(self):
         boolean_fact_type = self.create_project_fact_type(data_type='boolean')
         result = self.fetch(
@@ -200,6 +207,13 @@ class ProjectFactTests(base.TestCaseWithReset):
         self.assertEqual(200, result.code)
 
         fact = json.loads(result.body)[0]
+        self.assertEqual(fact['score'], 0)
+
+        result = self.fetch(f'/projects/{self.project["id"]}?full=true',
+                            headers=self.headers)
+        self.assertEqual(200, result.code)
+        project = json.loads(result.body)
+        fact = project['facts'][0]
         self.assertEqual(fact['score'], 0)
 
     def test_unknown_fact_id(self):

--- a/tests/endpoints/test_project_facts.py
+++ b/tests/endpoints/test_project_facts.py
@@ -7,7 +7,9 @@ from tests import base
 
 
 class ProjectFactTests(base.TestCaseWithReset):
-    TRUNCATE_TABLES = ['v1.projects', 'v1.project_fact_types']
+    TRUNCATE_TABLES = ['v1.project_facts',
+                       'v1.projects',
+                       'v1.project_fact_types']
 
     def setUp(self) -> None:
         super().setUp()
@@ -163,6 +165,42 @@ class ProjectFactTests(base.TestCaseWithReset):
             self.assertEqual(
                 400, result.code,
                 f'Unexpected response for {invalid_fact["value"]}')
+
+    def test_true_boolean_fact(self):
+        boolean_fact_type = self.create_project_fact_type(data_type='boolean')
+        result = self.fetch(
+            f'/projects/{self.project["id"]}/facts',
+            method='POST',
+            body=json.dumps([{
+                'fact_type_id': boolean_fact_type['id'],
+                'value': 'true'}]).encode('utf-8'),
+            headers=self.headers)
+        self.assertEqual(204, result.code)
+
+        result = self.fetch(f'/projects/{self.project["id"]}/facts',
+                            headers=self.headers)
+        self.assertEqual(200, result.code)
+
+        fact = json.loads(result.body)[0]
+        self.assertEqual(fact['score'], 100)
+
+    def test_false_boolean_fact(self):
+        boolean_fact_type = self.create_project_fact_type(data_type='boolean')
+        result = self.fetch(
+            f'/projects/{self.project["id"]}/facts',
+            method='POST',
+            body=json.dumps([{
+                'fact_type_id': boolean_fact_type['id'],
+                'value': 'false'}]).encode('utf-8'),
+            headers=self.headers)
+        self.assertEqual(204, result.code)
+
+        result = self.fetch(f'/projects/{self.project["id"]}/facts',
+                            headers=self.headers)
+        self.assertEqual(200, result.code)
+
+        fact = json.loads(result.body)[0]
+        self.assertEqual(fact['score'], 0)
 
     def test_unknown_fact_id(self):
         result = self.fetch(f'/projects/{self.project["id"]}/facts',


### PR DESCRIPTION
When fetching project data at /projects/<project_id>, boolean
facts for the project were always returning a score of 0. The
boolean fact type was just missing and the default 0 was selected.