### PR TITLE
Simplify tests

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -78,6 +78,9 @@ class TestCase(testing.SprocketsHttpTestCase):
         request_headers.update(kwargs.pop('headers', {}))
         if json_body is not None:
             kwargs['body'] = json.dumps(json_body).encode('utf-8')
+        if (kwargs.get('method') in {'PATCH', 'POST', 'PUT'}
+                and not kwargs.get('body')):
+            kwargs.setdefault('allow_nonstandard_methods', True)
         return super().fetch(path, raise_error=raise_error,
                              headers=request_headers, **kwargs)
 

--- a/tests/endpoints/test_authentication_tokens.py
+++ b/tests/endpoints/test_authentication_tokens.py
@@ -12,7 +12,7 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
         # Create the token
         token_name = str(uuid.uuid4())
         response = self.fetch(
-            '/authentication-tokens', method='POST', headers=self.headers,
+            '/authentication-tokens', method='POST',
             body=json.dumps({'name': token_name}))
         self.assertEqual(response.code, 200)
         result = json.loads(response.body.decode('utf-8'))
@@ -38,7 +38,7 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
         self.assertEqual(response.code, 204)
 
         # Get the collection and ensure there's one less token
-        response = self.fetch('/authentication-tokens', headers=self.headers)
+        response = self.fetch('/authentication-tokens')
         self.assertEqual(response.code, 200)
         tokens = json.loads(response.body.decode('utf-8'))
         self.assertEqual(len(tokens), token_count - 1)

--- a/tests/endpoints/test_authentication_tokens.py
+++ b/tests/endpoints/test_authentication_tokens.py
@@ -11,9 +11,8 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
     def test_token_lifecycle(self):
         # Create the token
         token_name = str(uuid.uuid4())
-        response = self.fetch(
-            '/authentication-tokens', method='POST',
-            body=json.dumps({'name': token_name}))
+        response = self.fetch('/authentication-tokens', method='POST',
+                              json_body={'name': token_name})
         self.assertEqual(response.code, 200)
         result = json.loads(response.body.decode('utf-8'))
         self.assertEqual(result['name'], token_name)

--- a/tests/endpoints/test_cookie_cutters.py
+++ b/tests/endpoints/test_cookie_cutters.py
@@ -111,11 +111,8 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
 
     def test_method_not_implemented(self):
         for method in {'DELETE', 'PATCH'}:
-            result = self.fetch(
-                '/cookie-cutters', method=method,
-                allow_nonstandard_methods=True)
+            result = self.fetch('/cookie-cutters', method=method)
             self.assertEqual(result.code, 405)
-        result = self.fetch(
-            '/cookie-cutters/' + str(uuid.uuid4()), method='POST',
-            allow_nonstandard_methods=True)
+        result = self.fetch('/cookie-cutters/{}'.format(uuid.uuid4()),
+                            method='POST')
         self.assertEqual(result.code, 405)

--- a/tests/endpoints/test_cookie_cutters.py
+++ b/tests/endpoints/test_cookie_cutters.py
@@ -30,7 +30,7 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
 
         # Create
         result = self.fetch(
-            '/cookie-cutters', method='POST', headers=self.headers,
+            '/cookie-cutters', method='POST',
             body=json.dumps(record).encode('utf-8'))
         self.assertEqual(result.code, 200)
         url = self.get_url('/cookie-cutters/{}'.format(record['name']))
@@ -57,19 +57,17 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
             'last_modified_by': self.USERNAME[self.ADMIN_ACCESS]
         })
 
-        result = self.fetch(
-            url, method='PATCH', body=patch_value, headers=self.headers)
+        result = self.fetch(url, method='PATCH', body=patch_value)
         self.assertEqual(result.code, 200)
         new_value = json.loads(result.body.decode('utf-8'))
         self.assertDictEqual(new_value, record)
 
         # Patch no change
-        result = self.fetch(
-            url, method='PATCH', body=patch_value, headers=self.headers)
+        result = self.fetch(url, method='PATCH', body=patch_value)
         self.assertEqual(result.code, 304)
 
         # GET
-        result = self.fetch(url, headers=self.headers)
+        result = self.fetch(url)
         self.assertEqual(result.code, 200)
         self.assertIsNotNone(result.headers['Date'])
         self.assertIsNotNone(result.headers['Last-Modified'])
@@ -81,7 +79,7 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
         self.assertDictEqual(new_value, record)
 
         # Collection
-        result = self.fetch('/cookie-cutters', headers=self.headers)
+        result = self.fetch('/cookie-cutters')
         self.assertEqual(result.code, 200)
         self.assertListEqual(
             json.loads(result.body.decode('utf-8')),
@@ -89,15 +87,15 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
               if k not in ['created_by', 'last_modified_by']}])
 
         # DELETE
-        result = self.fetch(url, method='DELETE', headers=self.headers)
+        result = self.fetch(url, method='DELETE')
         self.assertEqual(result.code, 204)
 
         # GET record should not exist
-        result = self.fetch(url, headers=self.headers)
+        result = self.fetch(url)
         self.assertEqual(result.code, 404)
 
         # DELETE should fail as record should not exist
-        result = self.fetch(url, method='DELETE', headers=self.headers)
+        result = self.fetch(url, method='DELETE')
         self.assertEqual(result.code, 404)
 
     def test_create_with_missing_fields(self):
@@ -108,7 +106,7 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
             'url': 'http://{}/{}.git'.format(uuid.uuid4(), uuid.uuid4())
         }
         result = self.fetch(
-            '/cookie-cutters', method='POST', headers=self.headers,
+            '/cookie-cutters', method='POST',
             body=json.dumps(record).encode('utf-8'))
         self.assertEqual(result.code, 200)
         new_value = json.loads(result.body.decode('utf-8'))
@@ -118,10 +116,10 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
     def test_method_not_implemented(self):
         for method in {'DELETE', 'PATCH'}:
             result = self.fetch(
-                '/cookie-cutters', method=method, headers=self.headers,
+                '/cookie-cutters', method=method,
                 allow_nonstandard_methods=True)
             self.assertEqual(result.code, 405)
         result = self.fetch(
             '/cookie-cutters/' + str(uuid.uuid4()), method='POST',
-            allow_nonstandard_methods=True, headers=self.headers)
+            allow_nonstandard_methods=True)
         self.assertEqual(result.code, 405)

--- a/tests/endpoints/test_cookie_cutters.py
+++ b/tests/endpoints/test_cookie_cutters.py
@@ -29,9 +29,7 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
         }
 
         # Create
-        result = self.fetch(
-            '/cookie-cutters', method='POST',
-            body=json.dumps(record).encode('utf-8'))
+        result = self.fetch('/cookie-cutters', method='POST', json_body=record)
         self.assertEqual(result.code, 200)
         url = self.get_url('/cookie-cutters/{}'.format(record['name']))
         self.assert_link_header_equals(result, url)
@@ -105,9 +103,7 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
             'project_type_id': self.project_type['id'],
             'url': 'http://{}/{}.git'.format(uuid.uuid4(), uuid.uuid4())
         }
-        result = self.fetch(
-            '/cookie-cutters', method='POST',
-            body=json.dumps(record).encode('utf-8'))
+        result = self.fetch('/cookie-cutters', method='POST', json_body=record)
         self.assertEqual(result.code, 200)
         new_value = json.loads(result.body.decode('utf-8'))
         self.assertEqual(new_value['name'], record['name'])

--- a/tests/endpoints/test_environments.py
+++ b/tests/endpoints/test_environments.py
@@ -22,9 +22,7 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
         }
 
         # Create
-        result = self.fetch(
-            '/environments', method='POST',
-            body=json.dumps(record).encode('utf-8'))
+        result = self.fetch('/environments', method='POST', json_body=record)
         self.assertEqual(result.code, 200)
         url = self.get_url('/environments/{}'.format(record['name']))
         self.assert_link_header_equals(result, url)
@@ -96,8 +94,7 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
             'name': str(uuid.uuid4()),
             'icon_class': 'fas fa-blind'
         }
-        result = self.fetch('/environments', method='POST',
-                            body=json.dumps(record).encode('utf-8'))
+        result = self.fetch('/environments', method='POST', json_body=record)
         self.assertEqual(result.code, 200)
         new_value = json.loads(result.body.decode('utf-8'))
         self.assertEqual(new_value['name'], record['name'])

--- a/tests/endpoints/test_environments.py
+++ b/tests/endpoints/test_environments.py
@@ -103,11 +103,8 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
 
     def test_method_not_implemented(self):
         for method in {'DELETE', 'PATCH'}:
-            result = self.fetch(
-                '/environments', method=method,
-                allow_nonstandard_methods=True)
+            result = self.fetch('/environments', method=method)
             self.assertEqual(result.code, 405)
         url = '/environments/' + str(uuid.uuid4())
-        result = self.fetch(
-            url, method='POST', allow_nonstandard_methods=True)
+        result = self.fetch(url, method='POST')
         self.assertEqual(result.code, 405)

--- a/tests/endpoints/test_environments.py
+++ b/tests/endpoints/test_environments.py
@@ -23,7 +23,7 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
 
         # Create
         result = self.fetch(
-            '/environments', method='POST', headers=self.headers,
+            '/environments', method='POST',
             body=json.dumps(record).encode('utf-8'))
         self.assertEqual(result.code, 200)
         url = self.get_url('/environments/{}'.format(record['name']))
@@ -50,19 +50,17 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
             'icon_class': updated['icon_class'],
             'last_modified_by': self.USERNAME[self.ADMIN_ACCESS]
         })
-        result = self.fetch(
-            url, method='PATCH', body=patch_value, headers=self.headers)
+        result = self.fetch(url, method='PATCH', body=patch_value)
         self.assertEqual(result.code, 200)
         new_value = json.loads(result.body.decode('utf-8'))
         self.assertDictEqual(new_value, record)
 
         # Patch no change
-        result = self.fetch(
-            url, method='PATCH', body=patch_value, headers=self.headers)
+        result = self.fetch(url, method='PATCH', body=patch_value)
         self.assertEqual(result.code, 304)
 
         # GET
-        result = self.fetch(url, headers=self.headers)
+        result = self.fetch(url)
         self.assertEqual(result.code, 200)
         self.assertIsNotNone(result.headers['Date'])
         self.assertIsNotNone(result.headers['Last-Modified'])
