### PR TITLE
Create PagerDuty service automation

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -44,7 +44,7 @@ services:
       - opensearch
 
   postgres:
-    image: aweber/imbi-postgres:0.20.2
+    image: aweber/imbi-postgres:0.21.0
     ports:
       - 5432
     volumes:

--- a/imbi/automations/models.py
+++ b/imbi/automations/models.py
@@ -8,7 +8,9 @@ import typing
 
 import pydantic
 
-from imbi import automations, errors, slugify
+from . import do_nothing
+from imbi import errors, slugify
+
 if typing.TYPE_CHECKING:
     from imbi import app
 
@@ -38,7 +40,7 @@ def verify_legal_callable(v):
 
 CallableType = typing.Annotated[pydantic.ImportString,
                                 pydantic.AfterValidator(verify_legal_callable),
-                                pydantic.Field(default=automations.do_nothing)]
+                                pydantic.Field(default=do_nothing)]
 PathIdType: typing.TypeAlias = typing.Union[int, slugify.Slug]
 
 

--- a/imbi/automations/pagerduty.py
+++ b/imbi/automations/pagerduty.py
@@ -1,0 +1,90 @@
+import dataclasses
+import typing
+
+from imbi import automations, errors, models
+from imbi.clients import pagerduty
+
+
+@dataclasses.dataclass
+class PagerDutyContext:
+    integration_name: str
+    service_info: pagerduty.ServiceInfo
+
+
+async def create_service(
+    context: automations.AutomationContext,
+    automation: models.Automation,
+    project: models.Project,
+) -> None:
+    """Create a PagerDuty service for an Imbi project
+
+    This automation creates a new PagerDuty service using the same
+    name as `project` and attaching it to the escalation policy
+    associated with the namespace. The generated service ID is saved
+    as a pagerduty project identifier. A link to the dashboard is
+    added to the project if the `automations/pagerduty/project_link_type_id`
+    configuration value is set.
+
+    The PagerDuty service information is saved in the context using
+    the function object (eg, `create_service`) as the key.
+
+    @see https://developer.pagerduty.com/api-reference/7062f2631b397-create-a-service
+    """  # noqa: E501 -- line too long
+    if project.namespace.pagerduty_policy is None:
+        context.note_progress('not enabled for namespace %s, skipping',
+                              project.namespace.name)
+        return
+
+    client = await pagerduty.create_client(context.application,
+                                           automation.integration_name)
+    service = await client.create_service(project)
+    context[create_service] = PagerDutyContext(
+        integration_name=automation.integration_name, service_info=service)
+    context.add_callback(_delete_project)
+
+    await context.run_query(
+        'INSERT INTO v1.project_identifiers (external_id, integration_name,'
+        '                                    project_id, created_by)'
+        '     VALUES (%(pagerduty_id)s, %(integration_name)s, %(project_id)s,'
+        '             %(user)s)', {
+            'pagerduty_id': service.id,
+            'integration_name': automation.integration_name,
+            'project_id': project.id,
+            'user': context.user.username,
+        }, 'insert-project-identifiers')
+    context.note_progress(
+        'registered PagerDuty service %s for Imbi project %s', service.id,
+        project.id)
+
+    settings = context.application.settings['automations']['pagerduty']
+    if (link_type_id := settings.get('project_link_type_id')) is not None:
+        await context.run_query(
+            'INSERT INTO v1.project_links (project_id, link_type_id,'
+            '                              created_by, url)'
+            '     VALUES (%(project_id)s, %(link_type_id)s, %(user)s,'
+            '             %(url)s)', {
+                'project_id': project.id,
+                'link_type_id': link_type_id,
+                'user': context.user.username,
+                'url': str(service.html_url),
+            }, 'insert-project-links')
+        context.note_progress('created PagerDuty link %s for Imbi project %s',
+                              service.html_url, project.id)
+
+
+async def _delete_project(context: automations.AutomationContext,
+                          _error: BaseException) -> None:
+    try:
+        pd_info = typing.cast(PagerDutyContext, context[create_service])
+    except KeyError:
+        return
+
+    try:
+        client = await pagerduty.create_client(context.application,
+                                               pd_info.integration_name)
+    except errors.ClientUnavailableError:
+        pass
+    else:
+        context.note_progress('removing PagerDuty service %s due to error',
+                              pd_info.service_info.id)
+        await client.remove_service(pd_info.service_info.id)

