### PR TITLE
Handle project score details requests for projects w/o range/enum facts

### DIFF
--- a/imbi/endpoints/base.py
+++ b/imbi/endpoints/base.py
@@ -150,6 +150,13 @@ class RequestHandler(cors.CORSMixin, postgres.RequestHandlerMixin,
         namespace.update({'version': version})
         return namespace
 
+    def on_postgres_error(self, metric_name: str,
+                          exc: Exception) -> Exception | None:
+        self.logger.exception('processing postgres error: %s',
+                              exc.__class__.__name__,
+                              exc_info=exc)
+        return super().on_postgres_error(metric_name, exc)
+
     def on_postgres_timing(self, metric_name: str, duration: float) -> None:
         """Invoked by sprockets-postgres after each query"""
         self.application.loop.add_callback(

--- a/imbi/endpoints/project_score_details.py
+++ b/imbi/endpoints/project_score_details.py
@@ -108,7 +108,7 @@ class ProjectScoreDetailHandler(base.AuthenticatedRequestHandler):
             for row in result:
                 enum_details[row['fact_type_id']].append(row)
         for enum_value in enum_details.values():
-            enum_value.sort(key=lambda e: (e['score'], e['value']),
+            enum_value.sort(key=operator.itemgetter('score', 'value'),
                             reverse=True)
         return enum_details
 

--- a/imbi/endpoints/project_score_details.py
+++ b/imbi/endpoints/project_score_details.py
@@ -46,6 +46,11 @@ class RangeScoreDetail(ScoreDetail):
     ranges: list[RangeValue]
 
 
+FactId = int
+FactRow = collections.abc.Mapping[str, typing.Union[int, str, float]]
+FactMap = collections.abc.Mapping[FactId, collections.abc.Sequence[FactRow]]
+
+
 class ProjectScoreDetailHandler(base.AuthenticatedRequestHandler):
     """Implementation of the v1.project_score() stored proc in Python
 
@@ -65,8 +70,21 @@ class ProjectScoreDetailHandler(base.AuthenticatedRequestHandler):
             raise errors.ItemNotFound()
 
         facts = await models.project_facts(project_id, self.application)
-        enum_details = await self._gather_enum_facts(facts)
-        range_details = await self._gather_range_facts(facts)
+        enum_details = await self._gather_facts(
+            [f.id for f in facts if f.fact_type == 'enum'],
+            'SELECT fact_type_id, value, score'
+            '  FROM v1.project_fact_type_enums'
+            ' WHERE fact_type_id IN %(fact_type_ids)s',
+            'score',
+            'value',
+        )
+        range_details = await self._gather_facts(
+            [f.id for f in facts if f.fact_type == 'range'],
+            'SELECT fact_type_id, score, min_value, max_value'
+            '  FROM v1.project_fact_type_ranges'
+            ' WHERE fact_type_id IN %(fact_type_ids)s',
+            'score',
+        )
         scored_facts = sorted((f for f in facts if f.weight),
                               key=operator.attrgetter('weight'),
                               reverse=True)
@@ -94,40 +112,17 @@ class ProjectScoreDetailHandler(base.AuthenticatedRequestHandler):
                 } for f in facts if not f.weight]
             })
 
-    async def _gather_enum_facts(
-        self, facts: collections.abc.Sequence[models.ProjectFact]
-    ) -> dict[int, list[dict]]:
-        enum_details = collections.defaultdict[int, list[dict]](list)
-        enum_facts = [f.id for f in facts if f.fact_type == 'enum']
-        if enum_facts:
+    async def _gather_facts(self, fact_ids: collections.abc.Sequence[int],
+                            query: str, *sort_params: str) -> FactMap:
+        details = collections.defaultdict[int, list[dict]](list)
+        if fact_ids:
             result = await self.postgres_execute(
-                'SELECT fact_type_id, value, score'
-                '  FROM v1.project_fact_type_enums'
-                ' WHERE fact_type_id IN %(fact_type_ids)s',
-                {'fact_type_ids': tuple(enum_facts)})
+                query, {'fact_type_ids': tuple(fact_ids)})
             for row in result:
-                enum_details[row['fact_type_id']].append(row)
-        for enum_value in enum_details.values():
-            enum_value.sort(key=operator.itemgetter('score', 'value'),
-                            reverse=True)
-        return enum_details
-
-    async def _gather_range_facts(
-        self, facts: collections.abc.Sequence[models.ProjectFact]
-    ) -> dict[int, list[dict]]:
-        range_details = collections.defaultdict[int, list[dict]](list)
-        range_facts = [f.id for f in facts if f.fact_type == 'range']
-        if range_facts:
-            result = await self.postgres_execute(
-                'SELECT fact_type_id, score, min_value, max_value'
-                '  FROM v1.project_fact_type_ranges'
-                ' WHERE fact_type_id IN %(fact_type_ids)s',
-                {'fact_type_ids': tuple(range_facts)})
-            for row in result:
-                range_details[row['fact_type_id']].append(row)
-        for range_value in range_details.values():
-            range_value.sort(key=operator.itemgetter('score'), reverse=True)
-        return range_details
+                details[row['fact_type_id']].append(row)
+        for value in details.values():
+            value.sort(key=operator.itemgetter(*sort_params), reverse=True)
+        return details
 
     @staticmethod
     def _generate_score_detail(


### PR DESCRIPTION
The `ProjectScoreDetailHandler` was generating SQL with empty `IN()` clauses if the project did not have enum or range facts.  I added some `if` statements to guard against the empty sets. I also implemented a postgres exception handler that logs the exception stack.