@@ -74,7 +72,7 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
         self.assertDictEqual(new_value, record)
 
         # Collection
-        result = self.fetch('/environments', headers=self.headers)
+        result = self.fetch('/environments')
         self.assertEqual(result.code, 200)
         self.assertListEqual(
             json.loads(result.body.decode('utf-8')),
@@ -82,15 +80,15 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
              if k not in ['created_by', 'last_modified_by']}])
 
         # DELETE
-        result = self.fetch(url, method='DELETE', headers=self.headers)
+        result = self.fetch(url, method='DELETE')
         self.assertEqual(result.code, 204)
 
         # GET record should not exist
-        result = self.fetch(url, headers=self.headers)
+        result = self.fetch(url)
         self.assertEqual(result.code, 404)
 
         # DELETE should fail as record should not exist
-        result = self.fetch(url, method='DELETE', headers=self.headers)
+        result = self.fetch(url, method='DELETE')
         self.assertEqual(result.code, 404)
 
     def test_create_with_missing_fields(self):
@@ -98,9 +96,8 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
             'name': str(uuid.uuid4()),
             'icon_class': 'fas fa-blind'
         }
-        result = self.fetch(
-            '/environments', method='POST', headers=self.headers,
-            body=json.dumps(record).encode('utf-8'))
+        result = self.fetch('/environments', method='POST',
+                            body=json.dumps(record).encode('utf-8'))
         self.assertEqual(result.code, 200)
         new_value = json.loads(result.body.decode('utf-8'))
         self.assertEqual(new_value['name'], record['name'])
@@ -110,11 +107,10 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
     def test_method_not_implemented(self):
         for method in {'DELETE', 'PATCH'}:
             result = self.fetch(
-                '/environments', method=method, headers=self.headers,
+                '/environments', method=method,
                 allow_nonstandard_methods=True)
             self.assertEqual(result.code, 405)
         url = '/environments/' + str(uuid.uuid4())
         result = self.fetch(
-            url, method='POST', allow_nonstandard_methods=True,
-            headers=self.headers)
+            url, method='POST', allow_nonstandard_methods=True)
         self.assertEqual(result.code, 405)

--- a/tests/endpoints/test_fact_type_enums.py
+++ b/tests/endpoints/test_fact_type_enums.py
@@ -29,9 +29,8 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
         }
 
         # Create
-        result = self.fetch(
-            '/project-fact-type-enums',
-            method='POST', body=json.dumps(record).encode('utf-8'))
+        result = self.fetch('/project-fact-type-enums', method='POST',
+                            json_body=record)
         self.assertEqual(result.code, 200)
         response = json.loads(result.body.decode('utf-8'))
         url = self.get_url(

--- a/tests/endpoints/test_fact_type_enums.py
+++ b/tests/endpoints/test_fact_type_enums.py
@@ -31,8 +31,7 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
         # Create
         result = self.fetch(
             '/project-fact-type-enums',
-            method='POST', body=json.dumps(record).encode('utf-8'),
-            headers=self.headers)
+            method='POST', body=json.dumps(record).encode('utf-8'))
         self.assertEqual(result.code, 200)
         response = json.loads(result.body.decode('utf-8'))
         url = self.get_url(
@@ -56,8 +55,7 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
         patch = jsonpatch.make_patch(record, updated)
         patch_value = patch.to_string().encode('utf-8')
 
-        result = self.fetch(
-            url, method='PATCH', body=patch_value, headers=self.headers)
+        result = self.fetch(url, method='PATCH', body=patch_value)
         self.assertEqual(result.code, 200)
         self.assert_link_header_equals(result, url)
         record.update({
@@ -68,12 +66,11 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
         self.assertDictEqual(new_value, record)
 
         # Patch no change
-        result = self.fetch(
-            url, method='PATCH', body=patch_value, headers=self.headers)
+        result = self.fetch(url, method='PATCH', body=patch_value)
         self.assertEqual(result.code, 304)
 
         # GET
-        result = self.fetch(url, headers=self.headers)
+        result = self.fetch(url)
         self.assertEqual(result.code, 200)
         self.assert_link_header_equals(result, url)
         self.assertIsNotNone(result.headers['Date'])
@@ -85,7 +82,7 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
         self.assertDictEqual(new_value, record)
 
         # Collection
-        result = self.fetch('/project-fact-type-enums', headers=self.headers)
+        result = self.fetch('/project-fact-type-enums')
         self.assertEqual(result.code, 200)
         self.assertListEqual(
             json.loads(result.body.decode('utf-8')),
@@ -93,13 +90,13 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
               if k not in ['created_by', 'last_modified_by']}])
 
         # DELETE
-        result = self.fetch(url, method='DELETE', headers=self.headers)
+        result = self.fetch(url, method='DELETE')
         self.assertEqual(result.code, 204)
 
         # GET record should not exist
-        result = self.fetch(url, headers=self.headers)
+        result = self.fetch(url)
         self.assertEqual(result.code, 404)
 
         # DELETE should fail as record should not exist
-        result = self.fetch(url, method='DELETE', headers=self.headers)
+        result = self.fetch(url, method='DELETE')
         self.assertEqual(result.code, 404)

--- a/tests/endpoints/test_fact_type_ranges.py
+++ b/tests/endpoints/test_fact_type_ranges.py
@@ -28,9 +28,8 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
         }
 
         # Create
-        result = self.fetch(
-            '/project-fact-type-ranges',
-            method='POST', body=json.dumps(record).encode('utf-8'))
+        result = self.fetch('/project-fact-type-ranges', method='POST',
+                            json_body=record)
         self.assertEqual(result.code, 200)
         response = json.loads(result.body.decode('utf-8'))
         url = self.get_url(

--- a/tests/endpoints/test_fact_type_ranges.py
+++ b/tests/endpoints/test_fact_type_ranges.py
@@ -30,8 +30,7 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
         # Create
         result = self.fetch(
             '/project-fact-type-ranges',
-            method='POST', body=json.dumps(record).encode('utf-8'),
-            headers=self.headers)
+            method='POST', body=json.dumps(record).encode('utf-8'))
         self.assertEqual(result.code, 200)
         response = json.loads(result.body.decode('utf-8'))
         url = self.get_url(
@@ -56,7 +55,7 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
         patch_value = patch.to_string().encode('utf-8')
 
         result = self.fetch(
-            url, method='PATCH', body=patch_value, headers=self.headers)
+            url, method='PATCH', body=patch_value)
         self.assertEqual(result.code, 200)
         self.assert_link_header_equals(result, url)
         record.update({
@@ -67,12 +66,11 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
         self.assertDictEqual(new_value, record)
 
         # Patch no change
-        result = self.fetch(
-            url, method='PATCH', body=patch_value, headers=self.headers)
+        result = self.fetch(url, method='PATCH', body=patch_value)
         self.assertEqual(result.code, 304)
 
         # GET
-        result = self.fetch(url, headers=self.headers)
+        result = self.fetch(url)
         self.assertEqual(result.code, 200)
         self.assert_link_header_equals(result, url)
         self.assertIsNotNone(result.headers['Date'])
@@ -84,7 +82,7 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
         self.assertDictEqual(new_value, record)
 
         # Collection
-        result = self.fetch('/project-fact-type-ranges', headers=self.headers)
+        result = self.fetch('/project-fact-type-ranges')
         self.assertEqual(result.code, 200)
         self.assertListEqual(
             json.loads(result.body.decode('utf-8')),
@@ -92,13 +90,13 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
               if k not in ['created_by', 'last_modified_by']}])
 
         # DELETE
-        result = self.fetch(url, method='DELETE', headers=self.headers)
+        result = self.fetch(url, method='DELETE')
         self.assertEqual(result.code, 204)
 
         # GET record should not exist
-        result = self.fetch(url, headers=self.headers)
+        result = self.fetch(url)
         self.assertEqual(result.code, 404)
 
         # DELETE should fail as record should not exist
-        result = self.fetch(url, method='DELETE', headers=self.headers)
+        result = self.fetch(url, method='DELETE')
         self.assertEqual(result.code, 404)

--- a/tests/endpoints/test_fact_types.py
+++ b/tests/endpoints/test_fact_types.py
@@ -30,7 +30,7 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
         # Create
         result = self.fetch(
             '/project-fact-types', method='POST',
-            body=json.dumps(record).encode('utf-8'), headers=self.headers)
+            body=json.dumps(record).encode('utf-8'))
         self.assertEqual(result.code, 200)
         response = json.loads(result.body.decode('utf-8'))
         record['id'] = response['id']
@@ -58,20 +58,18 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
             'weight': updated['weight'],
             'last_modified_by': self.USERNAME[self.ADMIN_ACCESS]
         })
-        result = self.fetch(
-            url, method='PATCH', body=patch_value, headers=self.headers)
+        result = self.fetch(url, method='PATCH', body=patch_value)
         self.assertEqual(result.code, 200)
         self.assert_link_header_equals(result, url)
         new_value = json.loads(result.body.decode('utf-8'))
         self.assertDictEqual(new_value, record)
 
         # Patch no change
-        result = self.fetch(
-            url, method='PATCH', body=patch_value, headers=self.headers)
+        result = self.fetch(url, method='PATCH', body=patch_value)
         self.assertEqual(result.code, 304)
 
         # GET
-        result = self.fetch(url, headers=self.headers)
+        result = self.fetch(url)
         self.assertEqual(result.code, 200)
         self.assert_link_header_equals(result, url)
         self.assertIsNotNone(result.headers['Date'])
@@ -83,7 +81,7 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
         self.assertDictEqual(new_value, record)
 
         # Collection
-        result = self.fetch('/project-fact-types', headers=self.headers)
+        result = self.fetch('/project-fact-types')
         self.assertEqual(result.code, 200)
         self.assertListEqual(
             json.loads(result.body.decode('utf-8')),
@@ -91,15 +89,15 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
               if k not in ['created_by', 'last_modified_by']}])
 
         # DELETE
-        result = self.fetch(url, method='DELETE', headers=self.headers)
+        result = self.fetch(url, method='DELETE')
         self.assertEqual(result.code, 204)
 
         # GET record should not exist