--- a/imbi/clients/pagerduty.py
+++ b/imbi/clients/pagerduty.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import logging
+import typing
+
+import pydantic
+import sprockets.mixins.http
+import yarl
+
+from imbi import errors, models, version
+if typing.TYPE_CHECKING:  # pragma: nocover
+    from imbi import app
+
+
+class ServiceInfo(pydantic.BaseModel):
+    html_url: pydantic.HttpUrl  # aweber.pagerduty.com/...
+    id: str
+    self: pydantic.HttpUrl  # api.pagerduty.com/...
+
+
+class _CreateServiceResponse(pydantic.BaseModel):
+    service: ServiceInfo
+
+
+class _PagerDutyClient(sprockets.mixins.http.HTTPClientMixin):
+    def __init__(self, info: models.Integration, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.logger = logging.getLogger(__package__).getChild(
+            'PagerDutyClient')
+        self.api_url = yarl.URL(str(info.api_endpoint))
+        self.api_secret = info.api_secret
+        self.headers = {
+            'Accept': 'application/json',
+            'Authorization': f'Token token={info.api_secret}',
+        }
+
+    async def api(self,
+                  url: yarl.URL | str,
+                  *,
+                  method: str = 'GET',
+                  **kwargs) -> sprockets.mixins.http.HTTPResponse:
+        if not isinstance(url, yarl.URL):
+            url = yarl.URL(url)
+        url = self.api_url / url.path.removeprefix('/')
+
+        request_headers = kwargs.pop('request_headers', {})
+        request_headers.update(self.headers)
+        kwargs['request_headers'] = request_headers
+
+        if kwargs.get('body') is not None:
+            request_headers['Content-Type'] = 'application/json'
+            kwargs['content_type'] = 'application/json'
+        kwargs['user_agent'] = f'imbi/{version} (PagerDutyClient)'
+        rsp = await self.http_fetch(str(url), method=method, **kwargs)
+        if not rsp.ok:
+            self.logger.error('%s %s failed: %s', method, url, rsp.code)
+            self.logger.debug('pagerduty key: %s...%s', self.api_secret[:4],
+                              self.api_secret[-4:])
+            self.logger.debug('response body: %r', rsp.body)
+        return rsp
+
+    async def create_service(self, project: models.Project) -> ServiceInfo:
+        """Create a PagerDuty service for `project`
+
+        The new service is named `project.slug` and assigned to the
+        escalation policy from `project.namespace.pagerduty_policy`.
+        If the namespaces pagerduty policy is NULL, then an
+        ``InternalServiceError`` is raised.
+        """
+        if project.namespace.pagerduty_policy is None:
+            raise errors.InternalServerError(
+                'PagerDuty is not enabled for namespace %s',
+                project.namespace.slug)
+        body = {
+            'name': project.slug,
+            'escalation_policy': {
+                'id': project.namespace.pagerduty_policy,
+                'type': 'escalation_policy_reference'
+            }
+        }
+        if project.description:
+            body['description'] = project.description
+        self.logger.debug('creating PagerDuty service with: %r', body)
+        response = await self.api('/services', method='POST', body=body)
+        if not response.ok:
+            self.logger.error('PagerDuty API failure: body %r', response.body)
+            raise errors.InternalServerError(
+                'POST %s failed for name=%r policy=%r: %s',
+                response.history[-1].effective_url,
+                project.slug,
+                project.namespace.pagerduty_policy,
+                response.code,
+                title='PagerDuty API Failure')
+
+        try:
+            parsed_rsp = _CreateServiceResponse.model_validate(response.body)
+        except pydantic.ValidationError as error:
+            raise errors.InternalServerError(
+                'Failed to parse the PagerDuty response: %s',
+                error,
+                title='PagerDuty API Failure')
+        else:
+            return parsed_rsp.service
+
+    async def remove_service(self, service_id: str) -> None:
+        """Delete `service_id` from PagerDuty"""
+        await self.api(yarl.URL('/services') / service_id, method='DELETE')
+
+
+async def create_client(application: app.Application,
+                        integration_name: str) -> _PagerDutyClient:
+    """Create a PagerDuty API client
+
+    The settings need to create a client are stored in the database.
+    However, you can disable the PagerDuty client by setting the
+    `/automations/pagerduty/enabled` property to false in the
+    configuration file.
+
+    If the automation is disabled in the configuration file, the
+    integration is missing from the database, or the integration
+    does not have an API secret set, then a ``ClientUnavailableError``
+    is raised with an appropriate diagnostic message.
+    """
+    logger = logging.getLogger(__package__).getChild('create_client')
+    try:
+        settings = application.settings['automations']['pagerduty']
+        enabled = settings['enabled']
+    except KeyError:
+        raise errors.ClientUnavailableError(integration_name, 'not configured')
+    else:
+        if not enabled:
+            raise errors.ClientUnavailableError(integration_name, 'disabled')
+
+    pagerduty_info = await models.integration(integration_name, application)
+    if not pagerduty_info:
+        logger.warning('%r integration is enabled by not configured',
+                       integration_name)
+        raise errors.ClientUnavailableError(integration_name, 'not configured')
+    if not pagerduty_info.api_secret:
+        logger.warning('API secret is missing for %r', integration_name)
+        raise errors.ClientUnavailableError(integration_name, 'misconfigured')
+
+    return _PagerDutyClient(pagerduty_info)

--- a/imbi/endpoints/integrations/automations.py
+++ b/imbi/endpoints/integrations/automations.py
@@ -12,7 +12,7 @@ from psycopg2 import extensions
 
 from imbi import errors, postgres, slugify
 from imbi.endpoints import base
-from . import models
+from imbi.automations import models
 
 PathIdType: typing.TypeAlias = typing.Union[int, slugify.Slug]
 

--- a/imbi/endpoints/namespaces.py
+++ b/imbi/endpoints/namespaces.py
@@ -8,7 +8,7 @@ class _RequestHandlerMixin:
     ID_KEY = 'id'
     FIELDS = [
         'id', 'name', 'slug', 'icon_class', 'maintained_by',
-        'gitlab_group_name', 'sentry_team_slug'
+        'gitlab_group_name', 'sentry_team_slug', 'pagerduty_policy'
     ]
     DEFAULTS = {'icon_class': 'fas fa-users', 'maintained_by': []}
 
@@ -17,7 +17,8 @@ class _RequestHandlerMixin:
         SELECT id, "name", created_at, created_by,
                last_modified_at, last_modified_by,
                slug, icon_class, maintained_by,
-               gitlab_group_name, sentry_team_slug
+               gitlab_group_name, sentry_team_slug,
+               pagerduty_policy
           FROM v1.namespaces WHERE id=%(id)s""")
 
 
@@ -30,17 +31,17 @@ class CollectionRequestHandler(_RequestHandlerMixin,
     COLLECTION_SQL = re.sub(
         r'\s+', ' ', """ \
         SELECT id, "name", slug, icon_class, maintained_by, gitlab_group_name,
-               sentry_team_slug
+               sentry_team_slug, pagerduty_policy
           FROM v1.namespaces ORDER BY "name" ASC""")
 
     POST_SQL = re.sub(
         r'\s+', ' ', """\
         INSERT INTO v1.namespaces
                     ("name", created_by, slug, icon_class, "maintained_by",
-                     gitlab_group_name, sentry_team_slug)
+                     gitlab_group_name, sentry_team_slug, pagerduty_policy)
              VALUES (%(name)s, %(username)s, %(slug)s, %(icon_class)s,
                      %(maintained_by)s, %(gitlab_group_name)s,
-                     %(sentry_team_slug)s)
+                     %(sentry_team_slug)s, %(pagerduty_policy)s)
           RETURNING id""")
 
 
@@ -60,5 +61,6 @@ class RecordRequestHandler(_RequestHandlerMixin, base.AdminCRUDRequestHandler):
                icon_class = %(icon_class)s,
                "maintained_by" = %(maintained_by)s,
                gitlab_group_name = %(gitlab_group_name)s,
-               sentry_team_slug = %(sentry_team_slug)s
+               sentry_team_slug = %(sentry_team_slug)s,
+               pagerduty_policy = %(pagerduty_policy)s
          WHERE id=%(id)s""")

