### PR TITLE
Create Consul KV access tokens when creating a project

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -81,7 +81,7 @@ export OPENSEARCH_HOST=${TEST_HOST}
 export OPENSEARCH_PORT=$(get_exposed_port opensearch 9200)
 export SESSION_REDIS_URL=redis://${TEST_HOST}:$(get_exposed_port redis 6379)/0
 export STATS_REDIS_URL=redis://${TEST_HOST}:$(get_exposed_port redis 6379)/1
-export POSTGRES_URL=postgres://postgres@${TEST_HOST}:$(get_exposed_port postgres 5432)/postgres
+export POSTGRES_URL=postgresql://postgres@${TEST_HOST}:$(get_exposed_port postgres 5432)/postgres
 EOF
 
 cat > build/debug.yaml <<EOF
@@ -93,7 +93,7 @@ automations:
       "Development":
         datacenter: "development"
         token: "$imbi_token"
-        url: "http:${TEST_HOST}:$(get_exposed_port consul 8500)"
+        url: "http://${TEST_HOST}:$(get_exposed_port consul 8500)"
     templates:
       key_value_path: "/{namespace.slug}/{project_type.slug}/{project.slug}"
       service_url: "http://{project.slug}.services.{environment.datacenter}.consul"
@@ -140,7 +140,7 @@ opensearch:
     use_ssl: false
   redis_url: redis://${TEST_HOST}:$(get_exposed_port redis 6379)/2
 postgres:
-  url: postgres://postgres@${TEST_HOST}:$(get_exposed_port postgres 5432)/postgres
+  url: postgresql://postgres@${TEST_HOST}:$(get_exposed_port postgres 5432)/postgres
 project_url_template: http://{slug}.service.{environment}.consul
 ops_log_ticket_slug_template: "https://github.com/AWeber-Imbi/Imbi/issues/{slug}"
 session:
@@ -197,7 +197,7 @@ opensearch:
     use_ssl: false
   redis_url: redis://${TEST_HOST}:$(get_exposed_port redis 6379)/2
 postgres:
-  url: postgres://postgres@${TEST_HOST}:$(get_exposed_port postgres 5432)/postgres
+  url: postgresql://postgres@${TEST_HOST}:$(get_exposed_port postgres 5432)/postgres
 project_url_template: ~
 session:
   redis_url: redis://${TEST_HOST}:$(get_exposed_port redis 6379)/0

--- a/bootstrap
+++ b/bootstrap
@@ -47,20 +47,27 @@ wait_for_healthy_containers() {
   report_done
 }
 
-mkdir -p build ddl/build imbi/static/css imbi/static/fonts imbi/static/js
+mkdir -p build/consul-data ddl/build imbi/static/css imbi/static/fonts imbi/static/js
 
 # Stop any running instances and clean up after them, then pull images
 docker-compose down --volumes --remove-orphans
 printf "Pulling and starting containers ... "
 docker-compose pull -q
-docker-compose up -d ldap opensearch postgres redis
+docker-compose up -d consul ldap opensearch postgres redis
 report_done
 
 wait_for_healthy_containers 4
 
 docker-compose exec -T postgres psql -U postgres -d postgres -f /tmp/postgres/dml.sql -q
 
+docker-compose exec -T consul consul acl bootstrap >build/consul-bootstrap-data
+consul_token=`awk '/^SecretID:/{print $2}' build/consul-bootstrap-data`
+docker-compose exec -T consul consul acl policy create -token=$consul_token -name 'Imbi-Administration' -rules 'acl = "write"' >build/consul-policy-data
+docker-compose exec -T consul consul acl token create -policy-name=Imbi-Administration -token=$consul_token -local >build/consul-imbi-token
+imbi_token=`awk '/^SecretID:/{print $2}' build/consul-imbi-token`
+
 cat > .env <<EOF
+export CONSUL_HTTP_TOKEN=$imbi_token
 export ENVIRONMENT=development
 export LDAP_ENABLED=true
 export LDAP_HOST=${TEST_HOST}
@@ -80,6 +87,16 @@ EOF
 cat > build/debug.yaml <<EOF
 ---
 automations:
+  consul:
+    enabled_for: []
+    environments:
+      "Development":
+        datacenter: "development"
+        token: "$imbi_token"
+        url: "http:${TEST_HOST}:$(get_exposed_port consul 8500)"
+    templates:
+      key_value_path: "/{namespace.slug}/{project_type.slug}/{project.slug}"
+      service_url: "http://{project.slug}.services.{environment.datacenter}.consul"
   gitlab:
     project_link_type_id: ~
     restrict_to_user: true

--- a/bootstrap
+++ b/bootstrap
@@ -178,6 +178,13 @@ EOF
 
 cat > build/test.yaml <<EOF
 ---
+automations:
+  consul:
+    environment:
+      "Development":
+        datacenter: "development"
+        token: "$imbi_token"
+        url: "http://${TEST_HOST}:$(get_exposed_port consul 8500)"
 http:
   canonical_server_name: imbi.example.org
 ldap:
@@ -219,5 +226,10 @@ logging:
   disable_existing_loggers: true
   incremental: false
 EOF
+
+if test -n "$CI"
+then
+  sed -i "s/00000000-0000-0000-0000-000000000000/$imbi_token/" ci/config.yaml
+fi
 
 printf "\nBootstrap complete\n\n"

--- a/ci/config.yaml
+++ b/ci/config.yaml
@@ -1,4 +1,14 @@
 # Prebuilt configuration file for use INSIDE of the docker compose environment
