### PR TITLE
Add operations log occurred at property

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -44,7 +44,7 @@ services:
       - opensearch
 
   postgres:
-    image: aweber/imbi-postgres:0.22.7
+    image: aweber/imbi-postgres:latest
     ports:
       - 5432
     volumes:

--- a/imbi/models.py
+++ b/imbi/models.py
@@ -342,6 +342,7 @@ class Project:
 @dataclasses.dataclass
 class OperationsLog:
     id: int
+    occurred_at: datetime.datetime
     recorded_at: datetime.datetime
     recorded_by: str
     display_name: str
@@ -359,6 +360,7 @@ class OperationsLog:
     SQL: typing.ClassVar = re.sub(
         r'\s+', ' ', """\
         SELECT o.id,
+               o.occurred_at,
                o.recorded_at,
                o.recorded_by,
                u.display_name,

--- a/imbi/templates/openapi.yaml
+++ b/imbi/templates/openapi.yaml
@@ -3112,8 +3112,12 @@ paths:
                     id:
                       description: Surrogate ID for deleting and modifying entries
                       type: number
+                    occurred_at:
+                      description: Timestamp indicating when the event occurred
+                      type: string
+                      format: iso8601-timestamp
                     recorded_at:
-                      description: Timestamp indicating when the change was made
+                      description: Timestamp indicating when the event was recorded
                       type: string
                       format: iso8601-timestamp
                     recorded_by:
@@ -3240,8 +3244,12 @@ paths:
                     id:
                       description: Surrogate ID for deleting and modifying entries
                       type: number
+                    occurred_at:
+                      description: Timestamp indicating when the event occurred
+                      type: string
+                      format: iso8601-timestamp
                     recorded_at:
-                      description: Timestamp indicating when the change was made
+                      description: Timestamp indicating when the event was recorded
                       type: string
                       format: iso8601-timestamp
                     recorded_by:
@@ -3371,13 +3379,11 @@ paths:
               description: Describes an audit log entry for entity operational changes
               type: object
               properties:
-                recorded_at:
-                  description: Timestamp indicating when the change was made
+                occurred_at:
+                  description: Timestamp indicating when the event occurred
                   type: string
                   format: iso8601-timestamp
-                recorded_by:
-                  description: The user who recorded the change
-                  type: string
+                  nullable: true
                 completed_at:
                   description: 'If specified, indicates the change occurred over a span of time'
                   type: string
@@ -3424,8 +3430,6 @@ paths:
                   type: string
                   nullable: true
               required:
-                - recorded_at
-                - recorded_by
                 - environment
                 - change_type
                 - description

--- a/tests/base.py
+++ b/tests/base.py
@@ -118,6 +118,26 @@ class TestCase(testing.SprocketsHttpTestCase):
                 self.assertEqual(link.target, expectation)
                 break
 
+    @staticmethod
+    def extract_link_header(response, rel):
+        by_rel = {
+            header.parameters[0][1]: header
+            for header in headers.parse_link(response.headers['Link'])
+        }
+        try:
+            return by_rel[rel].target
+        except KeyError:
+            return None
+
+    def assert_has_link(self, response, rel):
+        link = self.extract_link_header(response, rel)
+        self.assertIsNotNone(link, f'Expected {rel!r} link not found')
+        return link
+
+    def assert_no_link(self, response, rel):
+        link = self.extract_link_header(response, rel)
+        self.assertIsNone(link, f'Unexpected {rel!r} link found')
+
     def validate_response(self, response):
         """Validate the response using the OpenAPI expectations"""
         validator = tornado_openapi3.ResponseValidator(

--- a/tests/endpoints/test_activity_feed.py
+++ b/tests/endpoints/test_activity_feed.py
@@ -73,8 +73,7 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
                 json_body={
                     'change_type': 'Deployed',
                     'environment': self.environments[0],
-                    'recorded_by': self.USERNAME[self.ADMIN_ACCESS],
-                    'recorded_at': now(),
+                    'occurred_at': now(),
                     'notes': notes[-1],
                     'description': 'Deployed app',
                 },

--- a/tests/endpoints/test_project_activity_feed.py
+++ b/tests/endpoints/test_project_activity_feed.py
@@ -45,8 +45,7 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
             'change_type': 'Deployed',
             'environment': self.environments[0],
             'project_id': self.project['id'],
-            'recorded_by': self.USERNAME[self.ADMIN_ACCESS],
-            'recorded_at': now(),
+            'occurred_at': now(),
             'description': 'deployed app',
             'notes': '',
         }


### PR DESCRIPTION
This is the user supplied value for when the event occurred at as opposed to when the event was created at.

I also removed the ability to set or change the "recorded_by" property since that should always come from the authorization token. The same for the "recorded_at" property.

This includes the rendered version of https://github.com/AWeber-Imbi/imbi-openapi/pull/42

This also requires that https://github.com/AWeber-Imbi/imbi-schema/pull/28 is merged and released BEFORE the tests will pass.