### PR TITLE
Add CORS support

### DIFF
--- a/imbi/cors.py
+++ b/imbi/cors.py
@@ -1,0 +1,305 @@
+from __future__ import annotations
+
+import copy
+import logging
+
+import yarl
+from tornado import web
+
+LOGGER = logging.getLogger(__name__)
+
+
+class Unspecified:
+    """Sentinel value for optional parameters"""
+    pass
+
+
+class Origins:
+    """Collection of CORS origins
+
+    This acts like a set of URLs with a special property to
+    enable any URL to match without being present.  This is
+    used to determine whether CORS should be enabled for
+    requests from a specific Origin.
+
+    By default, any origin is acceptable.  If the application
+    adds a specific origin value, then the "any" flag is
+    disabled since that is usually what is desired.  The "add"
+    operation enforces that only absolute URLs are acceptable
+    as origins -- this explicitly means that ``null`` is not
+    valid as an acceptable origin. (:rfc:`6454`).
+
+    """
+    def __init__(self, *, allow_any: bool = True):
+        self.allow_any: bool = allow_any
+        self._origins: set[yarl.URL] = set()
+
+    def add(self, item: str) -> None:
+        """Add a new URL to the set of origins
+
+        If `item` is not an absolute URL, then a :exc:`ValueError`
+        will be raised.
+
+        """
+        url = yarl.URL(item)
+        if not url.is_absolute():
+            raise ValueError(f'{item!r} is not a valid URL')
+
+        self.allow_any = False
+        self._origins.add(url)
+
+    def __str__(self) -> str:
+        return '<{} allow_any:{} origins:{}>'.format(
+            self.__class__.__name__,
+            self.allow_any,
+            ','.join(str(s) for s in self._origins))
+
+    def __copy__(self) -> Origins:
+        return self.__deepcopy__()
+
+    def __deepcopy__(self, *args, **kwargs) -> Origins:
+        clone = self.__class__(allow_any=self.allow_any)
+        clone._origins.update(self._origins)
+        return clone
+
+    def __contains__(self, item: str) -> bool:
+        if self.allow_any:
+            return True
+        return yarl.URL(item) in self._origins
+
+
+class CORSConfig:
+    """Application-level CORS configuration defaults
+
+    :param allow_any_origin: should "any" origin be allowed
+        to participate in resource sharing?
+    :param allow_credentials: should requests including
+        an Authorization header or Cookies be sent to the server?
+        Also, should responses with Set-Cookie be returned?
+    :param exposed_headers: the list of response headers that
+        should be exposed to the JS layer
+    :param max_age: the maximum number of seconds that the JS
+        layer may cache the CORS response
+
+    """
+
+    def __init__(
+            self,
+            *,
+            allow_any_origin: bool = True,
+            allow_credentials: bool = True,
+            allow_methods: set[str] | None = None,
+            exposed_headers: set[str] | None = None,
+            max_age: int = 5,
+    ):
+        # allow_credentials is True by default to ensure that any
+        # cookies we set will be returned to the JS client
+        self.allow_credentials = allow_credentials
+
+        self.allowed_methods: set[str] = set()
+        if allow_methods:
+            self.allowed_methods.update(allow_methods)
+
+        self.allowed_origins = Origins(allow_any=allow_any_origin)
+
+        self.exposed_headers: set[str] = {'Cache-Control', 'Date',
+                                          'Last-Modified', 'Link'}
+        if exposed_headers:
+            self.exposed_headers.update(exposed_headers)
+
+        self.max_age = max_age
+
+    def __str__(self) -> str:
+        return (('<{} allow_credentials:{} max_age:{} allowed_methods:{!r}'
+                 ' exposed_headers:{!r} origins:{}>').format(
+            self.__class__.__name__,
+            self.allow_credentials,
+            self.max_age,
+            self.allowed_methods,
+            self.exposed_headers,
+            self.allowed_origins,
+        ))
+
+    def __copy__(self) -> CORSConfig:
+        clone = CORSConfig(
+            allow_credentials=self.allow_credentials,
+            allow_methods=self.allowed_methods,
+            exposed_headers=self.exposed_headers,
+            max_age=self.max_age)
+        clone.allowed_origins = copy.deepcopy(self.allowed_origins)
+        return clone
+
+    def __deepcopy__(self, *args, **kwargs) -> CORSConfig:
+        return self.__copy__()
+
+    def update(self, *,
+               allow_any_origin: bool | Unspecified = Unspecified(),
+               allow_credentials: bool | Unspecified = Unspecified(),
+               allow_methods: set[str] | Unspecified = Unspecified(),
+               allow_origins: set[str] | Unspecified = Unspecified(),
+               exposed_headers: set[str] | Unspecified = Unspecified(),
+               max_age: int | Unspecified = Unspecified(),
+               ) -> None:
+        """Update selected attributes"""
+        if not isinstance(allow_any_origin, Unspecified):
+            self.allowed_origins.allow_any = allow_any_origin
+        if not isinstance(allow_credentials, Unspecified):
+            self.allow_credentials = allow_credentials
+        if not isinstance(allow_methods, Unspecified):
+            self.allowed_methods.update(allow_methods)
+        if not isinstance(allow_origins, Unspecified):
+            for origin in allow_origins:
+                self.allowed_origins.add(origin)
+        if not isinstance(exposed_headers, Unspecified):
+            self.exposed_headers.update(exposed_headers)
+        if not isinstance(max_age, Unspecified):
+            self.max_age = max_age
+
+
+class CORSProcessor:
+    """CORS Request processor
+
+    An instance of this is created for each request using the
+    default configuration as the `config` parameter along with
+    optional overrides.  It is instantiated with each handler
+    instance, then :meth:`process_request` is called inside
+    :meth:`tornado.web.RequestHandler.prepare`.  "Processing"
+    the request results in setting the response headers based
+    on the CORS protocol.
+
+    The separation between ``process_request`` and ``set_headers``
+    is necessary since the request handler logic resets the header
+    set when an exception occurs.  The ``CORSMixin`` accounts for
+    this by calling :meth:`set_headers` in ``set_default_headers``
+    which is called after the request handler resets the headers.
+    However, it is also called during instance initialization which
+    the mixin also accounts for.  You should rarely need to call
+    `set_headers` directly.
+
+    """
+    def __init__(self, config: CORSConfig, **overrides) -> None:
+        self.config = copy.deepcopy(config)
+        self.config.update(**overrides)
+        self.requested_origin: str | None = None
+        self.is_preflight = None
+
+    @property
+    def ok(self) -> bool:
+        """Is the request Origin acceptable?"""
+        return self.requested_origin is not None
+
+    def process_request(self, handler: web.RequestHandler) -> None:
+        """Determine the CORS result for a request
+
+        This is the main logic for CORS handling and should be
+        called from your request handler's ``prepare`` method.
+
+        """
+        request = handler.request
+        if request.method == 'OPTIONS':
+            try:
+                request.headers['Access-Control-Request-Method']
+                origin = request.headers['Origin']
+            except KeyError as error:
+                LOGGER.debug('not a CORS request, missing required header %s',
+                             error.args[0])
+            else:
+                self.is_preflight = True
+                origin = origin.strip()
+                if origin in self.config.allowed_origins:
+                    self.requested_origin = origin
+                else:
+                    LOGGER.debug('CORS preflight origin %r not allowed',
+                                 origin)
+        else:
+            self.is_preflight = False
+            origin = request.headers.get('origin', '').strip()
+            if origin in self.config.allowed_origins:
+                self.requested_origin = origin
+
+        self.set_headers(handler)
+
+    def set_headers(self, handler: web.RequestHandler) -> None:
+        """Set the appropriate CORS response headers
+
+        **You probably do not need to invoke this method directly!**
+
+        The response header set is determined by a call to
+        :meth:`process_request`.  If it has not been called, then
+        only the ``Access-Control-Allow-Origin`` header will be set
+        if we are configured to allow any origin.
+
+        """
+        if self.is_preflight and self.ok:
+            def add_headers(name, values):
+                for value in values:
+                    handler.add_header(name, value)
+
+            add_headers('Access-Control-Allow-Methods',
+                        self.config.allowed_methods)
+            add_headers('Access-Control-Allow-Headers',
+                        handler.request.headers.get_list(
+                            'Access-Control-Request-Headers'))
+            add_headers('Access-Control-Expose-Headers',
+                        self.config.exposed_headers)
+            handler.set_header('Access-Control-Max-Age',
+                               str(self.config.max_age))
+
+        if self.requested_origin:
+            best_origin = self.requested_origin
+            if self.config.allow_credentials:
+                handler.set_header('Access-Control-Allow-Credentials', 'true')
+            elif self.config.allowed_origins.allow_any:
+                best_origin = '*'
+            handler.set_header('Access-Control-Allow-Origin', best_origin)
+        elif self.config.allowed_origins.allow_any:
+            handler.set_header('Access-Control-Allow-Origin', '*')
+
+        handler.add_header('Vary', 'Origin')
+
+
+class CORSMixin(web.RequestHandler):
+    """Mix this in to enable CORS pre-flight and request processing
+
+    This mix-in uses the application level CORS configuration to
+    determine how a specific response (or future request) is made
+    accessible to a JavaScript client. See the [fetch specification]
+    for the gory details.
+
+    [fetch specification]: https://fetch.spec.whatwg.org/#http-cors-protocol
+
+    """
+
+    cors_overrides = {}
+    """Add specific overrides for CORSProcessor here"""
+
+    def __init__(self, application, request, **kwargs):
+        super().__init__(application, request, **kwargs)
+        cors_config = getattr(application, 'cors_config', CORSConfig())
+        self.cors = CORSProcessor(cors_config, **self.cors_overrides)
+
+        # This little snippet is responsible for determining which
+        # methods are actually implemented and building the
+        # "allowed methods" default if it is not configured
+        if not self.cors.config.allowed_methods:
+            defined_methods = set()
+            for method_name in self.SUPPORTED_METHODS:
+                method = getattr(self, method_name.lower())
+                if method and method.__name__ == method_name.lower():
+                    defined_methods.add(method_name)
+            defined_methods.discard('OPTIONS')
+            self.cors.config.update(allow_methods=defined_methods)
+
+    async def prepare(self):
+        maybe_coro = super().prepare()
+        if maybe_coro:  # pragma: no cover
+            await maybe_coro
+        self.cors.process_request(self)
+
+    def options(self) -> None:
+        self.set_status(204)
+
+    def set_default_headers(self) -> None:
+        super().set_default_headers()
+        if hasattr(self, 'cors'):
+            self.cors.set_headers(self)