+automations:
+  consul:
+    environments:
+      "Development":
+        datacenter: "development"
+        token: "00000000-0000-0000-0000-000000000000"
+        url: "http://consul:8500"
+    templates:
+      key_value_path: "/{namespace.slug}/{project_type.slug}/{project.slug}"
+      service_url: "http://{project.slug}.services.{environment.datacenter}.consul"
 http:
   canonical_server_name: imbi
   cookie_secret: imbi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,16 @@
 version: "3.7"
 services:
+  consul:
+    image: consul:1.10.2
+    ports:
+      - 8500
+    volumes:
+      - type: bind
+        source: ./scaffolding/consul
+        target: /consul/config
+      - type: bind
+        source: ./build/consul-data
+        target: /consul/data
   ldap:
     image: osixia/openldap:1.4.0
     environment:

--- a/imbi/automations/consul.py
+++ b/imbi/automations/consul.py
@@ -1,0 +1,259 @@
+from __future__ import annotations
+
+import dataclasses
+import logging
+import re
+
+import jsonpath_ng
+import sprockets.mixins.http
+import yarl
+
+from imbi import errors, version
+from imbi.automations import base
+
+
+def expand_template(source: str, context: dict) -> str:
+    """Expands JSON path expressions within a string template
+
+    >>> context = {'project': {'slug': 'foo'}, 'environment': 'staging'}
+    >>> expand_template(
+    ...     'https://{project.slug}.services.{environment}.consul', context)
+    >>> 'https://foo.services.staging.consul'
+
+    The template is scanned for expressions bracketed by ``{`` and ``}``.
+    Each expression is matched as a JSON path expression against the
+    supplied context and the result is inserted into the output.
+
+    """
+    result = []
+    last_pos = 0
+    for expr in re.finditer(r'{([^}]+)}', source):
+        first, last = expr.span(0)
+        if last_pos < first:
+            result.append(source[last_pos:first])
+            last_pos = last
+        matches = jsonpath_ng.parse(expr.group(1)).find(context)
+        if len(matches) == 1:
+            result.append(matches[0].value)
+    rest = source[last_pos:]
+    if rest:
+        result.append(rest)
+    return ''.join(result)
+
+
+class ConsulClient(sprockets.mixins.http.HTTPClientMixin):
+    # TODO: move this into imbi.clients
+    def __init__(self, env_config: dict) -> None:
+        super().__init__()
+        self.logger = logging.getLogger(__package__).getChild('ConsulClient')
+
+        self.api_url = yarl.URL(env_config['url']) / 'v1'
+        self.datacenter = env_config['datacenter']
+        self.headers = {
+            'Authorization': f'Bearer {env_config["token"]}',
+            'Content-Type': 'application/json',
+        }
+
+    async def create_token(self, project, templates) -> tuple[str, str]:
+        self.logger.info('creating tokens for project %s in %s', project.id,
+                         self.datacenter)
+        project_dict = dataclasses.asdict(project)
+        context = {
+            'environment': {
+                'datacenter': self.datacenter
+            },
+            'namespace': project_dict['namespace'],
+            'project': project_dict,
+            'project_type': project_dict['project_type'],
+        }
+
+        kv_path = expand_template(templates['key_value_path'], context)
+        kv_path = kv_path.strip('/') + '/'
+        rule = f'key_prefix "{kv_path}" {{ policy = "read" }}'
+        response = await self.api(
+            '/acl/policy',
+            method='PUT',
+            body={
+                'Name': '-'.join([
+                    'imbi', 'generated', project.namespace.slug, project.slug
+                ]),
+                'Description': f'Access policy for {project.slug}',
+                'Rules': rule,
+                'Datacenters': [self.datacenter],
+            })
+        policy_id = response.body['ID']
+
+        try:
+            response = await self.api(
+                '/acl/token',
+                method='PUT',
+                body={
+                    'Description': f'Token for {project.slug}',
+                    'Policies': [{
+                        'ID': policy_id
+                    }],
+                    'Local': True,
+                })
+            return response.body['AccessorID'], response.body['SecretID']
+        except Exception as error:
+            self.logger.error('failed to create token: %s', error)
+            await self.api(self.api_url / 'acl' / 'policy' / policy_id,
+                           method='DELETE',
+                           raise_error=False)
+            raise error
+
+    async def delete_token(self, accessor_id) -> None:
+        response = await self.api(self.api_url / 'acl' / 'token' / accessor_id,
+                                  method='GET',
+                                  raise_error=False)
+        if response.ok:
+            for policy in response.body.get('Policies', []):
+                self.logger.info('removing policy %r during rollback',
+                                 policy['ID'])
+                await self.api(self.api_url / 'acl' / 'policy' / policy['ID'],
+                               method='DELETE',
+                               raise_error=False)
+            self.logger.info('removing token %r during rollback', accessor_id)
+            await self.api(self.api_url / 'acl' / 'token' / accessor_id,
+                           method='DELETE',
+                           raise_error=False)
+
+    async def api(self,
+                  path: str | yarl.URL,
+                  *,
+                  method: str,
+                  raise_error=True,
+                  **kwargs):
+        if isinstance(path, yarl.URL):
+            url = path
+        else:
+            url = self.api_url / path.lstrip('/')
+
+        request_headers = self.headers.copy()
+        request_headers.update(kwargs.pop('request_headers', {}))
+        response = await super().http_fetch(
+            str(url),
+            method=method,
+            request_headers=request_headers,
+            user_agent=f'imbi/{version} (ConsulClient)',
+            dont_retry={500},
+            **kwargs)
+        if raise_error and not response.ok:
+            raise errors.InternalServerError('%s %s failed: %s',
+                                             method,
+                                             url,
+                                             response.code,
+                                             title='Consul API Failure')
+        return response
+
+
+class ConsulCreateTokenAutomation(base.Automation):
+    def __init__(self, application, project_id, current_user, db) -> None:
+        super().__init__(application, current_user, db)
+        self.imbi_project_id = project_id
+        self.project = None
+        self.settings = self.automation_settings['consul']
+        self.enabled = bool(self.settings.get('environments'))
+
+    async def prepare(self) -> list[str]:
+        if not self.enabled:
+            self.logger.warning(
+                'consul token creation disabled: no environment tokens '
+                'configured')
+            return self.errors
+
+        project = await self._get_project(self.imbi_project_id)
+        if project is None:
+            self._add_error('Project id {} does not exist',
+                            self.imbi_project_id)
+        elif project.project_type.name not in self.settings['enabled_for']:
+            self.logger.warning(
+                'disabling consul automation since project type %r not '
+                'found in %r', project.project_type.name,
+                self.settings['enabled_for'])
+            self.enabled = False
+        else:
+            self.project = project
+
+        return self.errors
+
+    async def run(self):
+        if not self.enabled:
+            return None
+        if not self.project.environments:
+            self.logger.debug('no data centers selected, nothing to do')
+            return None
+
+        templates = self.settings.get('templates', {})
+        clients: dict[str, ConsulClient] = {}
+        tokens: dict[str, tuple[str, str]] = {}
+
+        try:
+            for target_env in self.project.environments:
+                try:
+                    env_config = self.settings['environments'][target_env]
+                except KeyError:
+                    self.logger.info(
+                        'not creating tokens for environment %r since it is '
+                        'not configured', target_env)
+                else:
+                    if env_config['datacenter'] in tokens.keys():
+                        continue  # allow environments to share Consul DCs
+                    try:
+                        client = clients[env_config['datacenter']]
+                    except KeyError:
+                        client = ConsulClient(env_config)
+                        clients[env_config['datacenter']] = client
+                    accessor_id, secret_id = await client.create_token(
+                        self.project, templates)
+                    tokens[env_config['datacenter']] = (accessor_id, secret_id)
+                    await self.insert_secrets(env_config['datacenter'],
+                                              accessor_id, secret_id)
+        except Exception as error:
+            self.logger.error(
+                'failed to create consul tokens, rollback back: %s', error)
+            for datacenter, keys in tokens.items():
+                await clients[datacenter].delete_token(keys[0])
+            await self.db.execute(
+                'DELETE FROM v1.project_secrets'
+                ' WHERE project_id = %(imbi_project_id)s'
+                "   AND name LIKE 'consul_%%'", {
+                    'imbi_project_id': self.project.id,
+                })
+            raise error
+
+    async def insert_secrets(self, datacenter, accessor_id, secret_id) -> None:
+        self.logger.debug('inserting tokens for project=%s datacenter=%s',
+                          self.project.id, datacenter)
+        await self.db.execute(
+            'INSERT INTO v1.project_secrets(project_id, name, value,'
+            '                               created_by)'
+            ' VALUES (%(imbi_project_id)s, %(key_name)s,'
+            '         %(key_value)s, %(username)s)'
+            ' ON CONFLICT '
+            ' ON CONSTRAINT project_secrets_pkey '
+            ' DO UPDATE '
+            ' SET value = %(key_value)s,'
+            '     last_modified_at = CURRENT_TIMESTAMP,'
+            '     last_modified_by = %(username)s', {
+                'imbi_project_id': self.project.id,
+                'key_name': f'consul_{datacenter}_accessor',
+                'key_value': self.application.encrypt_value(accessor_id),
+                'username': self.user.username,
+            })
+        await self.db.execute(
+            'INSERT INTO v1.project_secrets(project_id, name, value,'
+            '                               created_by)'
+            ' VALUES (%(imbi_project_id)s, %(key_name)s,'
+            '         %(key_value)s, %(username)s)'
+            ' ON CONFLICT '
+            ' ON CONSTRAINT project_secrets_pkey '
+            ' DO UPDATE '
+            ' SET value = %(key_value)s,'
+            '     last_modified_at = CURRENT_TIMESTAMP,'
+            '     last_modified_by = %(username)s', {
+                'imbi_project_id': self.project.id,
+                'key_name': f'consul_{datacenter}_secret',
+                'key_value': self.application.encrypt_value(secret_id),
+                'username': self.user.username,
+            })

