### PR TITLE
Sort the Project.environments property

### DIFF
--- a/imbi/endpoints/projects.py
+++ b/imbi/endpoints/projects.py
@@ -418,6 +418,8 @@ class RecordRequestHandler(project.RequestHandlerMixin, _RequestHandlerMixin,
                 raise errors.ItemNotFound()
 
             output = project.row
+            if output['environments']:
+                output['environments'] = sorted(output['environments'])
             output.update({
                 'facts': facts.rows,
                 'links': links.rows,


### PR DESCRIPTION
The ordering of the project urls in the UI reflects the order of the `environments` property in the `/projects/{id}` response. This PR sorts the `environments` list so that it is consistent across projects. This will address the issue with the current UI but does not really fix the problem there.

See https://github.com/AWeber-Imbi/imbi-ui/issues/74 for the genesis of this change.