### PR TITLE
Add feed entry type

### DIFF
--- a/imbi/endpoints/activity_feed.py
+++ b/imbi/endpoints/activity_feed.py
@@ -10,8 +10,9 @@ class RequestHandler(base.ValidatingRequestHandler):
     NAME = 'activity-feed'
 
     SQL = re.sub(r'\s+', ' ', """\
-        SELECT "when", namespace_id, namespace, project_id, project_name,
-                project_type, who, display_name, email_address, what
+        SELECT 'ProjectFeedEntry' AS "type", "when", namespace_id,
+               namespace, project_id, project_name, project_type, who,
+               display_name, email_address, what
           FROM v1.activity_feed
          ORDER BY "when" DESC
         OFFSET {offset}

--- a/imbi/endpoints/operations_log.py
+++ b/imbi/endpoints/operations_log.py
@@ -17,7 +17,8 @@ class _RequestHandlerMixin:
     GET_SQL = re.sub(r'\s+', ' ', """\
         SELECT id, recorded_at, recorded_by, completed_at,
                project_id, environment, change_type, description,
-               link, notes, ticket_slug, version
+               link, notes, ticket_slug, version,
+               'OperationsLogEntry' AS "type"
           FROM v1.operations_log
          WHERE id = %(id)s""")
 
@@ -31,7 +32,8 @@ class CollectionRequestHandler(operations_log.RequestHandlerMixin,
     COLLECTION_SQL = re.sub(r'\s+', ' ', """\
         SELECT o.id, o.recorded_at, o.recorded_by, o.completed_at,
                o.project_id, o.environment, o.change_type, o.description,
-               o.link, o.notes, o.ticket_slug, o.version
+               o.link, o.notes, o.ticket_slug, o.version,
+               'OperationsLogEntry' as "type"
           FROM v1.operations_log AS o
           {{JOIN}} {{WHERE}}
       ORDER BY o.recorded_at {{ORDER}}, o.id {{ORDER}}

--- a/imbi/endpoints/project_activity_feed.py
+++ b/imbi/endpoints/project_activity_feed.py
@@ -48,7 +48,8 @@ class CollectionRequestHandler(base.CollectionRequestHandler):
                b.display_name,
                a.what,
                a.fact_name,
-               a.value
+               a.value,
+               'ProjectFeedEntry' as "type"
           FROM combined AS a
           JOIN v1.users AS b
             ON b.username = a.who

--- a/imbi/templates/openapi.yaml
+++ b/imbi/templates/openapi.yaml
@@ -1880,6 +1880,11 @@ paths:
                         - Rolled Back
                         - Scaled
                         - Upgraded
+                    type:
+                      description: The entry type for this item
+                      type: string
+                      enum:
+                        - OperationsLogEntry
                     description:
                       description: The single line description of the change
                       type: string
@@ -1904,6 +1909,7 @@ paths:
                     - id: 1
                       recorded_at: 2021-05-21T18:39:24.197Z
                       recorded_by: gavinr
+                      type: OperationsLogEntry
                       completed_at: null
                       project_id: 100
                       environment: Testing
@@ -1916,6 +1922,7 @@ paths:
                     - id: 2
                       recorded_at: 2021-05-21T18:42:00.000Z
                       recorded_by: gavinr
+                      type: OperationsLogEntry
                       completed_at: null
                       project_id: 100
                       environment: Staging
@@ -1928,6 +1935,7 @@ paths:
                     - id: 3
                       recorded_at: 2021-05-21T19:00:00.000Z
                       recorded_by: gavinr
+                      type: OperationsLogEntry
                       completed_at: null
                       project_id: 100
                       environment: Staging
@@ -1978,6 +1986,11 @@ paths:
                         - Rolled Back
                         - Scaled
                         - Upgraded
+                    type:
+                      description: The entry type for this item
+                      type: string
+                      enum:
+                        - OperationsLogEntry
                     description:
                       description: The single line description of the change
                       type: string
@@ -2002,6 +2015,7 @@ paths:
                     - id: 1
                       recorded_at: 2021-05-21T18:39:24.197Z
                       recorded_by: gavinr
+                      type: OperationsLogEntry
                       completed_at: null
                       project_id: 100
                       environment: Testing
@@ -2014,6 +2028,7 @@ paths:
                     - id: 2
                       recorded_at: 2021-05-21T18:42:00.000Z
                       recorded_by: gavinr
+                      type: OperationsLogEntry
                       completed_at: null
                       project_id: 100
                       environment: Staging
@@ -2026,6 +2041,7 @@ paths:
                     - id: 3
                       recorded_at: 2021-05-21T19:00:00.000Z
                       recorded_by: gavinr
+                      type: OperationsLogEntry
                       completed_at: null
                       project_id: 100
                       environment: Staging
@@ -2159,6 +2175,7 @@ paths:
                     id: 1
                     recorded_at: 2021-05-21T18:39:24.197Z
                     recorded_by: gavinr
+                    type: OperationsLogEntry
                     completed_at: null
                     project_id: 100
                     environment: Testing
@@ -2178,6 +2195,7 @@ paths:
                     id: 1
                     recorded_at: 2021-05-21T18:39:24.197Z
                     recorded_by: gavinr
+                    type: OperationsLogEntry
                     completed_at: null
                     project_id: 100
                     environment: Testing

--- a/imbi/templates/openapi.yaml
+++ b/imbi/templates/openapi.yaml
@@ -55,6 +55,11 @@ paths:
                   type: object
                   description: Feed Item Entry
                   properties:
+                    type:
+                      description: Describes the format of this entry
+                      type: string
+                      enum:
+                        - ProjectFeedEntry
                     when:
                       description: The timestamp of the entry
                       type: string
@@ -95,6 +100,7 @@ paths:
                   summary: IMBI project changes
                   value:
                     - when: 2021-05-21T20:43:08.639Z
+                      type: ProjectFeedEntry
                       namespace: Example
                       namespace_id: 1
                       project_id: 1
@@ -105,6 +111,7 @@ paths:
                       email_address: gmr@imbi.co
                       what: updated facts
                     - when: 2021-05-21T20:41:06.423Z
+                      type: ProjectFeedEntry
                       namespace: Example
                       namespace_id: 1
                       project_id: 1
@@ -115,6 +122,7 @@ paths:
                       email_address: gmr@imbi.co
                       what: updated
                     - when: 2021-05-20T20:30:21.987Z
+                      type: ProjectFeedEntry
                       namespace: Example
                       namespace_id: 1
                       project_id: 1
@@ -131,6 +139,11 @@ paths:
                   type: object
                   description: Feed Item Entry
                   properties:
+                    type:
+                      description: Describes the format of this entry
+                      type: string
+                      enum:
+                        - ProjectFeedEntry
                     when:
                       description: The timestamp of the entry
                       type: string
@@ -171,6 +184,7 @@ paths:
                   summary: IMBI project changes
                   value:
                     - when: 2021-05-21T20:43:08.639Z
+                      type: ProjectFeedEntry
                       namespace: Example
                       namespace_id: 1
                       project_id: 1
@@ -181,6 +195,7 @@ paths:
                       email_address: gmr@imbi.co
                       what: updated facts
                     - when: 2021-05-21T20:41:06.423Z
+                      type: ProjectFeedEntry
                       namespace: Example
                       namespace_id: 1
                       project_id: 1
@@ -191,6 +206,7 @@ paths:
                       email_address: gmr@imbi.co
                       what: updated
                     - when: 2021-05-20T20:30:21.987Z
+                      type: ProjectFeedEntry
                       namespace: Example
                       namespace_id: 1
                       project_id: 1
@@ -1135,16 +1151,89 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/paths/~1projects~1%7Bid%7D~1notes~1%7Bnote_id%7D/patch/requestBody/content/application~1json/schema'
+              title: JSON Patch
+              description: 'A JSONPatch document as defined by [RFC 6902](https://www.rfc-editor.org/rfc/rfc6902)'
+              type: array
+              items:
+                anyOf:
+                  - title: Add / Replace / Test
+                    type: object
+                    properties:
+                      path:
+                        description: A JSON Pointer path to apply the operation to
+                        type: string
+                        pattern: '^(/[^/~]*(~[01][^/~]*)*)*$'
+                      op:
+                        description: The operation to perform
+                        type: string
+                        enum:
+                          - add
+                          - replace
+                          - test
+                      value:
+                        description: 'The value to add, replace, or test'
+                        oneOf:
+                          - type: array
+                            items:
+                              $ref: '#/paths/~1groups~1%7Bname%7D/patch/requestBody/content/application~1json/schema/items/anyOf/0/properties/value'
+                          - type: boolean
+                          - type: number
+                          - type: object
+                          - type: string
+                        nullable: true
+                    required:
+                      - path
+                      - op
+                      - value
+                  - title: Copy / Move
+                    type: object
+                    properties:
+                      path:
+                        description: A JSON Pointer path to apply the operation to
+                        type: string
+                        pattern: '^(/[^/~]*(~[01][^/~]*)*)*$'
+                      op:
+                        description: The operation to perform
+                        type: string
+                        enum:
+                          - copy
+                          - move
+                      from:
+                        description: A JSON Pointer path to the referenced value
+                        type: string
+                        pattern: '^(/[^/~]*(~[01][^/~]*)*)*$'
+                    required:
+                      - path
+                      - op
+                      - from
+                  - title: Remove
+                    type: object
+                    properties:
+                      path:
+                        description: A JSON Pointer path to apply the operation to
+                        type: string
+                        pattern: '^(/[^/~]*(~[01][^/~]*)*)*$'
+                      op:
+                        description: The operation to perform
+                        type: string
+                        enum:
+                          - remove
+                    required:
+                      - path
+                      - op
+              example:
+                - op: replace
+                  path: /icon_class
+                  value: fas fa-microscope
           application/msgpack:
             schema:
-              $ref: '#/paths/~1projects~1%7Bid%7D~1notes~1%7Bnote_id%7D/patch/requestBody/content/application~1json/schema'
+              $ref: '#/paths/~1groups~1%7Bname%7D/patch/requestBody/content/application~1json/schema'
           application/json-patch+json:
             schema:
-              $ref: '#/paths/~1projects~1%7Bid%7D~1notes~1%7Bnote_id%7D/patch/requestBody/content/application~1json/schema'
+              $ref: '#/paths/~1groups~1%7Bname%7D/patch/requestBody/content/application~1json/schema'
           application/json-patch+msgpack:
             schema:
-              $ref: '#/paths/~1projects~1%7Bid%7D~1notes~1%7Bnote_id%7D/patch/requestBody/content/application~1json/schema'
+              $ref: '#/paths/~1groups~1%7Bname%7D/patch/requestBody/content/application~1json/schema'
       responses:
         '200':
           $ref: '#/paths/~1groups/post/responses/200'
@@ -4823,6 +4912,11 @@ paths:
                   type: object
                   description: Feed Item Entry
                   properties:
+                    type:
+                      description: Describes the format of this entry
+                      type: string
+                      enum:
+                        - ProjectFeedEntry
                     when:
                       description: The timestamp of the entry
                       type: string
@@ -4851,12 +4945,14 @@ paths:
                   summary: Feed entries
                   value:
                     - when: 2021-03-18T03:02:00.912Z
+                      type: ProjectFeedEntry
                       who: Gavin Roy
                       username: gavinr
                       what: updated fact
                       fact_name: Programming Language
                       value: ES2015+
                     - when: 2021-03-18T02:55:50.865Z
+                      type: ProjectFeedEntry
                       who: Gavin Roy
                       username: gavinr
                       what: created
@@ -4869,6 +4965,11 @@ paths:
                   type: object
                   description: Feed Item Entry
                   properties:
+                    type:
+                      description: Describes the format of this entry
+                      type: string
+                      enum:
+                        - ProjectFeedEntry
                     when:
                       description: The timestamp of the entry
                       type: string
@@ -4897,12 +4998,14 @@ paths:
                   summary: Feed entries
                   value:
                     - when: 2021-03-18T03:02:00.912Z
+                      type: ProjectFeedEntry
                       who: Gavin Roy
                       username: gavinr
                       what: updated fact
                       fact_name: Programming Language
                       value: ES2015+
                     - when: 2021-03-18T02:55:50.865Z
+                      type: ProjectFeedEntry
                       who: Gavin Roy
                       username: gavinr
                       what: created
@@ -5309,88 +5412,7 @@ paths:
       tags:
         - Project Notes
       requestBody:
-        description: 'JSON Patch document as defined by [RFC 6902](https://www.rfc-editor.org/rfc/rfc6902)'
-        content:
-          application/json:
-            schema:
-              title: JSON Patch
-              description: 'A JSONPatch document as defined by [RFC 6902](https://www.rfc-editor.org/rfc/rfc6902)'
-              type: array
-              items:
-                anyOf:
-                  - title: Add / Replace / Test
-                    type: object
-                    properties:
-                      path:
-                        description: A JSON Pointer path to apply the operation to
-                        type: string
-                        pattern: '^(/[^/~]*(~[01][^/~]*)*)*$'
-                      op:
-                        description: The operation to perform
-                        type: string
-                        enum:
-                          - add
-                          - replace
-                          - test
-                      value:
-                        description: 'The value to add, replace, or test'
-                        oneOf:
-                          - type: array
-                            items:
-                              $ref: '#/paths/~1projects~1%7Bid%7D~1notes~1%7Bnote_id%7D/patch/requestBody/content/application~1json/schema/items/anyOf/0/properties/value'
-                          - type: boolean
-                          - type: number
-                          - type: object
-                          - type: string
-                        nullable: true
-                    required:
-                      - path
-                      - op
-                      - value
-                  - title: Copy / Move
-                    type: object
-                    properties:
-                      path:
-                        description: A JSON Pointer path to apply the operation to
-                        type: string
-                        pattern: '^(/[^/~]*(~[01][^/~]*)*)*$'
-                      op:
-                        description: The operation to perform
-                        type: string
-                        enum:
-                          - copy
-                          - move
-                      from:
-                        description: A JSON Pointer path to the referenced value
-                        type: string
-                        pattern: '^(/[^/~]*(~[01][^/~]*)*)*$'
-                    required:
-                      - path
-                      - op
-                      - from
-                  - title: Remove
-                    type: object
-                    properties:
-                      path:
-                        description: A JSON Pointer path to apply the operation to
-                        type: string
-                        pattern: '^(/[^/~]*(~[01][^/~]*)*)*$'
-                      op:
-                        description: The operation to perform
-                        type: string
-                        enum:
-                          - remove
-                    required:
-                      - path
-                      - op
-              example:
-                - op: replace
-                  path: /icon_class
-                  value: fas fa-microscope
-            example:
-              - op: replace
-                path: /content
-                value: 'Bacon ipsum dolor amet alcatra tongue shankle, beef ribs ribeye filet mignon drumstick landjaeger capicola andouille pancetta meatloaf cupim bresaola rump. Pork belly ham turkey, salami prosciutto ribeye beef ribs swine ground round pork loin leberkas tri-tip pig cow pastrami. Prosciutto tri-tip strip steak cow. Shankle hamburger kevin, pig meatloaf burgdoggen kielbasa ball tip pastrami tongue sirloin corned beef turducken flank porchetta. Filet mignon bacon chislic, chicken burgdoggen cow pig. Landjaeger chicken jowl kielbasa bresaola bacon. Spare ribs turkey prosciutto boudin pastrami pancetta leberkas.'
+        $ref: '#/paths/~1groups~1%7Bname%7D/patch/requestBody'
       responses:
         '200':
           description: Note was updated

--- a/tests/endpoints/test_operations_log.py
+++ b/tests/endpoints/test_operations_log.py
@@ -42,13 +42,11 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
                 'ticket_slug': str(uuid.uuid4()),
                 'version': str(uuid.uuid4()),
             }