--- a/imbi/endpoints/base.py
+++ b/imbi/endpoints/base.py
@@ -91,7 +91,7 @@ class RequestHandler(postgres.RequestHandlerMixin,
         await self.session.initialize()
         self._current_user = await self.get_current_user()
         future = super().prepare()
-        if asyncio.isfuture(future):
+        if asyncio.isfuture(future) or asyncio.iscoroutine(future):
             await future
 
     def on_finish(self) -> None:

--- a/imbi/server.py
+++ b/imbi/server.py
@@ -173,6 +173,7 @@ def load_configuration(config: str, debug: bool) -> typing.Tuple[dict, dict]:
         'canonical_server_name': http_settings['canonical_server_name'],
         'compress_response': http_settings.get('compress_response', True),
         'cookie_secret': http_settings.get('cookie_secret', 'imbi'),
+        'cors': config.get('cors', None),
         'debug': debug,
         'encryption_key': encryption_key,
         'footer_link': {

--- a/tests/test_cors.py
+++ b/tests/test_cors.py
@@ -1,0 +1,326 @@
+from __future__ import annotations
+
+import copy
+import unittest.mock
+import uuid
+
+import yarl
+from tornado import httputil, web
+
+from imbi import cors
+
+
+class OriginTests(unittest.TestCase):
+    def test_defaults(self):
+        origins = cors.Origins()
+        self.assertTrue(origins.allow_any)
+        self.assertIn(f'https://{uuid.uuid4()}.example.com', origins)
+
+    def test_adding_origin_disables_allow_any(self):
+        origins = cors.Origins()
+        self.assertTrue(origins.allow_any)
+
+        origins.add('https://example.com/')
+        self.assertFalse(origins.allow_any)
+
+    def test_adding_relative_origin(self):
+        origins = cors.Origins()
+        with self.assertRaises(ValueError):
+            origins.add('/foo')
+
+
+class ConfigTests(unittest.TestCase):
+    def test_default_configuration(self):
+        cfg = cors.CORSConfig()
+        self.assertTrue(cfg.allow_credentials)
+        self.assertSetEqual(set(), cfg.allowed_methods)
+        self.assertIn('https://example.com', cfg.allowed_origins)
+        self.assertIn('Cache-Control', cfg.exposed_headers)
+        self.assertIn('Date', cfg.exposed_headers)
+        self.assertIn('Last-Modified', cfg.exposed_headers)
+        self.assertIn('Link', cfg.exposed_headers)
+
+    def test_that_allow_credentials_can_be_set(self):
+        cfg = cors.CORSConfig(allow_credentials=False)
+        self.assertFalse(cfg.allow_credentials)
+
+    def test_that_allow_any_origin_can_be_set(self):
+        cfg = cors.CORSConfig(allow_any_origin=False)
+        self.assertNotIn('https://example.com', cfg.allowed_origins)
+
+    def test_that_allow_methods_can_be_set(self):
+        cfg = cors.CORSConfig(allow_methods={'POST'})
+        self.assertSetEqual({'POST'}, cfg.allowed_methods)
+
+    def test_updating(self):
+        cfg = cors.CORSConfig(allow_any_origin=True,
+                              allow_credentials=True,
+                              allow_methods={'POST'})
+
+        cfg.update(allow_any_origin=False,
+                   allow_credentials=False)
+        self.assertFalse(cfg.allowed_origins.allow_any)
+        self.assertFalse(cfg.allow_credentials)
+        self.assertSetEqual({'POST'}, cfg.allowed_methods)
+
+        # no-op is allowed
+        cfg.update()
+        self.assertFalse(cfg.allowed_origins.allow_any)
+        self.assertFalse(cfg.allow_credentials)
+        self.assertSetEqual({'POST'}, cfg.allowed_methods)
+
+        # allow_methods appends
+        cfg.update(allow_methods={'DELETE'})
+        self.assertFalse(cfg.allowed_origins.allow_any)
+        self.assertFalse(cfg.allow_credentials)
+        self.assertSetEqual({'DELETE', 'POST'}, cfg.allowed_methods)
+
+        # allow_origins appends
+        cfg.update(allow_origins={'https://example.net'})
+        self.assertSetEqual({yarl.URL('https://example.net')},
+                            cfg.allowed_origins._origins)
+
+        # exposed_headers appends
+        starting = cfg.exposed_headers.copy()
+        cfg.update(exposed_headers={'ETag'})
+        self.assertSetEqual(starting.union({'ETag'}), cfg.exposed_headers)
+
+        # max_age overwrites
+        cfg.update(max_age=0)
+        self.assertEqual(0, cfg.max_age)
+
+    def test_copying(self):
+        source = cors.CORSConfig(allow_methods={'DELETE', 'GET'})
+        source.allowed_origins.add('https://example.com')
+
+        clone = copy.copy(source)
+        self.assertEqual(source.allow_credentials, clone.allow_credentials)
+        self.assertSetEqual(source.allowed_methods, clone.allowed_methods)
+
+
+class RequestProcessingTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.request = httputil.HTTPServerRequest(
+            headers=httputil.HTTPHeaders({
+                'Origin': 'https://example.com',
+            }),
+            connection=unittest.mock.Mock(),
+            uri='/')
+        self.response_headers = httputil.HTTPHeaders()
+        self.handler = web.RequestHandler(web.Application(), self.request)
+        self.handler.set_header = self.response_headers.__setitem__
+        self.handler.add_header = self.response_headers.add
+
+
+class PreflightProcessingTests(RequestProcessingTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.cors_processor = cors.CORSProcessor(
+            cors.CORSConfig(allow_methods={'POST'}))
+        self.request.method = 'OPTIONS'
+        self.request.headers['Access-Control-Request-Method'] = 'POST'
+
+    def assert_preflight_failure(self):
+        self.assertFalse(self.cors_processor.ok)
+        self.assertIn('Origin', self.response_headers.get_list('Vary'))
+        self.assertNotIn('Access-Control-Allow-Credentials',
+                         self.response_headers)
+
+    def test_correct_cors_preflight(self):
+        self.cors_processor.process_request(self.handler)
+        self.assertTrue(self.cors_processor.ok)
+        self.assertEqual(
+            self.request.headers['Origin'],
+            self.response_headers.get('Access-Control-Allow-Origin'))
+        self.assertEqual(
+            'POST', self.response_headers.get('Access-Control-Allow-Methods'))
+        self.assertNotIn('Access-Control-Allow-Headers', self.response_headers)
+        self.assertEqual(str(self.cors_processor.config.max_age),
+                         self.response_headers.get('Access-Control-Max-Age'))
+        self.assertIn('Origin', self.response_headers.get_list('Vary'))
+
+    def test_correct_cors_preflight_with_request_headers(self):
+        self.request.headers.add(
+            'Access-Control-Request-Headers', 'Cache-Control')
+        self.cors_processor.process_request(self.handler)
+        self.assertTrue(self.cors_processor.ok)
+        self.assertIn(
+            'Cache-Control',
+            self.response_headers.get_list('Access-Control-Allow-Headers'))
+
+    def test_correct_cors_preflight_with_exposed_headers(self):
+        self.cors_processor.config.exposed_headers.add('Link')
+        self.cors_processor.process_request(self.handler)
+        self.assertTrue(self.cors_processor.ok)
+        self.assertIn(
+            'Link',
+            self.response_headers.get_list('Access-Control-Expose-Headers'))
+
+    def test_preflight_without_ac_request_method(self):
+        del self.request.headers['Access-Control-Request-Method']
+        self.cors_processor.process_request(self.handler)
+        self.assert_preflight_failure()
+        self.assertEqual(
+            '*', self.response_headers['Access-Control-Allow-Origin'])
+
+    def test_preflight_without_origin(self):
+        del self.request.headers['Origin']
+        self.cors_processor.process_request(self.handler)
+        self.assert_preflight_failure()
+        self.assertEqual(
+            '*', self.response_headers['Access-Control-Allow-Origin'])
+
+    def test_preflight_with_explicit_allowed_origin(self):
+        self.cors_processor.config.allowed_origins.allow_any = False
+        self.cors_processor.config.allowed_origins.add(
+            self.request.headers['Origin'])
+        self.cors_processor.process_request(self.handler)
+        self.assertTrue(self.cors_processor.ok)
+        self.assertEqual(self.request.headers['Origin'],
+                         self.response_headers['Access-Control-Allow-Origin'])
+
+    def test_preflight_without_explicit_allowed_origin(self):
+        self.cors_processor.config.allowed_origins.allow_any = False
+        self.request.headers['Origin'] = f'https://example.net'
+        self.cors_processor.process_request(self.handler)
+        self.assert_preflight_failure()
+        self.assertNotIn('Access-Control-Allow-Origin', self.response_headers)
+
+
+class RequestProcessingTests(RequestProcessingTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.request.method = 'DELETE'
+
+    def process_request(self, **overrides):
+        self.response_headers.clear()
+        cors_processor = cors.CORSProcessor(
+            cors.CORSConfig(allow_methods={'DELETE'}), **overrides)
+        cors_processor.process_request(self.handler)
+
+    def test_allowed_request(self):
+        self.process_request()
+        self.assertEqual(self.request.headers['Origin'],
+                         self.response_headers['Access-Control-Allow-Origin'])
+        self.assertEqual(
+            'true', self.response_headers['Access-Control-Allow-Credentials'])
+
+    def test_request_with_unallowed_method(self):
+        # NB -- CORS does not require that the request method matches
+        #       the preflight Access-Control-Request-Method    o_O
+        self.request.method = 'POST'
+        self.process_request()
+        self.assertEqual(self.request.headers['Origin'],
+                         self.response_headers['Access-Control-Allow-Origin'])
+        self.assertEqual(
+            'true', self.response_headers['Access-Control-Allow-Credentials'])
+
+    def test_request_without_origin(self):
+        del self.request.headers['Origin']
+        self.process_request()
+        self.assertEqual(
+            '*', self.response_headers['Access-Control-Allow-Origin'])
+        self.assertNotIn('Access-Control-Allow-Credentials',
+                         self.response_headers)
+
+        self.process_request(allow_any_origin=False)
+        self.assertNotIn('Access-Control-Allow-Origin', self.response_headers)
+        self.assertNotIn('Access-Control-Allow-Credentials',
+                         self.response_headers)
+
+    def test_that_allowed_origin_is_widened_without_credentials(self):
+        self.process_request(allow_any_origin=True, allow_credentials=False)
+        self.assertEqual(
+            '*', self.response_headers['Access-Control-Allow-Origin'])
+
+        self.process_request(allow_credentials=False,
+                             allow_origins={self.request.headers['Origin']})
+        self.assertEqual(self.request.headers['Origin'],
+                         self.response_headers['Access-Control-Allow-Origin'])
+
+
+class MixinTests(unittest.IsolatedAsyncioTestCase):
+
+    class Handler(cors.CORSMixin):
+        def delete(self) -> None:
+            self.set_status(204)
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.origin = 'https://example.com'
+        self.application = web.Application()
+
+    async def run_handler(self, method: str, *, headers: None | dict = None,
+                          **cors_overrides) -> httputil.HTTPHeaders:
+        self.Handler.cors_overrides.clear()
+        self.Handler.cors_overrides.update(cors_overrides)
+
+        request = httputil.HTTPServerRequest(
+            method=method,
+            headers=httputil.HTTPHeaders({'Origin': self.origin}),
+            connection=unittest.mock.Mock(),
+            uri='/')
+        if headers:
+            for name, value in headers.items():
+                request.headers[name] = value
+
+        handler = self.Handler(self.application, request)
+        response_headers = httputil.HTTPHeaders()
+        handler.set_header = response_headers.__setitem__
+        handler.add_header = response_headers.add
+        await handler._execute([])
+
+        return response_headers
+
+    async def test_preflight_request_without_configuration(self):
+        response_headers = await self.run_handler(
+            'OPTIONS',
+            headers={'Access-Control-Request-Method': 'DELETE'})
+        self.assertEqual(
+            self.origin, response_headers['Access-Control-Allow-Origin'])
+        self.assertCountEqual(
+            ['DELETE'],
+            response_headers.get_list('Access-Control-Allow-Methods'))
+
+    async def test_preflight_request_with_methods_defined(self):
+        response_headers = await self.run_handler(
+            'OPTIONS',
+            headers={'Access-Control-Request-Method': 'GET'},
+            allow_methods={'GET'})
+        self.assertEqual(
+            self.origin, response_headers['Access-Control-Allow-Origin'])
+        self.assertCountEqual(
+            ['GET'], response_headers.get_list('Access-Control-Allow-Methods'))
+
+    async def test_preflight_request_with_application_config(self):
+        self.application.cors_config = cors.CORSConfig(
+            allow_any_origin=False, allow_credentials=True, max_age=300)
+        self.application.cors_config.allowed_origins.add(self.origin)
+        response_headers = await self.run_handler(
+            'OPTIONS', headers={'Access-Control-Request-Method': 'DELETE'})
+        self.assertEqual(
+            self.origin, response_headers['Access-Control-Allow-Origin'])
+        self.assertCountEqual(
+            ['DELETE'],
+            response_headers.get_list('Access-Control-Allow-Methods'))
+        self.assertEqual(str(self.application.cors_config.max_age),
+                         response_headers['Access-Control-Max-Age'])
+
+    async def test_non_preflight_response_headers(self):
+        response_headers = await self.run_handler('DELETE')
+        self.assertIn('Origin', response_headers.get('Vary'))
+        self.assertEqual(
+            self.origin, response_headers['Access-Control-Allow-Origin'])
+
+    async def test_cors_headers_on_request_failure(self):
+        with unittest.mock.patch.object(
+                self.Handler, 'delete', new_callable=unittest.mock.MagicMock
+        ) as delete:
+            delete.__name__ = 'delete'
+            delete.side_effect = RuntimeError('injected failure')
+            response_headers = await self.run_handler('DELETE')
+
+        self.assertIn('Origin', response_headers.get('Vary'))
+        self.assertEqual(
+            self.origin, response_headers['Access-Control-Allow-Origin'])


### PR DESCRIPTION
This PR adds CORS support to the basic request handler to address https://github.com/AWeber-Imbi/imbi/issues/65.  There are a few tunables in the application class that are exposed in the configuration file, but the default behavior should allow [JS fetch](https://fetch.spec.whatwg.org/) to make requests to the various API endpoints.  We can further tune the endpoints to disallow JS access or hide functionality on an endpoint-by-endpoint basis should we find a need to do so.

My goal of this PR is to allow the following to be executed from the JS console in Chrome:
```javascript
window.fetch("http://localhost:8000/projects", {headers: {"Private-Token":"0183a...af6a7c8"}}).then((data)=>{console.log(data)})
```

The inclusion of the `Private-Token` header requires a CORS pre-flight check that looks something like:
```
OPTIONS /projects HTTP/1.1
Host: localhost:8000
User-Agent: curl/7.78.0 (daves)
Accept: */*
Origin: http://whatever.example.com
Access-Control-Request-Method: GET,
Access-Control-Request-Headers: private-token

HTTP/1.1 204 No Content
Server: imbi/0.15.0
Date: Thu, 06 Oct 2022 16:27:50 GMT
Access-Control-Allow-Methods: DELETE
Access-Control-Allow-Methods: GET
Access-Control-Allow-Methods: PATCH
Access-Control-Allow-Methods: POST
Access-Control-Allow-Headers: private-token
Access-Control-Expose-Headers: Date
Access-Control-Expose-Headers: Cache-Control
Access-Control-Expose-Headers: Link
Access-Control-Expose-Headers: Last-Modified
Access-Control-Max-Age: 5
Access-Control-Allow-Credentials: true
Access-Control-Allow-Origin: http://whatever.example.com
Vary: Origin, Accept-Encoding
```
The important thing to note is that preflight checks will not include custom headers (such as our `Private-Token` header) and they are required due to the presence of a custom header or a non form-based body for mutations.

The default behavior is to allow any origin, any requested headers, and to expose `Date`, `Cache-Control`, `Link`, and `Last-Modified` response headers in the fetch result.  The preflight response does precisely that.

In the future, I want to make the origin calculations a little more forgiving (e.g., realizing that `http://localhost:8000`, `http://127.0.0.1:8000', and `http://[::1]:8000` are all the same thing) but we do not need that currently.  You can explicitly configure the acceptable origins using the `cors` stanza in the configuration file:
```yaml
cors:
  max_age: 3600
  origins:
    - https://imbi-frontend.example.com
```

Closes: AWeber-Imbi/imbi#65