-        result = self.fetch(url, headers=self.headers)
+        result = self.fetch(url)
         self.assertEqual(result.code, 404)
 
         # DELETE should fail as record should not exist
-        result = self.fetch(url, method='DELETE', headers=self.headers)
+        result = self.fetch(url, method='DELETE')
         self.assertEqual(result.code, 404)
 
     def test_create_with_missing_fields(self):
@@ -108,20 +106,18 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
             'name': str(uuid.uuid4())
         }
         result = self.fetch(
-            '/project-fact-types', method='POST', headers=self.headers,
+            '/project-fact-types', method='POST',
             body=json.dumps(record).encode('utf-8'))
         self.assertEqual(result.code, 400)
 
     def test_method_not_implemented(self):
         for method in {'DELETE', 'PATCH'}:
-            result = self.fetch(
-                '/project-fact-types', method=method,
-                allow_nonstandard_methods=True, headers=self.headers)
+            result = self.fetch('/project-fact-types', method=method,
+                                allow_nonstandard_methods=True)
             self.assertEqual(result.code, 405)
 
-        result = self.fetch(
-            '/project-fact-types/99999', method='POST',
-            allow_nonstandard_methods=True, headers=self.headers)
+        result = self.fetch('/project-fact-types/99999', method='POST',
+                            allow_nonstandard_methods=True)
         self.assertEqual(result.code, 405)
 
     def test_missing_project_type_id(self):
@@ -134,7 +130,7 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
                 'description': 'Test description',
                 'ui_options': ['hidden'],
                 'weight': 100
-            }).encode('utf-8'), headers=self.headers)
+            }).encode('utf-8'))
         self.assertEqual(result.code, 200)
 
     def test_empty_ui_options(self):
@@ -148,5 +144,5 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
                 'description': 'Test description',
                 'ui_options': [],
                 'weight': 100
-            }).encode('utf-8'), headers=self.headers)
+            }).encode('utf-8'))
         self.assertEqual(result.code, 200)

--- a/tests/endpoints/test_fact_types.py
+++ b/tests/endpoints/test_fact_types.py
@@ -28,9 +28,8 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
         }
 
         # Create
-        result = self.fetch(
-            '/project-fact-types', method='POST',
-            body=json.dumps(record).encode('utf-8'))
+        result = self.fetch('/project-fact-types', method='POST',
+                            json_body=record)
         self.assertEqual(result.code, 200)
         response = json.loads(result.body.decode('utf-8'))
         record['id'] = response['id']
@@ -105,38 +104,35 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
             'project_type_ids': [self.project_type['id']],
             'name': str(uuid.uuid4())
         }
-        result = self.fetch(
-            '/project-fact-types', method='POST',
-            body=json.dumps(record).encode('utf-8'))
+        result = self.fetch('/project-fact-types', method='POST',
+                            json_body=record)
         self.assertEqual(result.code, 400)
 
     def test_method_not_implemented(self):
         for method in {'DELETE', 'PATCH'}:
-            result = self.fetch('/project-fact-types', method=method,
-                                allow_nonstandard_methods=True)
+            result = self.fetch('/project-fact-types', method=method)
             self.assertEqual(result.code, 405)
 
-        result = self.fetch('/project-fact-types/99999', method='POST',
-                            allow_nonstandard_methods=True)
+        result = self.fetch('/project-fact-types/99999', method='POST')
         self.assertEqual(result.code, 405)
 
     def test_missing_project_type_id(self):
         result = self.fetch(
             '/project-fact-types', method='POST',
-            body=json.dumps({
+            json_body={
                 'name': str(uuid.uuid4()),
                 'fact_type': 'free-form',
                 'data_type': 'string',
                 'description': 'Test description',
                 'ui_options': ['hidden'],
                 'weight': 100
-            }).encode('utf-8'))
+            })
         self.assertEqual(result.code, 200)
 
     def test_empty_ui_options(self):
         result = self.fetch(
             '/project-fact-types', method='POST',
-            body=json.dumps({
+            json_body={
                 'project_type_ids': [],
                 'name': str(uuid.uuid4()),
                 'fact_type': 'free-form',
@@ -144,5 +140,5 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
                 'description': 'Test description',
                 'ui_options': [],
                 'weight': 100
-            }).encode('utf-8'))
+            })
         self.assertEqual(result.code, 200)

--- a/tests/endpoints/test_groups.py
+++ b/tests/endpoints/test_groups.py
@@ -106,9 +106,8 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
 
     def test_method_not_implemented(self):
         for method in {'DELETE', 'PATCH'}:
-            result = self.fetch('/groups', method=method,
-                                allow_nonstandard_methods=True)
+            result = self.fetch('/groups', method=method)
             self.assertEqual(result.code, 405)
         url = '/groups/' + str(uuid.uuid4())
-        result = self.fetch(url, method='POST', allow_nonstandard_methods=True)
+        result = self.fetch(url, method='POST')
         self.assertEqual(result.code, 405)

--- a/tests/endpoints/test_groups.py
+++ b/tests/endpoints/test_groups.py
@@ -21,8 +21,7 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
         }
 
         # Create
-        result = self.fetch('/groups', method='POST',
-                            body=json.dumps(record).encode('utf-8'))
+        result = self.fetch('/groups', method='POST', json_body=record)
         self.assertEqual(result.code, 200)
         url = self.get_url('/groups/{}'.format(record['name']))
         self.assert_link_header_equals(result, url)
@@ -97,8 +96,7 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
             'name': str(uuid.uuid4()),
             'group_type': 'internal'
         }
-        result = self.fetch('/groups', method='POST',
-                            body=json.dumps(record).encode('utf-8'))
+        result = self.fetch('/groups', method='POST', json_body=record)
         self.assertEqual(result.code, 200)
         new_value = json.loads(result.body.decode('utf-8'))
         self.assertEqual(new_value['name'], record['name'])

--- a/tests/endpoints/test_groups.py
+++ b/tests/endpoints/test_groups.py
@@ -21,9 +21,8 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
         }
 
         # Create
-        result = self.fetch(
-            '/groups', method='POST', headers=self.headers,
-            body=json.dumps(record).encode('utf-8'))
+        result = self.fetch('/groups', method='POST',
+                            body=json.dumps(record).encode('utf-8'))
         self.assertEqual(result.code, 200)
         url = self.get_url('/groups/{}'.format(record['name']))
         self.assert_link_header_equals(result, url)
@@ -51,19 +50,17 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
             'last_modified_by': self.USERNAME[self.ADMIN_ACCESS]
         })
 
-        result = self.fetch(
-            url, method='PATCH', body=patch_value, headers=self.headers)
+        result = self.fetch(url, method='PATCH', body=patch_value)
         self.assertEqual(result.code, 200)
         new_value = json.loads(result.body.decode('utf-8'))
         self.assertDictEqual(new_value, record)
 
         # Patch no change
-        result = self.fetch(
-            url, method='PATCH', body=patch_value, headers=self.headers)
+        result = self.fetch(url, method='PATCH', body=patch_value)
         self.assertEqual(result.code, 304)
 
         # GET
-        result = self.fetch(url, headers=self.headers)
+        result = self.fetch(url)
         self.assertEqual(result.code, 200)
         self.assertIsNotNone(result.headers['Date'])
         self.assertIsNotNone(result.headers['Last-Modified'])
@@ -75,7 +72,7 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
         self.assertDictEqual(new_value, record)
 
         # Collection
-        result = self.fetch('/groups', headers=self.headers)
+        result = self.fetch('/groups')
         self.assertEqual(result.code, 200)
         self.assertListEqual(
             [row for row in json.loads(result.body.decode('utf-8'))
@@ -84,15 +81,15 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
               if k not in ['created_by', 'last_modified_by']}])
 
         # DELETE
-        result = self.fetch(url, method='DELETE', headers=self.headers)
+        result = self.fetch(url, method='DELETE')
         self.assertEqual(result.code, 204)
 
         # GET record should not exist
-        result = self.fetch(url, headers=self.headers)
+        result = self.fetch(url)
         self.assertEqual(result.code, 404)
 
         # DELETE should fail as record should not exist
-        result = self.fetch(url, method='DELETE', headers=self.headers)
+        result = self.fetch(url, method='DELETE')
         self.assertEqual(result.code, 404)
 
     def test_create_with_missing_fields(self):
@@ -100,9 +97,8 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
             'name': str(uuid.uuid4()),
             'group_type': 'internal'
         }
-        result = self.fetch(
-            '/groups', method='POST', headers=self.headers,
-            body=json.dumps(record).encode('utf-8'))
+        result = self.fetch('/groups', method='POST',
+                            body=json.dumps(record).encode('utf-8'))
         self.assertEqual(result.code, 200)
         new_value = json.loads(result.body.decode('utf-8'))
         self.assertEqual(new_value['name'], record['name'])
@@ -112,12 +108,9 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
 
     def test_method_not_implemented(self):
         for method in {'DELETE', 'PATCH'}:
-            result = self.fetch(
-                '/groups', method=method, headers=self.headers,
-                allow_nonstandard_methods=True)
+            result = self.fetch('/groups', method=method,
+                                allow_nonstandard_methods=True)
             self.assertEqual(result.code, 405)
         url = '/groups/' + str(uuid.uuid4())
-        result = self.fetch(
-            url, method='POST', allow_nonstandard_methods=True,
-            headers=self.headers)
+        result = self.fetch(url, method='POST', allow_nonstandard_methods=True)
         self.assertEqual(result.code, 405)

--- a/tests/endpoints/test_metrics.py
+++ b/tests/endpoints/test_metrics.py
@@ -4,7 +4,7 @@ from tests import base
 class AsyncHTTPTestCase(base.TestCase):
 
     def test_status_ok(self):
-        response = self.fetch('/metrics', headers=self.headers)
+        response = self.fetch('/metrics')
         self.assertEqual(response.code, 200)
         self.assertIn(
             '# TYPE postgres_pool_free gauge', response.body.decode('utf-8'))

--- a/tests/endpoints/test_namespaces.py
+++ b/tests/endpoints/test_namespaces.py
@@ -120,10 +120,9 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
 
     def test_method_not_implemented(self):
         for method in {'DELETE', 'PATCH'}:
