### PR TITLE
Add sentry project creation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,7 @@ services:
       - opensearch
 
   postgres:
-    image: aweber/imbi-postgres:0.14.0-1
+    image: aweber/imbi-postgres:0.15.0
     ports:
       - 5432
     volumes:

--- a/docs/configuring-sentry.md
+++ b/docs/configuring-sentry.md
@@ -1,0 +1,22 @@
+# Configuration
+The Sentry automations are configured in the Imbi configuration file in the `automations/sentry`
+section using the following keys:
+
+* **project_link_type_id** optional Imbi identifier for the project link type created for Sentry links.
+  If this value is unspecified, then the automation will not create a project link to the Sentry
+  dashboard.
+* **auth_token** the Sentry authorization token used to create projects in sentry.  It needs the
+  following scopes -- `event:admin`, `event:read`, `member:read`, `org:read`, `project:read`,
+  `project:releases`, `team:read`, `event:write`, `project:write`, `project:admin`
+* **orgranization** the Sentry organization to create teams under.  This automation only supports a
+  single organization today.
+* **url** an optional URL to the Sentry instance.  This defaults to ``https://sentry.io/``
+
+If the `auth_token` and `organization` are set in the configuration file then the sentry automation
+will be enabled in the `/ui/settings` response which, in turn, enables the functionality in the
+frontend.
+
+# Sentry keys
+When a project is created in Sentry, the automation retrieves the public and private (deprecated)
+client DSNs and stores them as secrets in the `v1.project_secrets` table.  These are available from
+the API as `/projects/{id}/secrets`.

--- a/imbi/automations/base.py
+++ b/imbi/automations/base.py
@@ -35,16 +35,7 @@ class Automation:
         project = await models.project(project_id, self.application)
         if not project:
             self._add_error('project not found for {}', project_id)
-        else:
-            if project.namespace.gitlab_group_name is None:
-                self._add_error('missing GitLab group for namespace {}',
-                                project.namespace.slug)
-            if project.type.gitlab_project_prefix is None:
-                self._add_error('missing no GitLab prefix for project type {}',
-                                project.type.slug)
-
-        if not self._has_error():
-            return project
+        return None if self._has_error() else project
 
     async def _get_gitlab_token(self) \
             -> typing.Optional[oauth2.IntegrationToken]:

--- a/imbi/automations/sentry.py
+++ b/imbi/automations/sentry.py
@@ -46,24 +46,26 @@ class SentryCreateProjectAutomation(base.Automation):
                     'username': self.user.username,
                 }
             )
-            await self.db.execute(
-                '  INSERT INTO v1.project_links(project_id, link_type_id,'
-                '                               created_by, url)'
-                '       VALUES (%(imbi_project_id)s, %(project_link_type_id)s,'
-                '               %(username)s, %(url)s) '
-                '  ON CONFLICT '
-                'ON CONSTRAINT project_links_pkey'
-                '    DO UPDATE'
-                '          SET last_modified_at = CURRENT_TIMESTAMP,'
-                '              last_modified_by = %(username)s,'
-                '              url = %(url)s', {
-                    'imbi_project_id': self.imbi_project_id,
-                    'project_link_type_id':
-                        self.settings['project_link_type_id'],
-                    'url': project.link,
-                    'username': self.user.username,
-                }
-            )
+            if self.settings.get('project_link_type_id'):
+                await self.db.execute(
+                    '  INSERT INTO v1.project_links(project_id, link_type_id,'
+                    '                               created_by, url)'
+                    '       VALUES (%(imbi_project_id)s,'
+                    '               %(project_link_type_id)s, %(username)s,'
+                    '               %(url)s) '
+                    '  ON CONFLICT '
+                    'ON CONSTRAINT project_links_pkey'
+                    '    DO UPDATE'
+                    '          SET last_modified_at = CURRENT_TIMESTAMP,'
+                    '              last_modified_by = %(username)s,'
+                    '              url = %(url)s', {
+                        'imbi_project_id': self.imbi_project_id,
+                        'project_link_type_id':
+                            self.settings['project_link_type_id'],
+                        'url': project.link,
+                        'username': self.user.username,
+                    }
+                )
             for name, value in project.keys.items():
                 await self.db.execute(
                     '  INSERT INTO v1.project_secrets(project_id, name, value,'

--- a/imbi/automations/sentry.py
+++ b/imbi/automations/sentry.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from imbi import models
+from imbi.automations import base
+from imbi.clients import sentry
+
+
+class SentryCreateProjectAutomation(base.Automation):
+
+    def __init__(self, application, project_id, current_user, db) -> None:
+        super().__init__(application, current_user, db)
+        self.client = sentry.SentryClient(application)
+        self.imbi_project_id = project_id
+        self.project: models.Project | None = None
+        self.settings = self.automation_settings['sentry']
+
+    async def prepare(self) -> list[str]:
+        if not self.client.enabled:
+            self._add_error('Sentry integration is not enabled')
+        else:
+            project = await self._get_project(self.imbi_project_id)
+            if project is None:
+                self._add_error('Project id {} does not exist',
+                                self.imbi_project_id)
+            elif not project.namespace.sentry_team_slug:
+                self._add_error(
+                    'Namespace {} does not have a sentry slug, not creating'
+                    ' sentry project for project {}', project.namespace.slug,
+                    self.imbi_project_id)
+            else:
+                self.project = project
+        return self.errors
+
+    async def run(self) -> sentry.ProjectInfo:
+        project = await self.client.create_project(
+            self.project.namespace.sentry_team_slug, self.project.name)
+        try:
+            await self.db.execute(
+                'UPDATE v1.projects'
+                '   SET sentry_project_slug = %(slug)s,'
+                '       last_modified_at = CURRENT_TIMESTAMP,'
+                '       last_modified_by = %(username)s'
+                ' WHERE id = %(imbi_project_id)s', {
+                    'imbi_project_id': self.imbi_project_id,
+                    'slug': project.slug,
+                    'username': self.user.username,
+                }
+            )
+            await self.db.execute(
+                '  INSERT INTO v1.project_links(project_id, link_type_id,'
+                '                               created_by, url)'
+                '       VALUES (%(imbi_project_id)s, %(project_link_type_id)s,'
+                '               %(username)s, %(url)s) '
+                '  ON CONFLICT '
+                'ON CONSTRAINT project_links_pkey'
+                '    DO UPDATE'
+                '          SET last_modified_at = CURRENT_TIMESTAMP,'
+                '              last_modified_by = %(username)s,'
+                '              url = %(url)s', {
+                    'imbi_project_id': self.imbi_project_id,
+                    'project_link_type_id':
+                        self.settings['project_link_type_id'],
+                    'url': project.link,
+                    'username': self.user.username,
+                }
+            )
+            for name, value in project.keys.items():
+                await self.db.execute(
+                    '  INSERT INTO v1.project_secrets(project_id, name, value,'
+                    '                                 created_by)'
+                    '       VALUES (%(imbi_project_id)s, %(key_name)s,'
+                    '               %(key_value)s, %(username)s)'
+                    '  ON CONFLICT '
+                    'ON CONSTRAINT project_secrets_pkey'
+                    '    DO UPDATE'
+                    '          SET value = %(key_value)s,'
+                    '              last_modified_at = CURRENT_TIMESTAMP,'
+                    '              last_modified_by = %(username)s', {
+                        'imbi_project_id': self.imbi_project_id,
+                        'key_name': f'sentry_{name.lower()}',
+                        'key_value': self.application.encrypt_value(value),
+                        'username': self.user.username,
+                    }
+                )
+
+        except Exception:
+            await self.client.remove_project(project.slug)
+            raise
+
+        return project

--- a/imbi/automations/sentry.py
+++ b/imbi/automations/sentry.py
@@ -85,7 +85,12 @@ class SentryCreateProjectAutomation(base.Automation):
                     }
                 )
 
