### PR TITLE
Consolidate OAuth 2.0 logic

### DIFF
--- a/imbi/endpoints/integrations/gitlab.py
+++ b/imbi/endpoints/integrations/gitlab.py
@@ -49,9 +49,10 @@ class RedirectHandler(sprockets.mixins.http.HTTPClientMixin,
                     title='Gitlab authorization failure',
                     detail='unexpected email address {} for user {}'.format(
                         email, imbi_user.username))
-            await self.integration.add_user_token(imbi_user, str(user_id),
-                                                  token.access_token,
-                                                  token.refresh_token)
+            await self.integration.upsert_user_token(imbi_user.username,
+                                                     str(user_id),
+                                                     token.access_token,
+                                                     token.refresh_token)
 
         # Revoke the gitlab token if we cannot use or save it.  This
         # is a catch-all case since GitLab does not remove tokens based

--- a/imbi/endpoints/integrations/google.py
+++ b/imbi/endpoints/integrations/google.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import re
 import urllib.parse
 
 import aioredis
@@ -22,28 +21,6 @@ class RedirectHandler(sprockets.mixins.http.HTTPClientMixin,
     integration: oauth2.OAuth2Integration
 
     NAME = 'google-redirect'
-
-    ADD_TOKEN_SQL = re.sub(
-        r'\s+', ' ', """
-        INSERT INTO v1.user_oauth2_tokens
-                    (username, integration, external_id,
-                     access_token, refresh_token, oidc_token)
-             VALUES (%(username)s, %(integration)s, %(external_id)s,
-                     %(access_token)s, %(refresh_token)s, %(oidc_token)s)
-        ON CONFLICT (integration, external_id)
-                 DO UPDATE SET access_token = EXCLUDED.access_token,
-                              refresh_token = EXCLUDED.refresh_token
-    """)
-
-    UPDATE_TOKEN_SQL = re.sub(
-        r'\s+', ' ', """
-       UPDATE v1.user_oauth2_tokens
-          SET access_token = %(access_token)s,
-              oidc_token = %(oidc_token)s
-              username = %(username)s
-        WHERE integration = %(integration)s
-          AND external_id = %(external_id)s
-    """)
 
     @property
     def _redis(self) -> aioredis.Redis:
@@ -75,8 +52,10 @@ class RedirectHandler(sprockets.mixins.http.HTTPClientMixin,
 
         user = await self.sync_user(oidc_token)
         await self.save_session(user)
-        await self.upsert_token(user.username, user.external_id, access_token,
-                                refresh_token, oidc_token)
+        await self.integration.upsert_user_token(user.username,
+                                                 user.external_id,
+                                                 access_token, refresh_token,
+                                                 oidc_token)
 
         target = yarl.URL(self.request.full_url()).with_path('/ui/')
         self.redirect(str(target))
@@ -139,28 +118,6 @@ class RedirectHandler(sprockets.mixins.http.HTTPClientMixin,
         return (response.body.get('id_token'),
                 response.body.get('access_token'),
                 response.body.get('refresh_token'))
-
-    async def upsert_token(self, username, external_id, access_token,
-                           refresh_token, oidc_token):
-        if refresh_token:
-            await self.postgres_execute(
-                self.ADD_TOKEN_SQL, {
-                    'username': username,
-                    'external_id': external_id,
-                    'access_token': access_token,
-                    'refresh_token': refresh_token,
-                    'oidc_token': oidc_token,
-                    'integration': self.integration_name
-                })
-        else:
-            await self.postgres_execute(
-                self.UPDATE_TOKEN_SQL, {
-                    'username': username,
-                    'external_id': external_id,
-                    'access_token': access_token,
-                    'oidc_token': oidc_token,
-                    'integration': self.integration_name
-                })
 
     @property
     def integration_name(self):

--- a/imbi/oauth2.py
+++ b/imbi/oauth2.py
@@ -18,6 +18,7 @@ class IntegrationToken:
     integration: 'OAuth2Integration'
     access_token: str
     refresh_token: str
+    oidc_token: typing.Optional[str]
     external_id: str
 
 
@@ -39,7 +40,7 @@ class OAuth2Integration:
 
     SQL_GET_TOKENS = re.sub(
         r'\s+', ' ', """\
-        SELECT access_token, refresh_token, external_id
+        SELECT access_token, refresh_token, oidc_token, external_id
           FROM v1.user_oauth2_tokens
          WHERE username = %(username)s
            AND integration = %(integration)s""")
@@ -117,7 +118,8 @@ class OAuth2Integration:
             })
         return [
             IntegrationToken(self, row['access_token'], row['refresh_token'],
-                             row['external_id']) for row in result
+                             row['oidc_token'], row['external_id'])
+            for row in result
         ]
 
     @property


### PR DESCRIPTION
This pulls the unique SQL out of the google module and consolidates it into one `SQL_UPSERT_TOKEN` in the oauth2 module, that can now be used by both Gitlab and Google.

This also adds an optional OIDC token, and makes refresh tokens optional, as they are in the OAuth 2.0 spec.