--- a/imbi/models.py
+++ b/imbi/models.py
@@ -7,8 +7,8 @@ import re
 import typing
 
 from imbi import common, errors
-from imbi.endpoints.integrations.models import (Automation, Integration,
-                                                automation, integration)
+from imbi.automations.models import (Automation, Integration, automation,
+                                     integration)
 
 if typing.TYPE_CHECKING:
     from imbi import app

--- a/imbi/models.py
+++ b/imbi/models.py
@@ -63,6 +63,7 @@ class Namespace:
     maintained_by: typing.Optional[list[str]]
     gitlab_group_name: str
     sentry_team_slug: typing.Optional[str]
+    pagerduty_policy: typing.Optional[str]
 
     SQL: typing.ClassVar = re.sub(
         r'\s+', ' ', """\
@@ -76,7 +77,8 @@ class Namespace:
                icon_class,
                maintained_by,
                gitlab_group_name,
-               sentry_team_slug
+               sentry_team_slug,
+               pagerduty_policy
           FROM v1.namespaces
          WHERE id=%(id)s""")
 

--- a/imbi/server.py
+++ b/imbi/server.py
@@ -132,6 +132,9 @@ def load_configuration(config: str, debug: bool) -> typing.Tuple[dict, dict]:
         'enabled',
         automations_gitlab.get('project_link_type_id') is not None)
 