--- a/imbi/automations/consul.py
+++ b/imbi/automations/consul.py
@@ -1,150 +1,7 @@
 from __future__ import annotations
 
-import dataclasses
-import logging
-import re
-
-import jsonpath_ng
-import sprockets.mixins.http
-import yarl
-
-from imbi import errors, version
+import imbi.clients.consul
 from imbi.automations import base
-
-
-def expand_template(source: str, context: dict) -> str:
-    """Expands JSON path expressions within a string template
-
-    >>> context = {'project': {'slug': 'foo'}, 'environment': 'staging'}
-    >>> expand_template(
-    ...     'https://{project.slug}.services.{environment}.consul', context)
-    >>> 'https://foo.services.staging.consul'
-
-    The template is scanned for expressions bracketed by ``{`` and ``}``.
-    Each expression is matched as a JSON path expression against the
-    supplied context and the result is inserted into the output.
-
-    """
-    result = []
-    last_pos = 0
-    for expr in re.finditer(r'{([^}]+)}', source):
-        first, last = expr.span(0)
-        if last_pos < first:
-            result.append(source[last_pos:first])
-            last_pos = last
-        matches = jsonpath_ng.parse(expr.group(1)).find(context)
-        if len(matches) == 1:
-            result.append(matches[0].value)
-    rest = source[last_pos:]
-    if rest:
-        result.append(rest)
-    return ''.join(result)
-
-
-class ConsulClient(sprockets.mixins.http.HTTPClientMixin):
-    # TODO: move this into imbi.clients
-    def __init__(self, env_config: dict) -> None:
-        super().__init__()
-        self.logger = logging.getLogger(__package__).getChild('ConsulClient')
-
-        self.api_url = yarl.URL(env_config['url']) / 'v1'
-        self.datacenter = env_config['datacenter']
-        self.headers = {
-            'Authorization': f'Bearer {env_config["token"]}',
-            'Content-Type': 'application/json',
-        }
-
-    async def create_token(self, project, templates) -> tuple[str, str]:
-        self.logger.info('creating tokens for project %s in %s', project.id,
-                         self.datacenter)
-        project_dict = dataclasses.asdict(project)
-        context = {
-            'environment': {
-                'datacenter': self.datacenter
-            },
-            'namespace': project_dict['namespace'],
-            'project': project_dict,
-            'project_type': project_dict['project_type'],
-        }
-
-        kv_path = expand_template(templates['key_value_path'], context)
-        kv_path = kv_path.strip('/') + '/'
-        rule = f'key_prefix "{kv_path}" {{ policy = "read" }}'
-        response = await self.api(
-            '/acl/policy',
-            method='PUT',
-            body={
-                'Name': '-'.join([
-                    'imbi', 'generated', project.namespace.slug, project.slug
-                ]),
-                'Description': f'Access policy for {project.slug}',
-                'Rules': rule,
-                'Datacenters': [self.datacenter],
-            })
-        policy_id = response.body['ID']
-
-        try:
-            response = await self.api(
-                '/acl/token',
-                method='PUT',
-                body={
-                    'Description': f'Token for {project.slug}',
-                    'Policies': [{
-                        'ID': policy_id
-                    }],
-                    'Local': True,
-                })
-            return response.body['AccessorID'], response.body['SecretID']
-        except Exception as error:
-            self.logger.error('failed to create token: %s', error)
-            await self.api(self.api_url / 'acl' / 'policy' / policy_id,
-                           method='DELETE',
-                           raise_error=False)
-            raise error
-
-    async def delete_token(self, accessor_id) -> None:
-        response = await self.api(self.api_url / 'acl' / 'token' / accessor_id,
-                                  method='GET',
-                                  raise_error=False)
-        if response.ok:
-            for policy in response.body.get('Policies', []):
-                self.logger.info('removing policy %r during rollback',
-                                 policy['ID'])
-                await self.api(self.api_url / 'acl' / 'policy' / policy['ID'],
-                               method='DELETE',
-                               raise_error=False)
-            self.logger.info('removing token %r during rollback', accessor_id)
-            await self.api(self.api_url / 'acl' / 'token' / accessor_id,
-                           method='DELETE',
-                           raise_error=False)
-
-    async def api(self,
-                  path: str | yarl.URL,
-                  *,
-                  method: str,
-                  raise_error=True,
-                  **kwargs):
-        if isinstance(path, yarl.URL):
-            url = path
-        else:
-            url = self.api_url / path.lstrip('/')
-
-        request_headers = self.headers.copy()
-        request_headers.update(kwargs.pop('request_headers', {}))
-        response = await super().http_fetch(
-            str(url),
-            method=method,
-            request_headers=request_headers,
-            user_agent=f'imbi/{version} (ConsulClient)',
-            dont_retry={500},
-            **kwargs)
-        if raise_error and not response.ok:
-            raise errors.InternalServerError('%s %s failed: %s',
-                                             method,
-                                             url,
-                                             response.code,
-                                             title='Consul API Failure')
-        return response
 
 
 class ConsulCreateTokenAutomation(base.Automation):