-            result = self.fetch('/namespaces', method=method,
-                                allow_nonstandard_methods=True)
+            result = self.fetch('/namespaces', method=method)
             self.assertEqual(result.code, 405)
 
         url = '/namespaces/' + str(uuid.uuid4())
-        result = self.fetch(url, method='POST', allow_nonstandard_methods=True)
+        result = self.fetch(url, method='POST')
         self.assertEqual(result.code, 405)

--- a/tests/endpoints/test_namespaces.py
+++ b/tests/endpoints/test_namespaces.py
@@ -26,9 +26,8 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
         })
 
         # Create
-        result = self.fetch(
-            '/namespaces', method='POST', headers=self.headers,
-            body=json.dumps(record).encode('utf-8'))
+        result = self.fetch('/namespaces', method='POST',
+                            body=json.dumps(record).encode('utf-8'))
         self.assertEqual(result.code, 200)
         response = json.loads(result.body.decode('utf-8'))
         url = self.get_url('/namespaces/{}'.format(response['id']))
@@ -55,20 +54,18 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
             'last_modified_by': self.USERNAME[self.ADMIN_ACCESS]
         })
 
-        result = self.fetch(
-            url, method='PATCH', body=patch_value, headers=self.headers)
+        result = self.fetch(url, method='PATCH', body=patch_value)
         self.assertEqual(result.code, 200)
         self.assert_link_header_equals(result, url)
         response = json.loads(result.body.decode('utf-8'))
         self.assertDictEqual(response, record)
 
         # Patch no change
-        result = self.fetch(
-            url, method='PATCH', body=patch_value, headers=self.headers)
+        result = self.fetch(url, method='PATCH', body=patch_value)
         self.assertEqual(result.code, 304)
 
         # GET
-        result = self.fetch(url, headers=self.headers)
+        result = self.fetch(url)
         self.assertEqual(result.code, 200)
         self.assert_link_header_equals(result, url)
         self.assertIsNotNone(result.headers['Date'])
@@ -80,7 +77,7 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
         self.assertDictEqual(response, record)
 
         # Collection
-        result = self.fetch('/namespaces', headers=self.headers)
+        result = self.fetch('/namespaces')
         self.assertEqual(result.code, 200)
         self.assertListEqual(
             json.loads(result.body.decode('utf-8')),
@@ -88,15 +85,15 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
               if k not in ['created_by', 'last_modified_by']}])
 
         # DELETE
-        result = self.fetch(url, method='DELETE', headers=self.headers)
+        result = self.fetch(url, method='DELETE')
         self.assertEqual(result.code, 204)
 
         # GET record should not exist
-        result = self.fetch(url, headers=self.headers)
+        result = self.fetch(url)
         self.assertEqual(result.code, 404)
 
         # DELETE should fail as record should not exist
-        result = self.fetch(url, method='DELETE', headers=self.headers)
+        result = self.fetch(url, method='DELETE')
         self.assertEqual(result.code, 404)
 
     def test_create_with_missing_fields(self):
@@ -106,8 +103,7 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
             'icon_class': 'fas fa-blind'
         }
         result = self.fetch('/namespaces', method='POST',
-                            body=json.dumps(record).encode('utf-8'),
-                            headers=self.headers)
+                            body=json.dumps(record).encode('utf-8'))
         self.assertEqual(result.code, 200)
         response = json.loads(result.body.decode('utf-8'))
         url = self.get_url('/namespaces/{}'.format(response['id']))
@@ -117,23 +113,19 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
         self.assertIsNotNone(response['icon_class'])
 
         # DELETE
-        result = self.fetch(url, method='DELETE', headers=self.headers)
+        result = self.fetch(url, method='DELETE')
         self.assertEqual(result.code, 204)
 
         # GET record should not exist
-        result = self.fetch(url, headers=self.headers)
+        result = self.fetch(url)
         self.assertEqual(result.code, 404)
 
     def test_method_not_implemented(self):
         for method in {'DELETE', 'PATCH'}:
-            result = self.fetch(
-                '/namespaces', method=method,
-                allow_nonstandard_methods=True,
-                headers=self.headers)
+            result = self.fetch('/namespaces', method=method,
+                                allow_nonstandard_methods=True)
             self.assertEqual(result.code, 405)
 
         url = '/namespaces/' + str(uuid.uuid4())
-        result = self.fetch(url, method='POST',
-                            allow_nonstandard_methods=True,
-                            headers=self.headers)
+        result = self.fetch(url, method='POST', allow_nonstandard_methods=True)
         self.assertEqual(result.code, 405)

--- a/tests/endpoints/test_namespaces.py
+++ b/tests/endpoints/test_namespaces.py
@@ -26,8 +26,7 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
         })
 
         # Create
-        result = self.fetch('/namespaces', method='POST',
-                            body=json.dumps(record).encode('utf-8'))
+        result = self.fetch('/namespaces', method='POST', json_body=record)
         self.assertEqual(result.code, 200)
         response = json.loads(result.body.decode('utf-8'))
         url = self.get_url('/namespaces/{}'.format(response['id']))
@@ -102,8 +101,7 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
             'slug': str(uuid.uuid4().hex),
             'icon_class': 'fas fa-blind'
         }
-        result = self.fetch('/namespaces', method='POST',
-                            body=json.dumps(record).encode('utf-8'))
+        result = self.fetch('/namespaces', method='POST', json_body=record)
         self.assertEqual(result.code, 200)
         response = json.loads(result.body.decode('utf-8'))
         url = self.get_url('/namespaces/{}'.format(response['id']))

--- a/tests/endpoints/test_operations_log.py
+++ b/tests/endpoints/test_operations_log.py
@@ -335,10 +335,9 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
 
     def test_method_not_implemented(self):
         for method in {'DELETE', 'PATCH'}:
-            result = self.fetch('/operations-log', method=method,
-                                allow_nonstandard_methods=True)
+            result = self.fetch('/operations-log', method=method)
             self.assertEqual(result.code, 405)
 
         url = '/operations-log/' + str(uuid.uuid4())
-        result = self.fetch(url, method='POST', allow_nonstandard_methods=True)
+        result = self.fetch(url, method='POST')
         self.assertEqual(result.code, 405)

--- a/tests/endpoints/test_operations_log.py
+++ b/tests/endpoints/test_operations_log.py
@@ -43,7 +43,7 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
                 'version': str(uuid.uuid4()),
             }
             result = self.fetch('/operations-log', method='POST',
-                                body=json.dumps(record).encode('utf-8'))
+                                json_body=record)
             self.assertEqual(result.code, 200)
             records.append(json.loads(result.body.decode('utf-8')))
 
@@ -149,7 +149,7 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
                 'version': str(uuid.uuid4()),
             }
             result = self.fetch('/operations-log', method='POST',
-                                body=json.dumps(record).encode('utf-8'))
+                                json_body=record)
             self.assertEqual(result.code, 200)
             records.append(json.loads(result.body.decode('utf-8')))
 
@@ -198,8 +198,7 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
                 'ticket_slug': str(uuid.uuid4()),
                 'version': str(uuid.uuid4()),
             }
-        result = self.fetch('/operations-log', method='POST',
-                            body=json.dumps(record).encode('utf-8'))
+        result = self.fetch('/operations-log', method='POST', json_body=record)
         self.assertEqual(result.code, 200)
         records.insert(4, json.loads(result.body.decode('utf-8')))
 
@@ -250,8 +249,7 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
         }
 
         # Create
-        result = self.fetch('/operations-log', method='POST',
-                            body=json.dumps(record).encode('utf-8'))
+        result = self.fetch('/operations-log', method='POST', json_body=record)
         self.assertEqual(result.code, 200)
         response = json.loads(result.body.decode('utf-8'))
         url = self.get_url('/operations-log/{}'.format(response['id']))
@@ -319,8 +317,7 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
             'environment': self.environment,
             'change_type': 'Upgraded',
         }
-        result = self.fetch('/operations-log', method='POST',
-                            body=json.dumps(record).encode('utf-8'))
+        result = self.fetch('/operations-log', method='POST', json_body=record)
         self.assertEqual(result.code, 200)
         response = json.loads(result.body.decode('utf-8'))
         url = self.get_url('/operations-log/{}'.format(response['id']))

--- a/tests/endpoints/test_operations_log.py
+++ b/tests/endpoints/test_operations_log.py
@@ -42,17 +42,15 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
                 'ticket_slug': str(uuid.uuid4()),
                 'version': str(uuid.uuid4()),
             }
-            result = self.fetch(
-                '/operations-log', method='POST', headers=self.headers,
-                body=json.dumps(record).encode('utf-8'))
+            result = self.fetch('/operations-log', method='POST',
+                                body=json.dumps(record).encode('utf-8'))
             self.assertEqual(result.code, 200)
             records.append(json.loads(result.body.decode('utf-8')))
 
         # page 1
         namespace_id = self.namespace['id']
         result = self.fetch(
-            f'/operations-log?limit=4&namespace_id={namespace_id}',
-            headers=self.headers)
+            f'/operations-log?limit=4&namespace_id={namespace_id}')
         self.assertEqual(result.code, 200)
         response = json.loads(result.body.decode('utf-8'))
         self.assertEqual(len(response), 4)
@@ -68,7 +66,7 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
         self.assertIsNotNone(next_link)
 
         # page 2
-        result = self.fetch(next_link, headers=self.headers)
+        result = self.fetch(next_link)
         self.assertEqual(result.code, 200)
         response = json.loads(result.body.decode('utf-8'))
         self.assertEqual(len(response), 4)
@@ -86,7 +84,7 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
         self.assertIsNotNone(previous_link)
 
         # page 3
-        result = self.fetch(next_link, headers=self.headers)
+        result = self.fetch(next_link)
         self.assertEqual(result.code, 200)
         response = json.loads(result.body.decode('utf-8'))
         self.assertEqual(len(response), 2)
@@ -102,7 +100,7 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
         self.assertIsNotNone(previous_link)
 
         # page 2
-        result = self.fetch(previous_link, headers=self.headers)
+        result = self.fetch(previous_link)
         self.assertEqual(result.code, 200)
         response = json.loads(result.body.decode('utf-8'))
         self.assertEqual(len(response), 4)