-        except Exception:
+        # Using a wide catch of Exception here to ensure that we remove
+        # the sentry project if we fail to save it for any reason.  This
+        # prevents orphaning sentry projects when we have a DB problem.
+        except Exception as error:
+            self.logger.error('removing sentry project %s due to error: %s',
+                              project.slug, error)
             await self.client.remove_project(project.slug)
             raise
 

--- a/imbi/clients/sentry.py
+++ b/imbi/clients/sentry.py
@@ -135,7 +135,12 @@ class SentryClient(sprockets.mixins.http.HTTPClientMixin):
                     'public': data.dsn.public,
                     'secret': data.dsn.secret,
                 })
-        except Exception:
+
+        # If we fail to fetch or extract the keys that the client
+        # needs, then remove the project since we cannot use it.
+        except errors.ApplicationError as error:
+            self.logger.error('removing Sentry project %s due to error: %s',
+                              project.slug, error)
             await self.remove_project(project.slug)
             raise
 

--- a/imbi/clients/sentry.py
+++ b/imbi/clients/sentry.py
@@ -106,18 +106,15 @@ class SentryClient(sprockets.mixins.http.HTTPClientMixin):
             keys={}
         )
 
-        url = yarl.URL('/projects') / self.organization / project.slug
+        # TODO update the project platform based on the project details
+        #      so that python projects use "platform=python" and
+        #      JS projects use "platform=javascript"
+        # Not sure if this is actually necessary so I'm omitting it.
+        # https://github.com/AWeber-Imbi/imbi/issues/73
+        # ref: https://docs.sentry.io/api/projects/update-a-project/
+        # ref: https://docs.sentry.io/platforms/
 
-        try:
-            response = await self.api(url, method='PUT',
-                                      body={'platform': 'python'})
-            if not response.ok:
-                raise errors.InternalServerError(
-                    'Failed to set platform for project: %s', response.code,
-                    title='Sentry API Error')
-        except Exception:
-            await self.remove_project(project.slug)
-            raise
+        url = yarl.URL('/projects') / self.organization / project.slug
 
         try:
             response = await self.api(url / 'keys')