-            records.append(record)
             result = self.fetch(
                 '/operations-log', method='POST', headers=self.headers,
                 body=json.dumps(record).encode('utf-8'))
             self.assertEqual(result.code, 200)
-            records[i]['id'] = json.loads(result.body.decode('utf-8'))['id']
-            records[i]['completed_at'] = None
+            records.append(json.loads(result.body.decode('utf-8')))
 
         # page 1
         namespace_id = self.namespace['id']
@@ -152,13 +150,11 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
                 'ticket_slug': str(uuid.uuid4()),
                 'version': str(uuid.uuid4()),
             }
-            records.append(record)
             result = self.fetch(
                 '/operations-log', method='POST', headers=self.headers,
                 body=json.dumps(record).encode('utf-8'))
             self.assertEqual(result.code, 200)
-            records[i]['id'] = json.loads(result.body.decode('utf-8'))['id']
-            records[i]['completed_at'] = None
+            records.append(json.loads(result.body.decode('utf-8')))
 
         # page 1
         result = self.fetch('/operations-log?limit=3', headers=self.headers)
@@ -209,9 +205,7 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
             '/operations-log', method='POST', headers=self.headers,
             body=json.dumps(record).encode('utf-8'))
         self.assertEqual(result.code, 200)
-        record['id'] = json.loads(result.body.decode('utf-8'))['id']
-        record['completed_at'] = None
-        records.insert(4, record)
+        records.insert(4, json.loads(result.body.decode('utf-8')))
 
         # previous page (now page 2/3)
         result = self.fetch(previous_link, headers=self.headers)
@@ -272,11 +266,7 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
         self.assertEqual(
             result.headers['Cache-Control'], 'public, max-age={}'.format(
                 operations_log.RecordRequestHandler.TTL))
-        record.update({
-            'id': response['id'],
-            'completed_at': response['completed_at'],
-            'project_id': response['project_id'],
-        })
+        record.update(response)
         self.assertDictEqual(response, record)
 
         # PATCH


### PR DESCRIPTION
This PR adds a "type" property to the activity feed, project feed, and operations log entries.  This will be used to distinguish between operations log and project change feed entries when we combine the feeds together for https://github.com/AWeber-Imbi/imbi-ui/issues/30 and https://github.com/AWeber-Imbi/imbi-ui/issues/31.  https://github.com/AWeber-Imbi/imbi-ui/pull/38 is related in that it will protect the client against adding entry types that are not supported by the FE.

Note that this includes the OpenAPI updates from https://github.com/AWeber-Imbi/imbi-openapi/pull/12 inline.