### PR TITLE
Reindex the project after ingesting a SBoM

### DIFF
--- a/imbi/models.py
+++ b/imbi/models.py
@@ -440,7 +440,7 @@ async def project(project_id: int, application: 'app.Application') -> Project:
                     for value in results[5]
                 },
                 'components': [{
-                    'name': c.name,
+                    'name': c.package_url,
                     'version': c.version
                 } for c in results[6]]
             })

--- a/imbi/models.py
+++ b/imbi/models.py
@@ -291,6 +291,7 @@ class Project:
     urls: dict[str, str]
     project_score: int
     components: list[dict[str, str]]
+    component_versions: list[str]
 
     SQL: typing.ClassVar = re.sub(
         r'\s+', ' ', """\
@@ -442,7 +443,10 @@ async def project(project_id: int, application: 'app.Application') -> Project:
                 'components': [{
                     'name': c.package_url,
                     'version': c.version
-                } for c in results[6]]
+                } for c in results[6]],
+                'component_versions': [
+                    f'{c.package_url}@{c.version}' for c in results[6]
+                ]
             })
             return Project(**values)
 


### PR DESCRIPTION
This PR reindexes the project in the OpenSearch index after ingesting a SBoM.  I noticed that the indexed content was using the `name` instead of the `package_url` so I fixed that as well... _this was a direct result of not reindexing since I didn't notice that it was broken in dev_.

The last commit (b2efa309) adds a new field to the index named `component_versions` that is a list of `{package_url}@{version}` strings for components. This is a temporary workaround for shortcoming in our FE query builder. The version of kbn-es-query that we are using does not support nested query syntax. The workaround is to flatten the values in the index for the time being.