### PR TITLE
Fix user dict mismatch with Redis session

### DIFF
--- a/imbi/automations/base.py
+++ b/imbi/automations/base.py
@@ -15,7 +15,7 @@ class Automation:
         self.application = application
         self.automation_settings = self.application.settings['automations']
         self.db = db
-        self.errors: typing.List[str] = []
+        self.errors: list[str] = []
         self.logger = logging.getLogger(__package__).getChild(
             self.__class__.__name__)
         self.user = current_user

--- a/imbi/automations/gitlab.py
+++ b/imbi/automations/gitlab.py
@@ -42,7 +42,7 @@ class GitLabCreateProjectAutomation(base.Automation):
         self._gitlab_parent: typing.Optional[dict] = None
         self._project: typing.Optional[models.Project] = None
 
-    async def prepare(self) -> typing.List[str]:
+    async def prepare(self) -> list[str]:
         project: models.Project
         token: oauth2.IntegrationToken
         project, token = await asyncio.gather(
@@ -130,7 +130,7 @@ class GitLabInitialCommitAutomation(base.Automation):
         self._project: typing.Optional[models.Project] = None
         self._token: typing.Optional[oauth2.IntegrationToken] = None
 
-    async def prepare(self) -> typing.List[str]:
+    async def prepare(self) -> list[str]:
         self._project = await self._get_project(self._imbi_project_id)
         self._token = await self._get_gitlab_token()
         self._cookie_cutter = await self._get_cookie_cutter(

--- a/imbi/automations/sonarqube.py
+++ b/imbi/automations/sonarqube.py
@@ -35,7 +35,7 @@ class SonarCreateProject(base.Automation):
         self._project: typing.Optional[models.Project] = None
         self._sonar_client: typing.Optional[sonarqube.SonarQubeClient] = None
 
-    async def prepare(self) -> typing.List[str]:
+    async def prepare(self) -> list[str]:
         self._project = await self._get_project(self._imbi_project_id)
         token = await self._get_gitlab_token()
         if self._project and self._project.gitlab_project_id is None:

--- a/imbi/clients/gitlab.py
+++ b/imbi/clients/gitlab.py
@@ -83,7 +83,7 @@ class GitLabClient(sprockets.mixins.http.HTTPClientMixin):
         self.logger.debug('%s %s', method, url)
         return await super().http_fetch(str(url), method=method, **kwargs)
 
-    async def fetch_all_pages(self, *path, **query) -> typing.List[dict]:
+    async def fetch_all_pages(self, *path, **query) -> list[dict]:
         url = self.token.integration.api_endpoint
         for component in path:
             url /= str(component)

--- a/imbi/clients/opensearch.py
+++ b/imbi/clients/opensearch.py
@@ -133,7 +133,7 @@ class OpenSearch:
                                    normalize(sanitize_keys(document)))
 
     async def search(self, index: str, query: str, max_results: int = 1000) \
-            -> typing.Dict[str, typing.List[dict]]:
+            -> dict[str, list[dict]]:
         result = await self.client.search(body={
             'query': {
                 'query_string': {

--- a/imbi/endpoints/integrations/google.py
+++ b/imbi/endpoints/integrations/google.py
@@ -98,8 +98,10 @@ class RedirectHandler(sprockets.mixins.http.HTTPClientMixin,
         user_email = id_info['email']
         user_name = id_info['name']
         imbi_user = imbi.user.User(self.application, username=user_email,
-                                   google_user=True)
-        await imbi_user.google_refresh(user_email, user_id, user_name)
+                                   google_user=True, external_id=user_id,
+                                   display_name=user_name,
+                                   email_address=user_email)
+        await imbi_user.refresh()
         return imbi_user
 
     async def exchange_code_for_tokens(self, code):

--- a/imbi/endpoints/metrics.py
+++ b/imbi/endpoints/metrics.py
@@ -6,7 +6,6 @@ import collections
 import logging
 import re
 import socket
-import typing
 
 from . import base
 
@@ -60,7 +59,7 @@ class RequestHandler(base.RequestHandler):
             self.write('\n')
 
         timers = await self.application.stats.durations(all_hosts, flush)
-        values: typing.Dict[str, typing.List[str]] = {}
+        values: dict[str, list[str]] = {}
         for timer in sorted(timers.keys()):
             chunk_key = self._build_output_key(timer, 'seconds').split('{')[0]
             if chunk_key not in values:

--- a/imbi/errors.py
+++ b/imbi/errors.py
@@ -41,7 +41,7 @@ class ApplicationError(problemdetails.Problem):
     """
 
     # work around some typing weirdness in problemdetails...
-    document: typing.Dict[str, typing.Any]
+    document: dict[str, typing.Any]
     log_message: str
     reason: str
 

--- a/imbi/ldap.py
+++ b/imbi/ldap.py
@@ -5,7 +5,6 @@ LDAP Client
 """
 import dataclasses
 import logging
-import typing
 from concurrent import futures
 
 import ldap3
@@ -145,7 +144,7 @@ class Client:
             for k, v in conn.response[0]['attributes'].items()
         }
 
-    def _groups(self, conn: ldap3.Connection, dn: str) -> typing.List[str]:
+    def _groups(self, conn: ldap3.Connection, dn: str) -> list[str]:
         """Return the groups for the specified username.
 
         :param conn: The connection to use

--- a/imbi/models.py
+++ b/imbi/models.py
@@ -31,7 +31,7 @@ class Namespace:
     name: str
     slug: str
     icon_class: str
-    maintained_by: typing.Optional[typing.List[str]]
+    maintained_by: typing.Optional[list[str]]
     gitlab_group_name: str
     sentry_team_slug: typing.Optional[str]
 
@@ -63,7 +63,7 @@ class ProjectFact:
     fact_type: str
     data_type: str
     description: typing.Optional[str]
-    ui_options: typing.Optional[typing.List[str]]
+    ui_options: typing.Optional[list[str]]
     score: decimal.Decimal
     weight: int
 
@@ -212,15 +212,15 @@ class Project:
     name: str
     slug: str
     description: typing.Optional[str]
-    environments: typing.Optional[typing.List[str]]
+    environments: typing.Optional[list[str]]
     archived: bool
     gitlab_project_id: typing.Optional[int]
     sentry_project_slug: typing.Optional[str]
     sonarqube_project_key: typing.Optional[str]
     pagerduty_service_id: typing.Optional[str]
-    facts: typing.Dict[str, str]
-    links: typing.Dict[str, str]
-    urls: typing.Dict[str, str]
+    facts: dict[str, str]
+    links: dict[str, str]
+    urls: dict[str, str]
     project_score: int
 
     SQL: typing.ClassVar = re.sub(
@@ -300,7 +300,7 @@ async def _load(model: dataclasses.dataclass, obj_id: int,
 async def _load_collection(model: dataclasses.dataclass,
                            obj_id: int,
                            application: 'app.Application') \
-        -> typing.List[dataclasses.dataclass]:
+        -> list[dataclasses.dataclass]:
     def on_postgres_error(_metric_name: str, exc: Exception) -> None:
         LOGGER.error('Failed to execute query for collection %s: %s', obj_id,
                      exc)
@@ -362,13 +362,13 @@ async def project(project_id: int, application: 'app.Application') -> Project:
 
 async def project_facts(project_id: int,
                         application: 'app.Application') \
-        -> typing.List[ProjectFact]:
+        -> list[ProjectFact]:
     return await _load_collection(ProjectFact, project_id, application)
 
 
 async def project_links(project_id: int,
                         application: 'app.Application') \
-        -> typing.List[ProjectLink]:
+        -> list[ProjectLink]:
     return await _load_collection(ProjectLink, project_id, application)
 
 
@@ -379,5 +379,5 @@ async def project_type(project_type_id: int,
 
 async def project_urls(project_id: int,
                        application: 'app.Application') \
-        -> typing.List[ProjectURL]:
+        -> list[ProjectURL]:
     return await _load_collection(ProjectURL, project_id, application)

--- a/imbi/oauth2.py
+++ b/imbi/oauth2.py
@@ -108,7 +108,7 @@ class OAuth2Integration:
                 })
 
     async def get_user_tokens(self, user_info: 'user.User') \
-            -> typing.List[IntegrationToken]:
+            -> list[IntegrationToken]:
         async with self._application.postgres_connector(
                 on_error=self._on_postgres_error) as conn:
             result = await conn.execute(self.SQL_GET_TOKENS, {

--- a/imbi/opensearch/operations_log.py
+++ b/imbi/opensearch/operations_log.py
@@ -77,7 +77,7 @@ class OperationsLogIndex:
             self.INDEX, str(ops_log.id), self._ops_log_to_dict(ops_log), True)
 
     async def search(self, query: str, max_results: int = 1000) \
-            -> typing.Dict[str, typing.List[dict]]:
+            -> dict[str, list[dict]]:
         return await self.application.opensearch.search(
             self.INDEX, query, max_results)
 

--- a/imbi/opensearch/project.py
+++ b/imbi/opensearch/project.py
@@ -105,11 +105,11 @@ class ProjectIndex:
             self.INDEX, str(project.id), self._project_to_dict(project))
 
     async def search(self, query: str, max_results: int = 1000) \
-            -> typing.Dict[str, typing.List[dict]]:
+            -> dict[str, list[dict]]:
         return await self.application.opensearch.search(
             self.INDEX, query, max_results)
 
-    async def searchable_fields(self) -> typing.List[typing.Dict]:
+    async def searchable_fields(self) -> list[dict]:
         fields = []
         index_mappings = await self._build_mappings()
         for key, defn in index_mappings.items():

--- a/imbi/stats.py
+++ b/imbi/stats.py
@@ -67,7 +67,7 @@ class Stats:
 
     async def counters(self,
                        all_hosts: bool = False,
-                       flush: bool = False) -> typing.Dict[str, int]:
+                       flush: bool = False) -> dict[str, int]:
         """Return a dict of counters and their values
 
         :param all_hosts: Process counters for all hosts
@@ -88,7 +88,7 @@ class Stats:
     async def durations(self,
                         all_hosts: bool = False,
                         flush: bool = False) \
-            -> typing.Dict[str, typing.List[float]]:
+            -> dict[str, list[float]]:
         """Return a dict of durations and their values
 
         :param all_hosts: Process durations for all hosts

--- a/imbi/user.py
+++ b/imbi/user.py
@@ -128,7 +128,7 @@ class User:
         self.display_name = display_name
         self._password = password
         self.token = token
-        self.connected_integrations: list[ConnectedIntegration] = []
+        self.connected_integrations: list[str] = []
         self.groups: list[str] = []
         self.permissions: list[str] = []
         self.google_user: bool = google_user

--- a/imbi/user.py
+++ b/imbi/user.py
@@ -21,7 +21,7 @@ class Group:
     """Group class to represent a single group a user is a member of"""
     __slots__ = ['name', 'permissions']
 
-    def __init__(self, name: str, permissions: typing.List[str]):
+    def __init__(self, name: str, permissions: list[str]):
         self.name = name
         self.permissions = sorted(permissions or [])
 
@@ -128,9 +128,9 @@ class User:
         self.display_name = display_name
         self._password = password
         self.token = token
-        self.connected_integrations: typing.List[ConnectedIntegration] = []
-        self.groups: typing.List[Group] = []
-        self.permissions: typing.List[str] = []
+        self.connected_integrations: list[ConnectedIntegration] = []
+        self.groups: list[Group] = []
+        self.permissions: list[str] = []
         self.google_user: bool = google_user
 
     @property
@@ -256,7 +256,7 @@ class User:
             self.last_seen_at = result.row['last_seen_at']
 
     async def fetch_integration_tokens(self, integration: str) \
-            -> typing.List[oauth2.IntegrationToken]:
+            -> list[oauth2.IntegrationToken]:
         """Retrieve access tokens for the specified integration."""
         obj = await oauth2.OAuth2Integration.by_name(self._application,
                                                      integration)
@@ -285,7 +285,7 @@ class User:
         await self._db_refresh()
         return True
 
-    async def _db_groups(self) -> typing.List[Group]:
+    async def _db_groups(self) -> list[Group]:
         """Return the groups for the user as a list of group objects"""
         async with self._application.postgres_connector(
                 on_error=self.on_postgres_error) as conn:

--- a/imbi/user.py
+++ b/imbi/user.py
@@ -230,7 +230,7 @@ class User:
         self.groups = [group.name for group in db_groups]
         self.permissions = sorted(
             set(chain.from_iterable([g.permissions for g in db_groups])))
-        self.connected_integrations = await self._refresh_integrations()
+        self.connected_integrations = await self._get_integrations()
         self.last_refreshed_at = max(timestamp.utcnow(), self.last_seen_at)
 
     @property
@@ -308,7 +308,7 @@ class User:
             self.groups = [group.name for group in db_groups]
             self.permissions = sorted(
                 set(chain.from_iterable([g.permissions for g in db_groups])))
-            self.connected_integrations = await self._refresh_integrations()
+            self.connected_integrations = await self._get_integrations()
             self.last_refreshed_at = max(
                 timestamp.utcnow(), self.last_seen_at or timestamp.utcnow())
         else:
@@ -367,10 +367,10 @@ class User:
         self.groups = [group.name for group in db_groups]
         self.permissions = sorted(
             set(chain.from_iterable([g.permissions for g in db_groups])))
-        self.connected_integrations = await self._refresh_integrations()
+        self.connected_integrations = await self._get_integrations()
         self.last_refreshed_at = max(timestamp.utcnow(), self.last_seen_at)
 
-    async def _refresh_integrations(
+    async def _get_integrations(
             self) -> typing.Sequence[ConnectedIntegration]:
         """Fetch connected integration details from the DB."""
         async with self._application.postgres_connector(

--- a/imbi/user.py
+++ b/imbi/user.py
@@ -225,8 +225,7 @@ class User:
 
         # Update the groups attribute
         await self._refresh_groups()
-        self.connected_integrations = sorted(
-            {app.name for app in await self._get_integrations()})
+        await self._refresh_integrations()
         self.last_refreshed_at = max(timestamp.utcnow(), self.last_seen_at)
 
     @property
@@ -301,8 +300,7 @@ class User:
         if result:
             self._assign_values(result.row)
             await self._refresh_groups()
-            self.connected_integrations = sorted(
-                {app.name for app in await self._get_integrations()})
+            await self._refresh_integrations()
             self.last_refreshed_at = max(
                 timestamp.utcnow(), self.last_seen_at or timestamp.utcnow())
         else:
@@ -357,8 +355,7 @@ class User:
                 (self.username, ldap_groups), 'user-maintain-groups')
 
         await self._refresh_groups()
-        self.connected_integrations = sorted(
-            {app.name for app in await self._get_integrations()})
+        await self._refresh_integrations()
         self.last_refreshed_at = max(timestamp.utcnow(), self.last_seen_at)
 
     async def _refresh_groups(self):
@@ -366,6 +363,10 @@ class User:
         self.groups = [group.name for group in db_groups]
         self.permissions = sorted(
             set(chain.from_iterable([g.permissions for g in db_groups])))
+
+    async def _refresh_integrations(self):
+        self.connected_integrations = sorted(
+            {app.name for app in await self._get_integrations()})
 
     async def _get_integrations(
             self) -> typing.Sequence[ConnectedIntegration]:

--- a/imbi/user.py
+++ b/imbi/user.py
@@ -202,7 +202,7 @@ class User:
         return cls.on_postgres_error(metric_name, exc)
 
     async def refresh(self) -> None:
-        """Update the attributes from LDAP"""
+        """Refresh the user attributes from the respective data store."""
         if self.google_user:
             await self._google_refresh()
         elif self.external_id and self._ldap.is_enabled:

--- a/imbi/user.py
+++ b/imbi/user.py
@@ -161,9 +161,7 @@ class User:
                 '' if self.password is None else self.password),
             'permissions': self.permissions,
             'last_refreshed_at': timestamp.isoformat(self.last_refreshed_at),
-            'integrations': sorted(
-                {app.name
-                 for app in self.connected_integrations}),
+            'integrations': self.connected_integrations,
             'google_user': self.google_user,
         }
 
@@ -230,7 +228,8 @@ class User:
         self.groups = [group.name for group in db_groups]
         self.permissions = sorted(
             set(chain.from_iterable([g.permissions for g in db_groups])))
-        self.connected_integrations = await self._get_integrations()
+        self.connected_integrations = sorted(
+            {app.name for app in await self._get_integrations()})
         self.last_refreshed_at = max(timestamp.utcnow(), self.last_seen_at)
 
     @property
@@ -308,7 +307,8 @@ class User:
             self.groups = [group.name for group in db_groups]
             self.permissions = sorted(
                 set(chain.from_iterable([g.permissions for g in db_groups])))
-            self.connected_integrations = await self._get_integrations()
+            self.connected_integrations = sorted(
+                {app.name for app in await self._get_integrations()})
             self.last_refreshed_at = max(
                 timestamp.utcnow(), self.last_seen_at or timestamp.utcnow())
         else:
@@ -367,7 +367,8 @@ class User:
         self.groups = [group.name for group in db_groups]
         self.permissions = sorted(
             set(chain.from_iterable([g.permissions for g in db_groups])))
-        self.connected_integrations = await self._get_integrations()
+        self.connected_integrations = sorted(
+            {app.name for app in await self._get_integrations()})
         self.last_refreshed_at = max(timestamp.utcnow(), self.last_seen_at)
 
     async def _get_integrations(

--- a/tests/base.py
+++ b/tests/base.py
@@ -133,10 +133,10 @@ class TestCaseWithReset(TestCase):
 
     def setUp(self) -> None:
         super().setUp()
-        self.environments: typing.Optional[typing.List[typing.Dict]] = None
-        self.namespace: typing.Optional[typing.Dict] = None
-        self.project_fact_type: typing.Optional[typing.Dict] = None
-        self.project_type: typing.Optional[typing.Dict] = None
+        self.environments: typing.Optional[list[dict]] = None
+        self.namespace: typing.Optional[dict] = None
+        self.project_fact_type: typing.Optional[dict] = None
+        self.project_type: typing.Optional[dict] = None
         self.headers['Private-Token'] = self.run_until_complete(
             self.get_token())
 
@@ -166,7 +166,7 @@ class TestCaseWithReset(TestCase):
         self.assertEqual(result.code, 200)
         return json.loads(result.body.decode('utf-8'))
 
-    def create_environments(self) -> typing.List[dict]:
+    def create_environments(self) -> list[dict]:
         environments = []
         for iteration in range(0, 2):
             result = self.fetch('/environments',

--- a/tests/endpoints/test_project_facts.py
+++ b/tests/endpoints/test_project_facts.py
@@ -8,7 +8,8 @@ from tests import base
 
 class ProjectFactTests(base.TestCaseWithReset):
     TRUNCATE_TABLES = [
-        'v1.project_facts', 'v1.projects', 'v1.project_fact_types'
+        'v1.project_facts', 'v1.projects', 'v1.project_fact_types',
+        'v1.project_types', 'v1.namespaces', 'v1.environments'
     ]
 
     def setUp(self) -> None:


### PR DESCRIPTION
- Makes opinionated change to reduce the complexity of the user object attributes, so that groups and integrations are just lists of strings. This matches the redis session.
- Makes the user refresh follow our existing patterns when with Google
- Refactor of typehints with `typing.List` and `typing.Dict` to just use `list` and `dict`