### PR TITLE
Refactor OpenSearch helpers

### DIFF
--- a/imbi/endpoints/projects.py
+++ b/imbi/endpoints/projects.py
@@ -401,13 +401,6 @@ class RecordRequestHandler(project.RequestHandlerMixin, _RequestHandlerMixin,
         await self.index_document(kwargs['id'])
 
 
-class SearchRequestHandler(project.RequestHandlerMixin,
-                           base.AuthenticatedRequestHandler):
-    async def get(self):
-        result = await self.search_index.search(self.get_query_argument('s'))
-        self.send_response(result)
-
-
 class SearchIndexRequestHandler(opensearch.SearchIndexRequestHandler,
                                 project.RequestHandlerMixin,
                                 base.ValidatingRequestHandler):

--- a/imbi/opensearch/__init__.py
+++ b/imbi/opensearch/__init__.py
@@ -1,3 +1,69 @@
 """
 Modules for interacting with and materializing data for OpenSearch Indexes
 """
+import asyncio
+import typing
+
+import sprockets.mixins.mediatype.content
+import sprockets_postgres
+import tornado.web
+
+from imbi import errors
+
+
+class SupportsIndexDocumentById(typing.Protocol):
+    async def index_document_by_id(self, doc_id: int) -> bool:
+        ...
+
+
+class SearchIndexRequestHandler(
+        sprockets_postgres.RequestHandlerMixin,
+        sprockets.mixins.mediatype.content.ContentMixin,
+        tornado.web.RequestHandler,
+):
+    search_index: SupportsIndexDocumentById
+    SQL: typing.ClassVar[str] = ''
+
+    async def prepare(self) -> None:
+        maybe_coro = super().prepare()
+        if asyncio.isfuture(maybe_coro) or asyncio.iscoroutine(maybe_coro):
+            await maybe_coro
+        if not self.SQL:
+            raise errors.InternalServerError(
+                'Programming error in %s: SQL is not defined',
+                self.__class__.__name__,
+                reason='Internal Server Error',
+                title='Programming Error',
+                detail='SQL is not defined',
+                source=self.__class__.__name__,
+            )
+        if getattr(self, 'search_index', None) is None:
+            raise errors.InternalServerError(
+                'Programming error in %s: search_index is None',
+                self.__class__.__name__,
+                reason='Internal Server Error',
+                title='Programming Error',
+                detail='search_index is None',
+                source=self.__class__.__name__,
+            )
+
+    async def post(self) -> None:
+        docs_to_index: list[int] = []
+        if ids := self.get_query_arguments('id'):
+            try:
+                docs_to_index.extend(int(arg) for arg in ids)
+            except ValueError:
+                raise errors.BadRequest('Invalid ID found in %r', ids)
+        else:
+            docs_to_index.extend(
+                r['id'] for r in await self.postgres_execute(self.SQL))
+
+        indexed_documents = 0
+        for doc_id in docs_to_index:
+            if await self.search_index.index_document_by_id(doc_id):
+                indexed_documents += 1
+
+        self.send_response({
+            'status': 'ok',
+            'message': f'Queued {indexed_documents} documents for indexing'
+        })

--- a/imbi/opensearch/__init__.py
+++ b/imbi/opensearch/__init__.py
@@ -1,7 +1,11 @@
 """
 Modules for interacting with and materializing data for OpenSearch Indexes
 """
+from __future__ import annotations
+
 import asyncio
+import contextlib
+import logging
 import typing
 
 import sprockets.mixins.mediatype.content
@@ -9,11 +13,68 @@ import sprockets_postgres
 import tornado.web
 
 from imbi import errors
+if typing.TYPE_CHECKING:
+    from imbi import app
+
+ModelType = typing.TypeVar('ModelType')
 
 
 class SupportsIndexDocumentById(typing.Protocol):
     async def index_document_by_id(self, doc_id: int) -> bool:
         ...
+
+
+class SearchIndex(typing.Generic[ModelType]):
+    INDEX: typing.ClassVar[str] = ''
+
+    def __init__(
+        self, application: 'app.Application',
+        fetch_method: typing.Callable[[int, 'app.Application'],
+                                      typing.Awaitable[ModelType]]
+    ) -> None:
+        super().__init__()
+        self.application = application
+        self.fetch_document_by_id = fetch_method
+        self.logger = logging.getLogger(__name__).getChild(
+            self.__class__.__name__)
+
+    async def create_index(self) -> None:
+        await self.application.opensearch.create_index(self.INDEX)
+
+    async def create_mapping(self) -> None:
+        await self.application.opensearch.create_mapping(
+            self.INDEX, await self._build_mappings())
+
+    async def delete_document(self, doc_id: int | str) -> None:
+        await self.application.opensearch.delete_document(
+            self.INDEX, str(doc_id))
+
+    async def index_document(self, doc: ModelType) -> None:
+        await self.application.opensearch.index_document(
+            self.INDEX, str(doc.id), self._serialize_document(doc), True)
+
+    async def index_document_by_id(self, doc_id: int) -> bool:
+        doc = None
+        with contextlib.suppress(errors.DatabaseError):
+            doc = await self.fetch_document_by_id(doc_id, self.application)
+        if doc is None:
+            self.logger.warning('Document not found for %s while indexing',
+                                doc_id)
+            return False
+        await self.index_document(doc)
+        return True
+
+    async def search(self,
+                     query: str,
+                     max_results: int = 1000) -> dict[str, list[dict]]:
+        return await self.application.opensearch.search(
+            self.INDEX, query, max_results)
+
+    async def _build_mappings(self):
+        raise NotImplementedError()
+
+    def _serialize_document(self, doc: ModelType) -> dict[str, typing.Any]:
+        raise NotImplementedError()
 
 
 class SearchIndexRequestHandler(

--- a/imbi/templates/openapi.yaml
+++ b/imbi/templates/openapi.yaml
@@ -3600,10 +3600,19 @@ paths:
           pattern: ^\d+$
   /operations-log/build-search-index:
     post:
-      summary: Index the operations log
-      description: Queue all operations log entries to be added to the opensearch index
+      summary: Index operations log entries
+      description: |-
+        Queue operations log entries to be added to the opensearch index. If the `id`
+        query parameter is not given, then all operations log entries are reindexed.
       tags:
         - Operations Log
+      parameters:
+        - name: id
+          in: query
+          description: Optional operation entry ID(s) to reindex
+          required: false
+          schema:
+            type: integer
       responses:
         '200':
           description: The request to index the operations log was successful
@@ -8674,10 +8683,19 @@ paths:
           type: string
   /projects/build-search-index:
     post:
-      summary: Index all projects
-      description: Queue all projects to be added to the opensearch index
+      summary: Index projects
+      description: |-
+        Queue projects to be added to the opensearch index. If the `id` query
+        parameter is not given, then all projects are reindexed.
       tags:
         - Projects
+      parameters:
+        - name: id
+          in: query
+          description: Optional project ID(s) to reindex
+          required: false
+          schema:
+            type: integer
       responses:
         '200':
           description: The request to index all projects was successful


### PR DESCRIPTION
This PR removes a lot of duplication in the ops log and project opensearch helpers. I also added the ability to limit reindexing endpoints to one or more objects by including one or more `id=N` query parameters.

This includes the output of https://github.com/AWeber-Imbi/imbi-openapi/pull/45