### PR TITLE
Tighten up CSS on initialization page

### DIFF
--- a/imbi/static/css/backend.css
+++ b/imbi/static/css/backend.css
@@ -24,7 +24,7 @@ body > div > h1 > img {
   width: 32px;
 }
 
-body > div > div {
+#initializing {
   color: #888;
   font-family: monospace;
   font-size: 1.5em;
@@ -32,16 +32,16 @@ body > div > div {
   padding: 8px 12px;
 }
 
-body > div > div > p {
+#initializing p {
   margin: 0 0 .25em 0;
   padding: 0;
 }
 
-body > div > div > p.loading {
+#initializing .italic {
   font-style: italic;
 }
 
-body > div > div > p > span.blink {
+#initializing .blink {
   animation: blinker 1s linear infinite;
 }
 

--- a/imbi/templates/index.html
+++ b/imbi/templates/index.html
@@ -1,8 +1,10 @@
 {% extends "base.html" %}
 {% block title %}Initializing{% end %}
 {% block content %}
-<p>$ load "imbi.js", 8, 1<p>
-<p class="loading">
-  Initializing Imbi v{{ handler.application.settings['version'] }} <span class="blink">&hellip;</span>
-</p>
+<div id="initializing">
+  <p>$ load "imbi.js", 8, 1<p>
+  <p class="italic">
+    Initializing Imbi v{{ handler.application.settings['version'] }} <span class="blink">&hellip;</span>
+  </p>
+</div>
 {% end %}


### PR DESCRIPTION
Some of these styles were inadvertently being applied to the page after tailwind and components loaded. This tightens the scope to a specific element ID to prevent this.