@@ -185,7 +42,7 @@ class ConsulCreateTokenAutomation(base.Automation):
             return None
 
         templates = self.settings.get('templates', {})
-        clients: dict[str, ConsulClient] = {}
+        clients: dict[str, imbi.clients.consul.ConsulClient] = {}
         tokens: dict[str, tuple[str, str]] = {}
 
         try:
@@ -202,7 +59,7 @@ class ConsulCreateTokenAutomation(base.Automation):
                     try:
                         client = clients[env_config['datacenter']]
                     except KeyError:
-                        client = ConsulClient(env_config)
+                        client = imbi.clients.consul.ConsulClient(env_config)
                         clients[env_config['datacenter']] = client
                     accessor_id, secret_id = await client.create_token(
                         self.project, templates)

--- a/imbi/clients/consul.py
+++ b/imbi/clients/consul.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import dataclasses
+import logging
+import re
+
+import jsonpath_ng
+import sprockets.mixins.http
+import yarl
+
+from imbi import errors, models, version
+
+
+def expand_template(source: str, context: dict) -> str:
+    """Expands JSON path expressions within a string template
+
+    >>> context = {'project': {'slug': 'foo'}, 'environment': 'staging'}
+    >>> expand_template(
+    ...     'https://{project.slug}.services.{environment}.consul', context)
+    >>> 'https://foo.services.staging.consul'
+
+    The template is scanned for expressions bracketed by ``{`` and ``}``.
+    Each expression is matched as a JSON path expression against the
+    supplied context and the result is inserted into the output.
+
+    """
+    result = []
+    last_pos = 0
+    for expr in re.finditer(r'{([^{}]+)}', source):
+        first, last = expr.span(0)
+        if last_pos != first:
+            result.append(source[last_pos:first])
+        last_pos = last
+        matches = jsonpath_ng.parse(expr.group(1)).find(context)
+        if len(matches) == 1:
+            result.append(str(matches[0].value))
+        elif matches:
+            result.append(expr.group(0))
+    rest = source[last_pos:]
+    if rest:
+        result.append(rest)
+    return ''.join(result)
+
+
+class ConsulClient(sprockets.mixins.http.HTTPClientMixin):
+    """Consul API client
+
+    :param env_config: dictionary of configuration details for
+        the specific datacenter.  This should be a value from
+        application settings['automations']['consul']['environments']
+
+    API client that is connected to a specific datacenter.
+
+    """
+    def __init__(self, env_config: dict[str, str]) -> None:
+        super().__init__()
+        self.logger = logging.getLogger(__package__).getChild('ConsulClient')
+        try:
+            self.datacenter = env_config['datacenter']
+            token = env_config['token']
+            root_url = env_config['url']
+        except KeyError as error:
+            raise RuntimeError(
+                f'{error.args[0]} missing from consul configuration')
+        else:
+            self.api_url = yarl.URL(root_url) / 'v1'
+            self.headers = {
+                'Authorization': f'Bearer {token}',
+                'Content-Type': 'application/json',
+            }
+
+    async def create_token(self, project: models.Project,
+                           templates: dict[str, str]) -> tuple[str, str]:
+        """Create a new KV access token for `project`
+
+        This method creates a new policy that provides access to the
+        KV path and then generates an access token with the policy assigned.
+        The response is the accessor and secret IDs for the token.
+
+        """
+        self.logger.info('creating tokens for project %s in %s', project.id,
+                         self.datacenter)
+        project_dict = dataclasses.asdict(project)
+        context = {
+            'environment': {
+                'datacenter': self.datacenter,
+            },
+            'namespace': project_dict['namespace'],
+            'project': project_dict,
+            'project_type': project_dict['project_type'],
+        }
+        kv_path = expand_template(templates['key_value_path'], context)
+        kv_path = kv_path.strip('/') + '/'
+        rule = f'key_prefix "{kv_path}" {{ policy = "read" }}'
+        response = await self.api(
+            '/acl/policy',
+            method='PUT',
+            body={
+                'Name': '-'.join([
+                    'imbi', 'generated', project.namespace.slug, project.slug
+                ]),
+                'Description': f'Access policy for {project.slug}',
+                'Rules': rule,
+                'Datacenters': [self.datacenter],
+            })
+        policy_id = response.body['ID']
+
+        try:
+            response = await self.api(
+                '/acl/token',
+                method='PUT',
+                body={
+                    'Description': f'Token for {project.slug}',
+                    'Policies': [{
+                        'ID': policy_id
+                    }],
+                    'Local': True,
+                })
+            return response.body['AccessorID'], response.body['SecretID']
+
+        except Exception as error:
+            self.logger.error('failed to create token: %s', error)
+            await self.api(self.api_url / 'acl' / 'policy' / policy_id,
+                           method='DELETE',
+                           raise_error=False)
+            raise error
+
+    async def delete_token(self, accessor_id: str) -> None:
+        """Delete a consul token and related policies."""
+        url = self.api_url / 'acl'
+        response = await self.api(url / 'token' / accessor_id,
+                                  method='GET',
+                                  raise_error=False)
+        if response.ok:
+            for policy in response.body.get('Policies') or []:
+                await self.api(url / 'policy' / policy['ID'],
+                               method='DELETE',
+                               raise_error=False)
+            await self.api(url / 'token' / accessor_id,
+                           method='DELETE',
+                           raise_error=False)
+
+    async def api(self,
+                  path: str | yarl.URL,
+                  *,
+                  method: str,
+                  raise_error=True,
+                  **kwargs) -> sprockets.mixins.http.HTTPResponse:
+        """Send an authenticated Consul API request"""
+        if not isinstance(path, yarl.URL):
+            url = self.api_url / path.lstrip('/')
+        else:
+            url = path
+
+        request_headers = self.headers.copy()
+        request_headers.update(kwargs.pop('request_headers', {}))
+        response = await super().http_fetch(
+            str(url),
+            method=method,
+            request_headers=request_headers,
+            user_agent=f'imbi/{version} (ConsulClient)',
+            dont_retry={500},
+            **kwargs)
+        if raise_error and not response.ok:
+            raise errors.InternalServerError('%s %s failed: %s',
+                                             method,
+                                             url,
+                                             response.code,
+                                             title='Consul API Failure')
+        return response

