### PR TITLE
Handle notifications that match multiple projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+- Handle notifications on projects connected to more than one external project
 
 ## [0.22.12] - 2024-11-15
 ### Changed

--- a/imbi/endpoints/integrations/notifications/processing.py
+++ b/imbi/endpoints/integrations/notifications/processing.py
@@ -296,7 +296,8 @@ class ProcessingHandler(base.RequestHandler):
             if ignores:
                 should_process = False
                 for f, v in ignores:
-                    self.logger.info('ignoring %s matched %r', f.name, v)
+                    self.logger.info('ignoring %s found %r instead of %r',
+                                     f.name, v, f.value)
             elif process:
                 should_process = True
                 for f, v in process:


### PR DESCRIPTION
We had a few instances of more than one Imbi project connected to a single GitLab project. The notification processing was failing with a glorious 500 because the implementation was assuming a one-to-one relationship. It was easy enough to iterate over multiple projects and apply updates.