### PR TITLE
Bump imbi-postgres to 0.22.2

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -44,7 +44,7 @@ services:
       - opensearch
 
   postgres:
-    image: aweber/imbi-postgres:0.21.0
+    image: aweber/imbi-postgres:0.22.2
     ports:
       - 5432
     volumes:


### PR DESCRIPTION
This PR simply bumps the imbi-postgres version [to 0.22.2](https://hub.docker.com/layers/aweber/imbi-postgres/0.22.2/images/sha256-bc926a330f9398ad06bee45f9e65e831ea969dc48682d861419539ef786b9c9f)