### PR TITLE
Fix SQL syntax error in imbi.oauth2

### DIFF
--- a/imbi/oauth2.py
+++ b/imbi/oauth2.py
@@ -47,7 +47,7 @@ class OAuth2Integration:
         r'\s+', ' ', """
            UPDATE v1.user_oauth2_tokens
               SET access_token = %(access_token)s,
-                  id_token = %(id_token),
+                  id_token = %(id_token)s,
                   username = %(username)s
             WHERE integration = %(integration)s
               AND external_id = %(external_id)s


### PR DESCRIPTION
Somehow this made it the whole way into a tag before I caught it in my pre-flight check.