--- a/imbi/clients/sentry.py
+++ b/imbi/clients/sentry.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import logging
+
+import pydantic
+import sprockets.mixins.http
+import yarl
+
+from imbi import errors, version
+
+
+class _ProjectCreationResponse(pydantic.BaseModel):
+    name: str
+    slug: str
+    id: str
+
+
+class _ProjectKeysDsn(pydantic.BaseModel):
+    public: pydantic.HttpUrl
+    secret: pydantic.HttpUrl
+
+
+class _ProjectKeysResponse(pydantic.BaseModel):
+    dsn: _ProjectKeysDsn
+    id: str
+    isActive: bool
+    projectId: int
+
+
+class ProjectInfo(pydantic.BaseModel):
+    name: str
+    slug: str
+    id: str
+    link: pydantic.HttpUrl
+    keys: dict[str, str]
+
+
+class SentryClient(sprockets.mixins.http.HTTPClientMixin):
+    def __init__(self, application) -> None:
+        super().__init__()
+        self.logger = logging.getLogger(__package__).getChild('SentryClient')
+
+        settings = application.settings['automations']['sentry']
+        self.url = yarl.URL(settings['url'])
+        self.api_url = self.url / 'api' / '0'
+        self.enabled = settings['enabled']
+        self.organization = settings.get('organization')
+        self.token = settings.get('auth_token')
+        self.headers = {
+            'Accept': 'application/json',
+            'Authorization': f'Bearer {self.token}',
+        }
+
+    async def api(self, url: yarl.URL | str, *,
+                  method: str = 'GET', **kwargs):
+        if not self.enabled:
+            raise errors.InternalServerError('Sentry client is not enabled',
+                                             title='Sentry Client Error')
+
+        if not isinstance(url, yarl.URL):
+            url = yarl.URL(url)
+        if not url.is_absolute():
+            url = self.api_url / url.path.lstrip('/')
+
+        # the sentry API wants a trailing slash
+        url = str(url).rstrip('/') + '/'
+
+        request_headers = kwargs.pop('request_headers', {})
+        request_headers.update(self.headers)
+        if kwargs.get('body') is not None:
+            request_headers['Content-Type'] = 'application/json'
+            kwargs['content_type'] = 'application/json'
+        kwargs['request_headers'] = request_headers
+        kwargs['user_agent'] = f'imbi/{version} (SentryClient)'
+        rsp = await super().http_fetch(str(url), method=method, **kwargs)
+        if not rsp.ok:
+            self.logger.error('%s %s failed: %s', method, url, rsp.code)
+        return rsp
+
+    async def create_project(self, team_slug: str,
+                             project_name: str) -> ProjectInfo:
+        url = yarl.URL('/teams') / self.organization / team_slug / 'projects'
+        response = await self.api(url, method='POST',
+                                  body={'name': project_name})
+        if not response.ok:
+            self.logger.error('Sentry API failure: body %r', response.body)
+            raise errors.InternalServerError(
+                'POST %s failed: %s', url, response.code,
+                title='Sentry API Failure')
+        else:
+            try:
+                data = _ProjectCreationResponse.parse_obj(response.body)
+            except pydantic.ValidationError as error:
+                self.logger.error('failed to parse response body: %r',
+                                  response.body)
+                raise errors.InternalServerError(
+                    'Failed to parse sentry create_project response: %s',
+                    error, title='Sentry Client Failure')
+
+        project = ProjectInfo(
+            id=data.id,
+            name=data.name,
+            slug=data.slug,
+            link=str(self.url / 'organizations' / self.organization /
+                     'projects' / data.slug),
+            keys={}
+        )
+
+        url = yarl.URL('/projects') / self.organization / project.slug
+
+        try:
+            response = await self.api(url, method='PUT',
+                                      body={'platform': 'python'})
+            if not response.ok:
+                raise errors.InternalServerError(
+                    'Failed to set platform for project: %s', response.code,
+                    title='Sentry API Error')
+        except Exception:
+            await self.remove_project(project.slug)
+            raise
+
+        try:
+            response = await self.api(url / 'keys')
+            if not response.ok:
+                raise errors.InternalServerError(
+                    'Failed to retrieve sentry project keys: %s',
+                    response.code, title='Sentry API Error')
+            try:
+                data = _ProjectKeysResponse.parse_obj(response.body[0])
+            except pydantic.ValidationError as error:
+                self.logger.error('failed to parse response body: %r',
+                                  response.body)
+                raise errors.InternalServerError(
+                    'Failed to parse sentry project keys response: %s',
+                    error, title='Sentry Client Failure')
+            else:
+                project.keys.update({
+                    'public': data.dsn.public,
+                    'secret': data.dsn.secret,
+                })
+        except Exception:
+            await self.remove_project(project.slug)
+            raise
+
+        return project
+
+    async def remove_project(self, project_slug: str) -> None:
+        await self.api(
+            yarl.URL('/projects') / self.organization / project_slug,
+            method='DELETE')

--- a/imbi/endpoints/__init__.py
+++ b/imbi/endpoints/__init__.py
@@ -7,8 +7,8 @@ from . import (activity_feed, authentication_tokens, cookie_cutters, dashboard,
                operations_log, permissions, project_activity_feed,
                project_dependencies, project_fact_history, project_fact_types,
                project_facts, project_link_types, project_links,
-               project_score_history, project_types, project_urls, projects,
-               reports, status, ui)
+               project_score_history, project_secrets, project_types,
+               project_urls, projects, reports, status, ui)
 
 URLS = [
     web.url(r'^/$', ui.IndexRequestHandler),
@@ -102,6 +102,9 @@ URLS = [
     web.url(r'^/projects/(?P<project_id>\d+)/score-history$',
             project_score_history.CollectionRequestHandler,
             name='project-score-history'),
+    web.url(r'^/projects/(?P<project_id>\d+)/secrets$',
+            project_secrets.CollectionRequestHandler,
+            name='project-secrets'),
     web.url(r'^/projects/(?P<project_id>\d+)/urls$',
             project_urls.CollectionRequestHandler,
             name='project-urls'),

--- a/imbi/endpoints/base.py
+++ b/imbi/endpoints/base.py
@@ -229,6 +229,7 @@ class AuthenticatedRequestHandler(RequestHandler):
                         'javascript_url'))
             self.set_status(401)
             await self.finish()
+            raise web.Finish()
 
 
 class ValidatingRequestHandler(AuthenticatedRequestHandler):

--- a/imbi/endpoints/integrations/gitlab.py
+++ b/imbi/endpoints/integrations/gitlab.py
@@ -51,6 +51,10 @@ class RedirectHandler(sprockets.mixins.http.HTTPClientMixin,
             await self.integration.add_user_token(
                 imbi_user, str(user_id), token.access_token,
                 token.refresh_token)
+
+        # Revoke the gitlab token if we cannot use or save it.  This
+        # is a catch-all case since GitLab does not remove tokens based
+        # on a lifetime.
         except Exception:
             await self.revoke_gitlab_token(token)
             raise

--- a/imbi/endpoints/namespaces.py
+++ b/imbi/endpoints/namespaces.py
@@ -7,14 +7,14 @@ class _RequestHandlerMixin:
 
     ID_KEY = 'id'
     FIELDS = ['id', 'name', 'slug', 'icon_class', 'maintained_by',
-              'gitlab_group_name']
+              'gitlab_group_name', 'sentry_team_slug']
     DEFAULTS = {'icon_class': 'fas fa-users', 'maintained_by': []}
 
     GET_SQL = re.sub(r'\s+', ' ', """\
         SELECT id, "name", created_at, created_by,
                last_modified_at, last_modified_by,
                slug, icon_class, maintained_by,
-               gitlab_group_name
+               gitlab_group_name, sentry_team_slug
           FROM v1.namespaces WHERE id=%(id)s""")
 
 
