### PR TITLE
Add admin props to GET /components

### DIFF
--- a/imbi/endpoints/components.py
+++ b/imbi/endpoints/components.py
@@ -51,12 +51,18 @@ class CollectionRequestHandler(base.PaginatedCollectionHandler):
 
     COLLECTION_SQL = re.sub(
         r'\s+', ' ', """\
-        SELECT package_url, "name", status, home_page, icon_class,
-               active_version, created_at, created_by,
-               last_modified_at, last_modified_by
-          FROM v1.components
-         WHERE package_url > %(starting_package)s
-         ORDER BY package_url ASC
+        SELECT c.package_url, c."name", c.status, c.home_page, c.icon_class,
+               c.active_version, COUNT(v.id) AS version_count,
+               COUNT(p.project_id) AS project_count, c.created_at,
+               c.created_by, c.last_modified_at, c.last_modified_by
+          FROM v1.components AS c
+          LEFT JOIN v1.component_versions AS v ON v.package_url = c.package_url
+          LEFT JOIN v1.project_components AS p ON p.version_id = v.id
+         WHERE c.package_url > %(starting_package)s
+         GROUP BY c.package_url, c."name", c.status, c.home_page, c.icon_class,
+                  c.active_version, c.created_at, c.created_by,
+                  c.last_modified_at, c.last_modified_by
+         ORDER BY c.package_url ASC
          LIMIT %(limit)s
         """)
     GET_SQL = re.sub(

--- a/imbi/templates/openapi.yaml
+++ b/imbi/templates/openapi.yaml
@@ -595,12 +595,33 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/paths/~1components/post/responses/200/content/application~1json/schema'
+                  allOf:
+                    - $ref: '#/paths/~1components/post/responses/200/content/application~1json/schema'
+                    - type: object
+                      properties:
+                        link:
+                          type: string
+                          format: uri
+                          description: Canonical link to this component
+                        project_count:
+                          type: number
+                          description: Number of projects using this component
+                        version_count:
+                          type: number
+                          description: Number of component versions discovered
+                      required:
+                        - link
+                        - project_count
+                        - version_count
+                      example:
+                        link: /components/pkg%3Apypi%3Aimbi
+                        project_count: 1
+                        version_count: 13
             application/msgpack:
               schema:
                 type: array
                 items:
-                  $ref: '#/paths/~1components/post/responses/200/content/application~1json/schema'
+                  $ref: '#/paths/~1components/get/responses/200/content/application~1json/schema/items'
           headers:
             Link:
               description: |


### PR DESCRIPTION
We want to show the number of projects using a component along with the number of versions that exist in the DB in the Components admin view. This PR adds two new properties to the `GET /components` response for this. The API is used in https://github.com/AWeber-Imbi/imbi-ui/pull/79 and described in https://github.com/AWeber-Imbi/imbi-openapi/pull/27.