+    automations_pd = automations.get('pagerduty', {})
+    automations_pd.setdefault('enabled', True)
+
     # `enabled` is calculated at runtime so default it to "true" here
     # Keeping the setting so that the user can disable sentry via config
     automations_sentry = automations.get('sentry', {})
@@ -162,6 +165,7 @@ def load_configuration(config: str, debug: bool) -> typing.Tuple[dict, dict]:
             },
             # see https://pycqa.github.io/isort/reference/isort/settings.html
             'isort': automations.get('isort', {}),
+            'pagerduty': automations_pd,
             'sentry': automations_sentry,
             'sonarqube': {
                 'enabled': automations_sonar.get('enabled', False),

--- a/imbi/templates/openapi.yaml
+++ b/imbi/templates/openapi.yaml
@@ -1419,6 +1419,10 @@ paths:
                       description: Optional name of associated Sentry team
                       type: string
                       nullable: true
+                    pagerduty_policy:
+                      description: Optional ID of associated PagerDuty escalation policy
+                      type: string
+                      nullable: true
                   required:
                     - name
                     - slug
@@ -1483,6 +1487,10 @@ paths:
                       description: Optional name of associated Sentry team
                       type: string
                       nullable: true
+                    pagerduty_policy:
+                      description: Optional ID of associated PagerDuty escalation policy
+                      type: string
+                      nullable: true
                   required:
                     - name
                     - slug
@@ -1542,6 +1550,10 @@ paths:
                   nullable: true
                 sentry_team_slug:
                   description: Optional name of associated Sentry team
+                  type: string
+                  nullable: true
+                pagerduty_policy:
+                  description: Optional ID of associated PagerDuty escalation policy
                   type: string
                   nullable: true
               required:

--- a/tests/base.py
+++ b/tests/base.py
@@ -187,15 +187,14 @@ class TestCaseWithReset(TestCase):
                 json.loads(result.body.decode('utf-8'))['name'])
         return environments
 
-    def create_namespace(self) -> dict:
-        namespace_name = str(uuid.uuid4())
-        result = self.fetch('/namespaces',
-                            method='POST',
-                            json_body={
-                                'name': namespace_name,
-                                'slug': str(uuid.uuid4()),
-                                'icon_class': 'fas fa-blind'
-                            })
+    def create_namespace(self, **overrides) -> dict:
+        body = {
+            'name': str(uuid.uuid4()),
+            'slug': str(uuid.uuid4()),
+            'icon_class': 'fas fa-blind'
+        }
+        body.update(overrides)
+        result = self.fetch('/namespaces', method='POST', json_body=body)
         self.assertEqual(result.code, 200)
         return json.loads(result.body.decode('utf-8'))
 
@@ -240,4 +239,15 @@ class TestCaseWithReset(TestCase):
                                 'environment_urls': False
                             })
         self.assertEqual(result.code, 200)
+        return json.loads(result.body.decode('utf-8'))
+
+    def create_integration(self, **overrides) -> dict:
+        body = {
+            'name': str(uuid.uuid4()),
+            'api_endpoint': 'https://api.example.com',
+            'api_secret': None,
+        }
+        body.update(overrides)
+        result = self.fetch('/integrations', method='POST', json_body=body)
+        self.assertEqual(200, result.code)
         return json.loads(result.body.decode('utf-8'))

