### PR TITLE
Run automations on project dependency add/delete

### DIFF
--- a/imbi/automations/__init__.py
+++ b/imbi/automations/__init__.py
@@ -10,7 +10,7 @@ import graphlib
 import sprockets_postgres  # type: ignore[import-untyped]
 import typing_extensions as typing
 
-from imbi import errors, models
+from imbi import errors
 
 if typing.TYPE_CHECKING:  # pragma: nocover
     import imbi.app
@@ -260,7 +260,7 @@ def query_runner(
 
 async def retrieve_automations(
         application: imbi.app.Application, slugs: typing.Iterable[str],
-        project_type_id: int) -> list[models.Automation]:
+        project_type_id: int) -> list[imbi.models.Automation]:
     """Retrieve a list of automations by slug and validate them
 
     If a slug doesn't exist in the database or any automation is
@@ -268,7 +268,7 @@ async def retrieve_automations(
 
     """
     automation_instances = [
-        await models.automation(slug, application) for slug in slugs
+        await imbi.models.automation(slug, application) for slug in slugs
     ]
     required_automations = set()
     for a in automation_instances:
@@ -294,8 +294,8 @@ async def retrieve_automations(
 
 
 def sort_automations(
-    automations: typing.Sequence[models.Automation]
-) -> typing.Sequence[models.Automation]:
+    automations: typing.Sequence[imbi.models.Automation]
+) -> typing.Sequence[imbi.models.Automation]:
     if not automations:
         return automations
 

--- a/imbi/automations/models.py
+++ b/imbi/automations/models.py
@@ -46,6 +46,8 @@ PathIdType: typing.TypeAlias = typing.Union[int, slugify.Slug]
 
 class AutomationCategory(enum.Enum):
     CREATE_PROJECT = 'create-project'
+    CREATE_DEPENDENCY = 'create-project-dependency'
+    REMOVE_DEPENDENCY = 'remove-project-dependency'
 
 
 class Automation(pydantic.BaseModel):

--- a/imbi/endpoints/base.py
+++ b/imbi/endpoints/base.py
@@ -25,7 +25,7 @@ import umsgpack
 import yarl
 from ietfparse import datastructures
 from openapi_core.deserializing.exceptions import DeserializeError
-from openapi_core.schema.media_types.exceptions import InvalidContentType
+from openapi_core.templating.media_types.exceptions import MediaTypeNotFound
 from openapi_core.templating.paths.exceptions import \
     OperationNotFound, PathNotFound
 from openapi_core.unmarshalling.schemas.exceptions import ValidateError
@@ -270,7 +270,7 @@ class ValidatingRequestHandler(AuthenticatedRequestHandler):
                 title='OpenAPI Security Error')
         except OperationNotFound as err:
             raise errors.MethodNotAllowed(err.method.upper())