@@ -25,15 +25,17 @@ class CollectionRequestHandler(_RequestHandlerMixin,
     ITEM_NAME = 'namespace'
 
     COLLECTION_SQL = re.sub(r'\s+', ' ', """ \
-        SELECT id, "name", slug, icon_class, maintained_by, gitlab_group_name
+        SELECT id, "name", slug, icon_class, maintained_by, gitlab_group_name,
+               sentry_team_slug
           FROM v1.namespaces ORDER BY "name" ASC""")
 
     POST_SQL = re.sub(r'\s+', ' ', """\
         INSERT INTO v1.namespaces
                     ("name", created_by, slug, icon_class, "maintained_by",
-                     gitlab_group_name)
+                     gitlab_group_name, sentry_team_slug)
              VALUES (%(name)s, %(username)s, %(slug)s, %(icon_class)s,
-                     %(maintained_by)s, %(gitlab_group_name)s)
+                     %(maintained_by)s, %(gitlab_group_name)s,
+                     %(sentry_team_slug)s)
           RETURNING id""")
 
 
@@ -51,5 +53,6 @@ class RecordRequestHandler(_RequestHandlerMixin, base.AdminCRUDRequestHandler):
                slug = %(slug)s,
                icon_class = %(icon_class)s,
                "maintained_by" = %(maintained_by)s,
-               gitlab_group_name = %(gitlab_group_name)s
+               gitlab_group_name = %(gitlab_group_name)s,
+               sentry_team_slug = %(sentry_team_slug)s
          WHERE id=%(id)s""")

--- a/imbi/endpoints/project_secrets.py
+++ b/imbi/endpoints/project_secrets.py
@@ -1,0 +1,24 @@
+from imbi.endpoints import base
+
+
+class CollectionRequestHandler(base.CollectionRequestHandler):
+    NAME = 'project-secrets'
+    ID_KEY = ['project_id', 'name']
+    ITEM_NAME = 'project-secret'
+    FIELDS = ['project_id']
+    TTL = 300
+
+    COLLECTION_SQL = (
+        'SELECT s.project_id, p.slug AS project_slug, s.name, s.value,'
+        '       s.created_by, s.last_modified_by'
+        '  FROM v1.project_secrets AS s'
+        '  JOIN v1.projects AS p ON s.project_id = p.id'
+        ' WHERE s.project_id = %(project_id)s'
+    )
+
+    async def get(self, *args, **kwargs):
+        result = await self.postgres_execute(self.COLLECTION_SQL, kwargs,
+                                             metric_name=f'get-{self.NAME}')
+        for row in result.rows:
+            row['value'] = self.application.decrypt_value(row['value'])
+        self.send_response(result.rows)

--- a/imbi/endpoints/ui/automations/__init__.py
+++ b/imbi/endpoints/ui/automations/__init__.py
@@ -4,12 +4,14 @@ System Reports
 """
 from tornado import web
 
-from . import gitlab, sonarqube
+from . import gitlab, sentry, sonarqube
 
 URLS = [
     web.url(r'^/ui/automations/gitlab/commit',
             gitlab.InitialCommitRequestHandler),
     web.url(r'^/ui/automations/gitlab/create', gitlab.CreationRequestHandler),
+    web.url(r'^/ui/automations/sentry/create',
+            sentry.ProjectCreationRequestHandler),
     web.url(r'^/ui/automations/sonarqube/create',
-            sonarqube.CreationRequestHandler)
+            sonarqube.CreationRequestHandler),
 ]

--- a/imbi/endpoints/ui/automations/sentry.py
+++ b/imbi/endpoints/ui/automations/sentry.py
@@ -1,0 +1,25 @@
+from imbi.automations import sentry
+from imbi.endpoints import base, projects
+from imbi.endpoints.ui.automations import mixins
+
+
+class ProjectCreationRequestHandler(mixins.PrepareFailureMixin,
+                                    projects.OpensearchMixin,
+                                    base.ValidatingRequestHandler):
+    NAME = 'ui-sentry-create-project'
+
+    async def post(self) -> None:
+        request = self.get_request_body()
+        project_id = int(request['project_id'])
+        user = await self.get_current_user()  # never None
+        async with self.postgres_transaction() as transaction:
+            client = sentry.SentryCreateProjectAutomation(
+                self.application, project_id, user, transaction)
+            failures = await client.prepare()
+            if failures:
+                raise self.handle_prepare_failures('Create Project', failures)
+
+            project_info = await client.run()
+            self.send_response({'sentry_project_url': project_info.link})
+
+        await self.index_document(project_id)

--- a/imbi/endpoints/ui/settings.py
+++ b/imbi/endpoints/ui/settings.py
@@ -55,10 +55,8 @@ class RequestHandler(base.RequestHandler):
                     'clientId': gitlab_auth['client_id'],
                     'redirectURI': gitlab_auth['callback_url'],
                 })
-            gitlab['enabled'] = (
-                gitlab['project_link_type_id'] is not None and
-                gitlab['clientId'] is not None
-            )
+            gitlab['enabled'] = (cfg['enabled'] and
+                                 gitlab.get('clientId') is not None)
 
         sentry = {'enabled': False}
         cfg = automations.get('sentry')

--- a/imbi/endpoints/ui/settings.py
+++ b/imbi/endpoints/ui/settings.py
@@ -60,6 +60,16 @@ class RequestHandler(base.RequestHandler):
                 gitlab['clientId'] is not None
             )
 
