### PR TITLE
Return no params for project without environments

### DIFF
--- a/imbi/endpoints/project_ssm_configuration.py
+++ b/imbi/endpoints/project_ssm_configuration.py
@@ -54,6 +54,10 @@ class CollectionRequestHandler(sprockets.mixins.http.HTTPClientMixin,
             'get-project-namespace-id')
         project_info = result.row
 
+        if not project_info['environments']:
+            self.send_response([])
+            return
+
         if project_info['configuration_type'] != 'ssm':
             raise errors.ItemNotFound(
                 'Project %s does not use SSM configuration',


### PR DESCRIPTION
It was instead 500ing due to iterating through the environments, which is None when they don't exist. We can just exit early since zero environments means zero params.