### PR TITLE
Add Outdated Projects report

### DIFF
--- a/imbi/app.py
+++ b/imbi/app.py
@@ -207,8 +207,7 @@ class Application(sprockets_postgres.ApplicationMixin, app.Application):
         Note that this is called from `imbi --initialize` as well.
 
         """
-        config = self.settings.get('component_scoring', {})
-        fact_name = config.setdefault('fact_name', 'Component Score')
+        config = self.settings['component_scoring']
         if not config.get('enabled'):
             self.logger.info(
                 'Component scoring feature is disabled in configuration')
@@ -222,6 +221,7 @@ class Application(sprockets_postgres.ApplicationMixin, app.Application):
                              component_fact_id)
             return
 
+        fact_name = config['fact_name']
         result = await transaction.execute(
             'SELECT id'
             '  FROM v1.project_fact_types'

--- a/imbi/endpoints/components/handlers.py
+++ b/imbi/endpoints/components/handlers.py
@@ -257,7 +257,7 @@ class ProjectComponentsRequestHandler(base.PaginatedCollectionHandler):
     COLLECTION_SQL = re.sub(
         r'\s+', ' ', """\
         SELECT c.package_url, c."name", c.icon_class,
-               c.active_version, v.status
+               c.active_version, v.version, v.status
           FROM v1.project_components AS p
           JOIN v1.component_versions AS v ON v.id = p.version_id
           JOIN v1.components AS c ON c.package_url = v.package_url

--- a/imbi/endpoints/components/models.py
+++ b/imbi/endpoints/components/models.py
@@ -23,6 +23,13 @@ class ProjectComponentStatus(str, enum.Enum):
     FORBIDDEN = 'Forbidden'
 
 
+# these are considered "out of date" for scoring purposes
+OUTDATED_COMPONENT_STATUSES = frozenset((
+    ProjectComponentStatus.DEPRECATED.value,
+    ProjectComponentStatus.FORBIDDEN.value,
+    ProjectComponentStatus.OUTDATED.value,
+))
+
 # Describes the expected `stats` dict for ProjectStatus.calculate
 ProjectStatusCalculateStats = typing.TypedDict(
     'ProjectStatusCalculateStats',

--- a/imbi/endpoints/components/models.py
+++ b/imbi/endpoints/components/models.py
@@ -15,6 +15,7 @@ class ComponentStatus(str, enum.Enum):
     FORBIDDEN = 'Forbidden'
 
 
+# When you modify this, update the outdated_components report
 class ProjectComponentStatus(str, enum.Enum):
     UNSCORED = 'Unscored'
     UP_TO_DATE = 'Up-to-date'
@@ -28,14 +29,6 @@ class ProjectStatus(int, enum.Enum):
     OKAY = 100
     NEEDS_WORK = 80
     UNACCEPTABLE = 20
-
-
-class ProjectComponentRow(pydantic.BaseModel):
-    """Result of retrieving components associated with a project"""
-    package_url: str
-    status: ComponentStatus
-    active_version: typing.Union[semver.VersionRange, None]
-    version: str
 
 
 class Component(pydantic.BaseModel):

--- a/imbi/endpoints/reports/__init__.py
+++ b/imbi/endpoints/reports/__init__.py
@@ -5,12 +5,13 @@ System Reports
 from tornado import web
 
 from . import (component_usage, namespace_kpis, namespace_shs_history,
-               system_shs_history)
+               outdated_projects, system_shs_history)
 
 URLS = [
     web.url(r'/reports/component-usage', component_usage.RequestHandler),
     web.url(r'/reports/namespace-kpis', namespace_kpis.RequestHandler),
     web.url(r'/reports/namespace-shs-history',
             namespace_shs_history.RequestHandler),
+    web.url(r'/reports/outdated-projects', outdated_projects.RequestHandler),
     web.url(r'/reports/system-shs-history', system_shs_history.RequestHandler),
 ]

