### PR TITLE
Add login methods enabled flag to settings

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -103,6 +103,7 @@ automations:
     allow_multiline_dictionary_keys: true
     allow_split_before_dict_value: false
 google:
+  enabled: true
   valid_domains: gmail.com
 http:
   canonical_server_name: imbi.localhost
@@ -117,6 +118,8 @@ ldap:
   users_dn: ou=users,dc=example,dc=org
   username: cn
   pool_size: 5
+local_users:
+  enabled: true
 opensearch:
   connection:
     hosts:

--- a/imbi/server.py
+++ b/imbi/server.py
@@ -119,6 +119,7 @@ def load_configuration(config: str, debug: bool) -> typing.Tuple[dict, dict]:
     google = config.get('google', {})
     http_settings = config.get('http', {})
     ldap = config.get('ldap', {})
+    local_users = config.get('local_users', {})
     postgres = config.get('postgres', {})
     sentry = config.get('sentry', {})
     session = config.get('session', {})
@@ -183,6 +184,7 @@ def load_configuration(config: str, debug: bool) -> typing.Tuple[dict, dict]:
         },
         'frontend_url': config.get('frontend_url', None),
         'google': {
+            'enabled': google.get('enabled', False),
             'valid_domains': google.get('valid_domains', '').split(',')
         },
         'javascript_url': config.get('javascript_url', None),
@@ -198,6 +200,9 @@ def load_configuration(config: str, debug: bool) -> typing.Tuple[dict, dict]:
             'user_object_type': ldap.get('user_object_type', 'inetOrgPerson'),
             'username': ldap.get('username', 'uid'),
             'users_dn': ldap.get('users_dn')
+        },
+        'local_users': {
+            'enabled': local_users.get('enabled', True)
         },
         'number_of_procs': http_settings.get('processes', 2),
         'opensearch': config.get('opensearch', {}),

--- a/imbi/templates/base.html
+++ b/imbi/templates/base.html
@@ -18,6 +18,8 @@
          data-footer-text="{{ handler.application.settings['footer_link']['text'] }}"
          data-footer-url="{{ handler.application.settings['footer_link']['url'] }}"
          data-ldap="{{ str(handler.application.settings['ldap']['enabled']).lower() }}"
+         data-local-users="{{ str(handler.application.settings['local_users']['enabled']).lower() }}"
+         data-google="{{ str(handler.application.settings['google']['enabled']).lower() }}"
          data-sentry_dsn="{{ handler.application.settings['sentry_ui_dsn'] }}"
          data-url="{{ handler.request.protocol }}://{{ handler.request.host }}"
          data-version="{{ handler.application.settings['version'] }}"


### PR DESCRIPTION
This adds an enabled flag to each of the login types in settings: local, ldap, and google. It also passes these forward to the frontend, using the data attributes, so it can dynamically display the valid login methods.