### PR TITLE
Allow arbitrary schemes for project URL validation

### DIFF
--- a/imbi/openapi.py
+++ b/imbi/openapi.py
@@ -44,7 +44,7 @@ class ISO8601Formatter:
 class URIFormatter:
     @staticmethod
     def validate(value) -> bool:
-        return validators.url(value)
+        return validators.url(value, validate_scheme=lambda _: True)
 
     @staticmethod
     def unmarshal(value: str) -> str:


### PR DESCRIPTION
This should resolve https://github.com/AWeber-Imbi/imbi/issues/112

The [default scheme validator](https://github.com/python-validators/validators/blob/master/src/validators/url.py#L42-L65) has a specific set of protocols it allows.