@@ -120,7 +118,7 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
         self.assertIsNotNone(previous_link)
 
         # page 1
-        result = self.fetch(previous_link, headers=self.headers)
+        result = self.fetch(previous_link)
         self.assertEqual(result.code, 200)
         response = json.loads(result.body.decode('utf-8'))
         self.assertEqual(len(response), 4)
@@ -150,14 +148,13 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
                 'ticket_slug': str(uuid.uuid4()),
                 'version': str(uuid.uuid4()),
             }
-            result = self.fetch(
-                '/operations-log', method='POST', headers=self.headers,
-                body=json.dumps(record).encode('utf-8'))
+            result = self.fetch('/operations-log', method='POST',
+                                body=json.dumps(record).encode('utf-8'))
             self.assertEqual(result.code, 200)
             records.append(json.loads(result.body.decode('utf-8')))
 
         # page 1
-        result = self.fetch('/operations-log?limit=3', headers=self.headers)
+        result = self.fetch('/operations-log?limit=3')
         self.assertEqual(result.code, 200)
         response = json.loads(result.body.decode('utf-8'))
         self.assertEqual(len(response), 3)
@@ -173,7 +170,7 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
         self.assertIsNotNone(next_link)
 
         # page 2
-        result = self.fetch(next_link, headers=self.headers)
+        result = self.fetch(next_link)
         self.assertEqual(result.code, 200)
         response = json.loads(result.body.decode('utf-8'))
         self.assertEqual(len(response), 3)
@@ -201,14 +198,13 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
                 'ticket_slug': str(uuid.uuid4()),
                 'version': str(uuid.uuid4()),
             }
-        result = self.fetch(
-            '/operations-log', method='POST', headers=self.headers,
-            body=json.dumps(record).encode('utf-8'))
+        result = self.fetch('/operations-log', method='POST',
+                            body=json.dumps(record).encode('utf-8'))
         self.assertEqual(result.code, 200)
         records.insert(4, json.loads(result.body.decode('utf-8')))
 
         # previous page (now page 2/3)
-        result = self.fetch(previous_link, headers=self.headers)
+        result = self.fetch(previous_link)
         self.assertEqual(result.code, 200)
         response = json.loads(result.body.decode('utf-8'))
         self.assertEqual(len(response), 3)
@@ -226,7 +222,7 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
         self.assertIsNotNone(previous_link)
 
         # previous page (now page 1/3)
-        result = self.fetch(previous_link, headers=self.headers)
+        result = self.fetch(previous_link)
         self.assertEqual(result.code, 200)
         response = json.loads(result.body.decode('utf-8'))
         self.assertEqual(len(response), 1)
@@ -254,9 +250,8 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
         }
 
         # Create
-        result = self.fetch(
-            '/operations-log', method='POST', headers=self.headers,
-            body=json.dumps(record).encode('utf-8'))
+        result = self.fetch('/operations-log', method='POST',
+                            body=json.dumps(record).encode('utf-8'))
         self.assertEqual(result.code, 200)
         response = json.loads(result.body.decode('utf-8'))
         url = self.get_url('/operations-log/{}'.format(response['id']))
@@ -278,20 +273,18 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
             'description': updated['description'],
         })
 
-        result = self.fetch(
-            url, method='PATCH', body=patch_value, headers=self.headers)
+        result = self.fetch(url, method='PATCH', body=patch_value)
         self.assertEqual(result.code, 200)
         self.assert_link_header_equals(result, url)
         response = json.loads(result.body.decode('utf-8'))
         self.assertDictEqual(response, record)
 
         # Patch no change
-        result = self.fetch(
-            url, method='PATCH', body=patch_value, headers=self.headers)
+        result = self.fetch(url, method='PATCH', body=patch_value)
         self.assertEqual(result.code, 304)
 
         # GET
-        result = self.fetch(url, headers=self.headers)
+        result = self.fetch(url)
         self.assertEqual(result.code, 200)
         self.assert_link_header_equals(result, url)
         self.assertEqual(
@@ -301,22 +294,22 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
         self.assertDictEqual(response, record)
 
         # Collection
-        result = self.fetch('/operations-log', headers=self.headers)
+        result = self.fetch('/operations-log')
         self.assertEqual(result.code, 200)
         self.assertListEqual(
             json.loads(result.body.decode('utf-8')),
             [{k: v for k, v in record.items()}])
 
         # DELETE
-        result = self.fetch(url, method='DELETE', headers=self.headers)
+        result = self.fetch(url, method='DELETE')
         self.assertEqual(result.code, 204)
 
         # GET record should not exist
-        result = self.fetch(url, headers=self.headers)
+        result = self.fetch(url)
         self.assertEqual(result.code, 404)
 
         # DELETE should fail as record should not exist
-        result = self.fetch(url, method='DELETE', headers=self.headers)
+        result = self.fetch(url, method='DELETE')
         self.assertEqual(result.code, 404)
 
     def test_create_with_missing_fields(self):
@@ -327,8 +320,7 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
             'change_type': 'Upgraded',
         }
         result = self.fetch('/operations-log', method='POST',
-                            body=json.dumps(record).encode('utf-8'),
-                            headers=self.headers)
+                            body=json.dumps(record).encode('utf-8'))
         self.assertEqual(result.code, 200)
         response = json.loads(result.body.decode('utf-8'))
         url = self.get_url('/operations-log/{}'.format(response['id']))
@@ -337,23 +329,19 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
         self.assertEqual(response['change_type'], record['change_type'])
 
         # DELETE
-        result = self.fetch(url, method='DELETE', headers=self.headers)
+        result = self.fetch(url, method='DELETE')
         self.assertEqual(result.code, 204)
 
         # GET record should not exist
-        result = self.fetch(url, headers=self.headers)
+        result = self.fetch(url)
         self.assertEqual(result.code, 404)
 
     def test_method_not_implemented(self):
         for method in {'DELETE', 'PATCH'}:
-            result = self.fetch(
-                '/operations-log', method=method,
-                allow_nonstandard_methods=True,
-                headers=self.headers)
+            result = self.fetch('/operations-log', method=method,
+                                allow_nonstandard_methods=True)
             self.assertEqual(result.code, 405)
 
         url = '/operations-log/' + str(uuid.uuid4())
-        result = self.fetch(url, method='POST',
-                            allow_nonstandard_methods=True,
-                            headers=self.headers)
+        result = self.fetch(url, method='POST', allow_nonstandard_methods=True)
         self.assertEqual(result.code, 405)

--- a/tests/endpoints/test_permissions.py
+++ b/tests/endpoints/test_permissions.py
@@ -8,7 +8,7 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
     ADMIN_ACCESS = True
 
     def test_permission_values(self):
-        result = self.fetch('/permissions', headers=self.headers)
+        result = self.fetch('/permissions')
         self.assertEqual(result.code, 200)
         values = json.loads(result.body.decode('utf-8'))
         self.assertListEqual(values, list(self._app.settings['permissions']))
@@ -17,5 +17,5 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
 class AsyncHTTPUnauthorizedTestCase(base.TestCaseWithReset):
 
     def test_permission_values(self):
-        result = self.fetch('/permissions', headers=self.headers)
+        result = self.fetch('/permissions')
         self.assertEqual(result.code, 403)

--- a/tests/endpoints/test_project_endpoints.py
+++ b/tests/endpoints/test_project_endpoints.py
@@ -35,9 +35,8 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
         }
 
         # Create
-        result = self.fetch(
-            '/projects', method='POST', headers=self.headers,
-            body=json.dumps(record).encode('utf-8'))
+        result = self.fetch('/projects', method='POST',
+                            body=json.dumps(record).encode('utf-8'))
         self.assertEqual(result.code, 200)
         response = json.loads(result.body.decode('utf-8'))
         url = self.get_url('/projects/{}'.format(response['id']))
@@ -67,8 +66,7 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
         patch = jsonpatch.make_patch(record, updated)
         patch_value = patch.to_string().encode('utf-8')
 
-        result = self.fetch(
-            url, method='PATCH', body=patch_value, headers=self.headers)
+        result = self.fetch(url, method='PATCH', body=patch_value)
         self.assertEqual(result.code, 200)
         new_value = json.loads(result.body.decode('utf-8'))
         record['description'] = updated['description']
@@ -76,12 +74,11 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
         self.assertDictEqual(record, new_value)
 
         # Patch no change
-        result = self.fetch(
-            url, method='PATCH', body=patch_value, headers=self.headers)
+        result = self.fetch(url, method='PATCH', body=patch_value)
         self.assertEqual(result.code, 304)
 
         # GET
-        result = self.fetch(url, headers=self.headers)
+        result = self.fetch(url)
         self.assertEqual(result.code, 200)
         self.assert_link_header_equals(result, url)
         self.assertIsNotNone(result.headers['Date'])
@@ -95,15 +92,15 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
         self.assertDictEqual(record, new_value)
 
         # DELETE
-        result = self.fetch(url, method='DELETE', headers=self.headers)
+        result = self.fetch(url, method='DELETE')
         self.assertEqual(result.code, 204)
 
         # GET record should not exist
-        result = self.fetch(url, headers=self.headers)
+        result = self.fetch(url)
         self.assertEqual(result.code, 404)
 
         # DELETE should fail as record should not exist
-        result = self.fetch(url, method='DELETE', headers=self.headers)
+        result = self.fetch(url, method='DELETE')
         self.assertEqual(result.code, 404)
 
     def test_create_with_missing_fields(self):
@@ -116,9 +113,8 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
         }
 
         # Create
-        result = self.fetch(
-            '/projects', method='POST', headers=self.headers,
-            body=json.dumps(record).encode('utf-8'))
+        result = self.fetch('/projects', method='POST',
+                            body=json.dumps(record).encode('utf-8'))
         self.assertEqual(result.code, 200)
         response = json.loads(result.body.decode('utf-8'))
         url = self.get_url('/projects/{}'.format(response['id']))
@@ -150,9 +146,8 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
             'slug': str(uuid.uuid4().hex),
             'environments': self.environments
         }
-        result = self.fetch(
-            '/projects', method='POST', headers=self.headers,
-            body=json.dumps(project_a).encode('utf-8'))
+        result = self.fetch('/projects', method='POST',
+                            body=json.dumps(project_a).encode('utf-8'))
         self.assertEqual(result.code, 200)
         project_a = json.loads(result.body.decode('utf-8'))
 
