### PR TITLE
Add automation to create a gitlab project

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,15 +5,15 @@ repos:
       - id: bandit
         args: [ "--quiet", "--exclude", "tests", "--recursive", "imbi" ]
   - repo: https://github.com/PyCQA/flake8
-    rev: '3.7.9'
+    rev: '6.0.0'
     hooks:
       - id: flake8
         additional_dependencies:
-          - flake8-comprehensions==3.2.2
-          - flake8-deprecated==1.3
-          - flake8-import-order==0.18.1
-          - flake8-quotes==3.0.0
-          - flake8-rst-docstrings==0.0.13
+          - flake8-comprehensions==3.14.0
+          - flake8-deprecated==2.2.1
+          - flake8-import-order==0.18.2
+          - flake8-quotes==3.4.0
+          - flake8-rst-docstrings==0.3.0
           - flake8-tuple==0.4.1
   - repo: https://github.com/pre-commit/mirrors-yapf
     rev: 'v0.31.0'

--- a/Makefile
+++ b/Makefile
@@ -32,10 +32,10 @@ setup: .env env
 
 # Testing
 
-.PHONY: bandit
-bandit: env
-	@ printf "\nRunning Bandit\n"
-	@ env/bin/bandit -r imbi
+.PHONY: lint
+lint: env
+	@ printf "\nRunning pre-commit hooks\n"
+	@ env/bin/pre-commit run --all-files
 
 .PHONY: coverage
 coverage: .env env
@@ -44,17 +44,5 @@ coverage: .env env
 	@ env/bin/coverage xml
 	@ env/bin/coverage report
 
-.PHONY: flake8
-flake8: env
-	@ printf "\nRunning Flake8 Tests\n"
-	@ env/bin/flake8 --tee --output-file=build/flake8.txt
-
-.PHONY: yapf
-yapf: env
-	@ printf "\nRunning yapf Tests\n"
-	@ env/bin/yapf -dr imbi tests 2>&1 | tee build/yapf.diff
-
-# Testing Groups
-
 .PHONY: test
-test: bandit flake8 yapf coverage
+test: lint coverage

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -1,7 +1,7 @@
 #!/bin/sh -e
 
 echo "Installing utilities"
-apk --update add curl-dev gcc make musl-dev tzdata
+apk --update add curl-dev gcc git libffi-dev make musl-dev tzdata
 
 # upgrade pip to make sure that we get the most modern wheel selection alg
 pip install --upgrade pip setuptools wheel
@@ -13,6 +13,8 @@ ls -lR /tmp/test
 cd /tmp/test
 echo "Copying files from /source to $(pwd)"
 tar c -C /source -f - \
+    .gitignore \
+    .pre-commit-config.yaml \
     LICENSE \
     MANIFEST.in \
     Makefile \
@@ -31,6 +33,14 @@ cat > .env <<EOF
 export DEBUG=1
 EOF
 ls -al
+
+echo "Configuring git"
+git init --quiet
+git config user.email 'ci@aweber.io'
+git config user.name 'Imbi CI'
+git branch -M main
+git add .
+git commit -m 'fake'
 
 echo "Running tests in $(pwd)"
 make test

--- a/imbi/__init__.py
+++ b/imbi/__init__.py
@@ -1,9 +1,5 @@
 """
-Imbi
-====
-
 Imbi is an operational management platform for medium to large environments.
-
 """
 import warnings
 