--- a/imbi/endpoints/reports/outdated_projects.py
+++ b/imbi/endpoints/reports/outdated_projects.py
@@ -1,0 +1,50 @@
+from imbi.endpoints import base
+from imbi.endpoints.components import models
+
+
+class RequestHandler(base.AuthenticatedRequestHandler):
+    NAME = 'reports-outdated-projects'
+
+    async def get(self) -> None:
+        result = await self.postgres_execute(
+            'SELECT c.project_id, v.status, p.name AS project_name,'
+            '       n.name AS project_namespace,'
+            '       COUNT(c.version_id) AS num_components'
+            '  FROM v1.project_components AS c'
+            '  JOIN v1.component_versions AS v'
+            '    ON v.package_url = c.package_url AND v.id = c.version_id'
+            '  JOIN v1.projects AS p ON p.id = c.project_id'
+            '  JOIN v1.namespaces AS n ON n.id = p.namespace_id'
+            ' GROUP BY c.project_id, v.status, p.name, n.name'
+            ' ORDER BY c.project_id',
+            metric_name=self.NAME)
+
+        # using a helper here makes it easy to pick up the
+        # values from the last set of rows
+        def add_current_to_report() -> None:
+            outdated = sum(
+                current.get(k, 0) for k in models.OUTDATED_COMPONENT_STATUSES)
+            if outdated:
+                current['component_score'] = models.ProjectStatus.calculate(
+                    current)
+                # pivot from 'Up-to-date' to 'up_to_date'
+                for e in models.ProjectComponentStatus:
+                    current[e.name.lower()] = current.pop(e.value)
+                report_rows.append(current.copy())
+
+        report_rows = []
+        current = {}
+        empty = {e.value: 0 for e in models.ProjectComponentStatus}
+
+        for row in result.rows:
+            if row['project_id'] != current.get('project_id'):
+                add_current_to_report()
+                current = empty | {
+                    'project_id': row['project_id'],
+                    'project_namespace': row['project_namespace'],
+                    'project_name': row['project_name']
+                }
+            current[row['status']] = row['num_components']
+        add_current_to_report()  # capture the final in-progress row
+
+        self.send_response(report_rows)

--- a/imbi/server.py
+++ b/imbi/server.py
@@ -150,6 +150,7 @@ def load_configuration(config: str, debug: bool) -> typing.Tuple[dict, dict]:
     automations_sentry.setdefault('enabled', True)
     automations_sentry.setdefault('url', 'https://sentry.io/')
 
+    component_cfg.setdefault('fact_name', 'Component Score')
     component_cfg.setdefault('enabled', False)
 
     module_path = pathlib.Path(sys.modules['imbi'].__file__).parent

--- a/imbi/templates/openapi.yaml
+++ b/imbi/templates/openapi.yaml
@@ -5707,6 +5707,10 @@ paths:
                     version:
                       description: Version number that the project requires
                       type: string
+                    active_version:
+                      description: Optional "active" version specification
+                      type: string
+                      nullable: true
                     status:
                       description: Status for this version of this component
                       type: string
@@ -5754,6 +5758,10 @@ paths:
                     version:
                       description: Version number that the project requires
                       type: string
+                    active_version:
+                      description: Optional "active" version specification
+                      type: string
+                      nullable: true
                     status:
                       description: Status for this version of this component
                       type: string


### PR DESCRIPTION
This PR adds a new report that lists projects that contain outdated components. I moved the per-version component status into the database (see https://github.com/AWeber-Imbi/imbi-schema/pull/26) to make this much easier. This is done analogous to how project scores are maintained. The implementation is in 9e9376c5ed07c305de482289c60e44b3b9761880.

The report contains rows like the following for _every project that contains an outdated, deprecated, or forbidden component_. This corresponds with projects that are scored in the "needs work" and "unacceptable" categories.
```json
{
  "project_id": 1,
  "project_namespace": "Some Namespace",
  "project_name": "Some Project",
  "component_score": 80,
  "unscored": 61,
  "up_to_date": 3,
  "outdated": 0,
  "deprecated": 1,
  "forbidden": 0
}
```

Note that the column names for the counters match the lower-cased enumeration _names_ from `components.models.ProjectComponentStatus`. The only real difficulty in the implementation was to ensure that it is extensible by only changing the enumerated values.

The report itself is a fairly simple endpoint (3b93d6237d7bd6ed14943dc21b8f87c362634fdb) though I did have to do pivoting in the application code. It could be done with the [`tablefunc`](https://www.postgresql.org/docs/current/tablefunc.html) postgres extension except that the usage of an enum would still require either dynamic SQL in a SP or the application so I decided to just implement it in python.