### PR TITLE
Add component-usage report

### DIFF
--- a/imbi/endpoints/reports/__init__.py
+++ b/imbi/endpoints/reports/__init__.py
@@ -4,9 +4,11 @@ System Reports
 """
 from tornado import web
 
-from . import namespace_kpis, namespace_shs_history, system_shs_history
+from . import (component_usage, namespace_kpis, namespace_shs_history,
+               system_shs_history)
 
 URLS = [
+    web.url(r'/reports/component-usage', component_usage.RequestHandler),
     web.url(r'/reports/namespace-kpis', namespace_kpis.RequestHandler),
     web.url(r'/reports/namespace-shs-history',
             namespace_shs_history.RequestHandler),

--- a/imbi/endpoints/reports/component_usage.py
+++ b/imbi/endpoints/reports/component_usage.py
@@ -1,0 +1,24 @@
+import re
+
+from tornado import web
+
+from imbi.endpoints import base
+
+
+class RequestHandler(base.RequestHandler):
+    NAME = 'reports-component-usage'
+    SQL = re.sub(
+        r'\s+', ' ', """\
+        SELECT c.name, c.package_url, c.active_version, c.status,
+               COUNT(v.id) AS version_count,
+               COUNT(p.project_id) AS project_count
+          FROM v1.components AS c
+          JOIN v1.component_versions AS v ON v.package_url = c.package_url
+          LEFT JOIN v1.project_components AS p ON p.version_id = v.id
+         GROUP BY c.name, c.package_url, c.active_version
+        """)
+
+    @web.authenticated
+    async def get(self) -> None:
+        result = await self.postgres_execute(self.SQL, metric_name=self.NAME)
+        self.send_response(result.rows)

--- a/imbi/endpoints/reports/component_usage.py
+++ b/imbi/endpoints/reports/component_usage.py
@@ -1,11 +1,9 @@
 import re
 
-from tornado import web
-
 from imbi.endpoints import base
 
 
-class RequestHandler(base.RequestHandler):
+class RequestHandler(base.AuthenticatedRequestHandler):
     NAME = 'reports-component-usage'
     SQL = re.sub(
         r'\s+', ' ', """\
@@ -18,7 +16,6 @@ class RequestHandler(base.RequestHandler):
          GROUP BY c.name, c.package_url, c.active_version
         """)
 
-    @web.authenticated
     async def get(self) -> None:
         result = await self.postgres_execute(self.SQL, metric_name=self.NAME)
         self.send_response(result.rows)

--- a/imbi/endpoints/reports/namespace_kpis.py
+++ b/imbi/endpoints/reports/namespace_kpis.py
@@ -1,11 +1,9 @@
 import re
 
-from tornado import web
-
 from imbi.endpoints import base
 
 
-class RequestHandler(base.RequestHandler):
+class RequestHandler(base.AuthenticatedRequestHandler):
 
     NAME = 'reports-namespace-kpis'
 
@@ -41,7 +39,6 @@ class RequestHandler(base.RequestHandler):
          GROUP BY namespace_id, namespace
          ORDER BY namespace;""")
 
-    @web.authenticated
     async def get(self):
         result = await self.postgres_execute(self.SQL, metric_name=self.NAME)
         self.send_response(result.rows)

--- a/imbi/endpoints/reports/namespace_shs_history.py
+++ b/imbi/endpoints/reports/namespace_shs_history.py
@@ -1,11 +1,9 @@
 import re
 
-from tornado import web
-
 from imbi.endpoints import base
 
 
-class RequestHandler(base.RequestHandler):
+class RequestHandler(base.AuthenticatedRequestHandler):
 
     NAME = 'reports-namespace-shs-history'
 
