### PR TITLE
Switch to numeric component score

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -89,8 +89,8 @@ automations:
     admin_token: ~
     project_link_type_id: ~
     url: ~
-components:
-  project_fact_type_id: ~
+component_scoring:
+  enabled: true
 google:
   enabled: true
   valid_domains: gmail.com

--- a/example.yaml
+++ b/example.yaml
@@ -26,7 +26,9 @@
 #     project_link_type_id: ~
 #     url: ~
 
-# components:
+# component_scoring:
+#   enabled: false
+#   fact_name: "Component Score"
 #   project_fact_type_id: ~
 
 # cors: ~

--- a/imbi/endpoints/components/handlers.py
+++ b/imbi/endpoints/components/handlers.py
@@ -234,11 +234,15 @@ class ProjectComponentsRequestHandler(base.PaginatedCollectionHandler):
 
         """
         item['link'] = self.reverse_url('component', item['package_url'])
-        project_component = models.ProjectComponentRow.model_validate(item)
-        if project_component.active_version is None:
-            item['status'] = models.ProjectComponentStatus.UNSCORED
-        elif project_component.status == models.ComponentStatus.ACTIVE:
-            if project_component.version in project_component.active_version:
+        row = models.ProjectComponentRow.model_validate(item)
+        if row.status == models.ComponentStatus.FORBIDDEN:
+            item['status'] = models.ProjectComponentStatus.FORBIDDEN
+        elif row.status == models.ComponentStatus.DEPRECATED:
+            item['status'] = models.ProjectComponentStatus.DEPRECATED
+        elif row.status == models.ComponentStatus.ACTIVE:
+            if row.active_version is None:
+                item['status'] = models.ProjectComponentStatus.UNSCORED
+            elif row.version in row.active_version:
                 item['status'] = models.ProjectComponentStatus.UP_TO_DATE
             else:
                 item['status'] = models.ProjectComponentStatus.OUTDATED

--- a/imbi/endpoints/components/models.py
+++ b/imbi/endpoints/components/models.py
@@ -23,11 +23,11 @@ class ProjectComponentStatus(str, enum.Enum):
     FORBIDDEN = 'Forbidden'
 
 
-class ProjectStatus(str, enum.Enum):
+class ProjectStatus(int, enum.Enum):
     """Component Score project fact values"""
-    OKAY = 'Okay'
-    NEEDS_WORK = 'Needs Work'
-    UNACCEPTABLE = 'Unacceptable'
+    OKAY = 100
+    NEEDS_WORK = 80
+    UNACCEPTABLE = 0
 
 
 class ProjectComponentRow(pydantic.BaseModel):

--- a/imbi/endpoints/components/models.py
+++ b/imbi/endpoints/components/models.py
@@ -27,7 +27,7 @@ class ProjectStatus(int, enum.Enum):
     """Component Score project fact values"""
     OKAY = 100
     NEEDS_WORK = 80
-    UNACCEPTABLE = 0
+    UNACCEPTABLE = 20
 
 
 class ProjectComponentRow(pydantic.BaseModel):

--- a/imbi/endpoints/components/scoring.py
+++ b/imbi/endpoints/components/scoring.py
@@ -22,7 +22,7 @@ async def update_component_score_for_project(
     logger = logging.getLogger(__package__).getChild(
         'update_component_score_for_project')
 
-    fact_id = app.settings['components']['project_fact_type_id']
+    fact_id = app.settings['component_scoring']['project_fact_type_id']
     if not fact_id:
         return
 

--- a/imbi/server.py
+++ b/imbi/server.py
@@ -112,7 +112,7 @@ def load_configuration(config: str, debug: bool) -> typing.Tuple[dict, dict]:
     if automations_grafana.get('url') \
             and automations_grafana.get('admin_token'):
         automations_grafana['enabled'] = True
-    component_cfg = config.get('components', {})
+    component_cfg = config.get('component_scoring', {})
     footer_link = config.get('footer_link', {})
     google = config.get('google', {})
     http_settings = config.get('http', {})
@@ -142,6 +142,8 @@ def load_configuration(config: str, debug: bool) -> typing.Tuple[dict, dict]:
     automations_sentry = automations.get('sentry', {})
     automations_sentry.setdefault('enabled', True)
     automations_sentry.setdefault('url', 'https://sentry.io/')
+
+    component_cfg.setdefault('enabled', False)
 
     module_path = pathlib.Path(sys.modules['imbi'].__file__).parent
 
@@ -180,7 +182,7 @@ def load_configuration(config: str, debug: bool) -> typing.Tuple[dict, dict]:
             'yapf': automations.get('yapf', {}),
         },
         'canonical_server_name': http_settings['canonical_server_name'],
-        'components': component_cfg,
+        'component_scoring': component_cfg,
         'compress_response': http_settings.get('compress_response', True),
         'cookie_secret': http_settings.get('cookie_secret', 'imbi'),
         'cors': config.get('cors', None),


### PR DESCRIPTION
After some internal debate, I decided to switch from an enumerated fact type to a range fact type for component scores. The primary driver was that using an enumerated value meant that the user was required to manually create an enumerated fact type _with enumeration values that matched what was in the code_. This just felt funky...

This PR switches to a range fact type with three ranges (0-20), (20.01-80), and (80.01-100). My goal was to maximize the central range so that we can do something more interesting in the future. I also added project fact type creation during application initialization to remove the manual configuration requirement altogether.