--- a/tests/test_pagerduty_client.py
+++ b/tests/test_pagerduty_client.py
@@ -1,0 +1,190 @@
+import http.client
+import unittest.mock
+import uuid
+
+from tornado import httputil
+
+from imbi import errors, models, version
+from imbi.clients import pagerduty
+from tests import base
+
+
+class PagerDutyClientTestCase(base.TestCaseWithReset):
+    ADMIN_ACCESS = True
+    TRUNCATE_TABLES = ['v1.integrations']
+
+    def setUp(self) -> None:
+        super().setUp()
+        self._patcher = unittest.mock.patch.object(
+            pagerduty._PagerDutyClient,
+            'http_fetch',
+            new_callable=unittest.mock.AsyncMock,
+            create=True,
+        )
+        self.http_fetch_mock = self._patcher.start()
+        self.integration = self.create_integration(
+            api_endpoint='https://example.com/pagerduty/api',
+            api_secret='my-secret')
+
+        config = self.settings.setdefault('automations', {})
+        config['pagerduty'] = {'enabled': True}
+
+        self.client = self.run_until_complete(
+            pagerduty.create_client(self.app, self.integration['name']))
+
+    def tearDown(self) -> None:
+        self._patcher.stop()
+        super().tearDown()
+
+    @staticmethod
+    def create_successful_response(body=None):
+        if body is None:
+            body = {
+                'service': {
+                    'html_url': 'https://example.com/html_url',
+                    'id': str(uuid.uuid4()),
+                    'self': 'https://example.com/self',
+                }
+            }
+        response = unittest.mock.Mock()
+        response.ok = True
+        response.code = http.HTTPStatus.CREATED.value
+        response.body = body
+        return response
+
+
+class PagerDutyCreateClientTests(base.TestCaseWithReset):
+    ADMIN_ACCESS = True
+    TRUNCATE_TABLES = ['v1.integrations', 'v1.namespaces']
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.integration = self.create_integration(api_secret='my-secret')
+        config = self.settings.setdefault('automations', {})
+        config['pagerduty'] = {'enabled': True}
+
+    def test_correctly_configured(self) -> None:
+        self.run_until_complete(
+            pagerduty.create_client(self.app, self.integration['name']))
+
+    def test_missing_configuration(self) -> None:
+        del self.settings['automations']['pagerduty']
+        with self.assertRaises(errors.ClientUnavailableError):
+            self.run_until_complete(
+                pagerduty.create_client(self.app, self.integration['name']))
+
+    def test_pagerduty_disabled(self) -> None:
+        self.settings['automations']['pagerduty']['enabled'] = False
+        with self.assertRaises(errors.ClientUnavailableError):
+            self.run_until_complete(
+                pagerduty.create_client(self.app, self.integration['name']))
+
+    def test_with_incorrect_integration_name(self) -> None:
+        with self.assertRaises(errors.ClientUnavailableError):
+            self.run_until_complete(
+                pagerduty.create_client(self.app, str(uuid.uuid4())))
+
+    def test_with_missing_api_secret(self) -> None:
+        integration = self.create_integration()
+        with self.assertRaises(errors.ClientUnavailableError):
+            self.run_until_complete(
+                pagerduty.create_client(self.app, integration['name']))
+
+
+class PagerDutyProjectCreationTests(PagerDutyClientTestCase):
+    TRUNCATE_TABLES = [
+        'v1.environments', 'v1.integrations', 'v1.namespaces', 'v1.projects',
+        'v1.project_types'
+    ]
+
+    def setUp(self) -> None:
+        super().setUp()
+        project = self.create_project()
+        self.disabled_project: models.Project = self.run_until_complete(
+            models.project(project['id'], self.app))
+
+        enabled_namespace = self.create_namespace(pagerduty_policy='my-policy')
+        project = self.create_project(namespace_id=enabled_namespace['id'])
+        self.enabled_project: models.Project = self.run_until_complete(
+            models.project(project['id'], self.app))
+
+    def test_calling_with_namespace_policy(self) -> None:
+        self.http_fetch_mock.return_value = self.create_successful_response()
+        self.run_until_complete(
+            self.client.create_service(self.enabled_project))
+        self.http_fetch_mock.assert_awaited_once_with(
+            'https://example.com/pagerduty/api/services',
+            method='POST',
+            body={
+                'name': self.enabled_project.slug,
+                'description': self.enabled_project.description,
+                'escalation_policy': {
+                    'id': self.enabled_project.namespace.pagerduty_policy,
+                    'type': 'escalation_policy_reference'
+                }
+            },
+            request_headers=unittest.mock.ANY,
+            content_type='application/json',
+            user_agent=f'imbi/{version} (PagerDutyClient)')
+        _, kwargs = self.http_fetch_mock.await_args
+        request_headers = httputil.HTTPHeaders(kwargs['request_headers'])
+        self.assertEqual('Token token=my-secret',
+                         request_headers['Authorization'])
+
+    def test_calling_without_namespace_policy(self) -> None:
+        with self.assertRaises(errors.InternalServerError):
+            self.run_until_complete(
+                self.client.create_service(self.disabled_project))
+        self.http_fetch_mock.assert_not_awaited()
+
+    def test_empty_description_is_omitted(self) -> None:
+        self.http_fetch_mock.return_value = self.create_successful_response()
+        self.enabled_project.description = None
+        self.run_until_complete(
+            self.client.create_service(self.enabled_project))
+        self.http_fetch_mock.assert_awaited_once_with(
+            'https://example.com/pagerduty/api/services',
+            method='POST',
+            body={
+                'name': self.enabled_project.slug,
+                'escalation_policy': {
+                    'id': self.enabled_project.namespace.pagerduty_policy,
+                    'type': 'escalation_policy_reference'
+                }
+            },
+            request_headers=unittest.mock.ANY,
+            content_type='application/json',
+            user_agent=f'imbi/{version} (PagerDutyClient)')
+
+    def test_unexpected_response_handling(self) -> None:
+        self.http_fetch_mock.return_value = self.create_successful_response({})
+        with self.assertRaises(errors.InternalServerError):
+            self.run_until_complete(
+                self.client.create_service(self.enabled_project))
+
+    def test_pagerduty_api_failure(self) -> None:
+        response = unittest.mock.Mock()
+        response.ok = False
+        response.code = http.HTTPStatus.INTERNAL_SERVER_ERROR.value
+        response.history = [
+            unittest.mock.Mock(effective_url='https://example.com')
+        ]
+        self.http_fetch_mock.return_value = response
+
+        with self.assertRaises(errors.InternalServerError):
+            self.run_until_complete(
+                self.client.create_service(self.enabled_project))
+
+
+class PagerDutyProjectDeletionTests(PagerDutyClientTestCase):
+    def test_removing_service(self) -> None:
+        self.run_until_complete(self.client.remove_service('some-service-id'))
+        self.http_fetch_mock.assert_awaited_once_with(
+            'https://example.com/pagerduty/api/services/some-service-id',
+            method='DELETE',
+            request_headers=unittest.mock.ANY,
+            user_agent=f'imbi/{version} (PagerDutyClient)')
+        _, kwargs = self.http_fetch_mock.await_args
+        request_headers = httputil.HTTPHeaders(kwargs['request_headers'])
+        self.assertEqual('Token token=my-secret',
+                         request_headers['Authorization'])


