### PR TITLE
Pin versions

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -44,7 +44,7 @@ services:
       - opensearch
 
   postgres:
-    image: aweber/imbi-postgres:0.22.2
+    image: aweber/imbi-postgres:0.22.6
     ports:
       - 5432
     volumes:

--- a/compose.yml
+++ b/compose.yml
@@ -15,7 +15,7 @@ services:
     command: --loglevel debug --copy-service
 
   opensearch:
-    image: opensearchproject/opensearch:latest
+    image: opensearchproject/opensearch:2.2.0
     environment:
       - discovery.type=single-node
       - DISABLE_INSTALL_DEMO_CONFIG=true


### PR DESCRIPTION
This PR pins versions in the docker compose environment. For some reason the latest version of opensearch does not work correctly on my machine 😞 