### PR TITLE
Add optional project info in dependency endpoint

### DIFF
--- a/imbi/endpoints/project_dependencies.py
+++ b/imbi/endpoints/project_dependencies.py
@@ -31,12 +31,45 @@ class CollectionRequestHandler(projects.ProjectAttributeCollectionMixin,
            WHERE project_id=%(project_id)s
         ORDER BY dependency_id""")
 
+    COLLECTION_WITH_DEPENDENCY_SQL = re.sub(
+        r'\s+', ' ', """\
+        SELECT d.project_id, d.created_at, d.created_by, d.dependency_id,
+               p.name AS dependency_name,
+               p.namespace_id AS dependency_namespace_id,
+               p.project_type_id AS dependency_project_type_id
+          FROM v1.project_dependencies AS d
+          JOIN v1.projects AS p
+            ON d.dependency_id=p.id
+         WHERE project_id=%(project_id)s""")
+
     POST_SQL = re.sub(
         r'\s+', ' ', """\
         INSERT INTO v1.project_dependencies
                     (project_id, dependency_id, created_by)
              VALUES (%(project_id)s, %(dependency_id)s, %(username)s)
           RETURNING project_id, dependency_id""")
+
+    async def get(self, *args, **kwargs):
+        if 'dependency' in self.get_query_arguments('includes'):
+            result = await self.postgres_execute(
+                self.COLLECTION_WITH_DEPENDENCY_SQL,
+                kwargs,
+                metric_name='get-{}'.format(self.NAME))
+            response = [{
+                'project_id': row['project_id'],
+                'dependency_id': row['dependency_id'],
+                'created_at': row['created_at'],
+                'created_by': row['created_by'],
+                'dependency': {
+                    'id': row['dependency_id'],
+                    'name': row['dependency_name'],
+                    'namespace_id': row['dependency_namespace_id'],
+                    'project_type_id': row['dependency_project_type_id'],
+                }
+            } for row in result.rows]
+            self.send_response(response)
+        else:
+            await super().get(*args, **kwargs)
 
 
 class RecordRequestHandler(projects.ProjectAttributeCRUDMixin,

--- a/imbi/endpoints/project_dependencies.py
+++ b/imbi/endpoints/project_dependencies.py
@@ -50,7 +50,7 @@ class CollectionRequestHandler(projects.ProjectAttributeCollectionMixin,
           RETURNING project_id, dependency_id""")
 
     async def get(self, *args, **kwargs):
-        if 'dependency' in self.get_query_arguments('includes'):
+        if 'dependency' in self.get_query_arguments('include'):
             result = await self.postgres_execute(
                 self.COLLECTION_WITH_DEPENDENCY_SQL,
                 kwargs,

--- a/imbi/templates/openapi.yaml
+++ b/imbi/templates/openapi.yaml
@@ -7702,7 +7702,7 @@ paths:
         required: true
         schema:
           type: number
-      - name: includes
+      - name: include
         in: query
         description: Optionally expand the dependent project
         schema:

--- a/imbi/templates/openapi.yaml
+++ b/imbi/templates/openapi.yaml
@@ -7554,7 +7554,22 @@ paths:
                     dependency_id:
                       description: The ID of the project that is depended upon
                       type: number
-                  additionalProperties: false
+                    dependency:
+                      description: Optional project information of the dependency
+                      type: object
+                      properties:
+                        id:
+                          description: The ID of the project that is depended upon
+                          type: number
+                        name:
+                          description: The project name
+                          type: string
+                        namespace_id:
+                          description: The project namespace ID
+                          type: number
+                        project_type_id:
+                          description: The project type ID
+                          type: number
               examples:
                 records:
                   summary: Multiple records
@@ -7582,7 +7597,22 @@ paths:
                     dependency_id:
                       description: The ID of the project that is depended upon
                       type: number
-                  additionalProperties: false
+                    dependency:
+                      description: Optional project information of the dependency
+                      type: object
+                      properties:
+                        id:
+                          description: The ID of the project that is depended upon
+                          type: number
+                        name:
+                          description: The project name
+                          type: string
+                        namespace_id:
+                          description: The project namespace ID
+                          type: number
+                        project_type_id:
+                          description: The project type ID
+                          type: number
               examples:
                 records:
                   summary: Multiple records
@@ -7672,6 +7702,13 @@ paths:
         required: true
         schema:
           type: number
+      - name: includes
+        in: query
+        description: Optionally expand the dependent project
+        schema:
+          type: string
+          enum:
+            - dependency
   '/projects/{id}/dependencies/{dependency_id}':
     get:
       summary: Get Record


### PR DESCRIPTION
This adds the potential query string param "includes" where the request can specify that it wants extra information about the project dependencies. This will be used by the frontend to populate a dependency table.

Corresponding openapi PR: https://github.com/AWeber-Imbi/imbi-openapi/pull/35