@@ -163,16 +158,15 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
             'slug': str(uuid.uuid4().hex),
             'environments': self.environments
         }
-        result = self.fetch(
-            '/projects', method='POST', headers=self.headers,
-            body=json.dumps(project_b).encode('utf-8'))
+        result = self.fetch('/projects', method='POST',
+                            body=json.dumps(project_b).encode('utf-8'))
         self.assertEqual(result.code, 200)
         project_b = json.loads(result.body.decode('utf-8'))
 
         # Create the dependency
         result = self.fetch(
             '/projects/{}/dependencies'.format(project_b['id']),
-            method='POST', headers=self.headers,
+            method='POST',
             body=json.dumps({
                 'dependency_id': project_a['id']
             }).encode('utf-8'))
@@ -180,7 +174,7 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
 
         result = self.fetch(
             '/projects/{}/dependencies'.format(project_b['id']),
-            method='GET', headers=self.headers)
+            method='GET')
         self.assertEqual(result.code, 200)
         self.assertListEqual(
             json.loads(result.body.decode('utf-8')),
@@ -191,9 +185,9 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
             }])
 
         result = self.fetch(
-            '/projects/{}/dependencies/{}'.format(
-                project_b['id'], project_a['id']),
-            method='GET', headers=self.headers)
+            '/projects/{}/dependencies/{}'.format(project_b['id'],
+                                                  project_a['id']),
+            method='GET')
         self.assertEqual(result.code, 200)
         self.assertDictEqual(
             json.loads(result.body.decode('utf-8')),
@@ -206,13 +200,13 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
         result = self.fetch(
             '/projects/{}/dependencies/{}'.format(
                 project_b['id'], project_a['id']),
-            method='DELETE', headers=self.headers)
+            method='DELETE')
         self.assertEqual(result.code, 204)
 
         result = self.fetch(
             '/projects/{}/dependencies/{}'.format(
                 project_b['id'], project_a['id']),
-            method='GET', headers=self.headers)
+            method='GET')
         self.assertEqual(result.code, 404)
 
     def test_links(self):
@@ -224,9 +218,8 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
             'environments': self.environments
         }
 
-        result = self.fetch(
-            '/projects', method='POST', headers=self.headers,
-            body=json.dumps(project_record).encode('utf-8'))
+        result = self.fetch('/projects', method='POST',
+                            body=json.dumps(project_record).encode('utf-8'))
         self.assertEqual(result.code, 200)
         response = json.loads(result.body.decode('utf-8'))
 
@@ -241,9 +234,8 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
             response['id'], self.project_link_type['id']))
 
         # Create
-        result = self.fetch(
-            links_url, headers=self.headers, method='POST',
-            body=json.dumps(record).encode('utf-8'))
+        result = self.fetch(links_url, method='POST',
+                            body=json.dumps(record).encode('utf-8'))
         self.assertEqual(result.code, 200)
         link_record = json.loads(result.body.decode('utf-8'))
         self.assert_link_header_equals(result, url)
@@ -255,7 +247,7 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
         self.assertEqual(link_record['url'], record['url'])
 
         # Get links
-        result = self.fetch(links_url, headers=self.headers)
+        result = self.fetch(links_url)
         self.assertEqual(result.code, 200)
         self.assert_link_header_equals(result, links_url)
         records = []
@@ -271,8 +263,7 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
         patch = jsonpatch.make_patch(record, updated)
         patch_value = patch.to_string().encode('utf-8')
 
-        result = self.fetch(
-            url, method='PATCH', body=patch_value, headers=self.headers)
+        result = self.fetch(url, method='PATCH', body=patch_value)
         self.assertEqual(result.code, 200)
         self.assert_link_header_equals(result, url)
         record = json.loads(result.body.decode('utf-8'))
@@ -284,13 +275,12 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
         self.assertDictEqual(record, updated)
 
         # Patch no change
-        result = self.fetch(
-            url, method='PATCH', body=patch_value, headers=self.headers)
+        result = self.fetch(url, method='PATCH', body=patch_value)
         self.assertEqual(result.code, 304)
         self.assert_link_header_equals(result, url)
 
         # Get
-        result = self.fetch(url, headers=self.headers)
+        result = self.fetch(url)
         self.assertEqual(result.code, 200)
         record = json.loads(result.body.decode('utf-8'))
         for field in {'link_type', 'icon_class'}:
@@ -301,11 +291,11 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
         self.assertDictEqual(record, updated)
 
         # Delete
-        result = self.fetch(url, method='DELETE', headers=self.headers)
+        result = self.fetch(url, method='DELETE')
         self.assertEqual(result.code, 204)
 
         # Get 404
-        result = self.fetch(url, headers=self.headers)
+        result = self.fetch(url)
         self.assertEqual(result.code, 404)
 
     def test_urls(self):
@@ -317,9 +307,8 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
             'environments': self.environments
         }
 
-        result = self.fetch(
-            '/projects', method='POST', headers=self.headers,
-            body=json.dumps(project_record).encode('utf-8'))
+        result = self.fetch('/projects', method='POST',
+                            body=json.dumps(project_record).encode('utf-8'))
         self.assertEqual(result.code, 200)
         response = json.loads(result.body.decode('utf-8'))
 
@@ -334,9 +323,8 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
             response['id'], self.environments[0]))
 
         # Create
-        result = self.fetch(
-            urls_url, headers=self.headers, method='POST',
-            body=json.dumps(record).encode('utf-8'))
+        result = self.fetch(urls_url, method='POST',
+                            body=json.dumps(record).encode('utf-8'))
         self.assertEqual(result.code, 200)
         url_record = json.loads(result.body.decode('utf-8'))
         self.assert_link_header_equals(result, url)
@@ -348,7 +336,7 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
         self.assertEqual(url_record['url'], record['url'])
 
         # Get URLs
-        result = self.fetch(urls_url, headers=self.headers)
+        result = self.fetch(urls_url)
         self.assertEqual(result.code, 200)
         self.assert_link_header_equals(result, urls_url)
         records = []
@@ -364,8 +352,7 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
         patch = jsonpatch.make_patch(record, updated)
         patch_value = patch.to_string().encode('utf-8')
 
-        result = self.fetch(
-            url, method='PATCH', body=patch_value, headers=self.headers)
+        result = self.fetch(url, method='PATCH', body=patch_value)
         self.assertEqual(result.code, 200)
         self.assert_link_header_equals(result, url)
         record = json.loads(result.body.decode('utf-8'))
@@ -374,21 +361,19 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
         self.assertDictEqual(record, updated)
 
         # Patch no change
-        result = self.fetch(
-            url, method='PATCH', body=patch_value, headers=self.headers)
+        result = self.fetch(url, method='PATCH', body=patch_value)
         self.assertEqual(result.code, 304)
         self.assert_link_header_equals(result, url)
 
         # Feed
-        result = self.fetch(
-            f'/projects/{record["project_id"]}/feed', headers=self.headers)
+        result = self.fetch(f'/projects/{record["project_id"]}/feed')
         self.assertEqual(result.code, 200)
         records = json.loads(result.body.decode('utf-8'))
         self.assertGreaterEqual(len(records), 1)
         self.assertEqual(records[0]['who'], self.USERNAME[self.ADMIN_ACCESS])
 
         # Get
-        result = self.fetch(url, headers=self.headers)
+        result = self.fetch(url)
         self.assertEqual(result.code, 200)
         record = json.loads(result.body.decode('utf-8'))
         for field in {'created_by', 'last_modified_by'}:
@@ -396,11 +381,11 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
         self.assertDictEqual(record, updated)
 
         # Delete
-        result = self.fetch(url, method='DELETE', headers=self.headers)
+        result = self.fetch(url, method='DELETE')
         self.assertEqual(result.code, 204)
 
         # Get 404
-        result = self.fetch(url, headers=self.headers)
+        result = self.fetch(url)
         self.assertEqual(result.code, 404)
 
     def test_project_search(self):
@@ -420,16 +405,14 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
             return False
 
         # Create
-        result = self.fetch(
-            '/projects', method='POST', headers=self.headers,
-            body=json.dumps(record).encode('utf-8'))
+        result = self.fetch('/projects', method='POST',
+                            body=json.dumps(record).encode('utf-8'))
         self.assertEqual(result.code, 200)
         response = json.loads(result.body.decode('utf-8'))
         proj_id = response['id']
 
         # Search by name
         part = record['name'].split('-')[4]
-        result = self.fetch(f'/projects?name={part}', method='GET',
-                            headers=self.headers)
+        result = self.fetch(f'/projects?name={part}', method='GET')
         self.assertTrue(in_results(proj_id,
                                    json.loads(result.body.decode('utf-8'))))

--- a/tests/endpoints/test_project_endpoints.py
+++ b/tests/endpoints/test_project_endpoints.py
@@ -35,8 +35,7 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
         }
 
         # Create
-        result = self.fetch('/projects', method='POST',
-                            body=json.dumps(record).encode('utf-8'))
+        result = self.fetch('/projects', method='POST', json_body=record)
         self.assertEqual(result.code, 200)
         response = json.loads(result.body.decode('utf-8'))
         url = self.get_url('/projects/{}'.format(response['id']))
@@ -113,8 +112,7 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
         }
 
         # Create
-        result = self.fetch('/projects', method='POST',
-                            body=json.dumps(record).encode('utf-8'))
+        result = self.fetch('/projects', method='POST', json_body=record)
         self.assertEqual(result.code, 200)
         response = json.loads(result.body.decode('utf-8'))
         url = self.get_url('/projects/{}'.format(response['id']))
@@ -146,8 +144,7 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
             'slug': str(uuid.uuid4().hex),
             'environments': self.environments
         }
-        result = self.fetch('/projects', method='POST',
-                            body=json.dumps(project_a).encode('utf-8'))
+        result = self.fetch('/projects', method='POST', json_body=project_a)
         self.assertEqual(result.code, 200)
         project_a = json.loads(result.body.decode('utf-8'))
 
@@ -158,18 +155,14 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
             'slug': str(uuid.uuid4().hex),
             'environments': self.environments
         }
