### PR TITLE
Add project identifiers endpoints

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,11 +45,12 @@ services:
       - opensearch
 
   postgres:
-    image: aweber/imbi-postgres:0.17.0
+    image: aweber/imbi-postgres:0.20.0
     ports:
       - 5432
     volumes:
       - ./scaffolding/postgres:/tmp/postgres
+
   redis:
     image: gavinmroy/alpine-redis:5.0.9-0
     ports:

--- a/imbi/endpoints/__init__.py
+++ b/imbi/endpoints/__init__.py
@@ -3,10 +3,11 @@ from tornado import web
 from imbi import constants
 from . import (activity_feed, authentication_tokens, cookie_cutters, dashboard,
                environments, fact_type_enums, fact_type_ranges, fact_types,
-               groups, integrations, metrics, namespaces, openapi, opensearch,
-               operations_log, permissions, project_activity_feed,
-               project_dependencies, project_fact_history, project_fact_types,
-               project_facts, project_link_types, project_links, project_notes,
+               groups, integration_identifiers, integrations, metrics,
+               namespaces, openapi, opensearch, operations_log, permissions,
+               project_activity_feed, project_dependencies,
+               project_fact_history, project_fact_types, project_facts,
+               project_link_types, project_links, project_notes,
                project_score_history, project_secrets, project_types,
                project_urls, projects, reports, status, ui)
 
