### PR TITLE
Add `github_org` override

### DIFF
--- a/imbi/automations/github.py
+++ b/imbi/automations/github.py
@@ -59,7 +59,7 @@ async def create_repository(
                                         automation.integration_name,
                                         context.user)
 
-    org = project.project_type.slug
+    org = project.project_type.github_org or project.project_type.slug
 
     settings = context.application.settings['automations']['github']
     default_attributes = settings.get('default_respository_attributes', {})

--- a/imbi/clients/github.py
+++ b/imbi/clients/github.py
@@ -86,9 +86,10 @@ class GitHubClient(sprockets.mixins.http.HTTPClientMixin):
         request_headers = kwargs.setdefault('request_headers', {})
         request_headers.update(self.headers)
         if kwargs.get('body', None) is not None:
-            request_headers[
-                'Content-Type'] = str(sprockets.mixins.http.CONTENT_TYPE_JSON)
-            kwargs['content_type'] = str(sprockets.mixins.http.CONTENT_TYPE_JSON)
+            request_headers['Content-Type'] = str(
+                sprockets.mixins.http.CONTENT_TYPE_JSON)
+            kwargs['content_type'] = str(
+                sprockets.mixins.http.CONTENT_TYPE_JSON)
         kwargs['user_agent'] = f'imbi/{version} (GitHubClient)'
         self.logger.debug('%s %s', method, url)
 

--- a/imbi/endpoints/integrations/github.py
+++ b/imbi/endpoints/integrations/github.py
@@ -77,16 +77,14 @@ class RedirectHandler(sprockets.mixins.http.HTTPClientMixin,
                 'Accept': str(sprockets.mixins.http.CONTENT_TYPE_JSON)
             })
         if not response.ok:
-            self.logger.error('failed to exchange auth code for token: (%s) %s',
-                              response.code,
-                              response.body)
+            self.logger.error(
+                'failed to exchange auth code for token: (%s) %s',
+                response.code, response.body)
             raise errors.InternalServerError(
                 'failed exchange auth code for token: %s',
                 response.code,
                 title='GitHub authorization failure',
-                instance={
-                    'error': response.body
-                },
+                instance={'error': response.body},
             )
         self.logger.debug('response_body %r', response.body)
         return GitHubToken(access_token=response.body['access_token'],

--- a/imbi/endpoints/project_types.py
+++ b/imbi/endpoints/project_types.py
@@ -8,7 +8,7 @@ class _RequestHandlerMixin:
     ID_KEY = 'id'
     FIELDS = [
         'id', 'name', 'plural_name', 'description', 'icon_class',
-        'environment_urls', 'gitlab_project_prefix'
+        'environment_urls', 'gitlab_project_prefix', 'github_org'
     ]
     DEFAULTS = {'icon_class': 'fas fa-folder'}
 
@@ -17,7 +17,7 @@ class _RequestHandlerMixin:
         SELECT id, "name", created_at, created_by,
                last_modified_at, last_modified_by,
                description, plural_name, slug, icon_class,
-               environment_urls, gitlab_project_prefix
+               environment_urls, gitlab_project_prefix, github_org
           FROM v1.project_types
          WHERE id=%(id)s""")
 
@@ -31,7 +31,7 @@ class CollectionRequestHandler(_RequestHandlerMixin,
     COLLECTION_SQL = re.sub(
         r'\s+', ' ', """\
         SELECT id, "name", plural_name, description, slug, icon_class,
-               environment_urls, gitlab_project_prefix
+               environment_urls, gitlab_project_prefix, github_org
           FROM v1.project_types
          ORDER BY "name" ASC""")
 
@@ -39,10 +39,11 @@ class CollectionRequestHandler(_RequestHandlerMixin,
         r'\s+', ' ', """\
         INSERT INTO v1.project_types
                     ("name", created_by, plural_name, description,
-                     slug, icon_class, environment_urls, gitlab_project_prefix)
+                     slug, icon_class, environment_urls, gitlab_project_prefix,
+                     github_org)
              VALUES (%(name)s, %(username)s, %(plural_name)s, %(description)s,
                      %(slug)s, %(icon_class)s, %(environment_urls)s,
-                     %(gitlab_project_prefix)s)
+                     %(gitlab_project_prefix)s, %(github_org)s)
           RETURNING id""")
 
 
@@ -63,5 +64,6 @@ class RecordRequestHandler(_RequestHandlerMixin, base.AdminCRUDRequestHandler):
                slug=%(slug)s,
                icon_class=%(icon_class)s,
                environment_urls=%(environment_urls)s,
-               gitlab_project_prefix=%(gitlab_project_prefix)s
+               gitlab_project_prefix=%(gitlab_project_prefix)s,
+               github_org=%(github_org)s
          WHERE id=%(id)s""")

--- a/imbi/models.py
+++ b/imbi/models.py
@@ -216,6 +216,7 @@ class ProjectType:
     icon_class: typing.Optional[str]
     environment_urls: bool
     gitlab_project_prefix: typing.Optional[str]
+    github_org: typing.Optional[str]
 
     SQL: typing.ClassVar = re.sub(
         r'\s+', ' ', """\
@@ -230,7 +231,8 @@ class ProjectType:
                description,
                icon_class,
                environment_urls,
-               gitlab_project_prefix
+               gitlab_project_prefix,
+               github_org
           FROM v1.project_types
          WHERE id=%(id)s""")
 

--- a/imbi/templates/openapi.yaml
+++ b/imbi/templates/openapi.yaml
@@ -4998,6 +4998,10 @@ paths:
                       description: Prefix for this project type in GitLab
                       type: string
                       nullable: true
+                    github_org:
+                      description: 'GitHub organization to use when creating repositories, overrides project type slug if set'
+                      type: string
+                      nullable: true
                   additionalProperties: false
               examples:
                 records:
@@ -5054,6 +5058,10 @@ paths:
                       description: Prefix for this project type in GitLab
                       type: string
                       nullable: true
+                    github_org:
+                      description: 'GitHub organization to use when creating repositories, overrides project type slug if set'
+                      type: string
+                      nullable: true
                   additionalProperties: false
               examples:
                 records:
@@ -5108,6 +5116,10 @@ paths:
                   default: false
                 gitlab_project_prefix:
                   description: Prefix for this project type in GitLab
+                  type: string
+                  nullable: true
+                github_org:
+                  description: 'GitHub organization to use when creating repositories, overrides project type slug if set'
                   type: string
                   nullable: true
               required:

--- a/tests/endpoints/test_project_types.py
+++ b/tests/endpoints/test_project_types.py
@@ -26,7 +26,8 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
             'description': str(uuid.uuid4()),
             'icon_class': 'fas fa-blind',
             'environment_urls': False,
-            'gitlab_project_prefix': 'foo'
+            'gitlab_project_prefix': 'foo',
+            'github_org': 'test-org'
         })
 
         # Create


### PR DESCRIPTION
Corresponding PRs: 
- ddl: https://github.com/AWeber-Imbi/imbi-schema/pull/31
- openapi: https://github.com/AWeber-Imbi/imbi-openapi/pull/46

This adds the `github_org` to the models and API responses. And crucially adds support for using it in repository creation, overriding the project type slug if present.