+        sentry = {'enabled': False}
+        cfg = automations.get('sentry')
+        if cfg:
+            sentry['project_link_type_id'] = cfg.get('project_link_type_id')
+            sentry['auth_token'] = cfg.get('auth_token')
+            sentry['enabled'] = (
+                sentry['project_link_type_id'] is not None and
+                sentry['auth_token'] is not None
+            )
+
         self.send_response({
             'integrations': {
                 'grafana': {

--- a/imbi/endpoints/ui/settings.py
+++ b/imbi/endpoints/ui/settings.py
@@ -62,11 +62,7 @@ class RequestHandler(base.RequestHandler):
         cfg = automations.get('sentry')
         if cfg:
             sentry['project_link_type_id'] = cfg.get('project_link_type_id')
-            sentry['auth_token'] = cfg.get('auth_token')
-            sentry['enabled'] = (
-                sentry['project_link_type_id'] is not None and
-                sentry['auth_token'] is not None
-            )
+            sentry['enabled'] = cfg['enabled']
 
         self.send_response({
             'integrations': {

--- a/imbi/models.py
+++ b/imbi/models.py
@@ -33,6 +33,7 @@ class Namespace:
     icon_class: str
     maintained_by: typing.Optional[typing.List[str]]
     gitlab_group_name: str
+    sentry_team_slug: typing.Optional[str]
 
     SQL: typing.ClassVar = re.sub(r'\s+', ' ', """\
         SELECT id,
@@ -44,7 +45,8 @@ class Namespace:
                slug,
                icon_class,
                maintained_by,
-               gitlab_group_name
+               gitlab_group_name,
+               sentry_team_slug
           FROM v1.namespaces
          WHERE id=%(id)s""")
 

--- a/imbi/server.py
+++ b/imbi/server.py
@@ -89,10 +89,6 @@ def load_configuration(config: str, debug: bool) -> typing.Tuple[dict, dict]:
     if automations_grafana.get('url') \
             and automations_grafana.get('admin_token'):
         automations_grafana['enabled'] = True
-    automations_sentry = automations.get('sentry', {})
-    if automations_sentry.get('url') \
-            and automations_sentry.get('admin_token'):
-        automations_sentry['enabled'] = True
     automations_sonar = automations.get('sonarqube', {})
     if automations_sonar.get('url') and automations_sonar.get('admin_token'):
         automations_sonar['enabled'] = True
@@ -103,6 +99,13 @@ def load_configuration(config: str, debug: bool) -> typing.Tuple[dict, dict]:
     sentry = config.get('sentry', {})
     session = config.get('session', {})
     stats = config.get('stats', {})
+
+    automations_sentry = automations.get('sentry', {})
+    automations_sentry.setdefault(
+        'enabled',
+        (automations_sentry.get('auth_token') is not None and
+         automations_sentry.get('organization') is not None))
+    automations_sentry.setdefault('url', 'https://sentry.io/')
 
     module_path = pathlib.Path(sys.modules['imbi'].__file__).parent
 
@@ -133,11 +136,7 @@ def load_configuration(config: str, debug: bool) -> typing.Tuple[dict, dict]:
             },
             # see https://pycqa.github.io/isort/reference/isort/settings.html
             'isort': automations.get('isort', {}),
-            'sentry': {
-                'enabled': automations_sentry.get('enabled', False),
-                'project_link_type_id':
-                    automations_sentry.get('project_link_type_id')
-            },
+            'sentry': automations_sentry,
             'sonarqube': {
                 'enabled': automations_sonar.get('enabled', False),
                 'admin_token': automations_sonar.get('admin_token'),

--- a/imbi/server.py
+++ b/imbi/server.py
@@ -84,7 +84,6 @@ def load_configuration(config: str, debug: bool) -> typing.Tuple[dict, dict]:
     log_config = config.get('logging', DEFAULT_LOG_CONFIG)
 
     automations = config.get('automations', {})
-    automations_gitlab = automations.get('gitlab', {})
     automations_grafana = automations.get('grafana', {})
     if automations_grafana.get('url') \
             and automations_grafana.get('admin_token'):
@@ -99,6 +98,11 @@ def load_configuration(config: str, debug: bool) -> typing.Tuple[dict, dict]:
     sentry = config.get('sentry', {})
     session = config.get('session', {})
     stats = config.get('stats', {})
+
+    automations_gitlab = automations.get('gitlab', {})
+    automations_gitlab.setdefault(
+        'enabled',
+        automations_gitlab.get('project_link_type_id') is not None)
 
     automations_sentry = automations.get('sentry', {})
     automations_sentry.setdefault(
@@ -123,12 +127,7 @@ def load_configuration(config: str, debug: bool) -> typing.Tuple[dict, dict]:
 
     settings = {
         'automations': {
-            'gitlab': {
-                'project_link_type_id':
-                    automations_gitlab.get('project_link_type_id'),
-                'restrict_to_user':
-                    automations_grafana.get('restrict_to_user', False)
-            },
+            'gitlab': automations_gitlab,
             'grafana': {
                 'enabled': automations_grafana.get('enabled', False),
                 'project_link_type_id':

--- a/imbi/templates/openapi.yaml
+++ b/imbi/templates/openapi.yaml
@@ -968,9 +968,9 @@ paths:
                     type: string
                     format: url
                 additionalProperties: false
-              example:
+              examples:
                 problemDetail:
-                  description: An example of the response body
+                  summary: '401'
                   value:
                     type: HTTPError
                     traceback: []
@@ -978,9 +978,9 @@ paths:
             application/msgpack:
               schema:
                 $ref: '#/paths/~1groups/get/responses/401/content/application~1json/schema'
-              example:
+              examples:
                 problemDetail:
-                  description: An example of the response body
+                  summary: '401'
                   value:
                     type: HTTPError
                     traceback: []
@@ -1081,9 +1081,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/paths/~1groups/get/responses/401/content/application~1json/schema'
-              example:
+              examples:
                 problemDetail:
-                  description: An example of the response body
+                  summary: '400'
                   value:
                     type: HTTPError
                     traceback: []
@@ -1091,9 +1091,9 @@ paths:
             application/msgpack:
               schema:
                 $ref: '#/paths/~1groups/get/responses/401/content/application~1json/schema'
-              example:
+              examples:
                 problemDetail:
-                  description: An example of the response body
+                  summary: '400'
                   value:
                     type: HTTPError
                     traceback: []
@@ -1106,23 +1106,23 @@ paths:
             application/json:
               schema:
                 $ref: '#/paths/~1groups/get/responses/401/content/application~1json/schema'
-              example:
+              examples:
                 problemDetail:
-                  description: An example of the response body
+                  summary: '409'
                   value:
                     type: HTTPError
                     traceback: []
-                    message: 'HTTP 409: Conflict'
+                    message: HTTP 409 Conflict
             application/msgpack:
               schema:
                 $ref: '#/paths/~1groups/get/responses/401/content/application~1json/schema'
-              example:
+              examples:
                 problemDetail:
-                  description: An example of the response body
+                  summary: '409'
                   value:
                     type: HTTPError
                     traceback: []
-                    message: 'HTTP 409: Conflict'
+                    message: HTTP 409 Conflict
   '/groups/{name}':
     get:
       summary: Get Record
@@ -1140,23 +1140,23 @@ paths:
             application/json:
               schema:
                 $ref: '#/paths/~1groups/get/responses/401/content/application~1json/schema'
-              example:
+              examples:
                 problemDetail:
-                  description: An example of the response body
+                  summary: '404'
                   value:
                     type: HTTPError
                     traceback: []
-                    message: 'HTTP 404: Resource not found'
+                    message: HTTP 404 Resource not found
             application/msgpack:
               schema:
                 $ref: '#/paths/~1groups/get/responses/401/content/application~1json/schema'
-              example:
+              examples:
                 problemDetail:
-                  description: An example of the response body
+                  summary: '404'
                   value:
                     type: HTTPError
                     traceback: []
-                    message: 'HTTP 404: Resource not found'
+                    message: HTTP 404 Resource not found
     patch:
       summary: Update Record
       description: 'Update a group, providing a JSON Patch (RFC-6209) payload of update operations to apply.'
@@ -1391,6 +1391,10 @@ paths:
                       description: Optional name of associated GitLab group
                       type: string
                       nullable: true
+                    sentry_team_slug:
+                      description: Optional name of associated Sentry team
+                      type: string
+                      nullable: true
                   required:
                     - name
                     - slug
@@ -1404,6 +1408,7 @@ paths:
                       name: Platform Support Engineering
                       slug: PSE
                       icon_class: fas fa-blind
+                      sentry_team_slug: pse
                       maintained_by:
                         - Developers
                         - Operations
@@ -1450,6 +1455,10 @@ paths:
                       description: Optional name of associated GitLab group
                       type: string
                       nullable: true
+                    sentry_team_slug:
+                      description: Optional name of associated Sentry team
+                      type: string
+                      nullable: true
                   required:
                     - name
                     - slug
@@ -1463,6 +1472,7 @@ paths:
                       name: Platform Support Engineering
                       slug: PSE
                       icon_class: fas fa-blind
+                      sentry_team_slug: pse
                       maintained_by:
                         - Developers
                         - Operations
@@ -1506,6 +1516,10 @@ paths:
                   description: Optional name of associated GitLab group
                   type: string
                   nullable: true
+                sentry_team_slug:
+                  description: Optional name of associated Sentry team
+                  type: string
+                  nullable: true
               required:
                 - name
                 - slug
@@ -1518,7 +1532,8 @@ paths:
                   name: Platform Support Engineering
                   slug: PSE
                   icon_class: fas fa-blind
-                  maintainted_by:
+                  sentry_team_slug: pse
+                  maintained_by:
                     - Developers
                     - Operations
           application/msgpack:
@@ -1531,7 +1546,8 @@ paths:
                   name: Platform Support Engineering
                   slug: PSE
                   icon_class: fas fa-blind
-                  maintainted_by:
+                  sentry_team_slug: pse
+                  maintained_by:
                     - Developers
                     - Operations
       tags:
@@ -1560,9 +1576,10 @@ paths:
                     name: Platform Support Engineering
                     slug: PSE
                     icon_class: fas fa-blind
-                    maintainted_by:
+                    maintained_by:
                       - Developers
                       - Operations
+                    sentry_team_slug: pse
             application/msgpack:
               schema:
                 $ref: '#/paths/~1namespaces/get/responses/200/content/application~1json/schema/items'
@@ -1576,9 +1593,10 @@ paths:
                     name: Platform Support Engineering
                     slug: PSE
                     icon_class: fas fa-blind
-                    maintainted_by:
+                    maintained_by:
                       - Developers
                       - Operations
+                    sentry_team_slug: pse
         '400':
           $ref: '#/paths/~1groups/post/responses/400'
         '401':
@@ -3662,6 +3680,7 @@ paths:
                 gitlab_project_prefix:
                   description: Prefix for this project type in GitLab
                   type: string
+                  nullable: true
               required:
                 - name
                 - plural_name
@@ -4867,9 +4886,9 @@ paths:
                     icon_class:
                       description: The Font Awesome icon class for the link
                       type: string
-              example:
+              examples:
                 records:
-                  summary: Multiple facts
+                  summary: Fact history
                   value:
                     - fact_type_id: 1
                       recorded_at: 2021-03-01T12:00:00.000Z
@@ -4918,9 +4937,9 @@ paths:
                     icon_class:
                       description: The Font Awesome icon class for the link
                       type: string
-              example:
+              examples:
                 records:
-                  summary: Multiple facts
+                  summary: Fact history
                   value:
                     - fact_type_id: 1
                       recorded_at: 2021-03-01T12:00:00.000Z
@@ -5515,6 +5534,77 @@ paths:
         required: true
         schema:
           type: number
+  '/projects/{id}/secrets':
+    parameters:
+      - name: id
+        in: path
+        description: ID of the project for the secrets
+        required: true
+        schema:
+          type: number
+    get:
+      description: Retrieve the collection of secrets for a project
+      summary: Get Secrets
+      tags:
+        - Projects
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  title: Project Secret
+                  description: Secrets related to the project
+                  type: object
+                  properties:
+                    project_id:
+                      description: Identifies the project associated with this secret
+                      type: number
+                    name:
+                      description: Name of this secret
+                      type: string
+                    project_slug:
+                      description: The "slug" of the associated project
+                      type: string
+                    value:
+                      description: Plaintext value of this secret
+                      type: string
+                    created_by:
+                      description: The user that created the record
+                      type: string
+                    last_modified_by:
+                      description: The user that last modified the record
+                      type: string
+                      format: datetime
+            application/msgpack:
+              schema:
+                type: array
+                items:
+                  title: Project Secret
+                  description: Secrets related to the project
+                  type: object
+                  properties:
+                    project_id:
+                      description: Identifies the project associated with this secret
+                      type: number
+                    name:
+                      description: Name of this secret
+                      type: string
+                    project_slug:
+                      description: The "slug" of the associated project
+                      type: string
+                    value:
+                      description: Plaintext value of this secret
+                      type: string
+                    created_by:
+                      description: The user that created the record
+                      type: string
+                    last_modified_by:
+                      description: The user that last modified the record
+                      type: string
+                      format: datetime
   '/projects/{id}/score-history':
     get:
       description: Retrieve the score history for a specific project.
@@ -6136,6 +6226,35 @@ paths:
                     type: integer
         '400':
           description: Request could not be processed
+  /ui/automations/sentry/create:
+    post:
+      summary: Create Sentry Project
+      description: Creates a new Sentry project using the info from the project.
+      tags:
+        - Automations
+      requestBody:
+        description: Project details
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                project_id:
+                  description: Imbi project ID to create the Sonarqube Project for
+                  type: integer
+              required:
+                - project_id
+      responses:
+        '200':
+          description: Sentry project was created successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  sentry_project_url:
+                    type: string
+                    format: url
 tags:
   - name: Activity Feed
     description: Endpoints that detail changes to projects and other entities in Imbi
@@ -6236,6 +6355,7 @@ x-tagGroups:
       - Project Dependencies
       - Project Facts
       - Project Fact Types
+      - Project Fact History
       - Project Links
       - Project Scores
       - Project URLs

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import base64
+import contextlib
+import io
 import os
 import tempfile
 import unittest.mock
@@ -12,22 +14,22 @@ from imbi import server
 
 
 class ConfigurationTestCase(unittest.TestCase):
+    temp_file: io.FileIO
+
     def setUp(self) -> None:
         super().setUp()
-        self._patchers = []
+        self._exit_stack = contextlib.ExitStack()
+        self.addCleanup(self._exit_stack.close)
         self.mock_stderr = self.patch_object(server.sys, 'stderr')
-
-    def tearDown(self) -> None:
-        for patcher in self._patchers:
-            patcher.stop()
-        super().tearDown()
+        self.temp_file = self._exit_stack.enter_context(
+            tempfile.NamedTemporaryFile(mode='w+t', encoding='utf-8'))
+        self.config = {'http': {'canonical_server_name': 'server.example.com'}}
 
     def patch_object(
             self, target: object, attribute: str, **kwargs
     ) -> unittest.mock.MagicMock | unittest.mock.AsyncMock:
-        patcher = unittest.mock.patch.object(target, attribute, **kwargs)
-        self._patchers.append(patcher)
-        return patcher.start()
+        return self._exit_stack.enter_context(
+            unittest.mock.patch.object(target, attribute, **kwargs))
 
 
 class LoadConfigurationTests(ConfigurationTestCase):
@@ -38,39 +40,60 @@ class LoadConfigurationTests(ConfigurationTestCase):
         self.mock_stderr.write.assert_called()
 
     def test_yaml_load_failure(self):
-        with tempfile.NamedTemporaryFile() as config_file:
-            config_file.write(b'\x00\x01\x02\x03')
-            config_file.flush()
-            with self.assertRaises(SystemExit):
-                server.load_configuration(config_file.name, False)
-            self.mock_stderr.write.assert_called()
+        self.temp_file.write('\x00\x01\x02\x03')
+        self.temp_file.flush()
+        with self.assertRaises(SystemExit):
+            server.load_configuration(self.temp_file.name, False)
+        self.mock_stderr.write.assert_called()
 
     def test_bad_yaml_doc(self):
-        with tempfile.NamedTemporaryFile() as config_file:
-            config_file.write(b'<config/>')
-            config_file.flush()
-            with self.assertRaises(SystemExit):
-                server.load_configuration(config_file.name, False)
-            self.mock_stderr.write.assert_called()
+        self.temp_file.write('<config/>')
+        self.temp_file.flush()
+        with self.assertRaises(SystemExit):
+            server.load_configuration(self.temp_file.name, False)
+        self.mock_stderr.write.assert_called()
 
     def test_encryption_key_encoding(self):
         secret = os.urandom(32)
-        with tempfile.NamedTemporaryFile(
-                mode='w+t', encoding='utf-8') as config_file:
-            yaml.dump(
-                {
-                    'encryption_key': base64.b64encode(secret).decode(),
-                    'http': {'canonical_server_name': 'server.example.com'},
-                }, config_file)
-            config, _ = server.load_configuration(config_file.name, False)
-            self.assertEqual(secret, config['encryption_key'])
+        self.config['encryption_key'] = base64.b64encode(secret).decode()
+        yaml.dump(self.config, self.temp_file)
+        config, _ = server.load_configuration(self.temp_file.name, False)
+        self.assertEqual(secret, config['encryption_key'])
 
-            config_file.seek(0)
-            secret = b'not valid base64'
-            yaml.dump(
-                {
-                    'encryption_key': secret.decode(),
-                    'http': {'canonical_server_name': 'server.example.com'},
-                }, config_file)
-            config, _ = server.load_configuration(config_file.name, False)
-            self.assertEqual(secret, config['encryption_key'])
+        self.temp_file.seek(0)
+        self.config['encryption_key'] = 'not valid base64'
+        yaml.dump(self.config, self.temp_file)
+        config, _ = server.load_configuration(self.temp_file.name, False)
+        self.assertEqual('not valid base64'.encode(), config['encryption_key'])
+
+
+class SentryConfigurationTests(ConfigurationTestCase):
+
+    def test_that_default_is_disabled(self):
+        yaml.dump(self.config, self.temp_file)
+        config, _ = server.load_configuration(self.temp_file.name, False)
+        self.assertFalse(config['automations']['sentry']['enabled'])
+
+    def test_that_sentry_is_enabled_fully_configured(self):
+        self.config['automations'] = {'sentry': {}}
+        yaml.dump(self.config, self.temp_file)
+        loaded, _ = server.load_configuration(self.temp_file.name, False)
+        self.assertFalse(loaded['automations']['sentry']['enabled'])
+        self.temp_file.seek(0)
+
+        self.config['automations']['sentry']['auth_token'] = '12345'
+        yaml.dump(self.config, self.temp_file)
+        loaded, _ = server.load_configuration(self.temp_file.name, False)
+        self.assertFalse(loaded['automations']['sentry']['enabled'])
+        self.temp_file.seek(0)
+
+        self.config['automations']['sentry']['organization'] = 'example-com'
+        yaml.dump(self.config, self.temp_file)
+        loaded, _ = server.load_configuration(self.temp_file.name, False)
+        self.assertTrue(loaded['automations']['sentry']['enabled'])
+
+    def test_that_sentry_url_has_sensible_default(self):
+        yaml.dump(self.config, self.temp_file)
+        config, _ = server.load_configuration(self.temp_file.name, False)
+        self.assertEqual(
+            'https://sentry.io/', config['automations']['sentry']['url'])

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import base64
 import os
 import tempfile
@@ -9,21 +11,26 @@ import yaml
 from imbi import server
 
 
-class LoadConfigurationTests(unittest.TestCase):
-    def setUp(self):
+class ConfigurationTestCase(unittest.TestCase):
+    def setUp(self) -> None:
         super().setUp()
         self._patchers = []
-        self.mock_stderr = self.add_patch(server.sys, 'stderr')
+        self.mock_stderr = self.patch_object(server.sys, 'stderr')
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         for patcher in self._patchers:
             patcher.stop()
         super().tearDown()
 
-    def add_patch(self, target, attribute, **kwargs):
-        self._patchers.append(
-            unittest.mock.patch.object(target, attribute, **kwargs))
-        return self._patchers[-1].start()
+    def patch_object(
+            self, target: object, attribute: str, **kwargs
+    ) -> unittest.mock.MagicMock | unittest.mock.AsyncMock:
+        patcher = unittest.mock.patch.object(target, attribute, **kwargs)
+        self._patchers.append(patcher)
+        return patcher.start()
+
+
+class LoadConfigurationTests(ConfigurationTestCase):
 
     def test_missing_configuration_file(self):
         with self.assertRaises(SystemExit):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -74,7 +74,7 @@ class SentryConfigurationTests(ConfigurationTestCase):
         config, _ = server.load_configuration(self.temp_file.name, False)
         self.assertFalse(config['automations']['sentry']['enabled'])
 
-    def test_that_sentry_is_enabled_fully_configured(self):
+    def test_that_sentry_is_enabled_when_fully_configured(self):
         self.config['automations'] = {'sentry': {}}
         yaml.dump(self.config, self.temp_file)
         loaded, _ = server.load_configuration(self.temp_file.name, False)
@@ -97,3 +97,23 @@ class SentryConfigurationTests(ConfigurationTestCase):
         config, _ = server.load_configuration(self.temp_file.name, False)
         self.assertEqual(
             'https://sentry.io/', config['automations']['sentry']['url'])
+
+
+class GitLabConfiguratTests(ConfigurationTestCase):
+
+    def test_that_default_is_disabled(self):
+        yaml.dump(self.config, self.temp_file)
+        config, _ = server.load_configuration(self.temp_file.name, False)
+        self.assertFalse(config['automations']['gitlab']['enabled'])
+
+    def test_that_gitlab_is_enabled_when_fully_configured(self):
+        self.config['automations'] = {'gitlab': {}}
+        yaml.dump(self.config, self.temp_file)
+        loaded, _ = server.load_configuration(self.temp_file.name, False)
+        self.assertFalse(loaded['automations']['gitlab']['enabled'])
+        self.temp_file.seek(0)
+
+        self.config['automations']['gitlab']['project_link_type_id'] = 1
+        yaml.dump(self.config, self.temp_file)
+        loaded, _ = server.load_configuration(self.temp_file.name, False)
+        self.assertTrue(loaded['automations']['gitlab']['enabled'])


### PR DESCRIPTION
This PR adds an automation that creates and associates a sentry project for an imbi project.  A separate PR to `imbi-ui` will make use of this functionality to enable the automation when creating a new project in imbi.  You can test this locally by creating an API token in sentry.io and following the instructions in _docs/configuring-sentry.md_