### PR TITLE
Add override to Operations Log recorded_by and related fields

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -48,6 +48,7 @@ services:
     ports:
       - 5432
     volumes:
+      - ./scaffolding/postgres/y01-migration.sql:/docker-entrypoint-initdb.d/y01-migration.sql
       - ./scaffolding/postgres/z01-data.sql:/docker-entrypoint-initdb.d/z01-data.sql
       - ./scaffolding/postgres/z02-imbi-db.sh:/docker-entrypoint-initdb.d/z02-imbi-db.sh
 

--- a/imbi/endpoints/base.py
+++ b/imbi/endpoints/base.py
@@ -419,7 +419,7 @@ class CRUDRequestHandler(ValidatingRequestHandler):
         original = dict(result.row)
         for key in {
                 'created_at', 'created_by', 'last_modified_at',
-                'last_modified_by'
+                'last_modified_by', 'recorded_at', 'recorded_by'
         }:
             if key in original:
                 del original[key]

--- a/imbi/endpoints/base.py
+++ b/imbi/endpoints/base.py
@@ -469,8 +469,8 @@ class CRUDRequestHandler(ValidatingRequestHandler):
         # Send the new record as a response
         await self._get(self._get_query_kwargs(updated))
 
-    async def _post(self, kwargs) -> dict:
-        values = self.get_request_body()
+    async def _post(self, kwargs, overrides=None) -> dict:
+        values = self.get_request_body().copy()  # avoid mutating cached copy
 
         # Handle compound keys for child object CRUD
         if isinstance(self.ID_KEY, list):
@@ -486,6 +486,9 @@ class CRUDRequestHandler(ValidatingRequestHandler):
                 values[name] = self.DEFAULTS.get(name)
 
         values['username'] = self._current_user.username
+        if overrides:
+            values.update(overrides)
+
         result = await self.postgres_execute(self.POST_SQL, values,
                                              'post-{}'.format(self.NAME))
         if not result.row_count:

--- a/imbi/endpoints/operations_log.py
+++ b/imbi/endpoints/operations_log.py
@@ -24,11 +24,13 @@ class _RequestHandlerMixin:
         SELECT o.id, o.recorded_at, o.recorded_by, o.completed_at,
                o.project_id, o.environment, o.change_type, o.description,
                o.link, o.notes, o.ticket_slug, o.version,
-               p.name AS project_name, u.email_address,
-               u.display_name, 'OperationsLogEntry' AS "type",
+               COALESCE(u.email_address, 'UNKNOWN') AS email_address,
+               COALESCE(u.display_name, o.recorded_by) AS display_name,
+               p.name AS project_name,
+               'OperationsLogEntry' AS "type",
                o.occurred_at
           FROM v1.operations_log AS o
-          JOIN v1.users AS u ON u.username = o.recorded_by
+          LEFT JOIN v1.users AS u ON u.username = o.recorded_by
           LEFT JOIN v1.projects AS p ON p.id = o.project_id
          WHERE o.id = %(id)s""")
 
@@ -44,10 +46,12 @@ class CollectionRequestHandler(operations_log.RequestHandlerMixin,
         SELECT o.id, o.recorded_at, o.recorded_by, o.completed_at,
                o.project_id, o.environment, o.change_type, o.description,
                o.link, o.notes, o.ticket_slug, o.version,
-               p.name AS project_name, u.email_address, u.display_name,
+               p.name AS project_name,
+               COALESCE(u.email_address, 'UNKNOWN') AS email_address,
+               COALESCE(u.display_name, o.recorded_by) AS display_name,
                'OperationsLogEntry' as "type", o.occurred_at
           FROM v1.operations_log AS o
-          JOIN v1.users AS u ON u.username = o.recorded_by
+          LEFT JOIN v1.users AS u ON u.username = o.recorded_by
           LEFT JOIN v1.projects AS p ON p.id = o.project_id
           {{WHERE}}
       ORDER BY o.occurred_at {{ORDER}}, o.id {{ORDER}}

--- a/imbi/models.py
+++ b/imbi/models.py
@@ -354,6 +354,7 @@ class OperationsLog:
     description: typing.Optional[str]
     link: typing.Optional[str]
     notes: typing.Optional[str]
+    performed_by: typing.Optional[str]
     ticket_slug: typing.Optional[str]
     version: typing.Optional[str]
 
@@ -363,7 +364,10 @@ class OperationsLog:
                o.occurred_at,
                o.recorded_at,
                o.recorded_by,
-               COALESCE(u.display_name, o.recorded_by) AS display_name,
+               COALESCE(
+                  u.display_name,
+                  COALESCE(u2.display_name, o.recorded_by)
+               ) AS display_name,
                o.completed_at,
                o.project_id,
                p.name AS project_name,
@@ -372,11 +376,14 @@ class OperationsLog:
                o.description,
                o.link,
                o.notes,
+               o.performed_by,
                o.ticket_slug,
                o.version
           FROM v1.operations_log AS o
      LEFT JOIN v1.users AS u
-            ON u.username = o.recorded_by
+            ON u.username = o.performed_by
+     LEFT JOIN v1.users AS u2
+            ON u2.username = o.recorded_by
      LEFT JOIN v1.projects AS p
             ON o.project_id = p.id
          WHERE o.id=%(id)s""")