@@ -98,6 +99,9 @@ URLS = [
     web.url(r'^/projects/(?P<project_id>\d+)/feed$',
             project_activity_feed.CollectionRequestHandler,
             name='project-activity-feed'),
+    web.url(r'^/projects/(?P<project_id>\d+)/identifiers$',
+            integration_identifiers.CollectionRequestHandler,
+            name='project-identifiers'),
     web.url(r'^/projects/(?P<project_id>\d+)/links$',
             project_links.CollectionRequestHandler,
             name='project-links'),

--- a/imbi/endpoints/__init__.py
+++ b/imbi/endpoints/__init__.py
@@ -102,6 +102,11 @@ URLS = [
     web.url(r'^/projects/(?P<project_id>\d+)/identifiers$',
             integration_identifiers.CollectionRequestHandler,
             name='project-identifiers'),
+    web.url(
+        r'^/projects/(?P<project_id>\d+)/identifiers/'
+        r'(?P<integration_name>.+)$',
+        integration_identifiers.RecordRequestHandler,
+        name='project-identifier'),
     web.url(r'^/projects/(?P<project_id>\d+)/links$',
             project_links.CollectionRequestHandler,
             name='project-links'),

--- a/imbi/endpoints/integration_identifiers.py
+++ b/imbi/endpoints/integration_identifiers.py
@@ -1,0 +1,46 @@
+import re
+
+from imbi import errors
+from imbi.endpoints import base
+
+
+class CollectionRequestHandler(base.CollectionRequestHandler):
+    NAME = 'project-identifiers'
+    ITEM_NAME = 'project-identifier'
+    ID_KEY = ['project_id', 'integration_name']
+    FIELDS = ['external_id', 'integration_name']
+
+    COLLECTION_SQL = re.sub(
+        r'\s+', ' ', """\
+        SELECT external_id, integration_name, project_id, created_at,
+               created_by, last_modified_at, last_modified_by
+          FROM v1.project_identifiers
+         ORDER BY project_id, integration_name
+        """)
+
+    GET_SQL = re.sub(
+        r'\s+', ' ', """\
+        SELECT external_id, integration_name, project_id,
+               created_at, created_by, last_modified_at, last_modified_by
+          FROM v1.project_identifiers
+         WHERE project_id = %(project_id)s
+           AND integration_name = %(integration_name)s
+        """)
+
+    POST_SQL = re.sub(
+        r'\s+', ' ', """\
+        INSERT INTO v1.project_identifiers
+                    (external_id, integration_name, project_id,
+                     created_at, created_by)
+             VALUES (%(external_id)s, %(integration_name)s, %(project_id)s,
+                     CURRENT_TIMESTAMP, %(username)s)
+          RETURNING external_id, integration_name, project_id
+        """)
+
+    async def get(self, *args, **kwargs) -> None:
+        result = await self.postgres_execute(
+            'SELECT id FROM v1.projects WHERE id = %(project_id)s', kwargs,
+            'get-project-id')
+        if not result:
+            raise errors.ItemNotFound()
+        await super().get(*args, **kwargs)

--- a/imbi/endpoints/integrations/__init__.py
+++ b/imbi/endpoints/integrations/__init__.py
@@ -4,15 +4,17 @@ Integration Endpoints
 """
 from tornado import web
 
-from . import gitlab, google, oauth2
+from . import _apps, gitlab, google
 
 URLS = [
     web.url(r'^/gitlab/auth', gitlab.RedirectHandler),
     web.url(r'^/gitlab/namespaces', gitlab.UserNamespacesHandler),
     web.url(r'^/gitlab/projects', gitlab.ProjectsHandler),
     web.url(r'^/google/auth', google.RedirectHandler),
-    web.url(r'^/integrations$', oauth2.CollectionRequestHandler),
+    web.url(r'^/integrations$',
+            _apps.CollectionRequestHandler,
+            name='integrations'),
     web.url(r'^/integrations/(?P<name>[\w_\-%\+]+)$',
-            oauth2.RecordRequestHandler,
-            name='integration')
+            _apps.RecordRequestHandler,
+            name='integration'),
 ]

--- a/imbi/endpoints/integrations/_apps.py
+++ b/imbi/endpoints/integrations/_apps.py
@@ -1,0 +1,77 @@
+import re
+
+from imbi.endpoints import base
+
+
+class CollectionRequestHandler(base.CollectionRequestHandler):
+    NAME = 'integrations'
+    ITEM_NAME = 'integration'
+    ID_KEY = 'name'
+    FIELDS = ['api_endpoint', 'api_secret']
+
+    COLLECTION_SQL = re.sub(
+        r'\s+', ' ', """\
+        SELECT name, api_endpoint
+          FROM v1.integrations
+         ORDER BY name
+        """)
+
+    GET_SQL = re.sub(
+        r'\s+', ' ', """\
+        SELECT name, api_endpoint
+          FROM v1.integrations
+         WHERE name = %(name)s
+        """)
+
+    POST_SQL = re.sub(
+        r'\s+', ' ', """\
+        INSERT INTO v1.integrations
+                    (name, api_endpoint, api_secret, created_at, created_by)
+             VALUES (%(name)s, %(api_endpoint)s, %(api_secret)s,
+                     CURRENT_TIMESTAMP, %(username)s)
+          RETURNING name, api_endpoint
+        """)
+
+    @base.require_permission('admin')
+    async def post(self, *args, **kwargs) -> None:
+        await super().post(*args, **kwargs)
+
+
+class RecordRequestHandler(base.CRUDRequestHandler):
+    NAME = 'integration'
+    ID_KEY = 'name'
+    OMIT_FIELDS = ['api_secret']
+
+    GET_SQL = re.sub(
+        r'\s+', ' ', """\
+        SELECT name, api_endpoint, api_secret, created_at, created_by,
+               last_modified_at, last_modified_by
+          FROM v1.integrations
+         WHERE name = %(name)s
+        """)
+
+    PATCH_SQL = re.sub(
+        r'\s+', ' ', """\
+        UPDATE v1.integrations
+           SET api_endpoint = %(api_endpoint)s,
+               api_secret = %(api_secret)s,
+               last_modified_by = %(username)s,
+               last_modified_at = CURRENT_TIMESTAMP
+         WHERE name = %(name)s
+           AND name = %(current_name)s
+        RETURNING api_endpoint
+        """)
+
+    DELETE_SQL = re.sub(
+        r'\s+', ' ', """\
+           DELETE FROM v1.integrations
+                 WHERE name = %(name)s
+           """)
+
+    @base.require_permission('admin')
+    async def delete(self, *args, **kwargs) -> None:
+        await super().delete(*args, **kwargs)
+
+    @base.require_permission('admin')
+    async def patch(self, *args, **kwargs) -> None:
+        await super().patch(*args, **kwargs)

--- a/imbi/endpoints/project_activity_feed.py
+++ b/imbi/endpoints/project_activity_feed.py
@@ -34,10 +34,20 @@ class CollectionRequestHandler(base.PaginatedRequestMixin,
               ON b.id = a.fact_type_id
            WHERE a.project_id = %(project_id)s
         ),
+        identifiers AS (
+          SELECT COALESCE(a.last_modified_at, a.created_at) AS "when",
+                 COALESCE(a.last_modified_by, a.created_by) AS who,
+                 'updated fact' AS what,
+                 (a.integration_name || ' external ID') AS fact_name,
+                 a.external_id AS value
+            FROM v1.project_identifiers AS a
+           WHERE a.project_id = %(project_id)s
+        ),
         combined AS (
                 SELECT * FROM created
           UNION SELECT * FROM updated
           UNION SELECT * FROM facts
+          UNION SELECT * FROM identifiers
         )
         SELECT 'ProjectFeedEntry' AS "type", c."when", c.who, u.display_name,
                c.what, c.fact_name, c.value

--- a/imbi/opensearch/project.py
+++ b/imbi/opensearch/project.py
@@ -163,6 +163,11 @@ class ProjectIndex:
                 defn[f'urls.{opensearch.sanitize_key(row["name"])}'] = {
                     'type': 'text'
                 }
+            result = await cursor.execute('SELECT name FROM v1.integrations;')
+            for row in result:
+                defn[f'identifiers.{opensearch.sanitize_key(row["name"])}'] = {
+                    'type': 'text'
+                }
         return defn
 
     @staticmethod

--- a/imbi/templates/openapi.yaml
+++ b/imbi/templates/openapi.yaml
@@ -1693,7 +1693,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/paths/~1integrations~1%7Bname%7D/get/responses/200/content/application~1json/schema'
+                  $ref: '#/paths/~1integrations/post/responses/200/content/application~1json/schema'
     post:
       description: Add a new integration
       summary: Add integration
@@ -1710,32 +1710,13 @@ paths:
                   type: string
                 api_endpoint:
                   type: string
-                callback_url:
-                  type: string
-                authorization_endpoint:
-                  type: string
-                token_endpoint:
-                  type: string
-                revoke_endpoint:
+                api_secret:
                   type: string
                   nullable: true
-                client_id:
-                  type: string
-                client_secret:
-                  type: string
-                  nullable: true
-                public_client:
-                  type: boolean
               required:
                 - name
                 - api_endpoint
-                - callback_url
-                - authorization_endpoint
-                - token_endpoint
-                - revoke_endpoint
-                - client_id
-                - client_secret
-                - public_client
+                - api_secret
               additionalProperties: false
           application/x-www-form-urlencoded:
             schema:
@@ -1750,6 +1731,12 @@ paths:
                 properties:
                   name:
                     type: string
+                  api_endpoint:
+                    type: string
+                required:
+                  - name
+                  - api_endpoint
+                additionalProperties: false
   '/integrations/{name}':
     parameters:
       - name: name
@@ -1768,31 +1755,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  name:
-                    type: string
-                  api_endpoint:
-                    type: string
-                  callback_url:
-                    type: string
-                  authorization_endpoint:
-                    type: string
-                  token_endpoint:
-                    type: string
-                  revoke_endpoint:
-                    type: string
-                  client_id:
-                    type: string
-                required:
-                  - name
-                  - api_endpoint
-                  - callback_url
-                  - authorization_endpoint
-                  - token_endpoint
-                  - revoke_endpoint
-                  - client_id
-                additionalProperties: false
+                $ref: '#/paths/~1integrations/post/responses/200/content/application~1json/schema'
     delete:
       description: Remove the specified integration
       summary: Delete an integration
@@ -1801,6 +1764,24 @@ paths:
       responses:
         '204':
           $ref: '#/paths/~1groups~1%7Bname%7D/delete/responses/204'
+        '401':
+          $ref: '#/paths/~1groups/get/responses/401'
+        '404':
+          $ref: '#/paths/~1groups~1%7Bname%7D/get/responses/404'
+    patch:
+      description: Update an integration
+      summary: Update an integration
+      tags:
+        - Integrations
+      requestBody:
+        $ref: '#/paths/~1groups~1%7Bname%7D/patch/requestBody'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/paths/~1integrations/post/responses/200/content/application~1json/schema'
         '401':
           $ref: '#/paths/~1groups/get/responses/401'
         '404':
@@ -5294,6 +5275,144 @@ paths:
             application/msgpack:
               schema:
                 type: object
+  '/projects/{id}/identifiers/{integration}':
+    parameters:
+      - name: id
+        in: path
+        description: Project ID
+        required: true
+        schema:
+          type: integer
+      - name: integration
+        in: path
+        description: Integration name
+        required: true
+        schema:
+          type: string
+    get:
+      description: Retrieve a specific surrogate identifier for the project
+      summary: Get Identifier
+      tags:
+        - Project Facts
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  external_id:
+                    type: string
+                  created_by:
+                    type: string
+                  created_at:
+                    type: string
+                    format: iso8601-timestamp
+                  modified_by:
+                    type: string
+                    nullable: true
+                  modified_at:
+                    type: string
+                    format: iso8601-timestamp
+                    nullable: true
+                required:
+                  - external_id
+                  - created_by
+                  - created_at
+                  - modified_by
+                  - modified_at
+                additionalProperties: true
+            application/msgpack:
+              schema:
+                type: object
+                properties:
+                  external_id:
+                    type: string
+                  created_by:
+                    type: string
+                  created_at:
+                    type: string
+                    format: iso8601-timestamp
+                  modified_by:
+                    type: string
+                    nullable: true
+                  modified_at:
+                    type: string
+                    format: iso8601-timestamp
+                    nullable: true
+                required:
+                  - external_id
+                  - created_by
+                  - created_at
+                  - modified_by
+                  - modified_at
+                additionalProperties: true
+    patch:
+      description: Update a specific surrogate identifier for the project
+      summary: Update identifier
+      requestBody:
+        $ref: '#/paths/~1groups~1%7Bname%7D/patch/requestBody'
+      responses:
+        '200':
+          description: Updated identifier
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  external_id:
+                    type: string
+                  created_by:
+                    type: string
+                  created_at:
+                    type: string
+                    format: iso8601-timestamp
+                  modified_by:
+                    type: string
+                    nullable: true
+                  modified_at:
+                    type: string
+                    format: iso8601-timestamp
+                    nullable: true
+                required:
+                  - external_id
+                  - created_by
+                  - created_at
+                  - modified_by
+                  - modified_at
+                additionalProperties: true
+            application/msgpack:
+              schema:
+                type: object
+                properties:
+                  external_id:
+                    type: string
+                  created_by:
+                    type: string
+                  created_at:
+                    type: string
+                    format: iso8601-timestamp
+                  modified_by:
+                    type: string
+                    nullable: true
+                  modified_at:
+                    type: string
+                    format: iso8601-timestamp
+                    nullable: true
+                required:
+                  - external_id
+                  - created_by
+                  - created_at
+                  - modified_by
+                  - modified_at
+                additionalProperties: true
+    delete:
+      description: Remove the surrogate identifier for the project in a specified integration
+      summary: Remove identifier
+      responses:
+        '204':
+          description: Identifier removed
   '/projects/{id}/links':
     get:
       description: Retrieve the collection of links for a project

--- a/imbi/templates/openapi.yaml
+++ b/imbi/templates/openapi.yaml
@@ -5176,6 +5176,124 @@ paths:
               $ref: '#/paths/~1activity-feed/get/responses/200/headers/Link'
         '401':
           $ref: '#/paths/~1groups/get/responses/401'
+  '/projects/{id}/identifiers':
+    parameters:
+      - name: id
+        in: path
+        description: Project ID
+        required: true
+        schema:
+          type: integer
+    get:
+      description: Retrieve surrogate identifiers for the project
+      summary: Get Identifiers
+      tags:
+        - Project Facts
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    external_id:
+                      type: string
+                    integration_name:
+                      type: string
+                    created_by:
+                      type: string
+                    created_at:
+                      type: string
+                      format: iso8601-timestamp
+                    modified_by:
+                      type: string
+                      nullable: true
+                    modified_at:
+                      type: string
+                      format: iso8601-timestamp
+                      nullable: true
+                  required:
+                    - external_id
+                    - integration_name
+                    - created_by
+                    - created_at
+                    - modified_by
+                    - modified_at
+                  additionalProperties: true
+            application/msgpack:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    external_id:
+                      type: string
+                    integration_name:
+                      type: string
+                    created_by:
+                      type: string
+                    created_at:
+                      type: string
+                      format: iso8601-timestamp
+                    modified_by:
+                      type: string
+                      nullable: true
+                    modified_at:
+                      type: string
+                      format: iso8601-timestamp
+                      nullable: true
+                  required:
+                    - external_id
+                    - integration_name
+                    - created_by
+                    - created_at
+                    - modified_by
+                    - modified_at
+                  additionalProperties: true
+    post:
+      description: Add a surrogate identifier for a project
+      summary: Add Identifier
+      tags:
+        - Project Facts
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                external_id:
+                  type: string
+                integration_name:
+                  type: string
+              required:
+                - external_id
+                - integration_name
+              additionalProperties: false
+          application/msgpack:
+            schema:
+              type: object
+              properties:
+                external_id:
+                  type: string
+                integration_name:
+                  type: string
+              required:
+                - external_id
+                - integration_name
+              additionalProperties: false
+      responses:
+        '200':
+          description: Newly created identifier
+          content:
+            application/json:
+              schema:
+                type: object
+            application/msgpack:
+              schema:
+                type: object
   '/projects/{id}/links':
     get:
       description: Retrieve the collection of links for a project

--- a/scaffolding/postgres/dml.sql
+++ b/scaffolding/postgres/dml.sql
@@ -10,3 +10,6 @@ INSERT INTO v1.users (username, user_type, external_id, email_address, display_n
 
 INSERT INTO v1.group_members("group", username) VALUES ('admin', 'test');
 INSERT INTO v1.group_members("group", username) VALUES ('imbi', 'ffink');
+
+INSERT INTO v1.authentication_tokens (name, username, token)
+     VALUES ('import', 'test', '00000000-0000-0000-0000-000000000000');


### PR DESCRIPTION
This PR adds the project identifier related endpoints as described by https://github.com/AWeber-Imbi/imbi-openapi/pull/19.

* `/projects/{id}/integrations` returns the integration identifiers for a project and adds a new one via `POST`
* `/projects/{id}/integrations/{name}` exposes fetch, update, and delete of specific identifiers
* `/integrations` returns the available integrations and adds a new one via `POST`
* `/integrations/{name}` exposes fetch, update, and delete of specific integrations
* the old `/integrations` endpoints are no longer available -- _these were for maintaining OAuth 2 details associated with GitLab and SonarQube_

The updates that were committed as https://github.com/AWeber-Imbi/imbi-openapi/pull/19 are present in the various commits as well. The plan is to merge the existing automation endpoints into the new `/integrations/{name}/...` URLs in the future as we fix project creation automations.

**Tip for reviewing:** you can play with the functionality by pulling everything locally. If not, reviewing it commit by commit will make it easier to grok. Most of the lines are OpenAPI spec 😉 

Closes #59, closes #60 