--- a/imbi/automations/__init__.py
+++ b/imbi/automations/__init__.py
@@ -149,3 +149,21 @@ async def run_automations(
         if last_automation is not None:
             raise AutomationFailedError(last_automation, error) from None
         raise
+
+
+def query_runner(metric_name: str, query: str, *args: object,
+                 **kwargs: object) -> CompensatingAction:
+    """Returns a CompensatingAction that calls context.run_query()
+
+    Use this to create compensating actions that run a simple
+    SQL query. If you need to do something more in-depth, then
+    write freestanding function.
+    """
+    kwargs['metric_name'] = metric_name
+
+    async def runner(context: AutomationContext, *_: object) -> None:
+        context.note_progress('running query %r with args %r', metric_name,
+                              args)
+        await context.run_query(query, *args, **kwargs)
+
+    return runner

--- a/imbi/automations/__init__.py
+++ b/imbi/automations/__init__.py
@@ -91,17 +91,17 @@ class AutomationContext:
         self.notes.append((datetime.datetime.now(datetime.timezone.utc),
                            message_format % args if args else message_format))
 
-    async def run_automation(self, automation: imbi.models.Automation, *args,
-                             **kwargs) -> None:
-        self.logger.debug('running automation %s = %r', automation.slug,
-                          automation.callable)
+    async def run_automation(self, automation: imbi.models.Automation,
+                             *args: object, **kwargs: object) -> None:
+        self.logger.debug('running automation %s = %r with args %r %r',
+                          automation.slug, automation.callable, args, kwargs)
         try:
             result = automation.callable(self, automation, *args, **kwargs)
             if inspect.isawaitable(result):
                 await result
         except Exception as error:
-            self.logger.error(
-                'automation %s failed with %s, running %s cleanups',
+            self.logger.exception(
+                'automation %s failed with %r, running %s cleanups',
                 automation.slug, error, len(self._cleanups))
             await self._run_cleanups(error)
             raise error

--- a/imbi/automations/__init__.py
+++ b/imbi/automations/__init__.py
@@ -1,2 +1,105 @@
-async def do_nothing(*_args, **_kwargs):
-    pass
+from __future__ import annotations
+
+import datetime
+import inspect
+import logging
+import types
+
+import typing_extensions as typing
+
+if typing.TYPE_CHECKING:  # pragma: nocover
+    import imbi.models
+
+CompensatingAction: typing.TypeAlias = typing.Callable[
+    ['AutomationContext', BaseException], typing.Union[typing.Awaitable[None],
+                                                       None]]
+
+
+async def do_nothing(context: AutomationContext,
+                     automation: imbi.models.Automation, *_args: object,
+                     **_kwargs: object) -> None:
+    context.note_progress('default action running for %s', automation.slug)
+
+
+class AutomationFailedError(Exception):
+    def __init__(self, automation: imbi.models.Automation,
+                 error: Exception) -> None:
+        super().__init__(f'Automation {automation.slug} failed: {error}')
+        self.automation = automation
+        self.error = error
+
+
+class AutomationContext:
+    """Run automations with automated cleanup & injected context
+
+    You may want to use the `run_automations` function instead of
+    directly creating a context instance.
+
+    The automation context provides a convenient way to run automation
+    *actions*. Each *action* is a callable that accepts the context
+    instance as it's first parameter. Additional parameters are passed
+    via `args` & `kwargs`.
+
+    The context also has a stack of *compensating callbacks* that will
+    be invoked if an exception is thrown during the processing of an
+    action. The callback stack is *only* invoked when an exception occurs
+    and each callback will be invoked exactly once. It is passed the
+    context instance and the exception instance that was caught.
+
+
+    """
+    def __init__(self) -> None:
+        self.logger = logging.getLogger('AutomationContext')
+        self.notes: list[tuple[datetime.datetime, str]] = []
+        self._cleanups: list[CompensatingAction] = []
+
+    def note_progress(self, message_format: str, *args: object) -> None:
+        """Add a note to the list of notes
+
+        These could be made available in an API response so don't
+        log anything sensitive.
+        """
+        self.logger.info(message_format, *args)
+        self.notes.append((datetime.datetime.now(datetime.timezone.utc),
+                           message_format % args if args else message_format))
+
+    async def run_automation(self, automation: imbi.models.Automation, *args,
+                             **kwargs) -> None:
+        self.logger.debug('running automation %s = %r', automation.slug,
+                          automation.callable)
+        try:
+            result = automation.callable(self, automation, *args, **kwargs)
+            if inspect.isawaitable(result):
+                await result
+        except Exception as error:
+            self.logger.error(
+                'automation %s failed with %s, running %s cleanups',
+                automation.slug, error, len(self._cleanups))
+            await self._run_cleanups(error)
+            raise error
+
+    def add_callback(self, compensating_action: CompensatingAction) -> None:
+        """Add a cleanup action"""
+        self._cleanups.append(compensating_action)
+
+    # Implement an async context manager that runs cleanups if an
+    # exception is raised
+    async def __aenter__(self) -> typing.Self:
+        return self
+
+    async def __aexit__(self, _exc_type: typing.Type[BaseException] | None,
+                        exc_val: BaseException | None,
+                        _exc_tb: types.TracebackType | None) -> None:
+        if exc_val is not None:
+            await self._run_cleanups(exc_val)
+
+    async def _run_cleanups(self, exc: BaseException) -> None:
+        cleanups, self._cleanups = self._cleanups, []
+        for cleanup in reversed(cleanups):
+            try:
+                maybe_coro = cleanup(self, exc)
+                if inspect.isawaitable(maybe_coro):
+                    await maybe_coro
+            except Exception as error:
+                self.logger.exception('cleanup %r failed with %s', cleanup,
+                                      error)

--- a/imbi/automations/gitlab.py
+++ b/imbi/automations/gitlab.py
@@ -1,0 +1,109 @@
+import http
+import typing
+
+import imbi.clients.gitlab
+from imbi import automations, errors, models
+
+
+async def create_project(
+    context: automations.AutomationContext,
+    automation: models.Automation,
+    project: models.Project,
+) -> None:
+    """Create a GitLab repository for an Imbi project
+
+    This automation creates the GitLab project, adds the ID of the
+    new project as a project identifier, and sets the GitLab link
+    of we have one configured. The project is created in the GitLab
+    group associated with the Project namespace and the sub-path
+    associated with the Project Type.
+
+    The gitlab project information is saved in the context using the
+    function object (eg, `create_project`) as the key.
+
+    @see https://gitlab.aweber.io/help/api/projects.md#create-project
+    """
+    tokens = await context.user.fetch_integration_tokens(
+        automation.integration_name)
+    if not tokens:
+        raise errors.Forbidden('missing %s token for %s',
+                               automation.integration_name,
+                               context.user.username)
+
+    group_name = (project.namespace.gitlab_group_name
+                  or project.namespace.slug,
+                  project.project_type.gitlab_project_prefix
+                  or project.project_type.slug)
+    client = imbi.clients.gitlab.GitLabClient(context.user, tokens[0],
+                                              context.application)
+    group_info = await client.fetch_group(*group_name)
+    if not group_info:
+        raise errors.ApplicationError(http.HTTPStatus.BAD_REQUEST,
+                                      'misconfigured',
+                                      'Group %r does not exist in GitLab',
+                                      '/'.join(group_name),
+                                      title='Imbi Misconfiguration')
+
+    gitlab_info = await client.create_project(
+        group_info,
+        project.name,
+        description=project.description,
+        path=project.slug,
+    )
+    context[create_project] = gitlab_info
+    context.add_callback(delete_project)
+    context.note_progress(
+        'created GitLab project %s (id=%s) for Imbi project %s',
+        gitlab_info.name_with_namespace, gitlab_info.id, project.id)
+
+    await context.run_query(
+        'INSERT INTO v1.project_identifiers'
+        '            (external_id, integration_name, project_id,'
+        '             created_at, created_by)'
+        '     VALUES (%(gitlab_id)s, %(integration_name)s, %(imbi_id)s,'
+        '             CURRENT_TIMESTAMP, %(username)s)', {
+            'gitlab_id': gitlab_info.id,
+            'imbi_id': project.id,
+            'integration_name': automation.integration_name,
+            'username': context.user.username,
+        })
+    context.note_progress(
+        'registered GitLab identifier %s for Imbi project %s', gitlab_info.id,
+        project.id)
+
+    settings = context.application.settings['automations']['gitlab']
+    link_type_id = settings.get('project_link_type_id', None)
+    if link_type_id is not None:
+        await context.run_query(
+            'INSERT INTO v1.project_links'
+            '            (project_id, link_type_id, created_by, url)'
+            '     VALUES (%(imbi_id)s, %(link_type_id)s, %(username)s,'
+            '             %(project_url)s)', {
+                'imbi_id': project.id,
+                'link_type_id': link_type_id,
+                'project_url': gitlab_info.web_url,
+                'username': context.user.username,
+            })
+        context.note_progress('created GitLab link %r for Imbi project %s',
+                              gitlab_info.web_url, project.id)
+
+
+async def delete_project(context: automations.AutomationContext,
+                         _error: BaseException):
+    """Compensating action that deletes a GitLab project
+
+    The project information is expected to be in ``context[create_project]``.
+    """
+    try:
+        gitlab_info = typing.cast(imbi.clients.gitlab.ProjectInfo,
+                                  context[create_project])
+    except KeyError:
+        return
+
+    tokens = await context.user.fetch_integration_tokens('gitlab')
+    if not tokens:
+        return
+
+    client = imbi.clients.gitlab.GitLabClient(context.user, tokens[0],
+                                              context.application)
+    await client.delete_project(gitlab_info)

--- a/imbi/clients/gitlab.py
+++ b/imbi/clients/gitlab.py
@@ -265,8 +265,6 @@ class GitLabClient(sprockets.mixins.http.HTTPClientMixin):
         body = urllib.parse.urlencode({
             'grant_type': 'refresh_token',
             'refresh_token': self.token.refresh_token,
-            'client_id': self.token.integration.client_id,
-            'client_secret': self.token.integration.client_secret,
         })
         self.logger.info('refreshing token for %s (%s)', self.user.username,
                          self.token.external_id)
@@ -276,6 +274,8 @@ class GitLabClient(sprockets.mixins.http.HTTPClientMixin):
             method='POST',
             body=body,
             content_type='application/x-www-form-urlencoded',
+            auth_username=self.token.integration.client_id,
+            auth_password=self.token.integration.client_secret,
         )
         if response.ok:
             self.logger.debug('refresh response: %r', response.body)

--- a/imbi/endpoints/integrations/gitlab.py
+++ b/imbi/endpoints/integrations/gitlab.py
@@ -131,7 +131,8 @@ class GitLabIntegratedHandler(base.AuthenticatedRequestHandler):
                 raise errors.Forbidden('no GitLab tokens for %r',
                                        imbi_user,
                                        title='GitLab Not Connected')
-            self.client = gitlab.GitLabClient(tokens[0], self.application)
+            self.client = gitlab.GitLabClient(imbi_user, tokens[0],
+                                              self.application)
 
 
 class UserNamespacesHandler(GitLabIntegratedHandler):

--- a/imbi/endpoints/integrations/models.py
+++ b/imbi/endpoints/integrations/models.py
@@ -97,7 +97,7 @@ async def automation(automation_slug: str,
     def on_postgres_error(_metric_name: str, exc: Exception) -> None:
         LOGGER.error('Failed to execute query for automation %s: %s',
                      automation_slug, exc)
-        raise errors.DatabaseError(f'Error loading Automation', error=exc)
+        raise errors.DatabaseError('Error loading Automation', error=exc)
 
     async with application.postgres_connector(
             on_error=on_postgres_error) as conn:

--- a/imbi/endpoints/integrations/oauth2.py
+++ b/imbi/endpoints/integrations/oauth2.py
@@ -23,7 +23,7 @@ class OAuth2CreationRequest(pydantic.BaseModel):
 class OAuth2Details(pydantic.BaseModel):
     authorization_endpoint: pydantic.HttpUrl
     token_endpoint: pydantic.HttpUrl
-    revoke_endpoint: typing.Union[pydantic.HttpUrl, None]
+    revoke_endpoint: typing.Union[pydantic.HttpUrl, None] = None
     callback_url: pydantic.HttpUrl
     client_id: str
     client_secret: typing.Union[str, None]
@@ -93,7 +93,8 @@ class RecordRequestHandler(base.PydanticHandlerMixin,
                 'callback_url': str(callback_url),
                 'authorization_endpoint': str(request.authorization_endpoint),
                 'token_endpoint': str(request.token_endpoint),
-                'revoke_endpoint': str(request.revoke_endpoint),
+                'revoke_endpoint': (str(request.revoke_endpoint)
+                                    if request.revoke_endpoint else None),
                 'client_id': request.client_id,
                 'client_secret': client_secret,
                 'public_client': request.use_pkce,

--- a/imbi/endpoints/projects.py
+++ b/imbi/endpoints/projects.py
@@ -251,6 +251,7 @@ class CollectionRequestHandler(project.RequestHandlerMixin,
         try:
             await automations.run_automations(selected_automations,
                                               project,
+                                              application=self.application,
                                               user=self._current_user,
                                               query_executor=self,
                                               addt_callbacks=[cleanup])

--- a/imbi/endpoints/projects.py
+++ b/imbi/endpoints/projects.py
@@ -255,6 +255,8 @@ class CollectionRequestHandler(project.RequestHandlerMixin,
                                               user=self._current_user,
                                               query_executor=self,
                                               addt_callbacks=[cleanup])
+        except errors.ApplicationError:  # this is meant for the end user
+            raise
         except automations.AutomationFailedError as error:
             raise errors.InternalServerError(str(error)) from None
 

--- a/imbi/endpoints/projects.py
+++ b/imbi/endpoints/projects.py
@@ -209,20 +209,27 @@ class CollectionRequestHandler(project.RequestHandlerMixin,
         automation_instances = [
             await models.automation(slug, self.application) for slug in slugs
         ]
+        required_automations = set()
+        for a in automation_instances:
+            required_automations.update(a.depends_on)
+        required_automations.difference_update(
+            {a.slug
+             for a in automation_instances})
         error = {
-            'missing_automations': [
+            'nonexistent_automations': [
                 name for name, matched in zip(slugs, automation_instances)
                 if matched is None
             ],
             'invalid_automations': [
                 a.name for a in automation_instances
                 if a is not None and project_type_id not in a.applies_to_ids
-            ]
+            ],
+            'missing_required_automations': list(required_automations),
         }
         error = {label: value for label, value in error.items() if value}
         if error:
-            raise errors.BadRequest('Invalid project creation request: %r',
-                                    error, **error)
+            raise errors.BadRequest('Invalid project creation request',
+                                    **error)
         return automation_instances
 
     async def _run_automations(

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,7 @@ author = Gavin M. Roy
 author_email = gavinr@aweber.com
 license = BSD 3-Clause License
 license_files =
-	LICENSE
+    LICENSE
 long_description = file: README.rst
 long_description_content_type = text/x-rst; charset=UTF-8
 home_page = https://github.com/aweber/imbi
@@ -77,6 +77,7 @@ install_requires =
     tornado==6.1
     tornado-problem-details>=0.0.6,<1
     tornado_openapi3>=0.2.4,<1
+    typing-extensions>=4.9,<4.10
     u-msgpack-python>=2.1,<3
     validators
     yapf==0.31.0

--- a/tests/automations/test_context.py
+++ b/tests/automations/test_context.py
@@ -7,7 +7,7 @@ import uuid
 
 import sprockets_postgres  # type: ignore[import-untyped]
 
-from imbi import automations, user
+from imbi import app, automations, user
 
 
 class AnyInstanceOf:
@@ -33,6 +33,7 @@ class AnyInstanceOf:
 class AutomationContextTests(unittest.IsolatedAsyncioTestCase):
     def setUp(self) -> None:
         super().setUp()
+        self.application = unittest.mock.Mock(spec=app.Application)
         self.user = unittest.mock.Mock(spec=user.User)
         self.query_function = unittest.mock.AsyncMock()
         self.context = automations.AutomationContext(self.application,
@@ -176,6 +177,7 @@ class AutomationContextTests(unittest.IsolatedAsyncioTestCase):
 class RunAutomationsTests(unittest.IsolatedAsyncioTestCase):
     def setUp(self) -> None:
         super().setUp()
+        self.application = unittest.mock.Mock(spec=app.Application)
         self.executor = unittest.mock.AsyncMock(
             spec=sprockets_postgres.RequestHandlerMixin)
         self.user = unittest.mock.Mock(spec=user.User)
@@ -187,6 +189,7 @@ class RunAutomationsTests(unittest.IsolatedAsyncioTestCase):
         action = unittest.mock.AsyncMock()
         actions = [unittest.mock.Mock(callable=action)]
         await automations.run_automations(actions,
+                                          application=self.application,
                                           user=self.user,
                                           query_executor=self.executor)
         action.assert_awaited_once_with(
@@ -198,6 +201,7 @@ class RunAutomationsTests(unittest.IsolatedAsyncioTestCase):
 
     async def test_without_explicit_callbacks(self) -> None:
         await automations.run_automations(self.automations,
+                                          application=self.application,
                                           user=self.user,
                                           query_executor=self.executor)
         for automation in self.automations:
@@ -212,6 +216,7 @@ class RunAutomationsTests(unittest.IsolatedAsyncioTestCase):
         self.automations[-1].callable.side_effect = error
         with self.assertRaises(automations.AutomationFailedError):
             await automations.run_automations(self.automations,
+                                              application=self.application,
                                               user=self.user,
                                               query_executor=self.executor,
                                               addt_callbacks=callbacks)
@@ -222,6 +227,7 @@ class RunAutomationsTests(unittest.IsolatedAsyncioTestCase):
     async def test_without_automations(self) -> None:
         callbacks = [unittest.mock.AsyncMock()]
         await automations.run_automations([],
+                                          application=self.application,
                                           user=self.user,
                                           query_executor=self.executor,
                                           addt_callbacks=callbacks)
@@ -235,6 +241,7 @@ class RunAutomationsTests(unittest.IsolatedAsyncioTestCase):
         ]
         await automations.run_automations(
             actions,
+            application=self.application,
             user=self.user,
             query_executor=self.executor,
         )
@@ -260,6 +267,7 @@ class RunAutomationsTests(unittest.IsolatedAsyncioTestCase):
             with self.assertRaises(RuntimeError):
                 await automations.run_automations(
                     self.automations,
+                    application=self.application,
                     user=self.user,
                     query_executor=self.executor,
                     addt_callbacks=[unittest.mock.Mock()])

--- a/tests/automations/test_context.py
+++ b/tests/automations/test_context.py
@@ -175,6 +175,23 @@ class AutomationContextTests(unittest.IsolatedAsyncioTestCase):
                          [n[1] for n in self.context.notes])
         autos[0].callback.assert_called_once_with(self.context, error)
 
+    async def test_state_storage(self) -> None:
+        async def writer(ctx: automations.AutomationContext,
+                         _auto: models.Automation) -> None:
+            ctx[self.test_state_storage] = 'hello'
+
+        async def reader(ctx: automations.AutomationContext,
+                         _auto: models.Automation) -> None:
+            ctx['out'] = f'{ctx[self.test_state_storage]} world'
+            del ctx[self.test_state_storage]
+
+        await self.context.run_automation(
+            unittest.mock.AsyncMock(callable=writer))
+        await self.context.run_automation(
+            unittest.mock.AsyncMock(callable=reader))
+        self.assertEqual('hello world', self.context['out'])
+        self.assertNotIn(self.test_state_storage, self.context)
+
 
 class RunAutomationsTests(unittest.IsolatedAsyncioTestCase):
     def setUp(self) -> None:

--- a/tests/automations/test_context.py
+++ b/tests/automations/test_context.py
@@ -4,15 +4,42 @@ import typing
 import unittest.mock
 import uuid
 
-from imbi import automations
+import sprockets_postgres  # type: ignore[import-untyped]
+
+from imbi import automations, user
+
+
+class AnyInstanceOf:
+    """Make any "equality" check work with isinstance
+
+    This is particularly useful to verify that a mock
+    was called with a specific type of object without
+    having to know the identity of the object::
+
+        mocked.assert_called_once_with(
+           AnyInstanceOf(automations.AutomationContext))
+
+    """
+    def __init__(self, cls: type) -> None:
+        self.expected_class = cls
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, self.expected_class):
+            return True
+        return NotImplemented
 
 
 class AutomationContextTests(unittest.IsolatedAsyncioTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.user = unittest.mock.Mock(spec=user.User)
+        self.query_function = unittest.mock.AsyncMock()
+
     async def test_callbacks_called_upon_failure(self) -> None:
         sync_callback = unittest.mock.Mock()
         async_callback = unittest.mock.AsyncMock()
         error = RuntimeError()
-        context = automations.AutomationContext()
+        context = automations.AutomationContext(self.user, self.query_function)
 
         with self.assertRaises(RuntimeError):
             async with context:
@@ -26,7 +53,8 @@ class AutomationContextTests(unittest.IsolatedAsyncioTestCase):
     async def test_callbacks_are_not_called_upon_success(self) -> None:
         sync_callback = unittest.mock.Mock()
         async_callback = unittest.mock.AsyncMock()
-        async with automations.AutomationContext() as context:
+        async with automations.AutomationContext(
+                self.user, self.query_function) as context:
             context.add_callback(sync_callback)
             context.add_callback(async_callback)
 
@@ -35,7 +63,7 @@ class AutomationContextTests(unittest.IsolatedAsyncioTestCase):
 
     async def test_run_automation(self) -> None:
         automation = unittest.mock.Mock()
-        context = automations.AutomationContext()
+        context = automations.AutomationContext(self.user, self.query_function)
 
         await context.run_automation(automation,
                                      unittest.mock.sentinel.pos_arg,
@@ -72,7 +100,7 @@ class AutomationContextTests(unittest.IsolatedAsyncioTestCase):
         compensating_action.assert_called_once_with(context, failure)
 
     async def test_that_failing_callbacks_are_reported(self) -> None:
-        context = automations.AutomationContext()
+        context = automations.AutomationContext(self.user, self.query_function)
         failure = RuntimeError()
 
         class Automation:
@@ -133,7 +161,7 @@ class AutomationContextTests(unittest.IsolatedAsyncioTestCase):
                 c.note_progress('action: param:%s', param)
                 c.add_callback(self.callback)
 
-        context = automations.AutomationContext()
+        context = automations.AutomationContext(self.user, self.query_function)
         error = RuntimeError()
         autos = [Automation(), Automation(error)]
 
@@ -144,3 +172,95 @@ class AutomationContextTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(1, len(context.notes))
         self.assertEqual(['action: param:0'], [n[1] for n in context.notes])
         autos[0].callback.assert_called_once_with(context, error)
+
+
+class RunAutomationsTests(unittest.IsolatedAsyncioTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.executor = unittest.mock.AsyncMock(
+            spec=sprockets_postgres.RequestHandlerMixin)
+        self.user = unittest.mock.Mock(spec=user.User)
+        self.automations = [unittest.mock.Mock() for _ in range(3)]
+        for automation in self.automations:
+            automation.callable = unittest.mock.AsyncMock()
+
+    async def test_that_context_is_correct(self) -> None:
+        action = unittest.mock.AsyncMock()
+        actions = [unittest.mock.Mock(callable=action)]
+        await automations.run_automations(actions,
+                                          user=self.user,
+                                          query_executor=self.executor)
+        action.assert_awaited_once_with(
+            AnyInstanceOf(automations.AutomationContext), actions[0])
+        context = typing.cast(automations.AutomationContext,
+                              action.call_args[0][0])
+        self.assertIs(self.user, context.user)
+        self.assertIs(self.executor.postgres_execute, context.run_query)
+
+    async def test_without_explicit_callbacks(self) -> None:
+        await automations.run_automations(self.automations,
+                                          user=self.user,
+                                          query_executor=self.executor)
+        for automation in self.automations:
+            automation.callable.assert_awaited_once_with(
+                AnyInstanceOf(automations.AutomationContext), automation)
+
+    async def test_with_explicit_callbacks(self) -> None:
+        error = RuntimeError()
+        callbacks = [
+            unittest.mock.AsyncMock() for _ in range(len(self.automations))
+        ]
+        self.automations[-1].callable.side_effect = error
+        with self.assertRaises(automations.AutomationFailedError):
+            await automations.run_automations(self.automations,
+                                              user=self.user,
+                                              query_executor=self.executor,
+                                              addt_callbacks=callbacks)
+        for cb in callbacks:
+            cb.assert_awaited_once_with(
+                AnyInstanceOf(automations.AutomationContext), error)
+
+    async def test_without_automations(self) -> None:
+        callbacks = [unittest.mock.AsyncMock()]
+        await automations.run_automations([],
+                                          user=self.user,
+                                          query_executor=self.executor,
+                                          addt_callbacks=callbacks)
+        callbacks[0].assert_not_awaited()
+
+    async def test_with_sync_and_nonsync_operations(self) -> None:
+        sync_ops = [unittest.mock.Mock() for _ in range(3)]
+        async_ops = [unittest.mock.AsyncMock() for _ in range(3)]
+        actions = [
+            unittest.mock.Mock(callable=op) for op in sync_ops + async_ops
+        ]
+        await automations.run_automations(
+            actions,
+            user=self.user,
+            query_executor=self.executor,
+        )
+        sync_ops[0].assert_called_once_with(
+            AnyInstanceOf(automations.AutomationContext),
+            unittest.mock.ANY,
+        )
+        action_iter = iter(actions)
+        context = sync_ops[0].call_args[0][0]
+        for op, act in zip(sync_ops, action_iter):
+            op.assert_called_once_with(context, act)
+        for op, act in zip(async_ops, action_iter):
+            op.assert_awaited_once_with(context, act)
+
+    async def test_insane_edge_case(self) -> None:
+        # this strange test covers the unlikely case that
+        # something raises in `run_automations` BEFORE we
+        # execute a single automation
+        with unittest.mock.patch.object(
+                automations.AutomationContext,
+                'add_callback',
+                new=unittest.mock.Mock(side_effect=RuntimeError)):
+            with self.assertRaises(RuntimeError):
+                await automations.run_automations(
+                    self.automations,
+                    user=self.user,
+                    query_executor=self.executor,
+                    addt_callbacks=[unittest.mock.Mock()])

--- a/tests/automations/test_context.py
+++ b/tests/automations/test_context.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import typing
+import unittest.mock
+import uuid
+
+from imbi import automations
+
+
+class AutomationContextTests(unittest.IsolatedAsyncioTestCase):
+    async def test_callbacks_called_upon_failure(self) -> None:
+        sync_callback = unittest.mock.Mock()
+        async_callback = unittest.mock.AsyncMock()
+        error = RuntimeError()
+        context = automations.AutomationContext()
+
+        with self.assertRaises(RuntimeError):
+            async with context:
+                context.add_callback(sync_callback)
+                context.add_callback(async_callback)
+                raise error
+
+        sync_callback.assert_called_once_with(context, error)
+        async_callback.assert_awaited_once_with(context, error)
+
+    async def test_callbacks_are_not_called_upon_success(self) -> None:
+        sync_callback = unittest.mock.Mock()
+        async_callback = unittest.mock.AsyncMock()
+        async with automations.AutomationContext() as context:
+            context.add_callback(sync_callback)
+            context.add_callback(async_callback)
+
+        sync_callback.assert_not_called()
+        async_callback.assert_not_awaited()
+
+    async def test_run_automation(self) -> None:
+        automation = unittest.mock.Mock()
+        context = automations.AutomationContext()
+
+        await context.run_automation(automation,
+                                     unittest.mock.sentinel.pos_arg,
+                                     keyword=unittest.mock.sentinel.kwarg)
+        automation.callable.assert_called_once_with(
+            context,
+            automation,
+            unittest.mock.sentinel.pos_arg,
+            keyword=unittest.mock.sentinel.kwarg)
+
+        automation.callable = unittest.mock.AsyncMock()
+        await context.run_automation(automation,
+                                     unittest.mock.sentinel.pos_arg,
+                                     keyword=unittest.mock.sentinel.kwarg)
+        automation.callable.assert_awaited_once_with(
+            context,
+            automation,
+            unittest.mock.sentinel.pos_arg,
+            keyword=unittest.mock.sentinel.kwarg)
+
+        failure = RuntimeError()
+        automation.callable = unittest.mock.AsyncMock(side_effect=failure)
+        compensating_action = unittest.mock.Mock()
+        context.add_callback(compensating_action)
+        with self.assertRaises(failure.__class__):
+            await context.run_automation(automation,
+                                         unittest.mock.sentinel.pos_arg,
+                                         keyword=unittest.mock.sentinel.kwarg)
+        automation.callable.assert_awaited_once_with(
+            context,
+            automation,
+            unittest.mock.sentinel.pos_arg,
+            keyword=unittest.mock.sentinel.kwarg)
+        compensating_action.assert_called_once_with(context, failure)
+
+    async def test_that_failing_callbacks_are_reported(self) -> None:
+        context = automations.AutomationContext()
+        failure = RuntimeError()
+
+        class Automation:
+            def __init__(self) -> None:
+                self.slug = str(uuid.uuid4())
+                self.action = unittest.mock.AsyncMock()
+                self.callback = unittest.mock.AsyncMock()
+
+            async def callable(self, c: automations.AutomationContext, *args,
+                               **kwargs) -> None:
+                await self.action(c, *args, **kwargs)
+                c.add_callback(self.callback)
+
+        autos = [Automation() for _ in range(3)]
+
+        # make the last automation fail
+        autos[-1].action.side_effect = failure
+
+        # make the first automation's cleanup fail... we want to
+        # verify that the failure is ignored
+        autos[0].callback.side_effect = ValueError()
+
+        with self.assertRaises(RuntimeError) as cm:
+            with self.assertLogs(context.logger) as log:
+                async with context:
+                    for a in autos:
+                        await context.run_automation(a)
+        self.assertIs(failure, cm.exception)
+        for record in log.records:
+            if (record.levelname == 'ERROR'
+                    and record.msg == 'cleanup %r failed with %s'):
+                break
+        else:
+            self.fail('Expected to find exception for cleanup failure')
+
+        # verify that all actions were invoked
+        for a in autos:
+            a.action.assert_awaited_once_with(context, a)
+
+        # verify that all callbacks except for the last one were invoked
+        # with the correct parameters
+        for a in autos[:-1]:
+            a.callback.assert_awaited_once_with(context, failure)
+
+        # verify that the final callback was not invoked
+        autos[-1].callback.assert_not_awaited()
+
+    async def test_using_context_from_within_action(self) -> None:
+        class Automation:
+            def __init__(self, side_effect: Exception | None = None) -> None:
+                self.slug = ''
+                self.action = unittest.mock.Mock(side_effect=side_effect)
+                self.callback = unittest.mock.Mock()
+
+            def callable(self, c: automations.AutomationContext,
+                         automation: typing.Self, param: int) -> None:
+                self.action()
+                c.note_progress('action: param:%s', param)
+                c.add_callback(self.callback)
+
+        context = automations.AutomationContext()
+        error = RuntimeError()
+        autos = [Automation(), Automation(error)]
+
+        with self.assertRaises(RuntimeError):
+            async with context:
+                for param, act in enumerate(autos):
+                    await context.run_automation(act, param)
+        self.assertEqual(1, len(context.notes))
+        self.assertEqual(['action: param:0'], [n[1] for n in context.notes])
+        autos[0].callback.assert_called_once_with(context, error)

--- a/tests/endpoints/test_operations_log.py
+++ b/tests/endpoints/test_operations_log.py
@@ -297,8 +297,7 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
         result = self.fetch('/operations-log')
         self.assertEqual(result.code, 200)
         self.assertListEqual(json.loads(result.body.decode('utf-8')),
-                             [{k: v
-                               for k, v in record.items()}])
+                             [dict(record.items())])
 
         # DELETE
         result = self.fetch(url, method='DELETE')

--- a/tests/test_cors.py
+++ b/tests/test_cors.py
@@ -181,7 +181,7 @@ class PreflightProcessingTests(RequestProcessingTestCase):
 
     def test_preflight_without_explicit_allowed_origin(self):
         self.cors_processor.config.allowed_origins.allow_any = False
-        self.request.headers['Origin'] = f'https://example.net'
+        self.request.headers['Origin'] = 'https://example.net'
         self.cors_processor.process_request(self.handler)
         self.assert_preflight_failure()
         self.assertNotIn('Access-Control-Allow-Origin', self.response_headers)


### PR DESCRIPTION
This PR builds on top of #72 by adding the `imbi.automations.gitlab.create_project` function that can be used as an automation callable. It does required that you have an OAuth 2 application defined in GitLab that is used to authorize Imbi to act as a specific GitLab user. You will need the OAuth 2 Client ID and Client Secret for that application to continue (details below).

Once you have the GitLab connection configured and a user connected, creating a new project of a project type that has automations enabled will add toggles for each available automation to the display.
![image](https://github.com/AWeber-Imbi/imbi-api/assets/350812/c77ec078-bab7-4138-a7f4-2cda6843d67f)

After creating the Imbi project, the project creation endpoint will run the selected automations (8400ff4b2a686fb2df29b71fe2bffe00d3790888). If none of the automations fail, then the endpoint responds with a 👍 to the client. If any automation fails, then any successful automations are rolled back, the Imbi project is deleted, and a 👎 is returned to the client. The only automation implemented in this PR is one to create a GitLab project (e7757205f391aee0fbea06ec6839f4cacc349313). The project location is determined by the `namespace.gitlab_group_name` and `project_type.gitlab_project_prefix`. If either is missing, then the slug is substituted. There are a few interesting error conditions that can pop up:

1. since the GitLab creation request is done as the connected GitLab user, you might not have access to create projects in the target -- _this one is handled with a reasonable message IIRC_
2. if the target GitLab parent doesn't exist, a "configuration error" is displayed -- _made this decision since the namespace or project-type data in Imbi is misconfigured_
3. you can configure interesting combinations of GitLab group and sub-group permissions that could result in _really strange errors_

Feel free to play around with different settings. The error handling can be changed fairly easily... as long as we can determine what to do programatically.

You will also need https://github.com/AWeber-Imbi/imbi-ui/pull/73 running to see the new UI options.

## Guru meditations

* should we make the project defaults configurable under `automations:gitlab:` in the configuration file?
* is using a default of slugs appropriate instead of explicit configuration?
* should we send automation dependency information to the client?  Attempts to create a project with unmet dependencies will fail today but I didn't spend a lot of time thinking through alternatives.

## Enabling the OAuth 2 connection and automation

### GitLab OAuth 2 Application Details
**Confidential** ☑️ \
**Scopes** `api` \
**Redirect URI** (one per line)
```
http://localhost:8000/gitlab/auth
http://127.0.0.1:8000/gitlab/auth
```

<details>
<summary><h3>Script to enable GitLab OAuth 2 integration & automation</h3></summary>

```python
#!/usr/bin/env python3

import contextlib
import getpass
import http.client
import json
import os
import sys
import textwrap
import urllib.parse


def get_string(prompt, secret=False):
    env_var = prompt.replace(' ', '_').upper()
    with contextlib.suppress(KeyError):
        return os.environ[env_var]

    try:
        if secret:
            return getpass.getpass(prompt + ': ')
        return input(prompt + ': ')
    except (IOError, KeyboardInterrupt):
        sys.exit('Canceled')


def post(conn, path, body, allow_statuses=None):
    allow_statuses = allow_statuses or []
    headers = {'Private-Token': imbi_api_token,
               'Content-Type': 'application/json'}
    conn.request('POST', path,
                 json.dumps(body).encode(),
                 headers=headers)
    rsp = conn.getresponse()
    rsp_body = rsp.read()
    if rsp.code >= 400:
        print('Imbi API Failure: POST {} -> {}'.format(
            path, rsp.code))
        if rsp.code in allow_statuses:
            print('Failure ignored here')
            print('')
        else:
            if rsp_body:
                json.dump(json.loads(rsp_body), sys.stdout, indent=2)
                print('')
            sys.exit(1)
    return json.loads(rsp_body) if rsp_body else None


if not os.environ.get('IMBI_API_TOKEN'):
    os.environ['IMBI_API_TOKEN'] =  '00000000-0000-0000-0000-000000000000'
imbi_api_token = get_string('Imbi API Token', secret=True)
gitlab_client_id = get_string('GitLab Client ID')
gitlab_client_secret = get_string('GitLab Client Secret', secret=True)
gitlab_url = get_string('GitLab URL')
imbi_url = get_string('Imbi URL')

parsed = urllib.parse.urlparse(gitlab_url)
gitlab_url = parsed.scheme + '://' + parsed.netloc

parsed = urllib.parse.urlparse(imbi_url)
if parsed.scheme == 'http':
    conn = http.client.HTTPConnection(parsed.hostname, parsed.port or 80)
elif parsed.scheme == 'https':
    conn = http.client.HTTPSConnection(parsed.hostname, parsed.port or 443)
else:
    sys.exit('Unhandled scheme: ' + parsed.scheme)
imbi_url = parsed.scheme + '://' + parsed.netloc

with contextlib.closing(conn):
    print('Created HTTP API project type')
    post(conn, '/project-types', {
        'name': 'HTTP API',
        'plural_name': 'HTTP APIs',
        'slug': 'api',
        'icon_class': 'fas cog',
        'environment_urls': True,
        'gitlab_project_prefix': 'api',
    }, allow_statuses=[409])

    print('Creating GitLab integration')
    post(conn, '/integrations', {
        'name': 'gitlab2',
        'api_endpoint': gitlab_url + '/api/v4',
        'api_secret': None,
    })

    print('Configuring GitLab OAuth2 connection')
    post(conn, '/integrations/gitlab2/oauth2', {
        'authorization_endpoint': gitlab_url + '/oauth/authorize',
        'token_endpoint': gitlab_url + '/oauth/token',
        'revoke_endpoint': None,
        'callback_url': imbi_url + '/gitlab/auth',
        'client_id': gitlab_client_id,
        'client_secret': gitlab_client_secret,
        'use_pkce': True,
    })

    print('Creating Create GitLab Project automation')
    post(conn, '/integrations/gitlab2/automations', {
        'name': 'Create GitLab Project',
        'callable': 'imbi.automations.gitlab.create_project',
        'categories': ['create-project'],
        'applies_to': ['api']
    })


term_size = os.get_terminal_size()

def display(*paragraphs):
    print()
    for p in paragraphs:
        msg = textwrap.dedent(p.format(**globals()))
        for line in textwrap.wrap(msg, term_size.columns * 0.7):
            print(line.strip())
        print()

display(
'''
    Your Imbi instance has been configured to connect to {gitlab_url}.
    Please open {imbi_url}/ui/user/profile and click the "Connect to
    GitLab" button.
''', '''
    If the button is not showing, reload the page. If that doesn't work
    then restart your Imbi instance.
'''
)
```
</details>