### PR DESCRIPTION
This PR adds an automation that creates a PagerDuty Service linked to the new Imbi project. The implementation uses a [API  Key](https://developer.pagerduty.com/docs/f59fdbd94ceab-o-auth-functionality#oauth-or-pagerduty-api-key) that you create in your PagerDuty account to create services. The automation creates a new PD service if the user enables the "Create PagerDuty Service" automation *and* the selected namespace has a `pagerduty_policy` property set. The policy identifies the Escalation Policy that the service is associated with. The resulting service identifier is stored as a "pagerduty" external identifier for the project. If the `/automations/pagerduty/project_link_type_id` configuration value is set, then the automation will add a link to the dashboard using the configured link type.

<details>
  <summary>Configuration</summary>

```
curl --header "Private-Token: $IMBI_API_TOKEN" http://localhost:8000/integrations --json '{
  "name": "pagerduty",
  "api_endpoint": "https://api.pagerduty.com",
  "api_secret": "YOUR API KEY HERE"
}'
curl --header "Private-Token: $IMBI_API_TOKEN" http://localhost:8000/integrations/pagerduty/automations --json '{
  "name": "Create PagerDuty Service",
  "applies_to": ["api"],
  "categories": ["create-project"],
  "callable": "imbi.automations.pagerduty.create_service"
}'
```
</details>

**Breadcrumbs**
* [Escalation Policy concept](https://developer.pagerduty.com/api-reference/a47605517c19a-api-concepts#escalation-policies)
* [Service concept](https://developer.pagerduty.com/api-reference/a47605517c19a-api-concepts#services)
* [Create Service API](https://developer.pagerduty.com/api-reference/7062f2631b397-create-a-service)