### PR TITLE
Coerce notification filter values to the types present in the notification

### DIFF
--- a/imbi/endpoints/integrations/automations.py
+++ b/imbi/endpoints/integrations/automations.py
@@ -41,10 +41,10 @@ PathIdType: typing.TypeAlias = typing.Union[int, slugify.Slug]
 
 class AddAutomationRequest(pydantic.BaseModel):
     name: str
-    categories: list[AutomationCategory] = pydantic.Field(min_items=1)
+    categories: list[AutomationCategory] = pydantic.Field(min_length=1)
     callable: CallableType
     applies_to: list[PathIdType] = pydantic.Field(default_factory=list,
-                                                  min_items=1)
+                                                  min_length=1)
     depends_on: list[PathIdType] = pydantic.Field(default_factory=list)
 
 
@@ -54,9 +54,9 @@ class Automation(pydantic.BaseModel):
     slug: slugify.Slug
     integration_name: str
     callable: CallableType
-    categories: list[AutomationCategory] = pydantic.Field(min_items=1)
+    categories: list[AutomationCategory] = pydantic.Field(min_length=1)
     applies_to: list[slugify.Slug] = pydantic.Field(default_factory=list,
-                                                    min_items=1)
+                                                    min_length=1)
     depends_on: list[slugify.Slug] = pydantic.Field(default_factory=list)
     created_by: str
     created_at: datetime.datetime


### PR DESCRIPTION
This PR changes notification filter processing slightly. The filter constraints are stored in the database as string values; however, the incoming notifications likely include JS typed values (_boolean_, _number_, etc). I added a coercion step during filter processing that attempts to convert from the filter constraint (`str`) into the value type from the notification. If the coercion fails, a warning is emitted and we go on like nothing happened though the filter is unlikely to match.

Here's an example of a GitLab notification for a `git push` with a bunch of fields omitted:
```json
{
  "object_kind": "push",
  "event_name": "push",
  "before": "3b4774d476f019190bd2f22051e8a35d9a35bb54",
  "after": "a3be10c9490a59ee68d31110346c34192bf3a80d",
  "ref": "refs/heads/develop",
  "ref_protected": false
}
```

I configured a notification that processes by default and then added filters to ignore stuff that I'm not interested in.
```
$ curl https://my-imbi/integrations/gitlab/notifications/commit/rules
[
  {
    "fact_type_id": 19,
    "integration_name": "gitlab",
    "notification_name": "commit",
    "pattern": "/commits/0/timestamp",
    "created_at": "2024-03-19T20:27:24.139978+00:00",
    "created_by": "test",
    "last_modified_at": null,
    "last_modified_by": null
  }
]

$ curl curl https://my-imbi/integrations/gitlab/notifications/commit/filters
[
  {
    "name": "ignore-non-push",
    "integration_name": "gitlab",
    "notification_name": "commit",
    "pattern": "/object_kind",
    "operation": "!=",
    "value": "push",
    "action": "ignore",
    "created_at": "2024-03-19T19:40:04.693933+00:00",
    "created_by": "test",
    "last_modified_at": null,
    "last_modified_by": null
  },
  {
    "name": "ignore-unprotected",
    "integration_name": "gitlab",
    "notification_name": "commit",
    "pattern": "/ref_protected",
    "operation": "==",
    "value": "false",
    "action": "ignore",
    "created_at": "2024-03-19T20:01:02.160277+00:00",
    "created_by": "test",
    "last_modified_at": null,
    "last_modified_by": null
  },
  {
    "name": "ignore-zero-commits",
    "integration_name": "gitlab",
    "notification_name": "commit",
    "pattern": "/total_commits_count",
    "operation": "==",
    "value": "0",
    "action": "ignore",
    "created_at": "2024-03-19T20:18:30.800301+00:00",
    "created_by": "test",
    "last_modified_at": "2024-03-19T20:23:03.167177+00:00",
    "last_modified_by": "test"
  }
]
```

When a notification with `"ref_protected": false` is processed, it should have been ignored but the filter didn't match because it was comparing `False` from the notification to `'false'` from the filter. The same thing occurred with the "ignore-zero-commits" filter except that it was comparing `'0'` and `0`.