--- a/imbi/endpoints/base.py
+++ b/imbi/endpoints/base.py
@@ -63,7 +63,7 @@ def require_permission(permission):
 
 class RequestHandler(cors.CORSMixin, postgres.RequestHandlerMixin,
                      mixins.ErrorLogger, problemdetails.ErrorWriter,
-                     mediatype.ContentMixin, web.RequestHandler):
+                     mediatype.content.ContentMixin, web.RequestHandler):
     """Base RequestHandler class used for recipients and subscribers."""
 
     APPLICATION_JSON = 'application/json'

--- a/imbi/endpoints/ui/automations/__init__.py
+++ b/imbi/endpoints/ui/automations/__init__.py
@@ -4,9 +4,11 @@ System Reports
 """
 from tornado import web
 
-from . import gitlab, sentry, sonarqube
+from . import consul, gitlab, sentry, sonarqube
 
 URLS = [
+    web.url(r'^/ui/automations/consul/create-token',
+            consul.CreateTokensRequestHandler),
     web.url(r'^/ui/automations/gitlab/commit',
             gitlab.InitialCommitRequestHandler),
     web.url(r'^/ui/automations/gitlab/create', gitlab.CreationRequestHandler),

--- a/imbi/endpoints/ui/automations/consul.py
+++ b/imbi/endpoints/ui/automations/consul.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from imbi.automations import consul
+from imbi.endpoints import base
+from imbi.endpoints.ui.automations import mixins
+
+
+class CreateTokensRequestHandler(mixins.PrepareFailureMixin,
+                                 base.AuthenticatedRequestHandler):
+    async def post(self):
+        request = self.get_request_body()
+        project_id = int(request['project_id'])
+        async with self.postgres_transaction() as transaction:
+            automation = consul.ConsulCreateTokenAutomation(
+                self.application, project_id, await self.get_current_user(),
+                transaction)
+            failures = await automation.prepare()
+            if failures:
+                raise self.handle_prepare_failures('Create Tokens', failures)
+            await automation.run()
+        self.set_status(204)

--- a/imbi/endpoints/ui/settings.py
+++ b/imbi/endpoints/ui/settings.py
@@ -66,8 +66,19 @@ class RequestHandler(base.RequestHandler):
             sentry['project_link_type_id'] = cfg.get('project_link_type_id')
             sentry['enabled'] = cfg['enabled']
 
+        proj_types = results[6].rows
+        consul = {'enabled': False}
+        cfg = automations.get('consul')
+        if cfg:
+            consul['enabled'] = bool(
+                len(cfg['enabled_for']) and len(cfg['environments']))
+            consul['enabled_project_types'] = [
+                t['id'] for t in proj_types if t['name'] in cfg['enabled_for']
+            ]
+
         self.send_response({
             'integrations': {
+                'consul': consul,
                 'grafana': {
                     'enabled': automations['grafana']['enabled'],
                     'project_link_type_id': automations['grafana']
@@ -92,7 +103,7 @@ class RequestHandler(base.RequestHandler):
                 'namespaces': results[3].rows,
                 'project_fact_types': results[4].rows,
                 'project_link_types': results[5].rows,
-                'project_types': results[6].rows
+                'project_types': proj_types,
             },
             'opensearch': {
                 'fields': results[7]

--- a/imbi/server.py
+++ b/imbi/server.py
@@ -150,6 +150,7 @@ def load_configuration(config: str, debug: bool) -> typing.Tuple[dict, dict]:
 
     settings = {
         'automations': {
+            'consul': automations.get('consul', {}),
             'gitlab': automations_gitlab,
             'grafana': {
                 'enabled': automations_grafana.get('enabled', False),

--- a/scaffolding/consul/config.hcl
+++ b/scaffolding/consul/config.hcl
@@ -1,0 +1,9 @@
+datacenter = "development"
+server = true
+ui_config = {
+	enabled = true
+}
+acl = {
+	enabled = true
+	enable_token_persistence = true
+}

--- a/setup.cfg
+++ b/setup.cfg
@@ -57,6 +57,7 @@ install_requires =
     isodate==0.6.0
     iso8601
     isort==5.9.2
+    jsonpath-ng==1.5.3
     ldap3>=2.5,<3
     openapi-core==0.13.4
     openapi-schema-validator==0.1.1

--- a/tests/clients/test_consul.py
+++ b/tests/clients/test_consul.py
@@ -38,7 +38,6 @@ class TemplateExpansionTests(unittest.TestCase):
             ('{string}{number}{bool}', 'value1True'),
             ('{{string}{{number}}{bool}}', '{value{1}True}'),
         ]
-        consul.expand_template('"{string}"', context)
         for template, expectation in candidates:
             self.assertEqual(consul.expand_template(template, context),
                              expectation)

--- a/tests/clients/test_consul.py
+++ b/tests/clients/test_consul.py
@@ -1,0 +1,364 @@
+from __future__ import annotations
+
+import datetime
+import http.client
+import json
+import typing
+import unittest.mock
+import uuid
+
+import yarl
+
+from imbi import errors, models
+from imbi.clients import consul
+from tests import base
+
+
+class TemplateExpansionTests(unittest.TestCase):
+    def test_string_without_template(self):
+        candidates = [
+            'string without a template', 'this {is not a template',
+            'neither is this}'
+        ]
+        for candidate in candidates:
+            self.assertEqual(consul.expand_template(candidate, {}), candidate,
+                             f'{candidate!r} was changed')
+
+    def test_simple_expansions(self):
+        context = {
+            'string': 'value',
+            'number': 1,
+            'bool': True,
+        }
+        candidates = [
+            ('{string}', 'value'),
+            ('{number}', '1'),
+            ('{bool}', 'True'),
+            ('"{string}"', '"value"'),
+            ('{string}{number}{bool}', 'value1True'),
+            ('{{string}{{number}}{bool}}', '{value{1}True}'),
+        ]
+        consul.expand_template('"{string}"', context)
+        for template, expectation in candidates:
+            self.assertEqual(consul.expand_template(template, context),
+                             expectation)
+
+    def test_dotted_expansion(self):
+        context = {'one': {'two': 3.0}}
+        self.assertEqual(consul.expand_template('{one.two}', context), '3.0')
+
+    def test_subscript_expansion(self):
+        context = {'one': [0, 1, 'three']}
+        self.assertEqual(consul.expand_template('{one[2]}', context), 'three')
+
+    def test_missing_keys(self):
+        context = {'a': 1}
+        self.assertEqual(consul.expand_template('{b}', context), '')
+
+    def test_ambiguous_expansion(self):
+        context = {'a': [1, 2, 3]}
+        self.assertEqual(consul.expand_template('{a[*]}', context), '{a[*]}')
+
+
+class ConfigurationTests(unittest.TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.env_config = {
+            'datacenter': 'development',
+            'token': '123456',
+            'url': 'https://example.com',
+        }
+
+    def test_creating_consul_with_missing_configuration(self):
+        for key in self.env_config:
+            cloned = self.env_config.copy()
+            cloned.pop(key)
+            with self.assertRaises(RuntimeError):
+                consul.ConsulClient(cloned)
+
+    def test_that_headers_are_configured(self):
+        client = consul.ConsulClient(self.env_config)
+        self.assertEqual(client.headers['Authorization'],
+                         f'Bearer {self.env_config["token"]}')
+
+    def test_that_v1_is_added_to_path(self):
+        client = consul.ConsulClient(self.env_config)
+        self.assertEqual(client.api_url.path, '/v1')
+
+
+class ConsulConnection:
+    def __init__(self, api_url: yarl.URL, token: str) -> None:
+        self.headers = {'Authorization': f'Bearer {token}'}
+        if api_url.scheme == 'http':
+            self.conn = http.client.HTTPConnection(api_url.host, api_url.port)
+        elif api_url.scheme == 'https':
+            self.conn = http.client.HTTPSConnection(api_url.host, api_url.port)
+        else:
+            raise RuntimeError('Unsupported consul connection')
+
+    def close(self) -> None:
+        self.conn.close()
+
+    @staticmethod
+    def _build_url(path: tuple[str, ...]) -> str:
+        if len(path) == 1:
+            url = yarl.URL(f'/v1/{path[0].lstrip("/")}', encoded=True)
+        else:
+            url = yarl.URL('/v1')
+            for c in path:
+                url /= c
+        return str(url)
+
+    def get(
+        self,
+        *path: str,
+        secret=None,
+        return_response=False
+    ) -> dict[str, typing.Any] | http.client.HTTPResponse:
+        if secret:
+            headers = {'X-Consul-Token': secret}
+        else:
+            headers = self.headers
+        resource = self._build_url(path)
+        self.conn.request('GET', resource, headers=headers)
+        rsp = self.conn.getresponse()
+        if return_response:
+            rsp.read()  # required by connection protocol
+            return rsp
+        if rsp.getcode() != 200:
+            raise AssertionError(f'Consul GET {resource} failed: {rsp.read()}')
+        return json.load(rsp)
+
+    def put(self, path: str, body: dict[str,
+                                        typing.Any]) -> dict[str, typing.Any]:
+        headers = self.headers.copy()
+        headers['Content-Type'] = 'application/json'
+        resource = f'/v1/{path.lstrip("/")}'
+        self.conn.request('PUT',
+                          resource,
+                          body=json.dumps(body).encode('utf-8'),
+                          headers=headers)
+        rsp = self.conn.getresponse()
+        if rsp.getcode() != 200:
+            raise AssertionError(f'Consul PUT {resource} failed: {rsp.read()}')
+        return json.load(rsp)
+
+    def delete(self, *path: str) -> None:
+        self.conn.request('DELETE',
+                          self._build_url(path),
+                          headers=self.headers)
+        self.conn.getresponse().read()  # reqd by the connection protocol
+
+
+class TokenCreationTests(unittest.IsolatedAsyncioTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.config = base.read_config()['automations']['consul']
+        self.env_config = self.config['environments']['Development']
+        self.client = consul.ConsulClient(self.env_config)
+
+        self.created_secrets: set[str] = set()
+        self.consul_conn = ConsulConnection(self.client.api_url,
+                                            self.env_config['token'])
+        self.addCleanup(self.cleanup)
+
+        now = datetime.datetime.now(datetime.timezone.utc)
+        namespace = models.Namespace(
+            id=1,
+            created_at=now,
+            created_by='me',
+            last_modified_at='',
+            last_modified_by=None,
+            name='Dev tools',
+            slug='dev',
+            icon_class='icon',
+            maintained_by=[],
+            gitlab_group_name='',
+            sentry_team_slug=None,
+        )
+        project_type = models.ProjectType(
+            id=1,
+            created_at=now,
+            created_by='me',
+            last_modified_at=None,
+            last_modified_by=None,
+            name='Stuff',
+            slug='stuff',
+            plural_name='Stuff',
+            description=None,
+            icon_class=None,
+            environment_urls=False,
+            gitlab_project_prefix=None,
+        )
+        self.project_name = str(uuid.uuid4())
+        self.project = models.Project(
+            id=1,
+            created_at=now,
+            created_by='me',
+            last_modified_at=None,
+            last_modified_by=None,
+            namespace=namespace,
+            project_type=project_type,
+            name=self.project_name,
+            slug=self.project_name.replace('-', ''),
+            description=None,
+            environments=[],
+            archived=False,
+            gitlab_project_id=None,
+            sentry_project_slug=None,
+            sonarqube_project_key=None,
+            pagerduty_service_id=None,
+            facts={},
+            links={},
+            urls={},
+            project_score=0,
+        )
+
+    def cleanup(self) -> None:
+        for secret in self.created_secrets:
+            token_info = self.consul_conn.get('/acl/token/self', secret=secret)
+            for policy in token_info['Policies'] or []:  # could be null
+                self.consul_conn.delete('acl', 'policy', policy['ID'])
+            self.consul_conn.delete('acl', 'token', token_info['AccessorID'])
+        self.consul_conn.close()
+
+    async def test_token_creation(self):
+        accessor, secret = await self.client.create_token(
+            self.project, self.config['templates'])
+        self.created_secrets.add(secret)
+
+        token_info = self.consul_conn.get('/acl/token/self', secret=secret)
+        self.assertTrue(token_info['Local'])
+        self.assertEqual(len(token_info['Policies']), 1)
+
+        policy_info = self.consul_conn.get('acl', 'policy',
+                                           token_info['Policies'][0]['ID'])
+        self.assertEqual(policy_info['Datacenters'],
+                         [self.env_config['datacenter']])
+        self.assertEqual(
+            policy_info['Rules'],
+            'key_prefix "%s/" { policy = "read" }' % '/'.join([
+                self.project.namespace.slug, self.project.project_type.slug,
+                self.project.slug
+            ]))
+
+    async def test_policy_creation_failure(self):
+        self.client.api_url = self.client.api_url.with_path('/' +
+                                                            str(uuid.uuid4()))
+        with self.assertRaises(errors.InternalServerError):
+            await self.client.create_token(self.project,
+                                           self.config['templates'])
+
+    async def test_token_creation_failure(self):
+        state = {}
+        real_api_method = self.client.api
+
+        async def wrapped(path, *, method, raise_error=True, **kwargs):
+            if path == '/acl/token':
+                raise errors.InternalServerError('injected failure')
+            else:
+                response = await real_api_method(path,
+                                                 method=method,
+                                                 raise_error=raise_error,
+                                                 **kwargs)
+                if path == '/acl/policy':
+                    state['policy_id'] = response.body['ID']
+            return response
+
+        mocked = unittest.mock.AsyncMock(wraps=wrapped)
+        with unittest.mock.patch.object(self.client, 'api', new=mocked):
+            with self.assertRaises(errors.InternalServerError):
+                await self.client.create_token(self.project,
+                                               self.config['templates'])
+
+        mocked.assert_has_awaits([
+            # creates the policy
+            unittest.mock.call('/acl/policy',
+                               method='PUT',
+                               body=unittest.mock.ANY),
+            # tries to create the token
+            unittest.mock.call('/acl/token',
+                               method='PUT',
+                               body=unittest.mock.ANY),
+            # removes the created policy
+            unittest.mock.call(self.client.api_url / 'acl' / 'policy' /
+                               state['policy_id'],
+                               method='DELETE',
+                               raise_error=False)
+        ])
+
+
+class TokenDeletionTests(unittest.IsolatedAsyncioTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.config = base.read_config()['automations']['consul']
+        self.env_config = self.config['environments']['Development']
+        self.client = consul.ConsulClient(self.env_config)
+        self.consul_conn = ConsulConnection(self.client.api_url,
+                                            self.env_config['token'])
+        self.policy, self.token = None, None
+        self.addCleanup(self.cleanup)
+
+        self.policy = self.consul_conn.put(
+            '/acl/policy', {
+                'Name': str(uuid.uuid4()),
+                'Rules': 'key_prefix "/" { policy = "read" }',
+                'Datacenters': [self.env_config['datacenter']],
+            })
+
+        self.token = self.consul_conn.put('/acl/token', {
+            'Policies': [{
+                'ID': self.policy['ID']
+            }],
+            'Local': True,
+        })
+
+    def cleanup(self) -> None:
+        if self.token:
+            self.consul_conn.delete('acl', 'token', self.token['AccessorID'])
+        if self.policy:
+            self.consul_conn.delete('acl', 'policy', self.policy['ID'])
+        self.consul_conn.close()
+
+    async def test_policy_is_deleted(self):
+        await self.client.delete_token(self.token['AccessorID'])
+        rsp = self.consul_conn.get('acl',
+                                   'policy',
+                                   self.policy['ID'],
+                                   return_response=True)
+        self.assertNotEqual(rsp.getcode(), 200)  # NB - consul returns a 403
+
+    async def test_that_all_policies_are_deleted(self):
+        token_info = self.consul_conn.get('acl', 'token',
+                                          self.token['AccessorID'])
+        another_policy = self.consul_conn.put(
+            '/acl/policy', {
+                'Name': str(uuid.uuid4()),
+                'Rules': 'key_prefix "/foo" { policy = "write" }',
+                'Datacenters': [self.env_config['datacenter']]
+            })
+        token_info['Policies'].append({
+            'ID': another_policy['ID'],
+            'Name': another_policy['Name'],
+        })
+        self.consul_conn.put(f'/acl/token/{self.token["AccessorID"]}',
+                             token_info)
+
+        await self.client.delete_token(self.token['AccessorID'])
+        rsp = self.consul_conn.get('acl',
+                                   'policy',
+                                   another_policy['ID'],
+                                   return_response=True)
+        self.assertNotEqual(rsp.getcode(), 200)  # NB - consul returns a 403
+
+    async def test_token_is_deleted(self):
+        await self.client.delete_token(self.token['AccessorID'])
+        rsp = self.consul_conn.get('acl',
+                                   'token',
+                                   self.token['AccessorID'],
+                                   return_response=True)
+        self.assertNotEqual(rsp.getcode(), 200)  # NB - consul returns a 403
+
+    async def test_that_deleting_nonexistent_token_succeeds(self):
+        await self.client.delete_token(self.token['AccessorID'])
+        await self.client.delete_token(self.token['AccessorID'])


### PR DESCRIPTION
This PR adds a new project creation automation that generates KV access tokens in a Consul cluster for the environments that are selected for the project.  There is a new configuration stanza that controls the naming of the KV paths using something akin to URL Templates.  For example:

```yaml
automations:
  consul:
    enabled_for: ["HTTP API"]
    environments:
      "Development":
        datacenter: "development"
        token: "11111111-1111-1111-1111-111111111111"
        url: "https://consul.example.com/"
      templates:
        key_value_path: "/{namespace.slug}/{project_type.slug}/{project.slug}"
```

The *enabled_for* key is an array of project types that the Consul token creation automation should be enabled for.  This is passed to the imbi-ui in the settings blob.

The *environments* key is a hash of environment name to the information needed to create the token.  The *token* needs the "acl:write" privilege to create new per-project tokens.

The *templates* key contains the templates that the automation uses for creating the ACL rule.

When the automation is run for a project, it verifies that the project type is in the *enabled_for* list, then creates a consul token for each environment that is configured for token creation that the project is deployed into -- essentially the intersection of `project.environments` and `config['automations']....['environments'].keys()`.  The token creation process involves creating a Policy that provides access to the KV path and a token that includes the policy.  The various keys are stored encrypted as project secrets in the `v1.project_secrets` table.

Once this PR is merged, the matching PR in the imbi-ui project can be merged.