-        except InvalidContentType as err:
+        except MediaTypeNotFound as err:
             raise errors.UnsupportedMediaType(err.mimetype)
         except PathNotFound as err:
             raise errors.InternalServerError('OpenAPI Spec Error: %s',

--- a/imbi/endpoints/project_dependencies.py
+++ b/imbi/endpoints/project_dependencies.py
@@ -24,7 +24,7 @@ class _DependencyRequestMixin:
         INSERT INTO v1.project_dependencies
                     (project_id, dependency_id, created_by)
              VALUES (%(project_id)s, %(dependency_id)s, %(username)s)
-          RETURNING project_id, dependency_id""")
+          RETURNING project_id, dependency_id, created_at, created_by""")
 
     async def _run_automations(
             self, dependency: models.ProjectDependency,
@@ -117,9 +117,11 @@ class CollectionRequestHandler(projects.ProjectAttributeCollectionMixin,
             raise errors.DatabaseError('Failed to create project dependency',
                                        title='Failed to create record')
 
-        dependency = await models.project_dependency(
-            result.row['project_id'], result.row['dependency_id'],
-            self.application)
+        dependency = models.ProjectDependency(
+            project_id=result.row['project_id'],
+            dependency_id=result.row['dependency_id'],
+            created_at=result.row['created_at'],
+            created_by=result.row['created_by'])
 
         try:
             await self._run_automations(dependency, selected_automations)

--- a/imbi/endpoints/projects.py
+++ b/imbi/endpoints/projects.py
@@ -176,8 +176,9 @@ class CollectionRequestHandler(project.RequestHandlerMixin,
             if name not in values:
                 values[name] = self.DEFAULTS.get(name)
 
-        selected_automations = await self._retrieve_automations(
-            values.get('automations', []), values['project_type_id'])
+        selected_automations = await automations.retrieve_automations(
+            self.application, values.get('automations', []),
+            values['project_type_id'])
 
         result = await self.postgres_execute(self.POST_SQL, values,
                                              f'post-{self.NAME}')
@@ -207,41 +208,6 @@ class CollectionRequestHandler(project.RequestHandlerMixin,
         else:
             raise errors.InternalServerError(
                 'Newly created project not found - id=%s', project.id)
-
-    async def _retrieve_automations(
-            self, slugs: typing.Iterable[str],
-            project_type_id: int) -> list[models.Automation]:
-        """Retrieve a list of automations by slug and validate them
-
-        If a slug doesn't exist in the database or any automation is
-        not applicable to the project type, then an exception is raised.
-
-        """
-        automation_instances = [
-            await models.automation(slug, self.application) for slug in slugs
-        ]
-        required_automations = set()
-        for a in automation_instances:
-            required_automations.update(a.depends_on)
-        required_automations.difference_update(
-            {a.slug
-             for a in automation_instances})
-        error = {
-            'nonexistent_automations': [
-                name for name, matched in zip(slugs, automation_instances)
-                if matched is None
-            ],
-            'invalid_automations': [
-                a.name for a in automation_instances
-                if a is not None and project_type_id not in a.applies_to_ids
-            ],
-            'missing_required_automations': list(required_automations),
-        }
-        error = {label: value for label, value in error.items() if value}
-        if error:
-            raise errors.BadRequest('Invalid project creation request',
-                                    **error)
-        return automation_instances
 
     async def _run_automations(
             self, project: models.Project,

--- a/imbi/endpoints/projects.py
+++ b/imbi/endpoints/projects.py
@@ -1,5 +1,4 @@
 import asyncio
-import graphlib
 import re
 import typing
 
@@ -219,11 +218,8 @@ class CollectionRequestHandler(project.RequestHandlerMixin,
         if not selected_automations:
             return
 
-        lookup = {a.slug: a for a in selected_automations}
-        dag = graphlib.TopologicalSorter()
-        for automation in selected_automations:
-            dag.add(automation.slug, *automation.depends_on)
-        ordered_automations = [lookup[a] for a in dag.static_order()]
+        ordered_automations = automations.sort_automations(
+            selected_automations)
 
         self.logger.info(
             'running create-project automations for project %s (%s): %r',

--- a/imbi/openapi.py
+++ b/imbi/openapi.py
@@ -9,7 +9,7 @@ import umsgpack
 import validators
 import yaml
 from jsonschema import validators as jsonschema_validators
-from openapi_core.schema.specs import factories, models
+from openapi_core.spec import paths
 from tornado import template
 
 from imbi import transcoders
@@ -71,7 +71,7 @@ _openapi_deserializers = {
 _openapi_spec_dict = {}
 
 
-def create_spec(settings: dict) -> models.Spec:
+def create_spec(settings: dict) -> paths.SpecPath:
     """Create and return the OpenAPI v3 Spec Model"""
     if not _openapi_spec_dict:
         loader = template.Loader(str(settings['template_path']))
@@ -85,9 +85,9 @@ def create_spec(settings: dict) -> models.Spec:
         '',
         _openapi_spec_dict,
         handlers=openapi_spec_validator.default_handlers)
-    spec_factory = factories.SpecFactory(spec_resolver,
-                                         config={'validate_spec': False})
-    return spec_factory.create(_openapi_spec_dict, spec_url='')
+    dereferencer = openapi_spec_validator.validators.Dereferencer(
+        spec_resolver)
+    return paths.SpecPath.from_spec(_openapi_spec_dict, dereferencer)
 
 
 def request_validator(settings: dict) -> tornado_openapi3.RequestValidator:

--- a/imbi/templates/openapi.yaml
+++ b/imbi/templates/openapi.yaml
@@ -2389,6 +2389,8 @@ paths:
                     type: string
                     enum:
                       - create-project
+                      - create-project-dependency
+                      - remove-project-dependency
                 callable:
                   allOf:
                     - description: |
@@ -2474,6 +2476,8 @@ paths:
                       type: string
                       enum:
                         - create-project
+                        - create-project-dependency
+                        - remove-project-dependency
                   applies_to:
                     description: Project type slugs that this automation can be run for
                     type: array
@@ -7541,13 +7545,17 @@ paths:
               schema:
                 type: array
                 items:
-                  title: Project
+                  title: Project Dependency
                   description: A record that indicates one project is dependent upon another
                   type: object
                   properties:
                     project_id:
                       description: The ID of the project that has the dependency
                       type: number
+                    created_at:
+                      description: The timestamp when the dependency was created
+                      type: string
+                      format: iso8601-timestamp
                     created_by:
                       description: The username indicating who created the record
                       type: string
@@ -7575,22 +7583,28 @@ paths:
                   summary: Multiple records
                   value:
                     - project_id: 2
+                      created_at: 1964-01-01T19:11:11.000Z
                       created_by: test_user
                       dependency_id: 1
                     - project_id: 3
+                      created_at: 1964-01-01T19:11:11.000Z
                       created_by: test_user
                       dependency_id: 1
             application/msgpack:
               schema:
                 type: array
                 items:
-                  title: Project
+                  title: Project Dependency
                   description: A record that indicates one project is dependent upon another
                   type: object
                   properties:
                     project_id:
                       description: The ID of the project that has the dependency
                       type: number
+                    created_at:
+                      description: The timestamp when the dependency was created
+                      type: string
+                      format: iso8601-timestamp
                     created_by:
                       description: The username indicating who created the record
                       type: string
@@ -7618,9 +7632,11 @@ paths:
                   summary: Multiple records
                   value:
                     - project_id: 2
+                      created_at: 1964-01-01T19:11:11.000Z
                       created_by: test_user
                       dependency_id: 1
                     - project_id: 3
+                      created_at: 1964-01-01T19:11:11.000Z
                       created_by: test_user
                       dependency_id: 1
         '401':
@@ -7635,10 +7651,16 @@ paths:
         content:
           application/json:
             schema:
-              title: Project
+              title: Project Dependency
               description: A record that indicates one project is dependent upon another
               type: object
               properties:
+                automations:
+                  description: List of automations to run while creating the project dependency
+                  type: array
+                  items:
+                    type: string
+                  nullable: true
                 dependency_id:
                   description: The ID of the project that is depended upon
                   type: number
@@ -7727,6 +7749,37 @@ paths:
       description: Remove a project dependency record
       tags:
         - Project Dependencies
+      requestBody:
+        description: Specify optional automation slugs to run
+        content:
+          application/json:
+            schema:
+              title: Project Dependency
+              description: A record that indicates one project is dependent upon another
+              type: object
+              properties:
+                automations:
+                  description: List of automations to run while creating the project dependency
+                  type: array
+                  items:
+                    type: string
+                  nullable: true
+              additionalProperties: false
+            examples:
+              record:
+                summary: Optional automations to run
+                value:
+                  automations:
+                    - create-pagerduty-dependency
+          application/msgpack:
+            schema:
+              $ref: '#/paths/~1projects~1%7Bid%7D~1dependencies~1%7Bdependency_id%7D/delete/requestBody/content/application~1json/schema'
+            examples:
+              record:
+                summary: Optional automations to run
+                value:
+                  automations:
+                    - create-pagerduty-dependency
       responses:
         '204':
           $ref: '#/paths/~1groups~1%7Bname%7D/delete/responses/204'

--- a/setup.cfg
+++ b/setup.cfg
@@ -62,7 +62,7 @@ install_requires =
     iso8601
     isort==5.9.2
     ldap3>=2.5,<3
-    openapi-core==0.13.4
+    openapi-core>=0.14.2,<0.15.0
     openapi-schema-validator==0.1.1
     openapi-spec-validator==0.2.9
     opensearch-py[async]>=1,<2

--- a/setup.cfg
+++ b/setup.cfg
@@ -77,7 +77,7 @@ install_requires =
     sprockets-postgres>=1.8.1,<2
     tornado==6.1
     tornado-problem-details>=0.0.6,<1
-    tornado_openapi3>=0.2.4,<1
+    tornado_openapi3>=1.1.2,<2
     typing-extensions>=4.9,<4.10
     u-msgpack-python>=2.1,<3
     validators


### PR DESCRIPTION
This adds the plumbing for create and remove project dependency automations, on the POST and DELETE endpoints. Some of the generic automations code got moved out of project creation and put into the `automations` package, to be re-used by the new dependency automations.