### PR TITLE
Use our custom errors when fetching SSM

### DIFF
--- a/imbi/endpoints/project_ssm_configuration.py
+++ b/imbi/endpoints/project_ssm_configuration.py
@@ -161,10 +161,12 @@ class CollectionRequestHandler(sprockets.mixins.http.HTTPClientMixin,
                                                       imbi_user, id_token,
                                                       refresh_token, True)
             elif error.response['Error']['Code'] == 'AccessDenied':
-                raise web.HTTPError(
-                    401,
-                    reason=('Not authorized to access SSM in this '
-                            'namespace & environment'))
+                raise errors.Unauthorized(
+                    '%s unauthorized to assume AWS role %s',
+                    imbi_user.username,
+                    role_arn,
+                    reason='Not authorized to access SSM in this '
+                    'namespace & environment')
             else:
                 self.logger.error(
                     'Unexpected AWS credential failure for '

--- a/imbi/endpoints/project_ssm_configuration.py
+++ b/imbi/endpoints/project_ssm_configuration.py
@@ -168,12 +168,13 @@ class CollectionRequestHandler(sprockets.mixins.http.HTTPClientMixin,
                     reason='Not authorized to access SSM in this '
                     'namespace & environment')
             else:
-                self.logger.error(
-                    'Unexpected AWS credential failure for '
-                    '%s and %s: %s', imbi_user.username, role_arn,
-                    error.response['Error']['Code'])
-                raise web.HTTPError(
-                    500, reason='Unexpected failure fetching AWS credentials')
+                raise errors.InternalServerError(
+                    'Unexpected AWS credential failure for'
+                    '%s assuming AWS role %s: %s',
+                    imbi_user.username,
+                    role_arn,
+                    error.response['Error']['Code'],
+                    reason='Unexpected failure fetching AWS credentials')
         creds = {
             'access_key_id': response['Credentials']['AccessKeyId'],
             'secret_access_key': response['Credentials']['SecretAccessKey'],

--- a/imbi/errors.py
+++ b/imbi/errors.py
@@ -71,6 +71,11 @@ class BadRequest(ApplicationError):
         super().__init__(400, 'bad-request', log_message, *log_args, **kwargs)
 
 
+class Unauthorized(ApplicationError):
+    def __init__(self, log_message, *log_args, **kwargs):
+        super().__init__(401, 'unauthorized', log_message, *log_args, **kwargs)
+
+
 class Forbidden(ApplicationError):
     def __init__(self, log_message, *log_args, **kwargs):
         super().__init__(403, 'forbidden', log_message, *log_args, **kwargs)


### PR DESCRIPTION
This makes the errors use a proper json problemdetails while still passing the reason to the frontend (displayed in "title")