### PR TITLE
Use new upsert_user postgres function

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,7 @@ services:
       - opensearch
 
   postgres:
-    image: aweber/imbi-postgres:0.16.0
+    image: aweber/imbi-postgres:0.17.0
     ports:
       - 5432
     volumes:

--- a/imbi/user.py
+++ b/imbi/user.py
@@ -99,23 +99,12 @@ class User:
 
     SQL_UPSERT_USER = re.sub(
         r'\s+', ' ', """\
-        INSERT INTO v1.users (username, user_type, external_id,
-                              display_name, email_address, last_seen_at)
-             VALUES (%(username)s,
-                     %(user_type)s,
-                     %(external_id)s,
-                     %(display_name)s,
-                     %(email_address)s,
-                     CURRENT_TIMESTAMP)
-        ON CONFLICT (username)
-                 DO UPDATE SET email_address = EXCLUDED.email_address,
-                                 external_id = EXCLUDED.external_id,
-                                   user_type = EXCLUDED.user_type,
-                                display_name = EXCLUDED.display_name,
-                                    password = NULL,
-                                last_seen_at = CURRENT_TIMESTAMP
-                        WHERE users.username = EXCLUDED.username
-          RETURNING last_seen_at""")
+        SELECT v1.upsert_user(%(username)s,
+                              %(user_type)s,
+                              %(external_id)s,
+                              %(display_name)s,
+                              %(email_address)s)
+             AS last_seen_at""")
 
     def __init__(self,
                  application,


### PR DESCRIPTION
We need to handle the case where there is a conflict on email_address, not just username, as Google users may have the same email as their LDAP counterparts, and we wish to update that user. Since we can't do two separate ON CONFLICT sections, we moved the logic into a stored proc.