### PR TITLE
Reindex projects during notification processing

### DIFF
--- a/imbi/endpoints/integrations/notifications/processing.py
+++ b/imbi/endpoints/integrations/notifications/processing.py
@@ -7,6 +7,7 @@ import psycopg2
 import pydantic
 import sprockets_postgres
 
+import imbi.opensearch.project
 from imbi import common, errors
 from imbi.endpoints import base
 
@@ -112,6 +113,8 @@ class ProcessingHandler(base.RequestHandler):
             return
 
         await self._update_facts(project, updates)
+        search_index = imbi.opensearch.project.ProjectIndex(self.application)
+        await search_index.index_document_by_id(project.id)
 
     async def get(self, *, integration_name: str, notification_name: str,
                   **_kwargs: str) -> None:

--- a/imbi/opensearch/project.py
+++ b/imbi/opensearch/project.py
@@ -130,6 +130,17 @@ class ProjectIndex:
         await self.application.opensearch.index_document(
             self.INDEX, str(project.id), self._project_to_dict(project))
 
+    async def index_document_by_id(self, project_id: int) -> bool:
+        try:
+            project = await models.project(project_id, self.application)
+        except errors.DatabaseError as error:
+            LOGGER.warning(
+                'Failed to retrieve project %s while indexing by id: %s',
+                project_id, error)
+            return False
+        await self.index_document(project)
+        return True
+
     async def search(self, query: str, max_results: int = 1000) \
             -> dict[str, list[dict]]:
         return await self.application.opensearch.search(


### PR DESCRIPTION
This PR reindexes a project after processing a notification for it. I missed this during implementation of notification processing. I added a new method to the project and operations log indexing helpers to index a document by ID so that I did not have to look up the model using the "other" model. My plan is to introduce POST methods to reindex specific documents by ID since it keeps coming up. That will be in a future PR.