-        result = self.fetch('/projects', method='POST',
-                            body=json.dumps(project_b).encode('utf-8'))
+        result = self.fetch('/projects', method='POST', json_body=project_b)
         self.assertEqual(result.code, 200)
         project_b = json.loads(result.body.decode('utf-8'))
 
         # Create the dependency
         result = self.fetch(
             '/projects/{}/dependencies'.format(project_b['id']),
-            method='POST',
-            body=json.dumps({
-                'dependency_id': project_a['id']
-            }).encode('utf-8'))
+            method='POST', json_body={'dependency_id': project_a['id']})
         self.assertEqual(result.code, 200)
 
         result = self.fetch(
@@ -219,7 +212,7 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
         }
 
         result = self.fetch('/projects', method='POST',
-                            body=json.dumps(project_record).encode('utf-8'))
+                            json_body=project_record)
         self.assertEqual(result.code, 200)
         response = json.loads(result.body.decode('utf-8'))
 
@@ -234,8 +227,7 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
             response['id'], self.project_link_type['id']))
 
         # Create
-        result = self.fetch(links_url, method='POST',
-                            body=json.dumps(record).encode('utf-8'))
+        result = self.fetch(links_url, method='POST', json_body=record)
         self.assertEqual(result.code, 200)
         link_record = json.loads(result.body.decode('utf-8'))
         self.assert_link_header_equals(result, url)
@@ -308,7 +300,7 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
         }
 
         result = self.fetch('/projects', method='POST',
-                            body=json.dumps(project_record).encode('utf-8'))
+                            json_body=project_record)
         self.assertEqual(result.code, 200)
         response = json.loads(result.body.decode('utf-8'))
 
@@ -323,8 +315,7 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
             response['id'], self.environments[0]))
 
         # Create
-        result = self.fetch(urls_url, method='POST',
-                            body=json.dumps(record).encode('utf-8'))
+        result = self.fetch(urls_url, method='POST', json_body=record)
         self.assertEqual(result.code, 200)
         url_record = json.loads(result.body.decode('utf-8'))
         self.assert_link_header_equals(result, url)
@@ -405,8 +396,7 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
             return False
 
         # Create
-        result = self.fetch('/projects', method='POST',
-                            body=json.dumps(record).encode('utf-8'))
+        result = self.fetch('/projects', method='POST', json_body=record)
         self.assertEqual(result.code, 200)
         response = json.loads(result.body.decode('utf-8'))
         proj_id = response['id']

--- a/tests/endpoints/test_project_facts.py
+++ b/tests/endpoints/test_project_facts.py
@@ -34,12 +34,10 @@ class ProjectFactTests(base.TestCaseWithReset):
         result = self.fetch(
             f'/projects/{self.project["id"]}/facts',
             method='POST',
-            body=json.dumps(facts).encode('utf-8'),
-            headers=self.headers)
+            body=json.dumps(facts).encode('utf-8'))
         self.assertEqual(204, result.code)
 
-        result = self.fetch(f'/projects/{self.project["id"]}/facts',
-                            headers=self.headers)
+        result = self.fetch(f'/projects/{self.project["id"]}/facts')
         self.assertEqual(200, result.code)
 
         data = json.loads(result.body)
@@ -61,12 +59,10 @@ class ProjectFactTests(base.TestCaseWithReset):
             body[0]['value'] = input_value
             result = self.fetch(
                 f'/projects/{self.project["id"]}/facts',
-                method='POST', body=json.dumps(body).encode('utf-8'),
-                headers=self.headers)
+                method='POST', body=json.dumps(body).encode('utf-8'))
             self.assertEqual(204, result.code, f'Failure for {input_value!r}')
 
-            result = self.fetch(f'/projects/{self.project["id"]}/facts',
-                                headers=self.headers)
+            result = self.fetch(f'/projects/{self.project["id"]}/facts')
             self.assertEqual(200, result.code)
             data = json.loads(result.body)
             self.assertEqual(expected_value, data[0]['value'])
@@ -160,8 +156,7 @@ class ProjectFactTests(base.TestCaseWithReset):
             result = self.fetch(
                 f'/projects/{self.project["id"]}/facts',
                 method='POST',
-                body=json.dumps([invalid_fact]).encode('utf-8'),
-                headers=self.headers)
+                body=json.dumps([invalid_fact]).encode('utf-8'))
             self.assertEqual(
                 400, result.code,
                 f'Unexpected response for {invalid_fact["value"]}')
@@ -173,19 +168,16 @@ class ProjectFactTests(base.TestCaseWithReset):
             method='POST',
             body=json.dumps([{
                 'fact_type_id': boolean_fact_type['id'],
-                'value': 'true'}]).encode('utf-8'),
-            headers=self.headers)
+                'value': 'true'}]).encode('utf-8'))
         self.assertEqual(204, result.code)
 
-        result = self.fetch(f'/projects/{self.project["id"]}/facts',
-                            headers=self.headers)
+        result = self.fetch(f'/projects/{self.project["id"]}/facts')
         self.assertEqual(200, result.code)
 
         fact = json.loads(result.body)[0]
         self.assertEqual(fact['score'], 100)
 
-        result = self.fetch(f'/projects/{self.project["id"]}?full=true',
-                            headers=self.headers)
+        result = self.fetch(f'/projects/{self.project["id"]}?full=true')
         self.assertEqual(200, result.code)
         project = json.loads(result.body)
         fact = project['facts'][0]
@@ -198,19 +190,16 @@ class ProjectFactTests(base.TestCaseWithReset):
             method='POST',
             body=json.dumps([{
                 'fact_type_id': boolean_fact_type['id'],
-                'value': 'false'}]).encode('utf-8'),
-            headers=self.headers)
+                'value': 'false'}]).encode('utf-8'))
         self.assertEqual(204, result.code)
 
-        result = self.fetch(f'/projects/{self.project["id"]}/facts',
-                            headers=self.headers)
+        result = self.fetch(f'/projects/{self.project["id"]}/facts')
         self.assertEqual(200, result.code)
 
         fact = json.loads(result.body)[0]
         self.assertEqual(fact['score'], 0)
 
-        result = self.fetch(f'/projects/{self.project["id"]}?full=true',
-                            headers=self.headers)
+        result = self.fetch(f'/projects/{self.project["id"]}?full=true')
         self.assertEqual(200, result.code)
         project = json.loads(result.body)
         fact = project['facts'][0]
@@ -219,6 +208,5 @@ class ProjectFactTests(base.TestCaseWithReset):
     def test_unknown_fact_id(self):
         result = self.fetch(f'/projects/{self.project["id"]}/facts',
                             method='POST',
-                            body=b'[{"fact_type_id":-1,"value":""}]',
-                            headers=self.headers)
+                            body=b'[{"fact_type_id":-1,"value":""}]')
         self.assertEqual(400, result.code)

--- a/tests/endpoints/test_project_facts.py
+++ b/tests/endpoints/test_project_facts.py
@@ -31,10 +31,8 @@ class ProjectFactTests(base.TestCaseWithReset):
             {'fact_type_id': string_fact['id'], 'value': 'hello world'},
             {'fact_type_id': timestamp_fact['id'], 'value': now.isoformat()},
         ]
-        result = self.fetch(
-            f'/projects/{self.project["id"]}/facts',
-            method='POST',
-            body=json.dumps(facts).encode('utf-8'))
+        result = self.fetch(f'/projects/{self.project["id"]}/facts',
+                            method='POST', json_body=facts)
         self.assertEqual(204, result.code)
 
         result = self.fetch(f'/projects/{self.project["id"]}/facts')
@@ -57,9 +55,8 @@ class ProjectFactTests(base.TestCaseWithReset):
         body = [{'fact_type_id': fact_type['id']}]
         for input_value, expected_value in values.items():
             body[0]['value'] = input_value
-            result = self.fetch(
-                f'/projects/{self.project["id"]}/facts',
-                method='POST', body=json.dumps(body).encode('utf-8'))
+            result = self.fetch(f'/projects/{self.project["id"]}/facts',
+                                method='POST', json_body=body)
             self.assertEqual(204, result.code, f'Failure for {input_value!r}')
 
             result = self.fetch(f'/projects/{self.project["id"]}/facts')
@@ -153,10 +150,8 @@ class ProjectFactTests(base.TestCaseWithReset):
             {'fact_type_id': decimal_fact['id'], 'value': 'not a number'},
         ]
         for invalid_fact in invalid_facts:
-            result = self.fetch(
-                f'/projects/{self.project["id"]}/facts',
-                method='POST',
-                body=json.dumps([invalid_fact]).encode('utf-8'))
+            result = self.fetch(f'/projects/{self.project["id"]}/facts',
+                                method='POST', json_body=[invalid_fact])
             self.assertEqual(
                 400, result.code,
                 f'Unexpected response for {invalid_fact["value"]}')
@@ -166,9 +161,8 @@ class ProjectFactTests(base.TestCaseWithReset):
         result = self.fetch(
             f'/projects/{self.project["id"]}/facts',
             method='POST',
-            body=json.dumps([{
-                'fact_type_id': boolean_fact_type['id'],
-                'value': 'true'}]).encode('utf-8'))
+            json_body=[{'fact_type_id': boolean_fact_type['id'],
+                        'value': 'true'}])
         self.assertEqual(204, result.code)
 
         result = self.fetch(f'/projects/{self.project["id"]}/facts')
@@ -188,9 +182,8 @@ class ProjectFactTests(base.TestCaseWithReset):
         result = self.fetch(
             f'/projects/{self.project["id"]}/facts',
             method='POST',
-            body=json.dumps([{
-                'fact_type_id': boolean_fact_type['id'],
-                'value': 'false'}]).encode('utf-8'))
+            json_body=[{'fact_type_id': boolean_fact_type['id'],
+                        'value': 'false'}])
         self.assertEqual(204, result.code)
 
         result = self.fetch(f'/projects/{self.project["id"]}/facts')

--- a/tests/endpoints/test_project_link_types.py
+++ b/tests/endpoints/test_project_link_types.py
@@ -19,9 +19,8 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
         }
 
         # Create
