### PR TITLE
Reindex project on surrogate ID changes

### DIFF
--- a/imbi/endpoints/integration_identifiers.py
+++ b/imbi/endpoints/integration_identifiers.py
@@ -1,10 +1,11 @@
 import re
 
 from imbi import errors
-from imbi.endpoints import base
+from imbi.endpoints import base, projects
 
 
-class CollectionRequestHandler(base.CollectionRequestHandler):
+class CollectionRequestHandler(projects.ProjectAttributeCollectionMixin,
+                               base.CollectionRequestHandler):
     NAME = 'project-identifiers'
     ITEM_NAME = 'project-identifier'
     ID_KEY = ['project_id', 'integration_name']
@@ -47,7 +48,8 @@ class CollectionRequestHandler(base.CollectionRequestHandler):
         await super().get(*args, **kwargs)
 
 
-class RecordRequestHandler(base.CRUDRequestHandler):
+class RecordRequestHandler(projects.ProjectAttributeCRUDMixin,
+                           base.CRUDRequestHandler):
     NAME = 'project-identifier'
     ID_KEY = ['project_id', 'integration_name']
 


### PR DESCRIPTION
One of our background processes wasn't updating Imbi correctly. It uses the `/opensearch/projects` endpoint to retrieve a project by a surrogate ID and was failing to match after the project was modified. I narrowed it down to the surrogate identifier endpoints not reindexing the project.  This PR fixes that.