### PR TITLE
Ops log in activity feed

### DIFF
--- a/imbi/common.py
+++ b/imbi/common.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import base64
 import datetime
 import decimal
 import typing
@@ -59,3 +60,13 @@ def coerce_project_fact(
         raise ValueError(f'{data_type!r} is not a known fact type')
 
     return value
+
+
+def urlsafe_padded_b64decode(data: str) -> bytes:
+    """Base64 decode 'data' after padding with '=' if needed"""
+    bin_data = data.encode('ascii')
+    data_len = len(bin_data)
+    pad_len = data_len % 4
+    if pad_len:
+        bin_data = bin_data.ljust(data_len + pad_len, b'=')
+    return base64.urlsafe_b64decode(bin_data)

--- a/imbi/endpoints/__init__.py
+++ b/imbi/endpoints/__init__.py
@@ -12,7 +12,7 @@ from . import (activity_feed, authentication_tokens, cookie_cutters, dashboard,
 
 URLS = [
     web.url(r'^/$', ui.IndexRequestHandler),
-    web.url(r'^/activity-feed$', activity_feed.RequestHandler),
+    web.url(r'^/activity-feed$', activity_feed.CollectionRequestHandler),
     web.url(r'^/api-docs/$', openapi.RequestHandler),
     web.url(r'^/api-docs/(openapi.yaml)$', openapi.RequestHandler),
     web.url(r'^/authentication-tokens$', authentication_tokens.RequestHandler),

--- a/imbi/endpoints/activity_feed.py
+++ b/imbi/endpoints/activity_feed.py
@@ -22,7 +22,8 @@ class CollectionRequestHandler(base.PaginatedRequestMixin,
                project_type, who, display_name, email_address,
                what
           FROM v1.activity_feed
-         WHERE "when" BETWEEN %(earlier)s AND %(later)s
+         WHERE "when" >  %(earlier)s
+           AND "when" <= %(later)s
          ORDER BY "when" DESC
          LIMIT %(remaining)s
         """)
@@ -38,7 +39,8 @@ class CollectionRequestHandler(base.PaginatedRequestMixin,
           FROM v1.operations_log AS o
           LEFT JOIN v1.projects AS p ON p.id = o.project_id
           LEFT JOIN v1.users AS u ON u.username = o.recorded_by
-         WHERE recorded_at BETWEEN %(earlier)s AND %(later)s
+         WHERE recorded_at >  %(earlier)s
+           AND recorded_at <= %(later)s
          ORDER BY o.recorded_at DESC, o.id DESC
          LIMIT %(remaining)s
         """)
@@ -50,7 +52,7 @@ class CollectionRequestHandler(base.PaginatedRequestMixin,
             UNION
             SELECT MIN(recorded_at) AS earliest FROM v1.operations_log
         )
-        SELECT MIN(earliest) AS earliest
+        SELECT COALESCE(MIN(earliest), CURRENT_TIMESTAMP) AS earliest
           FROM T
         """)
 

--- a/imbi/endpoints/activity_feed.py
+++ b/imbi/endpoints/activity_feed.py
@@ -35,7 +35,7 @@ class CollectionRequestHandler(base.PaginatedRequestMixin,
                o.project_id, o.environment, o.change_type,
                o.description, o.link, o.notes, o.ticket_slug,
                o.version, p.name AS project_name,
-               u.email_address
+               u.email_address, u.display_name
           FROM v1.operations_log AS o
           LEFT JOIN v1.projects AS p ON p.id = o.project_id
           LEFT JOIN v1.users AS u ON u.username = o.recorded_by

--- a/imbi/endpoints/activity_feed.py
+++ b/imbi/endpoints/activity_feed.py
@@ -1,30 +1,93 @@
+from __future__ import annotations
+
+import asyncio
+import datetime
 import re
+import typing
 
 from tornado import web
 
 from imbi.endpoints import base
 
 
-class CollectionRequestHandler(base.ValidatingRequestHandler):
+class CollectionRequestHandler(base.PaginatedRequestMixin,
+                               base.ValidatingRequestHandler):
 
     NAME = 'activity-feed'
 
-    SQL = re.sub(
+    PROJECT_FEED_SQL = re.sub(
         r'\s+', ' ', """\
-        SELECT 'ProjectFeedEntry' AS "type", "when", namespace_id,
-               namespace, project_id, project_name, project_type, who,
-               display_name, email_address, what
+        SELECT 'ProjectFeedEntry' AS "type", "when",
+               namespace_id, namespace, project_id, project_name,
+               project_type, who, display_name, email_address,
+               what
           FROM v1.activity_feed
+         WHERE "when" BETWEEN %(earlier)s AND %(later)s
          ORDER BY "when" DESC
-        OFFSET {offset}
-         LIMIT {limit};""")
+         LIMIT %(remaining)s
+        """)
+
+    OPERATIONS_LOG_SQL = re.sub(
+        r'\s+', ' ', """\
+        SELECT 'OperationsLogEntry' AS "type", o.id,
+               o.recorded_at, o.recorded_by, o.completed_at,
+               o.project_id, o.environment, o.change_type,
+               o.description, o.link, o.notes, o.ticket_slug,
+               o.version, p.name AS project_name,
+               u.email_address
+          FROM v1.operations_log AS o
+          LEFT JOIN v1.projects AS p ON p.id = o.project_id
+          LEFT JOIN v1.users AS u ON u.username = o.recorded_by
+         WHERE recorded_at BETWEEN %(earlier)s AND %(later)s
+         ORDER BY o.recorded_at DESC, o.id DESC
+         LIMIT %(remaining)s
+        """)
+
+    EARLIEST_EVENT_SQL = re.sub(
+        r'\s+', ' ', """\
+        WITH T AS (
+            SELECT MIN("when") AS earliest FROM v1.activity_feed
+            UNION
+            SELECT MIN(recorded_at) AS earliest FROM v1.operations_log
+        )
+        SELECT MIN(earliest) AS earliest
+          FROM T
+        """)
 
     @web.authenticated
     async def get(self):
-        result = await self.postgres_execute(
-            self.SQL.format(limit=int(self.get_query_argument('limit', '25')),
-                            offset=int(self.get_query_argument('offset',
-                                                               '0'))),
-            metric_name='reports-compliance',
-        )
-        self.send_response(result.rows)
+        token = await self._get_pagination_token()
+        buckets = await self.fetch_items(
+            token,
+            self._retrieve_rows,
+            datetime.timedelta(days=10),
+            omit_users=set(self.get_query_arguments('omit_user')))
+
+        self.send_response(buckets)
+
+    async def _retrieve_rows(
+            self, params) -> list[tuple[datetime.datetime, typing.Any]]:
+        activity_feed, ops_log = await asyncio.gather(
+            self.postgres_execute(self.PROJECT_FEED_SQL, params),
+            self.postgres_execute(self.OPERATIONS_LOG_SQL, params))
+        self.logger.debug('fetched page containing %s activity, %s ops log',
+                          len(activity_feed), len(ops_log))
+
+        all_rows = [(row['when'], row) for row in activity_feed
+                    if row['who'] not in params['omit_users']]
+        all_rows.extend((row['recorded_at'], row) for row in ops_log
+                        if row['recorded_by'] not in params['omit_users'])
+
+        return all_rows
+
+    async def _get_pagination_token(self):
+        token = self.get_pagination_token_from_request()
+        if token is None:
+            self.logger.info('creating new token')
+            result = await self.postgres_execute(self.EARLIEST_EVENT_SQL)
+            token = base.PaginationToken(
+                start=datetime.datetime.now(datetime.timezone.utc),
+                limit=int(self.get_query_argument('limit', '25')),
+                earliest=result.row['earliest'],
+            )
+        return token

--- a/imbi/endpoints/activity_feed.py
+++ b/imbi/endpoints/activity_feed.py
@@ -5,7 +5,7 @@ from tornado import web
 from imbi.endpoints import base
 
 
-class RequestHandler(base.ValidatingRequestHandler):
+class CollectionRequestHandler(base.ValidatingRequestHandler):
 
     NAME = 'activity-feed'
 

--- a/imbi/endpoints/base.py
+++ b/imbi/endpoints/base.py
@@ -524,14 +524,14 @@ QueryMethod = typing.Callable[[dict[str, typing.Any]],
 This is something that looks like:
 
   async def retrieve_data(
-      params: dict[str, typing.Any]) -> list[tuple[datetime.datetime, dict]:
+      params: dict[str, typing.Any]) -> list[tuple[datetime.datetime, dict]]:
     ...
 
 """
 
 
 class PaginatedRequestMixin(web.RequestHandler):
-    """Mix this in to repeated retrieve query results ordered by time
+    """Mix this in to repeatedly retrieve query results ordered by time
 
     Call the `fetch_items` method to call a specified query method
     repeatedly until "token.limit" items have been retrieved.  The

--- a/imbi/endpoints/base.py
+++ b/imbi/endpoints/base.py
@@ -577,17 +577,18 @@ class PaginatedRequestMixin(web.RequestHandler):
         """
         buckets = []
         params = initial_params.copy()
-        params.update({'end': token.start, 'remaining': token.limit})
-        while params['remaining'] > 0 and params['end'] >= token.earliest:
-            params.update({
-                'earlier': params['end'] - time_step,
-                'later': params['end'],
-            })
+        params.update({
+            'earlier': token.start - time_step,
+            'later': token.start,
+            'remaining': token.limit,
+        })
+        while params['remaining'] > 0 and params['later'] >= token.earliest:
             buckets.extend(await query(params))
             buckets.sort(key=operator.itemgetter(0), reverse=True)
             params.update({
+                'earlier': params['earlier'] - time_step,
+                'later': params['earlier'],
                 'remaining': token.limit - len(buckets),
-                'end': params['end'] - time_step,
             })
 
         buckets = buckets[:token.limit]

--- a/imbi/endpoints/operations_log.py
+++ b/imbi/endpoints/operations_log.py
@@ -22,7 +22,7 @@ class _RequestHandlerMixin:
                o.project_id, o.environment, o.change_type, o.description,
                o.link, o.notes, o.ticket_slug, o.version,
                p.name AS project_name, u.email_address,
-               'OperationsLogEntry' AS "type"
+               u.display_name, 'OperationsLogEntry' AS "type"
           FROM v1.operations_log AS o
           JOIN v1.users AS u ON u.username = o.recorded_by
           LEFT JOIN v1.projects AS p ON p.id = o.project_id
@@ -40,7 +40,7 @@ class CollectionRequestHandler(operations_log.RequestHandlerMixin,
         SELECT o.id, o.recorded_at, o.recorded_by, o.completed_at,
                o.project_id, o.environment, o.change_type, o.description,
                o.link, o.notes, o.ticket_slug, o.version,
-               p.name AS project_name, u.email_address,
+               p.name AS project_name, u.email_address, u.display_name,
                'OperationsLogEntry' as "type"
           FROM v1.operations_log AS o
           JOIN v1.users AS u ON u.username = o.recorded_by

--- a/imbi/endpoints/operations_log.py
+++ b/imbi/endpoints/operations_log.py
@@ -21,12 +21,12 @@ class _RequestHandlerMixin:
         SELECT o.id, o.recorded_at, o.recorded_by, o.completed_at,
                o.project_id, o.environment, o.change_type, o.description,
                o.link, o.notes, o.ticket_slug, o.version,
-               p.name AS project_name, u.email_address
+               p.name AS project_name, u.email_address,
                'OperationsLogEntry' AS "type"
           FROM v1.operations_log AS o
           JOIN v1.users AS u ON u.username = o.recorded_by
           LEFT JOIN v1.projects AS p ON p.id = o.project_id
-         WHERE id = %(id)s""")
+         WHERE o.id = %(id)s""")
 
 
 class CollectionRequestHandler(operations_log.RequestHandlerMixin,

--- a/imbi/endpoints/project_activity_feed.py
+++ b/imbi/endpoints/project_activity_feed.py
@@ -55,8 +55,8 @@ class CollectionRequestHandler(base.PaginatedRequestMixin,
                o.recorded_at, o.recorded_by, o.completed_at,
                o.project_id, o.environment, o.change_type,
                o.description, o.link, o.notes, o.ticket_slug,
-               o.version, p.name AS project_name,
-               u.email_address
+               o.version, p.name AS project_name, u.email_address,
+               u.display_name
           FROM v1.operations_log AS o
           LEFT JOIN v1.projects AS p ON p.id = o.project_id
           LEFT JOIN v1.users AS u ON u.username = o.recorded_by

--- a/imbi/endpoints/project_activity_feed.py
+++ b/imbi/endpoints/project_activity_feed.py
@@ -1,57 +1,114 @@
+import asyncio
+import datetime
 import re
+
+from tornado import web
 
 from imbi.endpoints import base
 
 
-class CollectionRequestHandler(base.CollectionRequestHandler):
+class CollectionRequestHandler(base.PaginatedRequestMixin,
+                               base.ValidatingRequestHandler):
 
     NAME = 'project-activity-feed'
-    ID = 'project_id'
-    COLLECTION_SQL = re.sub(
-        r'\s+', ' ', """\
+
+    PROJECT_FEED_SQL = re.sub(
+        r'\s+', ' ', """
         WITH created AS (
-                SELECT created_at AS "when",
-                       created_by AS who,
-                       'created' AS what,
-                       NULL AS fact_name,
-                       NULL AS value
-                  FROM v1.projects
-                 WHERE id = %(project_id)s),
-             updated AS (
-                SELECT last_modified_at AS "when",
-                       last_modified_by AS who,
-                       'updated' AS what,
-                       NULL AS fact_name,
-                       NULL AS value
-                  FROM v1.projects
-                 WHERE id = %(project_id)s),
-             facts AS (
-                SELECT a.recorded_at AS "when",
-                       a.recorded_by AS who,
-                       'updated fact' AS what,
-                       b.name AS fact_name,
-                       a.value
-                  FROM v1.project_facts AS a
-                  JOIN v1.project_fact_types AS b
-                    ON b.id = a.fact_type_id
-                 WHERE a.project_id = %(project_id)s),
-            combined AS (
-                SELECT *
-                  FROM created
-                 UNION
-                SELECT *
-                  FROM updated
-                 UNION
-                SELECT *
-                  FROM facts)
-        SELECT a.when,
-               a.who,
-               b.display_name,
-               a.what,
-               a.fact_name,
-               a.value,
-               'ProjectFeedEntry' as "type"
-          FROM combined AS a
-          JOIN v1.users AS b
-            ON b.username = a.who
-         ORDER BY a.when DESC;""")
+          SELECT created_at AS "when", created_by AS who,
+                 'created' AS what, NULL AS fact_name, NULL AS value
+            FROM v1.projects
+           WHERE id = %(project_id)s
+        ),
+        updated AS (
+          SELECT last_modified_at AS "when", last_modified_by AS who,
+                 'updated' AS what, NULL AS fact_name, NULL AS value
+            FROM v1.projects
+           WHERE id = %(project_id)s
+        ),
+        facts AS (
+          SELECT a.recorded_at AS "when", a.recorded_by AS who,
+                 'updated fact' AS what, b.name AS fact_name, a.value
+            FROM v1.project_facts AS a
+            JOIN v1.project_fact_types AS b
+              ON b.id = a.fact_type_id
+           WHERE a.project_id = %(project_id)s
+        ),
+        combined AS (
+                SELECT * FROM created
+          UNION SELECT * FROM updated
+          UNION SELECT * FROM facts
+        )
+        SELECT 'ProjectFeedEntry' AS "type", c."when", c.who, u.display_name,
+               c.what, c.fact_name, c.value
+          FROM combined AS c
+          JOIN v1.users AS u ON u.username = c.who
+         WHERE c."when" BETWEEN %(earlier)s AND %(later)s
+         ORDER BY c."when" DESC
+         LIMIT %(remaining)s
+        """)
+
+    OPERATIONS_LOG_SQL = re.sub(
+        r'\s+', ' ', """\
+        SELECT 'OperationsLogEntry' AS "type", o.id,
+               o.recorded_at, o.recorded_by, o.completed_at,
+               o.project_id, o.environment, o.change_type,
+               o.description, o.link, o.notes, o.ticket_slug,
+               o.version, p.name AS project_name,
+               u.email_address
+          FROM v1.operations_log AS o
+          LEFT JOIN v1.projects AS p ON p.id = o.project_id
+          LEFT JOIN v1.users AS u ON u.username = o.recorded_by
+         WHERE recorded_at BETWEEN %(earlier)s AND %(later)s
+         ORDER BY o.recorded_at DESC, o.id DESC
+         LIMIT %(remaining)s
+        """)
+
+    EARLIEST_EVENT_SQL = re.sub(
+        r'\s+', ' ', """\
+        WITH T AS (
+          SELECT created_at AS earliest
+            FROM v1.projects
+           WHERE id = %(project_id)s
+          UNION
+          SELECT MIN(recorded_at) AS earliest
+            FROM v1.operations_log
+           WHERE project_id = %(project_id)s
+        )
+        SELECT MIN(earliest) AS earliest
+          FROM T
+        """)
+
+    @web.authenticated
+    async def get(self, project_id: str) -> None:
+        token = await self._get_pagination_token(project_id)
+        buckets = await self.fetch_items(token,
+                                         self._retrieve_rows,
+                                         datetime.timedelta(days=90),
+                                         project_id=project_id)
+        self.send_response(buckets)
+
+    async def _retrieve_rows(
+            self, params: dict) -> list[tuple[datetime.datetime, dict]]:
+        activity_feed, ops_log = await asyncio.gather(
+            self.postgres_execute(self.PROJECT_FEED_SQL, params),
+            self.postgres_execute(self.OPERATIONS_LOG_SQL, params))
+        self.logger.debug('fetched page containing %s activity, %s ops log',
+                          len(activity_feed), len(ops_log))
+
+        all_rows = [(row['when'], row) for row in activity_feed]
+        all_rows.extend((row['recorded_at'], row) for row in ops_log)
+
+        return all_rows
+
+    async def _get_pagination_token(self, project_id) -> base.PaginationToken:
+        token = self.get_pagination_token_from_request()
+        if token is None:
+            result = await self.postgres_execute(self.EARLIEST_EVENT_SQL,
+                                                 {'project_id': project_id})
+            token = base.PaginationToken(
+                start=datetime.datetime.now(datetime.timezone.utc),
+                limit=int(self.get_query_argument('limit', '25')),
+                earliest=result.row['earliest'],
+            )
+        return token

--- a/imbi/endpoints/project_activity_feed.py
+++ b/imbi/endpoints/project_activity_feed.py
@@ -58,9 +58,10 @@ class CollectionRequestHandler(base.PaginatedRequestMixin,
                o.version, p.name AS project_name, u.email_address,
                u.display_name
           FROM v1.operations_log AS o
-          LEFT JOIN v1.projects AS p ON p.id = o.project_id
+          JOIN v1.projects AS p ON p.id = o.project_id
           LEFT JOIN v1.users AS u ON u.username = o.recorded_by
-         WHERE recorded_at >  %(earlier)s
+         WHERE p.id = %(project_id)s
+           AND recorded_at >  %(earlier)s
            AND recorded_at <= %(later)s
          ORDER BY o.recorded_at DESC, o.id DESC
          LIMIT %(remaining)s

--- a/imbi/endpoints/project_activity_feed.py
+++ b/imbi/endpoints/project_activity_feed.py
@@ -43,7 +43,8 @@ class CollectionRequestHandler(base.PaginatedRequestMixin,
                c.what, c.fact_name, c.value
           FROM combined AS c
           JOIN v1.users AS u ON u.username = c.who
-         WHERE c."when" BETWEEN %(earlier)s AND %(later)s
+         WHERE c."when" >  %(earlier)s
+           AND c."when" <= %(later)s
          ORDER BY c."when" DESC
          LIMIT %(remaining)s
         """)
@@ -59,7 +60,8 @@ class CollectionRequestHandler(base.PaginatedRequestMixin,
           FROM v1.operations_log AS o
           LEFT JOIN v1.projects AS p ON p.id = o.project_id
           LEFT JOIN v1.users AS u ON u.username = o.recorded_by
-         WHERE recorded_at BETWEEN %(earlier)s AND %(later)s
+         WHERE recorded_at >  %(earlier)s
+           AND recorded_at <= %(later)s
          ORDER BY o.recorded_at DESC, o.id DESC
          LIMIT %(remaining)s
         """)
@@ -75,7 +77,7 @@ class CollectionRequestHandler(base.PaginatedRequestMixin,
             FROM v1.operations_log
            WHERE project_id = %(project_id)s
         )
-        SELECT MIN(earliest) AS earliest
+        SELECT COALESCE(MIN(earliest), CURRENT_TIMESTAMP) AS earliest
           FROM T
         """)
 

--- a/imbi/templates/openapi.yaml
+++ b/imbi/templates/openapi.yaml
@@ -39,11 +39,11 @@ paths:
           description: Limit the number of records returned
           schema:
             type: number
-        - name: offset
+        - name: token
           in: query
-          description: The starting offset for the records returned
+          description: Opaque pagination token
           schema:
-            type: number
+            type: string
       responses:
         '200':
           description: Success
@@ -52,49 +52,52 @@ paths:
               schema:
                 type: array
                 items:
-                  type: object
-                  description: Feed Item Entry
-                  properties:
-                    type:
-                      description: Describes the format of this entry
-                      type: string
-                      enum:
-                        - ProjectFeedEntry
-                    when:
-                      description: The timestamp of the entry
-                      type: string
-                      format: iso8601-timestamp
-                    namespace_id:
-                      description: The namespace ID
-                      type: number
-                    namespace:
-                      description: The namespace of the project
-                      type: string
-                    project_id:
-                      description: The project ID
-                      type: number
-                    project_name:
-                      description: The project name
-                      type: string
-                    project_type:
-                      description: The project type
-                      type: string
-                    who:
-                      description: The username of the user who acted on the project
-                      type: string
-                    display_name:
-                      description: The display name of the user who acted on the project
-                      type: string
-                    email_address:
-                      description: The email address of the user who acted on the project
-                      type: string
-                    what:
-                      description: The action taken by the user
-                      type: string
-                      enum:
-                        - created
-                        - updated
-                        - updated facts
+                  oneOf:
+                    - type: object
+                      title: Project-related change
+                      properties:
+                        type:
+                          description: Describes the format of this entry
+                          type: string
+                          enum:
+                            - ProjectFeedEntry
+                        display_name:
+                          description: The display name of the user who acted on the project
+                          type: string
+                        email_address:
+                          description: The email address of the user who acted on the project
+                          type: string
+                          format: email
+                        namespace:
+                          description: The namespace of the project
+                          type: string
+                        namespace_id:
+                          description: The namespace ID
+                          type: integer
+                        project_id:
+                          description: The project ID
+                          type: integer
+                        project_name:
+                          description: The project name
+                          type: string
+                        project_type:
+                          description: The project type
+                          type: string
+                        what:
+                          description: The action taken by the user
+                          type: string
+                          enum:
+                            - created
+                            - updated
+                            - updated facts
+                        when:
+                          description: The timestamp of the entry
+                          type: string
+                          format: date-time
+                        who:
+                          description: The username of the user who acted on the project
+                          type: string
+                    - $ref: '#/paths/~1operations-log/get/responses/200/content/application~1json/schema/items'
               examples:
                 records:
                   summary: IMBI project changes
@@ -110,17 +113,21 @@ paths:
                       display_name: Gavin M. Roy
                       email_address: gmr@imbi.co
                       what: updated facts
-                    - when: 2021-05-21T20:41:06.423Z
-                      type: ProjectFeedEntry
-                      namespace: Example
-                      namespace_id: 1
+                    - id: 1
+                      when: 2021-05-21T20:41:06.423Z
+                      recorded_by: gavinr
+                      email_address: gavinr@example.com
+                      type: OperationsLogEntry
+                      completed_at: null
                       project_id: 1
                       project_name: Imbi
-                      project_type: Web Application
-                      who: gmr
-                      display_name: Gavin M. Roy
-                      email_address: gmr@imbi.co
-                      what: updated
+                      environment: Testing
+                      change_type: Deployment
+                      description: Added the Operations Log functionality
+                      link: 'https://github.com/aweber/imbi/releases/tag/0.13.0'
+                      notes: null
+                      ticket_slug: JIRA-32768
+                      version: 0.13.0
                     - when: 2021-05-20T20:30:21.987Z
                       type: ProjectFeedEntry
                       namespace: Example
@@ -136,49 +143,52 @@ paths:
               schema:
                 type: array
                 items:
-                  type: object
-                  description: Feed Item Entry
-                  properties:
-                    type:
-                      description: Describes the format of this entry
-                      type: string
-                      enum:
-                        - ProjectFeedEntry
-                    when:
-                      description: The timestamp of the entry
-                      type: string
-                      format: iso8601-timestamp
-                    namespace_id:
-                      description: The namespace ID
-                      type: number
-                    namespace:
-                      description: The namespace of the project
-                      type: string
-                    project_id:
-                      description: The project ID
-                      type: number
-                    project_name:
-                      description: The project name
-                      type: string
-                    project_type:
-                      description: The project type
-                      type: string
-                    who:
-                      description: The username of the user who acted on the project
-                      type: string
-                    display_name:
-                      description: The display name of the user who acted on the project
-                      type: string
-                    email_address:
-                      description: The email address of the user who acted on the project
-                      type: string
-                    what:
-                      description: The action taken by the user
-                      type: string
-                      enum:
-                        - created
-                        - updated
-                        - updated facts
+                  oneOf:
+                    - type: object
+                      title: Project-related change
+                      properties:
+                        type:
+                          description: Describes the format of this entry
+                          type: string
+                          enum:
+                            - ProjectFeedEntry
+                        display_name:
+                          description: The display name of the user who acted on the project
+                          type: string
+                        email_address:
+                          description: The email address of the user who acted on the project
+                          type: string
+                          format: email
+                        namespace:
+                          description: The namespace of the project
+                          type: string
+                        namespace_id:
+                          description: The namespace ID
+                          type: integer
+                        project_id:
+                          description: The project ID
+                          type: integer
+                        project_name:
+                          description: The project name
+                          type: string
+                        project_type:
+                          description: The project type
+                          type: string
+                        what:
+                          description: The action taken by the user
+                          type: string
+                          enum:
+                            - created
+                            - updated
+                            - updated facts
+                        when:
+                          description: The timestamp of the entry
+                          type: string
+                          format: date-time
+                        who:
+                          description: The username of the user who acted on the project
+                          type: string
+                    - $ref: '#/paths/~1operations-log/get/responses/200/content/application~1json/schema/items'
               examples:
                 records:
                   summary: IMBI project changes
@@ -194,17 +204,21 @@ paths:
                       display_name: Gavin M. Roy
                       email_address: gmr@imbi.co
                       what: updated facts
-                    - when: 2021-05-21T20:41:06.423Z
-                      type: ProjectFeedEntry
-                      namespace: Example
-                      namespace_id: 1
+                    - id: 1
+                      when: 2021-05-21T20:41:06.423Z
+                      recorded_by: gavinr
+                      email_address: gavinr@example.com
+                      type: OperationsLogEntry
+                      completed_at: null
                       project_id: 1
                       project_name: Imbi
-                      project_type: Web Application
-                      who: gmr
-                      display_name: Gavin M. Roy
-                      email_address: gmr@imbi.co
-                      what: updated
+                      environment: Testing
+                      change_type: Deployment
+                      description: Added the Operations Log functionality
+                      link: 'https://github.com/aweber/imbi/releases/tag/0.13.0'
+                      notes: null
+                      ticket_slug: JIRA-32768
+                      version: 0.13.0
                     - when: 2021-05-20T20:30:21.987Z
                       type: ProjectFeedEntry
                       namespace: Example
@@ -216,6 +230,21 @@ paths:
                       display_name: Gavin M. Roy
                       email_address: gmr@imbi.co
                       what: created
+          headers:
+            Link:
+              description: |
+                Links to related resources, in the format defined by
+                [RFC 5988](https://tools.ietf.org/html/rfc5988#section-5).  The following
+                link relation types are used in this API.
+
+                | "rel" value | Description                                      |
+                |:-----------:| -----------                                      |
+                | first       | link to the first page in a collection           |
+                | next        | link to the next page in the collection          |
+                | self        | the canonical URL for the resource if one exists |
+              schema:
+                type: string
+              style: simple
         '401':
           $ref: '#/paths/~1groups/get/responses/401'
   /authentication-tokens:
@@ -519,7 +548,7 @@ paths:
             Last-Modified:
               $ref: '#/paths/~1groups/post/responses/200/headers/Last-Modified'
             Link:
-              $ref: '#/paths/~1projects~1%7Bid%7D~1notes/get/responses/200/headers/Link'
+              $ref: '#/paths/~1activity-feed/get/responses/200/headers/Link'
           content:
             application/json:
               schema:
@@ -705,7 +734,7 @@ paths:
             Last-Modified:
               $ref: '#/paths/~1groups/post/responses/200/headers/Last-Modified'
             Link:
-              $ref: '#/paths/~1projects~1%7Bid%7D~1notes/get/responses/200/headers/Link'
+              $ref: '#/paths/~1activity-feed/get/responses/200/headers/Link'
           content:
             application/json:
               schema:
@@ -1045,7 +1074,7 @@ paths:
               schema:
                 type: string
             Link:
-              $ref: '#/paths/~1projects~1%7Bid%7D~1notes/get/responses/200/headers/Link'
+              $ref: '#/paths/~1activity-feed/get/responses/200/headers/Link'
           content:
             application/json:
               schema:
@@ -1547,7 +1576,7 @@ paths:
             Last-Modified:
               $ref: '#/paths/~1groups/post/responses/200/headers/Last-Modified'
             Link:
-              $ref: '#/paths/~1projects~1%7Bid%7D~1notes/get/responses/200/headers/Link'
+              $ref: '#/paths/~1activity-feed/get/responses/200/headers/Link'
           content:
             application/json:
               schema:
@@ -1713,6 +1742,12 @@ paths:
                   name:
                     type: string
   '/integrations/{name}':
+    parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
     get:
       description: Retrieve a specific integration by name
       summary: Fetch a single integration
@@ -1855,15 +1890,24 @@ paths:
                       type: string
                       format: iso8601-timestamp
                     recorded_by:
-                      description: The user who recorded the change
+                      description: The name of the user who recorded the change
+                      type: string
+                    email_address:
+                      description: The email address of the user who recorded the change
                       type: string
                     completed_at:
                       description: 'If specified, indicates the change occurred over a span of time'
                       type: string
                       format: iso8601-timestamp
+                      nullable: true
                     project_id:
                       description: The ID of the project that was changed
                       type: number
+                      nullable: true
+                    project_name:
+                      description: The name of the project that was changed
+                      type: string
+                      nullable: true
                     environment:
                       description: The environment that the change occurred in
                       type: string
@@ -1888,19 +1932,24 @@ paths:
                     description:
                       description: The single line description of the change
                       type: string
+                      nullable: true
                     link:
                       description: An optional link for additional context to the link
                       type: string
+                      nullable: true
                     notes:
                       description: Optional notes for the change in markdown format
                       type: string
+                      nullable: true
                     ticket_slug:
                       description: An optional slug of the ticket that the change was made for
                       type: string
                       pattern: '^[\w-]+$'
+                      nullable: true
                     version:
                       description: An optional version that the change was made for
                       type: string
+                      nullable: true
                   additionalProperties: false
               examples:
                 records:
@@ -1961,15 +2010,24 @@ paths:
                       type: string
                       format: iso8601-timestamp
                     recorded_by:
-                      description: The user who recorded the change
+                      description: The name of the user who recorded the change
+                      type: string
+                    email_address:
+                      description: The email address of the user who recorded the change
                       type: string
                     completed_at:
                       description: 'If specified, indicates the change occurred over a span of time'
                       type: string
                       format: iso8601-timestamp
+                      nullable: true
                     project_id:
                       description: The ID of the project that was changed
                       type: number
+                      nullable: true
+                    project_name:
+                      description: The name of the project that was changed
+                      type: string
+                      nullable: true
                     environment:
                       description: The environment that the change occurred in
                       type: string
@@ -1994,19 +2052,24 @@ paths:
                     description:
                       description: The single line description of the change
                       type: string
+                      nullable: true
                     link:
                       description: An optional link for additional context to the link
                       type: string
+                      nullable: true
                     notes:
                       description: Optional notes for the change in markdown format
                       type: string
+                      nullable: true
                     ticket_slug:
                       description: An optional slug of the ticket that the change was made for
                       type: string
                       pattern: '^[\w-]+$'
+                      nullable: true
                     version:
                       description: An optional version that the change was made for
                       type: string
+                      nullable: true
                   additionalProperties: false
               examples:
                 records:
@@ -2163,7 +2226,7 @@ paths:
           description: 'The request to create, update, or update the operations-log entry was successful'
           headers:
             Link:
-              $ref: '#/paths/~1projects~1%7Bid%7D~1notes/get/responses/200/headers/Link'
+              $ref: '#/paths/~1activity-feed/get/responses/200/headers/Link'
           content:
             application/json:
               schema:
@@ -2610,7 +2673,7 @@ paths:
             Last-Modified:
               $ref: '#/paths/~1groups/post/responses/200/headers/Last-Modified'
             Link:
-              $ref: '#/paths/~1projects~1%7Bid%7D~1notes/get/responses/200/headers/Link'
+              $ref: '#/paths/~1activity-feed/get/responses/200/headers/Link'
           content:
             application/json:
               schema:
@@ -2905,7 +2968,7 @@ paths:
             Last-Modified:
               $ref: '#/paths/~1groups/post/responses/200/headers/Last-Modified'
             Link:
-              $ref: '#/paths/~1projects~1%7Bid%7D~1notes/get/responses/200/headers/Link'
+              $ref: '#/paths/~1activity-feed/get/responses/200/headers/Link'
           content:
             application/json:
               schema:
@@ -3182,7 +3245,7 @@ paths:
             Last-Modified:
               $ref: '#/paths/~1groups/post/responses/200/headers/Last-Modified'
             Link:
-              $ref: '#/paths/~1projects~1%7Bid%7D~1notes/get/responses/200/headers/Link'
+              $ref: '#/paths/~1activity-feed/get/responses/200/headers/Link'
           content:
             application/json:
               schema:
@@ -3401,7 +3464,7 @@ paths:
             Last-Modified:
               $ref: '#/paths/~1groups/post/responses/200/headers/Last-Modified'
             Link:
-              $ref: '#/paths/~1projects~1%7Bid%7D~1notes/get/responses/200/headers/Link'
+              $ref: '#/paths/~1activity-feed/get/responses/200/headers/Link'
           content:
             application/json:
               schema:
@@ -3688,7 +3751,7 @@ paths:
             Last-Modified:
               $ref: '#/paths/~1groups/post/responses/200/headers/Last-Modified'
             Link:
-              $ref: '#/paths/~1projects~1%7Bid%7D~1notes/get/responses/200/headers/Link'
+              $ref: '#/paths/~1activity-feed/get/responses/200/headers/Link'
           content:
             application/json:
               schema:
@@ -4103,7 +4166,7 @@ paths:
             Last-Modified:
               $ref: '#/paths/~1groups/post/responses/200/headers/Last-Modified'
             Link:
-              $ref: '#/paths/~1projects~1%7Bid%7D~1notes/get/responses/200/headers/Link'
+              $ref: '#/paths/~1activity-feed/get/responses/200/headers/Link'
           content:
             application/json:
               schema:
@@ -4919,6 +4982,17 @@ paths:
           required: true
           schema:
             type: number
+        - name: limit
+          in: query
+          description: Limit the number of records returned
+          schema:
+            type: number
+            default: 25
+        - name: token
+          in: query
+          description: Opaque pagination token
+          schema:
+            type: string
       responses:
         '200':
           description: Success
@@ -4927,37 +5001,9 @@ paths:
               schema:
                 type: array
                 items:
-                  type: object
-                  description: Feed Item Entry
-                  properties:
-                    type:
-                      description: Describes the format of this entry
-                      type: string
-                      enum:
-                        - ProjectFeedEntry
-                    when:
-                      description: The timestamp of the entry
-                      type: string
-                      format: iso8601-timestamp
-                    who:
-                      description: The username of the user who acted on the project
-                      type: string
-                    display_name:
-                      description: The display name of the user who acted on the project
-                      type: string
-                    what:
-                      description: The action taken by the user
-                      type: string
-                      enum:
-                        - created
-                        - updated
-                        - updated fact
-                    fact_type:
-                      description: 'If the action was `updated fact`, the fact that was updated'
-                      type: string
-                    value:
-                      description: 'If the action was `updated fact`, the value of the updated fact'
-                      type: string
+                  oneOf:
+                    - $ref: '#/paths/~1activity-feed/get/responses/200/content/application~1json/schema/items/oneOf/0'
+                    - $ref: '#/paths/~1operations-log/get/responses/200/content/application~1json/schema/items'
               examples:
                 records:
                   summary: Feed entries
@@ -4969,6 +5015,20 @@ paths:
                       what: updated fact
                       fact_name: Programming Language
                       value: ES2015+
+                    - id: 1
+                      when: 2021-03-18T03:00:01.520Z
+                      recorded_by: gavinr
+                      email_address: gavinr@example.com
+                      type: OperationsLogEntry
+                      completed_at: null
+                      project_id: 1
+                      project_name: Imbi UI
+                      environment: Testing
+                      change_type: Deployment
+                      description: Added the Operations Log functionality
+                      notes: null
+                      ticket_slug: null
+                      version: 0.0.0
                     - when: 2021-03-18T02:55:50.865Z
                       type: ProjectFeedEntry
                       who: Gavin Roy
@@ -4980,37 +5040,9 @@ paths:
               schema:
                 type: array
                 items:
-                  type: object
-                  description: Feed Item Entry
-                  properties:
-                    type:
-                      description: Describes the format of this entry
-                      type: string
-                      enum:
-                        - ProjectFeedEntry
-                    when:
-                      description: The timestamp of the entry
-                      type: string
-                      format: iso8601-timestamp
-                    who:
-                      description: The username of the user who acted on the project
-                      type: string
-                    display_name:
-                      description: The display name of the user who acted on the project
-                      type: string
-                    what:
-                      description: The action taken by the user
-                      type: string
-                      enum:
-                        - created
-                        - updated
-                        - updated fact
-                    fact_type:
-                      description: 'If the action was `updated fact`, the fact that was updated'
-                      type: string
-                    value:
-                      description: 'If the action was `updated fact`, the value of the updated fact'
-                      type: string
+                  oneOf:
+                    - $ref: '#/paths/~1activity-feed/get/responses/200/content/application~1json/schema/items/oneOf/0'
+                    - $ref: '#/paths/~1operations-log/get/responses/200/content/application~1json/schema/items'
               examples:
                 records:
                   summary: Feed entries
@@ -5022,6 +5054,20 @@ paths:
                       what: updated fact
                       fact_name: Programming Language
                       value: ES2015+
+                    - id: 1
+                      when: 2021-03-18T03:00:01.520Z
+                      recorded_by: gavinr
+                      email_address: gavinr@example.com
+                      type: OperationsLogEntry
+                      completed_at: null
+                      project_id: 1
+                      project_name: Imbi UI
+                      environment: Testing
+                      change_type: Deployment
+                      description: Added the Operations Log functionality
+                      notes: null
+                      ticket_slug: null
+                      version: 0.0.0
                     - when: 2021-03-18T02:55:50.865Z
                       type: ProjectFeedEntry
                       who: Gavin Roy
@@ -5029,6 +5075,9 @@ paths:
                       what: created
                       fact_name: null
                       value: null
+          headers:
+            Link:
+              $ref: '#/paths/~1activity-feed/get/responses/200/headers/Link'
         '401':
           $ref: '#/paths/~1groups/get/responses/401'
   '/projects/{id}/links':
@@ -5199,7 +5248,7 @@ paths:
             Last-Modified:
               $ref: '#/paths/~1groups/post/responses/200/headers/Last-Modified'
             Link:
-              $ref: '#/paths/~1projects~1%7Bid%7D~1notes/get/responses/200/headers/Link'
+              $ref: '#/paths/~1activity-feed/get/responses/200/headers/Link'
           content:
             application/json:
               schema:
@@ -5343,18 +5392,7 @@ paths:
                   updated_by: null
           headers:
             Link:
-              description: |
-                Links to related resources, in the format defined by
-                [RFC 5988](https://tools.ietf.org/html/rfc5988#section-5).  The following
-                link relation types are used in this API.
-
-                | "rel" value | Description                                      |
-                |:-----------:| -----------                                      |
-                | canonical   | the canonical URL for the resource if one exists |
-                | first       | link to the first page in a collection           |
-                | next        | link to the next page in the collection          |
-              schema:
-                type: string
+              $ref: '#/paths/~1activity-feed/get/responses/200/headers/Link'
     post:
       summary: Create Record
       description: Create a new note for a project
@@ -5612,7 +5650,7 @@ paths:
             Last-Modified:
               $ref: '#/paths/~1groups/post/responses/200/headers/Last-Modified'
             Link:
-              $ref: '#/paths/~1projects~1%7Bid%7D~1notes/get/responses/200/headers/Link'
+              $ref: '#/paths/~1activity-feed/get/responses/200/headers/Link'
           content:
             application/json:
               schema:
@@ -5983,7 +6021,7 @@ paths:
             Last-Modified:
               $ref: '#/paths/~1groups/post/responses/200/headers/Last-Modified'
             Link:
-              $ref: '#/paths/~1projects~1%7Bid%7D~1notes/get/responses/200/headers/Link'
+              $ref: '#/paths/~1activity-feed/get/responses/200/headers/Link'
           content:
             application/json:
               schema:

--- a/imbi/templates/openapi.yaml
+++ b/imbi/templates/openapi.yaml
@@ -39,6 +39,12 @@ paths:
           description: Limit the number of records returned
           schema:
             type: number
+        - name: omit_user
+          in: query
+          description: Username to omit from the activity feed
+          schema:
+            type: string
+          explode: true
         - name: token
           in: query
           description: Opaque pagination token
@@ -1939,7 +1945,7 @@ paths:
                       type: string
                       nullable: true
                     link:
-                      description: An optional link for additional context to the link
+                      description: An optional link for additional context to the entry
                       type: string
                       nullable: true
                     notes:
@@ -2068,7 +2074,7 @@ paths:
                       type: string
                       nullable: true
                     link:
-                      description: An optional link for additional context to the link
+                      description: An optional link for additional context to the entry
                       type: string
                       nullable: true
                     notes:
@@ -2185,7 +2191,7 @@ paths:
                   type: string
                   nullable: true
                 link:
-                  description: An optional link for additional context to the link
+                  description: An optional link for additional context to the entry
                   type: string
                   nullable: true
                 notes:

--- a/imbi/templates/openapi.yaml
+++ b/imbi/templates/openapi.yaml
@@ -117,6 +117,7 @@ paths:
                       when: 2021-05-21T20:41:06.423Z
                       recorded_by: gavinr
                       email_address: gavinr@example.com
+                      display_name: Gavin M. Roy
                       type: OperationsLogEntry
                       completed_at: null
                       project_id: 1
@@ -208,6 +209,7 @@ paths:
                       when: 2021-05-21T20:41:06.423Z
                       recorded_by: gavinr
                       email_address: gavinr@example.com
+                      display_name: Gavin M. Roy
                       type: OperationsLogEntry
                       completed_at: null
                       project_id: 1
@@ -1895,6 +1897,9 @@ paths:
                     email_address:
                       description: The email address of the user who recorded the change
                       type: string
+                    display_name:
+                      description: Name of the user that recorded the change
+                      type: string
                     completed_at:
                       description: 'If specified, indicates the change occurred over a span of time'
                       type: string
@@ -1959,6 +1964,8 @@ paths:
                       recorded_at: 2021-05-21T18:39:24.197Z
                       recorded_by: gavinr
                       type: OperationsLogEntry
+                      display_name: Gavin M. Roy
+                      email_address: gavinr@example.com
                       completed_at: null
                       project_id: 100
                       environment: Testing
@@ -1972,6 +1979,8 @@ paths:
                       recorded_at: 2021-05-21T18:42:00.000Z
                       recorded_by: gavinr
                       type: OperationsLogEntry
+                      display_name: Gavin M. Roy
+                      email_address: gavinr@example.com
                       completed_at: null
                       project_id: 100
                       environment: Staging
@@ -1985,6 +1994,8 @@ paths:
                       recorded_at: 2021-05-21T19:00:00.000Z
                       recorded_by: gavinr
                       type: OperationsLogEntry
+                      display_name: Gavin M. Roy
+                      email_address: gavinr@example.com
                       completed_at: null
                       project_id: 100
                       environment: Staging
@@ -2015,6 +2026,9 @@ paths:
                     email_address:
                       description: The email address of the user who recorded the change
                       type: string
+                    display_name:
+                      description: Name of the user that recorded the change
+                      type: string
                     completed_at:
                       description: 'If specified, indicates the change occurred over a span of time'
                       type: string
@@ -2079,6 +2093,8 @@ paths:
                       recorded_at: 2021-05-21T18:39:24.197Z
                       recorded_by: gavinr
                       type: OperationsLogEntry
+                      display_name: Gavin M. Roy
+                      email_address: gavinr@example.com
                       completed_at: null
                       project_id: 100
                       environment: Testing
@@ -2092,6 +2108,8 @@ paths:
                       recorded_at: 2021-05-21T18:42:00.000Z
                       recorded_by: gavinr
                       type: OperationsLogEntry
+                      display_name: Gavin M. Roy
+                      email_address: gavinr@example.com
                       completed_at: null
                       project_id: 100
                       environment: Staging
@@ -2105,6 +2123,8 @@ paths:
                       recorded_at: 2021-05-21T19:00:00.000Z
                       recorded_by: gavinr
                       type: OperationsLogEntry
+                      display_name: Gavin M. Roy
+                      email_address: gavinr@example.com
                       completed_at: null
                       project_id: 100
                       environment: Staging
@@ -2239,6 +2259,8 @@ paths:
                     recorded_at: 2021-05-21T18:39:24.197Z
                     recorded_by: gavinr
                     type: OperationsLogEntry
+                    display_name: Gavin M. Roy
+                    email_address: gavinr@example.com
                     completed_at: null
                     project_id: 100
                     environment: Testing
@@ -2259,6 +2281,8 @@ paths:
                     recorded_at: 2021-05-21T18:39:24.197Z
                     recorded_by: gavinr
                     type: OperationsLogEntry
+                    display_name: Gavin M. Roy
+                    email_address: gavinr@example.com
                     completed_at: null
                     project_id: 100
                     environment: Testing
@@ -5010,16 +5034,17 @@ paths:
                   value:
                     - when: 2021-03-18T03:02:00.912Z
                       type: ProjectFeedEntry
-                      who: Gavin Roy
-                      username: gavinr
+                      display_name: Gavin Roy
+                      who: gavinr
                       what: updated fact
                       fact_name: Programming Language
                       value: ES2015+
                     - id: 1
-                      when: 2021-03-18T03:00:01.520Z
+                      recorded_at: 2021-03-18T03:00:01.520Z
                       recorded_by: gavinr
                       email_address: gavinr@example.com
                       type: OperationsLogEntry
+                      display_name: Gavin M Roy
                       completed_at: null
                       project_id: 1
                       project_name: Imbi UI
@@ -5031,8 +5056,8 @@ paths:
                       version: 0.0.0
                     - when: 2021-03-18T02:55:50.865Z
                       type: ProjectFeedEntry
-                      who: Gavin Roy
-                      username: gavinr
+                      display_name: Gavin Roy
+                      who: gavinr
                       what: created
                       fact_name: null
                       value: null
@@ -5049,16 +5074,17 @@ paths:
                   value:
                     - when: 2021-03-18T03:02:00.912Z
                       type: ProjectFeedEntry
-                      who: Gavin Roy
-                      username: gavinr
+                      display_name: Gavin Roy
+                      who: gavinr
                       what: updated fact
                       fact_name: Programming Language
                       value: ES2015+
                     - id: 1
-                      when: 2021-03-18T03:00:01.520Z
+                      recorded_at: 2021-03-18T03:00:01.520Z
                       recorded_by: gavinr
                       email_address: gavinr@example.com
                       type: OperationsLogEntry
+                      display_name: Gavin M Roy
                       completed_at: null
                       project_id: 1
                       project_name: Imbi UI
@@ -5070,8 +5096,8 @@ paths:
                       version: 0.0.0
                     - when: 2021-03-18T02:55:50.865Z
                       type: ProjectFeedEntry
-                      who: Gavin Roy
-                      username: gavinr
+                      display_name: Gavin Roy
+                      who: gavinr
                       what: created
                       fact_name: null
                       value: null

--- a/tests/endpoints/test_activity_feed.py
+++ b/tests/endpoints/test_activity_feed.py
@@ -1,0 +1,107 @@
+import datetime
+import json
+
+import ietfparse.headers
+
+from tests import base
+
+
+class AsyncHTTPTestCase(base.TestCaseWithReset):
+
+    ADMIN_ACCESS = True
+    TRUNCATE_TABLES = [
+        'v1.operations_log',
+        'v1.projects',
+        'v1.project_fact_types',
+        'v1.project_types',
+        'v1.namespaces',
+        'v1.environments',
+    ]
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.environments = self.create_environments()
+        self.namespace = self.create_namespace()
+        self.project_type = self.create_project_type()
+        self.project_fact_type = self.create_project_fact_type(
+            data_type='string', fact_type='free-form')
+        self.project = self.create_project()
+
+    def test_empty_collection(self):
+        # deleting the project removes it from the activity feed
+        self.fetch(f'/projects/{self.project["id"]}', method='DELETE')
+
+        result = self.fetch('/activity-feed')
+        self.assertEqual(result.code, 200)
+        self.assertEqual(result.body, json.dumps([]).encode())
+        for link in ietfparse.headers.parse_link(result.headers['Link']):
+            self.assertNotEqual(dict(link.parameters)['rel'], 'next')
+
+    def test_project_only_feed(self):
+        result = self.fetch(f'/projects/{self.project["id"]}/facts',
+                            method='POST',
+                            json_body=[{
+                                'fact_type_id': self.project_fact_type['id'],
+                                'value': 'foo'
+                            }])
+        self.assertEqual(result.code, 204)
+
+        result = self.fetch('/activity-feed')
+        self.assertEqual(result.code, 200)
+        for link in ietfparse.headers.parse_link(result.headers['Link']):
+            self.assertNotEqual(dict(link.parameters)['rel'], 'next')
+
+        body = json.loads(result.body.decode('utf-8'))
+        self.assertEqual(len(body), 2)
+        self.assertEqual([entry['what'] for entry in body],
+                         ['updated facts', 'created'])
+        self.assertGreater(
+            datetime.datetime.fromisoformat(body[0]['when']),
+            datetime.datetime.fromisoformat(body[1]['when']),
+        )
+
+    def test_pagination(self):
+        def now() -> str:
+            return datetime.datetime.now(datetime.timezone.utc).isoformat()
+
+        notes = []
+        for index in range(10):
+            notes.append(str(index))
+            result = self.fetch(
+                '/operations-log',
+                method='POST',
+                json_body={
+                    'change_type': 'Deployed',
+                    'environment': self.environments[0],
+                    'recorded_by': self.USERNAME[self.ADMIN_ACCESS],
+                    'recorded_at': now(),
+                    'notes': notes[-1],
+                },
+            )
+            self.assertEqual(result.code, 200)
+        notes.reverse()
+
+        remaining = len(notes) + 1  # includes project created entry
+        url = '/activity-feed?limit=3'
+        while url is not None:
+            result = self.fetch(url)
+            self.assertEqual(result.code, 200)
+
+            url = None
+            for link in ietfparse.headers.parse_link(result.headers['Link']):
+                params = dict(link.parameters)
+                if params['rel'] == 'next':
+                    url = link.target
+                    break
+
+            body = json.loads(result.body.decode('utf-8'))
+            self.assertEqual(len(body), min(3, remaining))
+            received_notes = [
+                entry['notes'] for entry in body
+                if entry['type'] == 'OperationsLogEntry'
+            ]
+            self.assertEqual(notes[:len(received_notes)], received_notes)
+            notes = notes[len(received_notes):]
+            remaining -= len(body)
+
+        self.assertEqual(notes, [])

--- a/tests/endpoints/test_project_activity_feed.py
+++ b/tests/endpoints/test_project_activity_feed.py
@@ -6,6 +6,10 @@ import ietfparse.headers
 from tests import base
 
 
+def now() -> str:
+    return datetime.datetime.now(datetime.timezone.utc).isoformat()
+
+
 class AsyncHTTPTestCase(base.TestCaseWithReset):
 
     ADMIN_ACCESS = True
@@ -27,7 +31,7 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
             data_type='string', fact_type='free-form')
         self.project = self.create_project()
 
-    def test_project_only_feed(self):
+    def update_project_fact(self) -> None:
         result = self.fetch(f'/projects/{self.project["id"]}/facts',
                             method='POST',
                             json_body=[{
@@ -35,6 +39,22 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
                                 'value': 'foo'
                             }])
         self.assertEqual(result.code, 204)
+
+    def add_operation_log_entry(self, **overrides) -> None:
+        body = {
+            'change_type': 'Deployed',
+            'environment': self.environments[0],
+            'project_id': self.project['id'],
+            'recorded_by': self.USERNAME[self.ADMIN_ACCESS],
+            'recorded_at': now(),
+            'notes': '',
+        }
+        body.update(overrides)
+        result = self.fetch('/operations-log', method='POST', json_body=body)
+        self.assertEqual(result.code, 200)
+
+    def test_project_only_feed(self):
+        self.update_project_fact()
 
         result = self.fetch(f'/projects/{self.project["id"]}/feed')
         self.assertEqual(result.code, 200)
@@ -51,25 +71,10 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
         )
 
     def test_pagination(self):
-        def now() -> str:
-            return datetime.datetime.now(datetime.timezone.utc).isoformat()
-
         notes = []
         for index in range(10):
             notes.append(str(index))
-            result = self.fetch(
-                '/operations-log',
-                method='POST',
-                json_body={
-                    'change_type': 'Deployed',
-                    'environment': self.environments[0],
-                    'project_id': self.project['id'],
-                    'recorded_by': self.USERNAME[self.ADMIN_ACCESS],
-                    'recorded_at': now(),
-                    'notes': notes[-1],
-                },
-            )
-            self.assertEqual(result.code, 200)
+            self.add_operation_log_entry(notes=notes[-1])
         notes.reverse()
 
         remaining = len(notes) + 1  # includes project created entry
@@ -96,3 +101,24 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
             remaining -= len(body)
 
         self.assertEqual(notes, [])
+
+    def test_mixed_activity_feed(self):
+        for index in range(10):
+            if index % 2 == 0:
+                self.add_operation_log_entry()
+            else:
+                self.add_operation_log_entry(project_id=None)
+
+        result = self.fetch(f'/projects/{self.project["id"]}/facts',
+                            method='POST',
+                            json_body=[{
+                                'fact_type_id': self.project_fact_type['id'],
+                                'value': 'foo'
+                            }])
+        self.assertEqual(result.code, 204)
+
+        result = self.fetch(f'/projects/{self.project["id"]}/feed?limit=20')
+        self.assertEqual(result.code, 200)
+        body = json.loads(result.body.decode('utf-8'))
+        # project created, 5 operation logs, and project updated
+        self.assertEqual(len(body), 1 + 5 + 1)

--- a/tests/endpoints/test_project_activity_feed.py
+++ b/tests/endpoints/test_project_activity_feed.py
@@ -1,0 +1,98 @@
+import datetime
+import json
+
+import ietfparse.headers
+
+from tests import base
+
+
+class AsyncHTTPTestCase(base.TestCaseWithReset):
+
+    ADMIN_ACCESS = True
+    TRUNCATE_TABLES = [
+        'v1.operations_log',
+        'v1.projects',
+        'v1.project_fact_types',
+        'v1.project_types',
+        'v1.namespaces',
+        'v1.environments',
+    ]
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.environments = self.create_environments()
+        self.namespace = self.create_namespace()
+        self.project_type = self.create_project_type()
+        self.project_fact_type = self.create_project_fact_type(
+            data_type='string', fact_type='free-form')
+        self.project = self.create_project()
+
+    def test_project_only_feed(self):
+        result = self.fetch(f'/projects/{self.project["id"]}/facts',
+                            method='POST',
+                            json_body=[{
+                                'fact_type_id': self.project_fact_type['id'],
+                                'value': 'foo'
+                            }])
+        self.assertEqual(result.code, 204)
+
+        result = self.fetch(f'/projects/{self.project["id"]}/feed')
+        self.assertEqual(result.code, 200)
+        for link in ietfparse.headers.parse_link(result.headers['Link']):
+            self.assertNotEqual(dict(link.parameters)['rel'], 'next')
+
+        body = json.loads(result.body.decode('utf-8'))
+        self.assertEqual(len(body), 2)
+        self.assertEqual([entry['what'] for entry in body],
+                         ['updated fact', 'created'])
+        self.assertGreater(
+            datetime.datetime.fromisoformat(body[0]['when']),
+            datetime.datetime.fromisoformat(body[1]['when']),
+        )
+
+    def test_pagination(self):
+        def now() -> str:
+            return datetime.datetime.now(datetime.timezone.utc).isoformat()
+
+        notes = []
+        for index in range(10):
+            notes.append(str(index))
+            result = self.fetch(
+                '/operations-log',
+                method='POST',
+                json_body={
+                    'change_type': 'Deployed',
+                    'environment': self.environments[0],
+                    'project_id': self.project['id'],
+                    'recorded_by': self.USERNAME[self.ADMIN_ACCESS],
+                    'recorded_at': now(),
+                    'notes': notes[-1],
+                },
+            )
+            self.assertEqual(result.code, 200)
+        notes.reverse()
+
+        remaining = len(notes) + 1  # includes project created entry
+        url = f'/projects/{self.project["id"]}/feed?limit=3'
+        while url is not None:
+            result = self.fetch(url)
+            self.assertEqual(result.code, 200)
+
+            url = None
+            for link in ietfparse.headers.parse_link(result.headers['Link']):
+                params = dict(link.parameters)
+                if params['rel'] == 'next':
+                    url = link.target
+                    break
+
+            body = json.loads(result.body.decode('utf-8'))
+            self.assertEqual(len(body), min(3, remaining))
+            received_notes = [
+                entry['notes'] for entry in body
+                if entry['type'] == 'OperationsLogEntry'
+            ]
+            self.assertEqual(notes[:len(received_notes)], received_notes)
+            notes = notes[len(received_notes):]
+            remaining -= len(body)
+
+        self.assertEqual(notes, [])


### PR DESCRIPTION
This PR adds the ops-log entries into both the dashboard activity feed and the project specific activity feed.  I changed the pagination to use token-based pagination instead of limit and offset since we are combining multiple feeds now.  Most of the implementation is in a new `PaginationMixin` in `endpoints.base`.  The commits seem a little backwards because they did not follow the actual implementation path.  I implemented the functionality inline in each handler before pulling it up into a base class and creating the usage contract after the fact.  Once you grok what is going on in the first commit (368c59c6d0144a9bbb1e4d23924c3debf9f09c08), move on to the other implementation commits (1693c11a2409e1f469dfdf2f5f65ed857dd6bb1e and 1693c11a2409e1f469dfdf2f5f65ed857dd6bb1e) and things should generally make a lot more sense.

There are quite a few comments & docstrings that explain things in 368c59c6d0144a9bbb1e4d23924c3debf9f09c08 as well.