-        result = self.fetch(
-            '/project-link-types', method='POST',
-            body=json.dumps(record).encode('utf-8'))
+        result = self.fetch('/project-link-types', method='POST',
+                            json_body=record)
         self.assertEqual(result.code, 200)
         response = json.loads(result.body.decode('utf-8'))
         url = self.get_url(
@@ -95,9 +94,7 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
     def test_create_with_missing_fields(self):
         result = self.fetch(
             '/project-link-types', method='POST',
-            body=json.dumps({
-                'link_type': str(uuid.uuid4())
-            }).encode('utf-8'))
+            json_body={'link_type': str(uuid.uuid4())})
         self.assertEqual(result.code, 400)
 
     def test_method_not_implemented(self):

--- a/tests/endpoints/test_project_link_types.py
+++ b/tests/endpoints/test_project_link_types.py
@@ -99,12 +99,8 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
 
     def test_method_not_implemented(self):
         for method in {'DELETE', 'PATCH'}:
-            result = self.fetch(
-                '/project-link-types', method=method,
-                allow_nonstandard_methods=True)
+            result = self.fetch('/project-link-types', method=method)
             self.assertEqual(result.code, 405)
         url = '/project-link-types/' + str(uuid.uuid4())
-        result = self.fetch(
-            url, method='POST', body='{}',
-            allow_nonstandard_methods=True)
+        result = self.fetch(url, method='POST', body='{}')
         self.assertEqual(result.code, 405)

--- a/tests/endpoints/test_project_link_types.py
+++ b/tests/endpoints/test_project_link_types.py
@@ -20,7 +20,7 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
 
         # Create
         result = self.fetch(
-            '/project-link-types', method='POST', headers=self.headers,
+            '/project-link-types', method='POST',
             body=json.dumps(record).encode('utf-8'))
         self.assertEqual(result.code, 200)
         response = json.loads(result.body.decode('utf-8'))
@@ -50,20 +50,18 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
             'icon_class': updated['icon_class'],
             'last_modified_by': self.USERNAME[self.ADMIN_ACCESS]
         })
-        result = self.fetch(
-            url, method='PATCH', body=patch_value, headers=self.headers)
+        result = self.fetch(url, method='PATCH', body=patch_value)
         self.assertEqual(result.code, 200)
         self.assert_link_header_equals(result, url)
         new_value = json.loads(result.body.decode('utf-8'))
         self.assertDictEqual(new_value, record)
 
         # Patch no change
-        result = self.fetch(
-            url, method='PATCH', body=patch_value, headers=self.headers)
+        result = self.fetch(url, method='PATCH', body=patch_value)
         self.assertEqual(result.code, 304)
 
         # GET
-        result = self.fetch(url, headers=self.headers)
+        result = self.fetch(url)
         self.assertEqual(result.code, 200)
         self.assert_link_header_equals(result, url)
         self.assertIsNotNone(result.headers['Date'])
@@ -75,7 +73,7 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
         self.assertDictEqual(new_value, record)
 
         # Collection
-        result = self.fetch('/project-link-types', headers=self.headers)
+        result = self.fetch('/project-link-types')
         self.assertEqual(result.code, 200)
         self.assertListEqual(
             json.loads(result.body.decode('utf-8')),
@@ -83,20 +81,20 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
               if k not in ['created_by', 'last_modified_by']}])
 
         # DELETE
-        result = self.fetch(url, method='DELETE', headers=self.headers)
+        result = self.fetch(url, method='DELETE')
         self.assertEqual(result.code, 204)
 
         # GET record should not exist
-        result = self.fetch(url, headers=self.headers)
+        result = self.fetch(url)
         self.assertEqual(result.code, 404)
 
         # DELETE should fail as record should not exist
-        result = self.fetch(url, method='DELETE', headers=self.headers)
+        result = self.fetch(url, method='DELETE')
         self.assertEqual(result.code, 404)
 
     def test_create_with_missing_fields(self):
         result = self.fetch(
-            '/project-link-types', method='POST', headers=self.headers,
+            '/project-link-types', method='POST',
             body=json.dumps({
                 'link_type': str(uuid.uuid4())
             }).encode('utf-8'))
@@ -105,11 +103,11 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
     def test_method_not_implemented(self):
         for method in {'DELETE', 'PATCH'}:
             result = self.fetch(
-                '/project-link-types', method=method, headers=self.headers,
+                '/project-link-types', method=method,
                 allow_nonstandard_methods=True)
             self.assertEqual(result.code, 405)
         url = '/project-link-types/' + str(uuid.uuid4())
         result = self.fetch(
-            url, method='POST', body='{}', headers=self.headers,
+            url, method='POST', body='{}',
             allow_nonstandard_methods=True)
         self.assertEqual(result.code, 405)

--- a/tests/endpoints/test_project_types.py
+++ b/tests/endpoints/test_project_types.py
@@ -31,7 +31,7 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
 
         # Create
         result = self.fetch(
-            '/project-types', method='POST', headers=self.headers,
+            '/project-types', method='POST',
             body=json.dumps(record).encode('utf-8'))
         self.assertEqual(result.code, 200)
         response = json.loads(result.body.decode('utf-8'))
@@ -59,20 +59,18 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
             'last_modified_by': self.USERNAME[self.ADMIN_ACCESS]
         })
 
-        result = self.fetch(
-            url, method='PATCH', body=patch_value, headers=self.headers)
+        result = self.fetch(url, method='PATCH', body=patch_value)
         self.assertEqual(result.code, 200)
         self.assert_link_header_equals(result, url)
         new_value = json.loads(result.body.decode('utf-8'))
         self.assertDictEqual(new_value, record)
 
         # Patch no change
-        result = self.fetch(
-            url, method='PATCH', body=patch_value, headers=self.headers)
+        result = self.fetch(url, method='PATCH', body=patch_value)
         self.assertEqual(result.code, 304)
 
         # GET
-        result = self.fetch(url, headers=self.headers)
+        result = self.fetch(url)
         self.assertEqual(result.code, 200)
         self.assertIsNotNone(result.headers['Date'])
         self.assertIsNotNone(result.headers['Last-Modified'])
@@ -84,7 +82,7 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
         self.assertDictEqual(new_value, record)
 
         # Collection
-        result = self.fetch('/project-types', headers=self.headers)
+        result = self.fetch('/project-types')
         self.assertEqual(result.code, 200)
         self.assertListEqual(
             json.loads(result.body.decode('utf-8')),
@@ -92,20 +90,20 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
               if k not in ['created_by', 'last_modified_by']}])
 
         # DELETE
-        result = self.fetch(url, method='DELETE', headers=self.headers)
+        result = self.fetch(url, method='DELETE')
         self.assertEqual(result.code, 204)
 
         # GET record should not exist
-        result = self.fetch(url, headers=self.headers)
+        result = self.fetch(url)
         self.assertEqual(result.code, 404)
 
         # DELETE should fail as record should not exist
-        result = self.fetch(url,  method='DELETE', headers=self.headers)
+        result = self.fetch(url,  method='DELETE')
         self.assertEqual(result.code, 404)
 
     def test_create_with_missing_fields(self):
         result = self.fetch(
-            '/project-types', method='POST', headers=self.headers,
+            '/project-types', method='POST',
             body=json.dumps({
                 'name': str(uuid.uuid4()),
                 'plural_name': str(uuid.uuid4()),
@@ -117,12 +115,11 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
         for method in {'DELETE', 'PATCH'}:
             result = self.fetch(
                 '/project-types', method=method,
-                allow_nonstandard_methods=True,
-                headers=self.headers)
+                allow_nonstandard_methods=True)
             self.assertEqual(result.code, 405)
 
         url = '/project-types/' + str(uuid.uuid4())
         result = self.fetch(
-            url, method='POST', headers=self.headers,
+            url, method='POST',
             allow_nonstandard_methods=True)
         self.assertEqual(result.code, 405)

--- a/tests/endpoints/test_project_types.py
+++ b/tests/endpoints/test_project_types.py
@@ -30,9 +30,7 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
         })
 
         # Create
-        result = self.fetch(
-            '/project-types', method='POST',
-            body=json.dumps(record).encode('utf-8'))
+        result = self.fetch('/project-types', method='POST', json_body=record)
         self.assertEqual(result.code, 200)
         response = json.loads(result.body.decode('utf-8'))
         url = self.get_url('/project-types/{}'.format(response['id']))
@@ -104,22 +102,18 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
     def test_create_with_missing_fields(self):
         result = self.fetch(
             '/project-types', method='POST',
-            body=json.dumps({
+            json_body={
                 'name': str(uuid.uuid4()),
                 'plural_name': str(uuid.uuid4()),
                 'slug': str(uuid.uuid4())
-            }).encode('utf-8'))
+            })
         self.assertEqual(result.code, 400)
 
     def test_method_not_implemented(self):
         for method in {'DELETE', 'PATCH'}:
-            result = self.fetch(
-                '/project-types', method=method,
-                allow_nonstandard_methods=True)
+            result = self.fetch('/project-types', method=method)
             self.assertEqual(result.code, 405)
 
         url = '/project-types/' + str(uuid.uuid4())
-        result = self.fetch(
-            url, method='POST',
-            allow_nonstandard_methods=True)
+        result = self.fetch(url, method='POST')
         self.assertEqual(result.code, 405)

--- a/tests/endpoints/test_status.py
+++ b/tests/endpoints/test_status.py
@@ -4,12 +4,12 @@ from tests import base
 class AsyncHTTPTestCase(base.TestCase):
 
     def test_status_ok(self):
-        response = self.fetch('/status', headers=self.headers)
+        response = self.fetch('/status')
         self.assertEqual(response.code, 200)
         self.validate_response(response)
 
     def test_status_error(self):
         self._app._ready_to_serve = False
-        response = self.fetch('/status', headers=self.headers)
+        response = self.fetch('/status')
         self.assertEqual(response.code, 503)
         self.validate_response(response)


### PR DESCRIPTION
This PR moves a lot of redundancy into the `self.fetch()` method on our `TestCase`.

- used `self.headers` by default instead of requiring everyone to remember to pass it
- replaced the pattern of `body=json.dumps(...).encode('utf-8')` with `json_body=...` - _there was at least one place where we were missing the `encode()` part_
- removed the need to pass `allow_nonstandard_methods=True` when checking for "method not allowed"

I kept this as a free-standing PR to keep things cleaner.