### PR TITLE
Consolidate OAuth 2.0 logic

### DIFF
--- a/imbi/endpoints/integrations/gitlab.py
+++ b/imbi/endpoints/integrations/gitlab.py
@@ -49,9 +49,10 @@ class RedirectHandler(sprockets.mixins.http.HTTPClientMixin,
                     title='Gitlab authorization failure',
                     detail='unexpected email address {} for user {}'.format(
                         email, imbi_user.username))
-            await self.integration.add_user_token(imbi_user, str(user_id),
-                                                  token.access_token,
-                                                  token.refresh_token)
+            await self.integration.upsert_user_tokens(imbi_user.username,
+                                                      str(user_id),
+                                                      token.access_token,
+                                                      token.refresh_token)
 
         # Revoke the gitlab token if we cannot use or save it.  This
         # is a catch-all case since GitLab does not remove tokens based

--- a/imbi/oauth2.py
+++ b/imbi/oauth2.py
@@ -18,6 +18,7 @@ class IntegrationToken:
     integration: 'OAuth2Integration'
     access_token: str
     refresh_token: str
+    id_token: typing.Optional[str]
     external_id: str
 
 
@@ -39,7 +40,7 @@ class OAuth2Integration:
 
     SQL_GET_TOKENS = re.sub(
         r'\s+', ' ', """\
-        SELECT access_token, refresh_token, external_id
+        SELECT access_token, refresh_token, id_token, external_id
           FROM v1.user_oauth2_tokens
          WHERE username = %(username)s
            AND integration = %(integration)s""")
@@ -117,7 +118,8 @@ class OAuth2Integration:
             })
         return [
             IntegrationToken(self, row['access_token'], row['refresh_token'],
-                             row['external_id']) for row in result
+                             row['id_token'], row['external_id'])
+            for row in result
         ]
 
     @property


### PR DESCRIPTION
This pulls the unique SQL out of the google module and consolidates it into one SQL_UPSERT_TOKEN in the oauth2 module, that can now be used by both Gitlab and Google.

This also adds an optional ID token, and makes refresh tokens optional, as they are in the OAuth 2.0 spec.