--- a/imbi/models.py
+++ b/imbi/models.py
@@ -363,7 +363,7 @@ class OperationsLog:
                o.occurred_at,
                o.recorded_at,
                o.recorded_by,
-               u.display_name,
+               COALESCE(u.display_name, o.recorded_by) AS display_name,
                o.completed_at,
                o.project_id,
                p.name AS project_name,

--- a/imbi/opensearch/operations_log.py
+++ b/imbi/opensearch/operations_log.py
@@ -50,6 +50,9 @@ OPS_LOG = {
     'notes': {
         'type': 'text'
     },
+    'performed_by': {
+        'type': 'text'
+    },
     'ticket_slug': {
         'type': 'text'
     },

--- a/imbi/opensearch/operations_log.py
+++ b/imbi/opensearch/operations_log.py
@@ -9,9 +9,13 @@ if typing.TYPE_CHECKING:
 
 LOGGER = logging.getLogger(__name__)
 
+# Make sure that the field names match models.OperationsLog.SQL
 OPS_LOG = {
     'id': {
         'type': 'integer'
+    },
+    'occurred_at': {
+        'type': 'date'
     },
     'recorded_at': {
         'type': 'date'

--- a/imbi/templates/openapi.yaml
+++ b/imbi/templates/openapi.yaml
@@ -3134,6 +3134,10 @@ paths:
                       type: string
                       format: iso8601-timestamp
                       nullable: true
+                    performed_by:
+                      description: Identifies the user that performed the action
+                      type: string
+                      nullable: true
                     project_id:
                       description: The ID of the project that was changed
                       type: number
@@ -3191,6 +3195,7 @@ paths:
                     - id: 1
                       recorded_at: 2021-05-21T18:39:24.197Z
                       recorded_by: gavinr
+                      performed_by: null
                       type: OperationsLogEntry
                       display_name: Gavin M. Roy
                       email_address: gavinr@example.com
@@ -3206,6 +3211,7 @@ paths:
                     - id: 2
                       recorded_at: 2021-05-21T18:42:00.000Z
                       recorded_by: gavinr
+                      performed_by: null
                       type: OperationsLogEntry
                       display_name: Gavin M. Roy
                       email_address: gavinr@example.com
@@ -3221,6 +3227,7 @@ paths:
                     - id: 3
                       recorded_at: 2021-05-21T19:00:00.000Z
                       recorded_by: gavinr
+                      performed_by: null
                       type: OperationsLogEntry
                       display_name: Gavin M. Roy
                       email_address: gavinr@example.com
@@ -3266,6 +3273,10 @@ paths:
                       type: string
                       format: iso8601-timestamp
                       nullable: true
+                    performed_by:
+                      description: Identifies the user that performed the action
+                      type: string
+                      nullable: true
                     project_id:
                       description: The ID of the project that was changed
                       type: number
@@ -3323,6 +3334,7 @@ paths:
                     - id: 1
                       recorded_at: 2021-05-21T18:39:24.197Z
                       recorded_by: gavinr
+                      performed_by: null
                       type: OperationsLogEntry
                       display_name: Gavin M. Roy
                       email_address: gavinr@example.com
@@ -3338,6 +3350,7 @@ paths:
                     - id: 2
                       recorded_at: 2021-05-21T18:42:00.000Z
                       recorded_by: gavinr
+                      performed_by: null
                       type: OperationsLogEntry
                       display_name: Gavin M. Roy
                       email_address: gavinr@example.com
@@ -3353,6 +3366,7 @@ paths:
                     - id: 3
                       recorded_at: 2021-05-21T19:00:00.000Z
                       recorded_by: gavinr
+                      performed_by: null
                       type: OperationsLogEntry
                       display_name: Gavin M. Roy
                       email_address: gavinr@example.com
@@ -3389,6 +3403,9 @@ paths:
                   type: string
                   format: iso8601-timestamp
                   nullable: true
+                performed_by:
+                  description: Identifies the user that performed the action
+                  type: string
                 project_id:
                   description: The ID of the project that was changed
                   type: number
@@ -3438,8 +3455,7 @@ paths:
               record:
                 summary: An operations log entry example
                 value:
-                  recorded_at: 2021-05-21T18:39:24.197Z
-                  recorded_by: gavinr
+                  performed_by: daves
                   completed_at: null
                   project_id: 100
                   environment: Testing
@@ -3456,8 +3472,7 @@ paths:
               record:
                 summary: An operations log entry example
                 value:
-                  recorded_at: 2021-05-21T18:39:24.197Z
-                  recorded_by: gavinr
+                  performed_by: daves
                   completed_at: null
                   project_id: 100
                   environment: Testing
@@ -3487,10 +3502,11 @@ paths:
                     recorded_at: 2021-05-21T18:39:24.197Z
                     recorded_by: gavinr
                     type: OperationsLogEntry
-                    display_name: Gavin M. Roy
-                    email_address: gavinr@example.com
+                    display_name: Dave Shawley
+                    email_address: daves@example.com
                     completed_at: null
                     project_id: 100
+                    performed_by: daves
                     environment: Testing
                     change_type: Deployment
                     description: Added the Operations Log functionality
@@ -3509,10 +3525,11 @@ paths:
                     recorded_at: 2021-05-21T18:39:24.197Z
                     recorded_by: gavinr
                     type: OperationsLogEntry
-                    display_name: Gavin M. Roy
-                    email_address: gavinr@example.com
+                    display_name: Dave Shawley
+                    email_address: daves@example.com
                     completed_at: null
                     project_id: 100
+                    performed_by: daves
                     environment: Testing
                     change_type: Deployment
                     description: Added the Operations Log functionality

--- a/scaffolding/postgres/y01-migration.sql
+++ b/scaffolding/postgres/y01-migration.sql
@@ -1,0 +1,2 @@
+-- placeholder for migration data
+-- add SQL here to apply over the imbi-postgres DDL

--- a/scaffolding/postgres/z02-imbi-db.sh
+++ b/scaffolding/postgres/z02-imbi-db.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env sh
 set -e
 createdb imbi
-psql -d imbi -f /docker-entrypoint-initdb.d/ddl.sql
-psql -d imbi -f /docker-entrypoint-initdb.d/z01-data.sql
+for f in /docker-entrypoint-initdb.d/*.sql
+do
+	psql -d imbi -f "$f"
+done


### PR DESCRIPTION
The Operations Log `recorded_by` field is the **username** that recorded the operations log entry. It uses the authenticated user so that we do not lose track of who recorded an entry. The field is used in a join against `v1.users` to get the display name and email address of the user when returning an ops log record across the API.

This PR adds the `performed_by` optional field that is used instead of `recorded_by` when determining the display name and email address. The database schema (https://github.com/AWeber-Imbi/imbi-schema/pull/29) uses a foreign key relationship to ensure that the value refers to a valid user when it is set and nullifies the column when the user is deleted.

I found a few bugs when implementing this feature so I squashed them as well.
* a5c86168b397ae839c09fdb27d082b967b95e086: the OpenSearch index was missing the `occurred_at` field (missed in https://github.com/AWeber-Imbi/imbi-api/pull/118)
* 3ce6adc597539dbf28029e5d97b35ff1bae66637: the `recorded_at` and `recorded_by` fields were mutable
* 4be1f2a7ba2fa8632896b3a8fd1cafc26d5c52a9: we were not catching `jsonpatch` and `jsonpointer` exceptions in our patch method
* ed32fd864543bdf2541cfa3e51340258730c6066: we explicitly do not require that the `recorded_by` field refers to a real user; however, you get a 404 back if you tried to create an operations log entry with a bogus user due to using a full join instead of a left join