@@ -20,7 +18,6 @@ class RequestHandler(base.RequestHandler):
          WHERE a.scored_on > CURRENT_DATE - interval '1 year'
       ORDER BY a.scored_on ASC, a.namespace_id ASC;""")
 
-    @web.authenticated
     async def get(self):
         result = await self.postgres_execute(self.SQL, metric_name=self.NAME)
         self.send_response(result.rows)

--- a/imbi/endpoints/reports/system_shs_history.py
+++ b/imbi/endpoints/reports/system_shs_history.py
@@ -1,11 +1,9 @@
 import re
 
-from tornado import web
-
 from imbi.endpoints import base
 
 
-class RequestHandler(base.RequestHandler):
+class RequestHandler(base.AuthenticatedRequestHandler):
 
     NAME = 'reports-system-shs-history'
 
@@ -18,7 +16,6 @@ class RequestHandler(base.RequestHandler):
       GROUP BY scored_on
       ORDER BY scored_on ASC""")
 
-    @web.authenticated
     async def get(self):
         result = await self.postgres_execute(self.SQL, metric_name=self.NAME)
         self.send_response(result.rows)

--- a/imbi/templates/openapi.yaml
+++ b/imbi/templates/openapi.yaml
@@ -7776,6 +7776,112 @@ paths:
                     type: string
         '401':
           $ref: '#/paths/~1groups/get/responses/401'
+  /reports/component-usage:
+    get:
+      description: Report of all defined components
+      summary: Component Usage
+      tags:
+        - Reports
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  description: Single component usage report
+                  properties:
+                    name:
+                      description: Component name
+                      type: string
+                    package_url:
+                      description: |
+                        Unique identifier for the component following the
+                        [purl spec](https://github.com/package-url/purl-spec)
+                      type: string
+                      pattern: '^pkg:'
+                    active_version:
+                      description: Optional semantic version range that is considered the "current" version
+                      type: string
+                      nullable: true
+                    status:
+                      description: Status for *all* versions of this component
+                      type: string
+                      enum:
+                        - Active
+                        - Deprecated
+                        - Forbidden
+                    project_count:
+                      description: Number of projects using this component
+                      type: number
+                    version_count:
+                      description: Number of known versions of this component
+                      type: number
+                  required:
+                    - active_version
+                    - name
+                    - package_url
+                    - project_count
+                    - status
+                    - version_count
+                  example:
+                    active_version: ~0.21
+                    name: imbi
+                    package_url: 'pkg:pypi:imbi'
+                    status: Active
+                    project_count: 1
+                    version_count: 12
+            application/msgpack:
+              schema:
+                type: array
+                items:
+                  type: object
+                  description: Single component usage report
+                  properties:
+                    name:
+                      description: Component name
+                      type: string
+                    package_url:
+                      description: |
+                        Unique identifier for the component following the
+                        [purl spec](https://github.com/package-url/purl-spec)
+                      type: string
+                      pattern: '^pkg:'
+                    active_version:
+                      description: Optional semantic version range that is considered the "current" version
+                      type: string
+                      nullable: true
+                    status:
+                      description: Status for *all* versions of this component
+                      type: string
+                      enum:
+                        - Active
+                        - Deprecated
+                        - Forbidden
+                    project_count:
+                      description: Number of projects using this component
+                      type: number
+                    version_count:
+                      description: Number of known versions of this component
+                      type: number
+                  required:
+                    - active_version
+                    - name
+                    - package_url
+                    - project_count
+                    - status
+                    - version_count
+                  example:
+                    active_version: ~0.21
+                    name: imbi
+                    package_url: 'pkg:pypi:imbi'
+                    status: Active
+                    project_count: 1
+                    version_count: 12
+        '401':
+          $ref: '#/paths/~1groups/get/responses/401'
   /reports/namespace-shs-history:
     get:
       description: The history of stack health scores for all namespaces for the last 12 months


### PR DESCRIPTION
This PR adds a simple component usage report that contains the known components. Each component is an array element with basic information, the number of projects using the component, and the number of known versions. See https://github.com/AWeber-Imbi/imbi-openapi/pull/29 for the PR that generated the OpenAPI spec.