### PR TITLE
Support GitHub deployments

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
           - flake8-quotes==3.4.0
           - flake8-rst-docstrings==0.3.0
           - flake8-tuple==0.4.1
-  - repo: https://github.com/pre-commit/mirrors-yapf
-    rev: 'v0.31.0'
+  - repo: https://github.com/google/yapf
+    rev: 'v0.43.0'
     hooks:
       - id: yapf

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
       - id: bandit
         args: [ "--quiet", "--exclude", "tests", "--recursive", "imbi" ]
   - repo: https://github.com/PyCQA/flake8
-    rev: '6.0.0'
+    rev: '7.3.0'
     hooks:
       - id: flake8
         additional_dependencies:

--- a/bootstrap
+++ b/bootstrap
@@ -77,10 +77,12 @@ EOF
 
 cat > build/debug.yaml <<EOF
 ---
+actions:
+  github_deployment:
+    enabled: true
 automations:
-  gitlab:
+  github:
     project_link_type_id: ~
-    restrict_to_user: true
   grafana:
     project_link_type_id: ~
   sentry:

--- a/imbi/app.py
+++ b/imbi/app.py
@@ -43,6 +43,7 @@ SIGNED_VALUE_PATTERN = re.compile(r'^(?:[1-9][0-9]*)\|(?:.*)$')
 
 
 class Application(sprockets_postgres.ApplicationMixin, app.Application):
+
     def __init__(self, *, initializing: bool = False, **settings: object):
         LOGGER.info('imbi v%s starting', settings['version'])
         settings['default_handler_class'] = default.RequestHandler
@@ -252,6 +253,7 @@ class Application(sprockets_postgres.ApplicationMixin, app.Application):
         to bother the user to manually configure.
 
         """
+
         def on_timing(metric_name: str, duration: float) -> None:
             self.loop.add_callback(
                 self.stats.add_duration, {

--- a/imbi/automations/__init__.py
+++ b/imbi/automations/__init__.py
@@ -23,6 +23,7 @@ CompensatingAction: typing.TypeAlias = typing.Callable[
 
 
 class QueryFunction(typing.Protocol):
+
     async def __call__(
         self,
         sql: str,
@@ -41,6 +42,7 @@ async def do_nothing(context: AutomationContext,
 
 
 class AutomationFailedError(Exception):
+
     def __init__(self, automation: imbi.models.Automation,
                  error: Exception) -> None:
         super().__init__(f'Automation {automation.slug} failed: {error}')
@@ -87,6 +89,7 @@ class AutomationContext:
       such as gitlab.
 
     """
+
     def __init__(self, application: imbi.app.Application, user: imbi.user.User,
                  query: QueryFunction) -> None:
         self.application = application
@@ -136,8 +139,8 @@ class AutomationContext:
                            message=message_format %
                            args if args else message_format))
 
-    async def run_automation(self, automation: imbi.models.Automation,
-                             *args: object, **kwargs: object) -> None:
+    async def run_automation(self, automation: imbi.models.Automation, *args:
+                             object, **kwargs: object) -> None:
         self.logger.debug('running automation %s = %r', automation.slug,
                           automation.callable)
         try:

--- a/imbi/automations/models.py
+++ b/imbi/automations/models.py
@@ -110,6 +110,7 @@ class Integration(pydantic.BaseModel):
 
 async def automation(automation_slug: str,
                      application: 'app.Application') -> Automation | None:
+
     def on_postgres_error(_metric_name: str, exc: Exception) -> None:
         LOGGER.error('Failed to execute query for automation %s: %s',
                      automation_slug, exc)
@@ -142,6 +143,7 @@ async def automation(automation_slug: str,
 
 async def integration(integration_name: str,
                       application: 'app.Application') -> Integration | None:
+
     def on_postgres_error(_metric_name: str, exc: Exception) -> None:
         LOGGER.error('Failed to execute query for integration %s: %s',
                      integration_name, exc)

--- a/imbi/clients/github.py
+++ b/imbi/clients/github.py
@@ -25,6 +25,7 @@ class Repository(pydantic.BaseModel):
 
 
 class GitHubAPIFailure(errors.ApplicationError):
+
     def __init__(self, response: sprockets.mixins.http.HTTPResponse,
                  log_message: str, *log_args, **kwargs) -> None:
         status_code = response.code
@@ -57,6 +58,7 @@ async def create_client(
 
 
 class GitHubClient(sprockets.mixins.http.HTTPClientMixin):
+
     def __init__(
         self,
         user: user.User,
@@ -260,9 +262,8 @@ class GitHubClient(sprockets.mixins.http.HTTPClientMixin):
         Args:
             org: The organization that contains the repository
             repo: The repository name
-            environment: The name of the environment to create
+            environment: The environment slug
         """
-        environment = environment.lower().replace(' ', '-')
         response = await self.api(
             f'/repos/{org}/{repo}/environments/{environment}',
             method='POST',
@@ -286,9 +287,8 @@ class GitHubClient(sprockets.mixins.http.HTTPClientMixin):
         Args:
             org: The organization that contains the repository
             repo: The repository name
-            environment: The name of the environment to delete
+            environment: The environment slug
         """
-        environment = environment.lower().replace(' ', '-')
         response = await self.api(
             f'/repos/{org}/{repo}/environments/{environment}',
             method='DELETE',
@@ -313,7 +313,7 @@ class GitHubClient(sprockets.mixins.http.HTTPClientMixin):
             org: The organization that contains the repository
             repo: The repository name
             ref: The ref to deploy (branch, SHA, or tag)
-            environment: The name of the environment to deploy to
+            environment: The environment slug to deploy to
 
         Docs: https://docs.github.com/rest/deployments/deployments#create-a-deployment
         """  # noqa: E501

--- a/imbi/clients/github.py
+++ b/imbi/clients/github.py
@@ -334,3 +334,30 @@ class GitHubClient(sprockets.mixins.http.HTTPClientMixin):
                 response,
                 'Failed to create deployment',
             )
+
+    async def get_matching_refs(
+        self,
+        org: str,
+        repo: str,
+        ref: str = 'tags',
+    ) -> list:
+        """
+        Get matching refs for a repository.
+
+        Args:
+            org: The organization that contains the repository
+            repo: The repository name
+            ref: The ref pattern to match (default: 'tags')
+
+        Docs: https://docs.github.com/rest/git/refs#list-matching-references
+        """
+        response = await self.api(
+            f'/repos/{org}/{repo}/git/matching-refs/{ref}',
+            method='GET',
+        )
+        if not response.ok:
+            raise GitHubAPIFailure(
+                response,
+                'Failed to get matching refs',
+            )
+        return response.body

--- a/imbi/clients/github.py
+++ b/imbi/clients/github.py
@@ -298,3 +298,39 @@ class GitHubClient(sprockets.mixins.http.HTTPClientMixin):
                 response,
                 'Failed to delete environment',
             )
+
+    async def create_deployment(
+        self,
+        org: str,
+        repo: str,
+        ref: str,
+        environment: str,
+    ) -> None:
+        """
+        Create a deployment for a repository.
+
+        Args:
+            org: The organization that contains the repository
+            repo: The repository name
+            ref: The ref to deploy (branch, SHA, or tag)
+            environment: The name of the environment to deploy to
+
+        Docs: https://docs.github.com/rest/deployments/deployments#create-a-deployment
+        """  # noqa: E501
+        payload = {
+            'ref': ref,
+            'environment': environment,
+            'auto_merge': False,
+            'required_contexts': [],
+        }
+
+        response = await self.api(
+            f'/repos/{org}/{repo}/deployments',
+            method='POST',
+            body=payload,
+        )
+        if not response.ok:
+            raise GitHubAPIFailure(
+                response,
+                'Failed to create deployment',
+            )

--- a/imbi/clients/gitlab.py
+++ b/imbi/clients/gitlab.py
@@ -52,6 +52,7 @@ PROJECT_DEFAULTS = {
 
 
 class GitLabAPIFailure(errors.ApplicationError):
+
     def __init__(self, response: sprockets.mixins.http.HTTPResponse,
                  log_message: str, *log_args, **kwargs) -> None:
         status_code = response.code
@@ -88,6 +89,7 @@ class _GitLabClient(sprockets.mixins.http.HTTPClientMixin):
     This client sends authenticated HTTP requests to the GitLab API.
 
     """
+
     def __init__(self, user: user.User, token: oauth2.IntegrationToken,
                  application: tornado.web.Application):
         super().__init__()

--- a/imbi/clients/pagerduty.py
+++ b/imbi/clients/pagerduty.py
@@ -52,6 +52,7 @@ class _GetServiceDependenciesResponse(pydantic.BaseModel):
 
 
 class _PagerDutyClient(sprockets.mixins.http.HTTPClientMixin):
+
     def __init__(self, info: models.Integration, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.logger = logging.getLogger(__package__).getChild(

--- a/imbi/clients/sentry.py
+++ b/imbi/clients/sentry.py
@@ -69,6 +69,7 @@ async def create_client(
 
 
 class _SentryClient(sprockets.mixins.http.HTTPClientMixin):
+
     def __init__(self, api_endpoint: yarl.URL, api_secret: str,
                  organization: str) -> None:
         super().__init__()

--- a/imbi/clients/sonarqube.py
+++ b/imbi/clients/sonarqube.py
@@ -61,6 +61,7 @@ class _SonarQubeClient(sprockets.mixins.http.HTTPClientMixin):
     that this is either `False` if it is disabled or the integration
     key (as a str) if it is enabled.
     """
+
     def __init__(self, api_endpoint: yarl.URL, api_secret: str, *args,
                  **kwargs):
         super().__init__(*args, **kwargs)

--- a/imbi/cors.py
+++ b/imbi/cors.py
@@ -30,6 +30,7 @@ class Origins:
     valid as an acceptable origin. (:rfc:`6454`).
 
     """
+
     def __init__(self, *, allow_any: bool = True):
         self.allow_any: bool = allow_any
         self._origins: set[yarl.URL] = set()
@@ -81,6 +82,7 @@ class CORSConfig:
         layer may cache the CORS response
 
     """
+
     def __init__(
         self,
         *,
@@ -177,6 +179,7 @@ class CORSProcessor:
     `set_headers` directly.
 
     """
+
     def __init__(self, config: CORSConfig, **overrides) -> None:
         self.config = copy.deepcopy(config)
         self.config.update(**overrides)
@@ -274,6 +277,7 @@ class CORSMixin(web.RequestHandler):
 
     cors_overrides = {}
     """Add specific overrides for CORSProcessor here"""
+
     def __init__(self, application, request, **kwargs):
         super().__init__(application, request, **kwargs)
         cors_config = getattr(application, 'cors_config', CORSConfig())

--- a/imbi/endpoints/base.py
+++ b/imbi/endpoints/base.py
@@ -46,7 +46,9 @@ def require_permission(permission):
     :raises: problemdetails.Problem
 
     """
+
     def _require_permission(f):
+
         def wrapped(self, *args, **kwargs):
             """Inner-wrapping of the decorator that performs the logic"""
             if not self._current_user or \
@@ -230,6 +232,7 @@ class RequestHandler(cors.CORSMixin, postgres.RequestHandlerMixin,
 
 class AuthenticatedRequestHandler(RequestHandler):
     """RequestHandler base class for authenticated requests"""
+
     async def prepare(self) -> None:
         await super().prepare()
 
@@ -250,6 +253,7 @@ class AuthenticatedRequestHandler(RequestHandler):
 
 class ValidatingRequestHandler(AuthenticatedRequestHandler):
     """Validates the request against the OpenAPI spec"""
+
     async def prepare(self) -> None:
         await super().prepare()
 
@@ -523,6 +527,7 @@ class CollectionRequestHandler(CRUDRequestHandler):
 
 
 class AdminCRUDRequestHandler(CRUDRequestHandler):
+
     @require_permission('admin')
     async def delete(self, *args, **kwargs):
         await super().delete(*args, **kwargs)
@@ -718,6 +723,7 @@ class PaginationToken:
              return MyToken(**kwargs)
 
     """
+
     def __init__(self, *, limit: int = 100, **other_props: object):
         self._data: dict[str, object] = {'limit': limit}
         self._data.update(other_props)
@@ -786,6 +792,7 @@ class PaginatedCollectionHandler(CollectionRequestHandler):
     to the COLLECTION_SQL query.
 
     """
+
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         if self.ID_KEY is None:
@@ -837,6 +844,7 @@ ModelType = typing.TypeVar('ModelType', bound=pydantic.BaseModel)
 
 
 class PydanticHandlerMixin(RequestHandler):
+
     def parse_request_body_as(
             self,
             model_cls: typing.Type[ModelType],

--- a/imbi/endpoints/components/models.py
+++ b/imbi/endpoints/components/models.py
@@ -69,6 +69,7 @@ class Component(pydantic.BaseModel):
 
 class ComponentToken(base.PaginationToken):
     """Pagination token that includes the starting package URL"""
+
     def __init__(self, *, starting_package: str = '', **kwargs) -> None:
         super().__init__(starting_package=starting_package, **kwargs)
 
@@ -79,6 +80,7 @@ class ComponentToken(base.PaginationToken):
 
 class ProjectComponentsToken(base.PaginationToken):
     """Pagination token that includes the starting package URL and project"""
+
     def __init__(self,
                  *,
                  starting_package: str = '',

--- a/imbi/endpoints/environments.py
+++ b/imbi/endpoints/environments.py
@@ -6,12 +6,12 @@ from imbi.endpoints import base
 class _RequestHandlerMixin:
 
     ID_KEY = 'name'
-    FIELDS = ['name', 'description', 'icon_class']
+    FIELDS = ['name', 'slug', 'description', 'icon_class']
     DEFAULTS = {'icon_class': 'fas fa-mountain'}
 
     GET_SQL = re.sub(
         r'\s+', ' ', """\
-        SELECT "name", created_at, created_by,
+        SELECT "name", slug, created_at, created_by,
                last_modified_at, last_modified_by,
                description, icon_class
           FROM v1.environments
@@ -26,15 +26,16 @@ class CollectionRequestHandler(_RequestHandlerMixin,
 
     COLLECTION_SQL = re.sub(
         r'\s+', ' ', """\
-        SELECT "name", description, icon_class
+        SELECT "name", slug, description, icon_class
           FROM v1.environments
          ORDER BY "name" ASC""")
 
     POST_SQL = re.sub(
         r'\s+', ' ', """\
         INSERT INTO v1.environments
-                    ("name", created_by, description, icon_class)
-             VALUES (%(name)s, %(username)s, %(description)s, %(icon_class)s)
+                    ("name", slug, created_by, description, icon_class)
+             VALUES (%(name)s, %(slug)s, %(username)s, %(description)s,
+                     %(icon_class)s)
           RETURNING "name";""")
 
 
@@ -48,6 +49,7 @@ class RecordRequestHandler(_RequestHandlerMixin, base.AdminCRUDRequestHandler):
         r'\s+', ' ', """\
         UPDATE v1.environments
            SET "name"=%(name)s,
+               slug=%(slug)s,
                last_modified_at=CURRENT_TIMESTAMP,
                last_modified_by=%(username)s,
                description=%(description)s,

--- a/imbi/endpoints/integrations/__init__.py
+++ b/imbi/endpoints/integrations/__init__.py
@@ -18,6 +18,10 @@ SLUG = r'[\w_\-%\+]+'
 
 URLS = [
     web.url(r'^/github/auth', github.RedirectHandler, name='github-callback'),
+    web.url(r'^/github/projects/(?P<project_id>[0-9]+)/tags$',
+            github.ProjectTagsHandler),
+    web.url(r'^/github/projects/(?P<project_id>[0-9]+)/deployments$',
+            github.ProjectDeploymentsHandler),
     web.url(r'^/gitlab/auth', gitlab.RedirectHandler, name='gitlab-callback'),
     web.url(r'^/gitlab/namespaces', gitlab.UserNamespacesHandler),
     web.url(r'^/gitlab/projects', gitlab.ProjectsHandler),

--- a/imbi/endpoints/integrations/github.py
+++ b/imbi/endpoints/integrations/github.py
@@ -1,11 +1,13 @@
 import base64
 import dataclasses
+import http
 import typing
 
 import sprockets.mixins.http
 import yarl
 
-from imbi import errors, oauth2, user
+from imbi import errors, models, oauth2, user
+from imbi.clients import github
 from imbi.endpoints import base
 
 
@@ -135,3 +137,130 @@ class RedirectHandler(sprockets.mixins.http.HTTPClientMixin,
                 'failed to revoke GitHub credentials for user %s: %s '
                 '(tokens: %s)', username, response.code,
                 ', '.join(token_types))
+
+
+class GitHubIntegratedHandler(base.AuthenticatedRequestHandler):
+    """Base handler for GitHub-integrated endpoints"""
+
+    NAME = 'github-integrated'
+
+    async def prepare(self) -> None:
+        await super().prepare()
+        if not self._finished:
+            self.client = await github.create_client(self.application,
+                                                     'github',
+                                                     self.current_user)
+
+
+class ProjectTagsHandler(GitHubIntegratedHandler):
+    """Handler for fetching GitHub tags for a project"""
+
+    NAME = 'github-project-tags'
+
+    async def get(self, project_id: str) -> None:
+        """Return list of tags from the project's GitHub repository
+
+        Tags are fetched from GitHub API and 'refs/tags/' prefix removed
+        """
+        try:
+            project_id_int = int(project_id)
+        except ValueError:
+            raise errors.BadRequest('Invalid project ID')
+
+        project = await models.project(project_id_int, self.application)
+        if project is None:
+            raise errors.ItemNotFound(instance=self.request.uri)
+
+        if 'github' not in project.identifiers:
+            raise errors.ItemNotFound(
+                'Project does not have a GitHub repository configured',
+                instance=self.request.uri)
+
+        org = project.project_type.github_org or project.project_type.slug
+        repo = project.slug
+
+        try:
+            refs = await self.client.get_matching_refs(org, repo, 'tags')
+        except Exception as e:
+            self.logger.error('Failed to fetch tags from GitHub: %s', e)
+            raise errors.InternalServerError(
+                'Failed to fetch tags from GitHub',
+                instance=self.request.uri) from e
+
+        tags = []
+        for ref_obj in refs:
+            ref = ref_obj.get('ref', '')
+            if ref.startswith('refs/tags/'):
+                tags.append(ref[len('refs/tags/'):])
+
+        self.send_response(tags)
+
+
+class ProjectDeploymentsHandler(GitHubIntegratedHandler):
+    """Handler for creating GitHub deployments"""
+
+    NAME = 'github-project-deployments'
+
+    async def post(self, project_id: str) -> None:
+        """Create a GitHub deployment for the project
+
+        Expects JSON body with:
+        - ref: Tag or branch to deploy
+        - environment: Target environment name
+        """
+        try:
+            project_id_int = int(project_id)
+        except ValueError:
+            raise errors.BadRequest('Invalid project ID')
+
+        body = self.get_request_body()
+        if not body:
+            raise errors.BadRequest('Request body is required')
+
+        ref = body.get('ref')
+        environment = body.get('environment')
+
+        if not ref:
+            raise errors.BadRequest('Field "ref" is required')
+        if not environment:
+            raise errors.BadRequest('Field "environment" is required')
+
+        project = await models.project(project_id_int, self.application)
+        if project is None:
+            raise errors.ItemNotFound(instance=self.request.uri)
+
+        if 'github' not in project.identifiers:
+            raise errors.ItemNotFound(
+                'Project does not have a GitHub identifier configured',
+                instance=self.request.uri)
+
+        if (project.environments is None
+                or environment not in project.environments):
+            raise errors.BadRequest(
+                f'Environment "{environment}" is not configured'
+                ' for this project')
+
+        # Fetch the environment slug from the database
+        result = await self.postgres_execute(
+            'SELECT slug FROM v1.environments WHERE name = %(name)s',
+            {'name': environment},
+            metric_name='fetch-environment-slug')
+        if not result.row_count:
+            raise errors.ItemNotFound(f'Environment "{environment}" not found',
+                                      instance=self.request.uri)
+        environment_slug = result.row['slug']
+
+        org = project.project_type.github_org or project.project_type.slug
+        repo = project.slug
+
+        try:
+            await self.client.create_deployment(org, repo, ref,
+                                                environment_slug)
+        except Exception as e:
+            self.logger.error('Failed to create GitHub deployment: %s', e)
+            raise errors.InternalServerError(
+                'Failed to create GitHub deployment',
+                instance=self.request.uri) from e
+
+        self.set_status(http.HTTPStatus.CREATED)
+        self.send_response({'message': 'Deployment created successfully'})

--- a/imbi/endpoints/opensearch.py
+++ b/imbi/endpoints/opensearch.py
@@ -5,6 +5,7 @@ from imbi.endpoints import base
 
 
 class RequestHandler(base.AuthenticatedRequestHandler):
+
     async def post(self, index: str):
         self.logger.debug('Request body: %r', self.get_request_body())
         try:

--- a/imbi/endpoints/project_sbom/handlers.py
+++ b/imbi/endpoints/project_sbom/handlers.py
@@ -146,6 +146,7 @@ class SBOMInjectionHandler(base.PydanticHandlerMixin,
 
 
 class ComponentVersionMap:
+
     def __init__(self, connector: sprockets_postgres.PostgresConnector,
                  package_urls: set[models.PackageURL]) -> None:
         self._purls_from_bom = package_urls.copy()

--- a/imbi/endpoints/projects.py
+++ b/imbi/endpoints/projects.py
@@ -45,12 +45,14 @@ class _RequestHandlerMixin:
 
 
 class ProjectAttributeCollectionMixin(project.RequestHandlerMixin):
+
     async def post(self, *_args, **kwargs):
         result = await self._post(kwargs)
         await self.index_document(result['project_id'])
 
 
 class ProjectAttributeCRUDMixin(project.RequestHandlerMixin):
+
     async def delete(self, *args, **kwargs):
         await super().delete(*args, **kwargs)
         await self.index_document(kwargs['project_id'])
@@ -389,8 +391,10 @@ class RecordRequestHandler(project.RequestHandlerMixin, _RequestHandlerMixin,
             output.update({
                 'facts': facts.rows,
                 'links': links.rows,
-                'urls': {row['environment']: row['url']
-                         for row in urls.rows}
+                'urls': {
+                    row['environment']: row['url']
+                    for row in urls.rows
+                }
             })
             self.send_response(output)
         else:

--- a/imbi/endpoints/ssm/handlers.py
+++ b/imbi/endpoints/ssm/handlers.py
@@ -274,6 +274,7 @@ class SSMRequestHandler(sprockets.mixins.http.HTTPClientMixin,
 
 
 class RecordRequestHandler(SSMRequestHandler, base.PydanticHandlerMixin):
+
     async def patch(self, *args, **kwargs):
         request_body = self.get_request_body()
         try:
@@ -339,6 +340,7 @@ class RecordRequestHandler(SSMRequestHandler, base.PydanticHandlerMixin):
 
 
 class CollectionRequestHandler(SSMRequestHandler):
+
     async def get(self, *args, **kwargs) -> None:
         project_info = await self._get_project_info(kwargs['project_id'])
         if not project_info['environments']:

--- a/imbi/endpoints/ssm/models.py
+++ b/imbi/endpoints/ssm/models.py
@@ -11,6 +11,7 @@ class Param(pydantic.BaseModel):
 
 
 class EnvironmentFieldMixin:
+
     @pydantic.computed_field
     @property
     def environment(self) -> str:

--- a/imbi/endpoints/static.py
+++ b/imbi/endpoints/static.py
@@ -2,6 +2,7 @@ from tornado import web
 
 
 class StaticFileHandler(web.StaticFileHandler):
+
     def set_default_headers(self) -> None:
         """Override the default headers, setting the Server response header"""
         super().set_default_headers()

--- a/imbi/endpoints/ui/__init__.py
+++ b/imbi/endpoints/ui/__init__.py
@@ -4,7 +4,7 @@ System Reports
 """
 from tornado import web
 
-from . import authentication, index, settings, user
+from . import authentication, index, project_actions, settings, user
 
 IndexRequestHandler = index.IndexRequestHandler
 
@@ -18,5 +18,7 @@ URLS = [
     web.url(r'^/ui/settings$', settings.RequestHandler),
     web.url(r'^/ui/user$', user.UserRequestHandler),
     web.url(r'^/ui/available-automations$', user.AvailableAutomationsHandler),
+    web.url(r'^/ui/projects/(?P<project_id>[0-9]+)/actions$',
+            project_actions.AvailableActionsHandler),
     web.url(r'^/ui/.*$', index.IndexRequestHandler)
 ]

--- a/imbi/endpoints/ui/authentication.py
+++ b/imbi/endpoints/ui/authentication.py
@@ -74,6 +74,7 @@ class LogoutRequestHandler(base.RequestHandler):
 
 
 class ConnectionRequestHandler(base.AuthenticatedRequestHandler):
+
     async def delete(self, integration_name: str) -> None:
         await self.postgres_execute(
             'DELETE FROM v1.user_oauth2_tokens'

--- a/imbi/endpoints/ui/project_actions.py
+++ b/imbi/endpoints/ui/project_actions.py
@@ -1,0 +1,71 @@
+import logging
+
+from imbi import errors, models
+from imbi.endpoints import base
+
+LOGGER = logging.getLogger(__name__)
+
+
+class AvailableActionsHandler(base.AuthenticatedRequestHandler):
+    """Handler for fetching available actions for a project"""
+
+    NAME = 'ui-project-actions'
+
+    async def get(self, project_id: str) -> None:
+        """Return list of available actions for the project
+
+        Actions are filtered based on:
+        - Configuration toggles
+        - User has required integration tokens
+        - Project has required identifiers
+        """
+        try:
+            project_id_int = int(project_id)
+        except ValueError:
+            raise errors.BadRequest('Invalid project ID')
+
+        # Load project to verify it exists
+        project = await models.project(project_id_int, self.application)
+        if project is None:
+            raise errors.ItemNotFound(instance=self.request.uri)
+
+        actions = []
+
+        # Check GitHub deployment action
+        github_action_config = self.application.settings.get(
+            'actions', {}).get('github_deployment', {})
+        github_action_enabled = github_action_config.get('enabled', False)
+
+        if github_action_enabled:
+            user_has_github = await self._user_has_integration_token('github')
+            project_has_github = 'github' in project.identifiers
+            integration_enabled = self.application.settings.get(
+                'automations', {}).get('github', {}).get('enabled', False)
+
+            LOGGER.debug(
+                'GitHub action checks: enabled=%s, user_has_github=%s, '
+                'project_has_github=%s, integration_enabled=%s, '
+                'project.identifiers=%s', github_action_enabled,
+                user_has_github, project_has_github, integration_enabled,
+                project.identifiers)
+
+            if user_has_github and project_has_github and integration_enabled:
+                actions.append({
+                    'id': 'github_deployment',
+                    'name': 'Create GitHub Deployment',
+                    'integration': 'github'
+                })
+
+        self.send_response(actions)
+
+    async def _user_has_integration_token(self, integration_name: str) -> bool:
+        """Check if the current user has an OAuth token for the integration"""
+        result = await self.postgres_execute(
+            'SELECT 1 FROM v1.user_oauth2_tokens '
+            'WHERE username = %(username)s AND integration = %(integration)s',
+            {
+                'username': self._current_user.username,
+                'integration': integration_name
+            },
+            metric_name='check-user-oauth-token')
+        return result.row_count > 0

--- a/imbi/errors.py
+++ b/imbi/errors.py
@@ -71,27 +71,32 @@ class ApplicationError(problemdetails.Problem):
 
 
 class BadRequest(ApplicationError):
+
     def __init__(self, log_message, *log_args, **kwargs):
         super().__init__(400, 'bad-request', log_message, *log_args, **kwargs)
 
 
 class Unauthorized(ApplicationError):
+
     def __init__(self, log_message, *log_args, **kwargs):
         super().__init__(401, 'unauthorized', log_message, *log_args, **kwargs)
 
 
 class Forbidden(ApplicationError):
+
     def __init__(self, log_message, *log_args, **kwargs):
         super().__init__(403, 'forbidden', log_message, *log_args, **kwargs)
 
 
 class ClientUnavailableError(Forbidden):
+
     def __init__(self, client_name: str, log_message: str, *log_args):
         message = log_message % log_args if log_args else log_message
         super().__init__('%s not available: %s', client_name, message)
 
 
 class ItemNotFound(ApplicationError):
+
     def __init__(self, log_message=None, *log_args, **kwargs):
         kwargs.setdefault('title', 'Item not found')
         super().__init__(
@@ -101,6 +106,7 @@ class ItemNotFound(ApplicationError):
 
 
 class MethodNotAllowed(ApplicationError):
+
     def __init__(self, requested_method: str, **kwargs):
         super().__init__(405, 'method-not-allowed',
                          '%s is not a supported HTTP method',
@@ -108,6 +114,7 @@ class MethodNotAllowed(ApplicationError):
 
 
 class UnsupportedMediaType(ApplicationError):
+
     def __init__(self, media_type: str, **kwargs):
         super().__init__(415, 'unsupported-media-type',
                          '%s is not a supported media type', media_type,
@@ -115,12 +122,14 @@ class UnsupportedMediaType(ApplicationError):
 
 
 class UnprocessableEntity(ApplicationError):
+
     def __init__(self, log_message: str, *log_args, **kwargs) -> None:
         fragment = kwargs.pop('fragment', 'unprocessable-entity')
         super().__init__(422, fragment, log_message, *log_args, **kwargs)
 
 
 class BadJsonPatch(UnprocessableEntity):
+
     def __init__(self, error: jsonpatch.JsonPatchException
                  | jsonpointer.JsonPointerException, **kwargs) -> None:
         kwargs.setdefault('title', 'Invalid JSON Patch')
@@ -128,11 +137,13 @@ class BadJsonPatch(UnprocessableEntity):
 
 
 class InternalServerError(ApplicationError):
+
     def __init__(self, log_message, *log_args, **kwargs):
         super().__init__(500, 'server-error', log_message, *log_args, **kwargs)
 
 
 class DatabaseError(InternalServerError):
+
     def __init__(self,
                  log_message=None,
                  *log_args,
@@ -150,6 +161,7 @@ class DatabaseError(InternalServerError):
 
 
 class IntegrationNotFound(InternalServerError):
+
     def __init__(self, integration_name: str):
         super().__init__('integration lookup failed for %s',
                          integration_name,
@@ -157,6 +169,7 @@ class IntegrationNotFound(InternalServerError):
 
 
 class PydanticValidationError(ApplicationError):
+
     def __init__(self,
                  error: pydantic.ValidationError,
                  log_message: str,

--- a/imbi/ldap.py
+++ b/imbi/ldap.py
@@ -45,6 +45,7 @@ class Client:
     - ``pool_size``: The size to allocate for the ThreadPoolExecutor
 
     """
+
     def __init__(self, settings: dict):
         self._settings = Settings(**settings)
         self._executor = futures.ThreadPoolExecutor(

--- a/imbi/models.py
+++ b/imbi/models.py
@@ -395,6 +395,7 @@ class OperationsLog:
 
 async def _load(model: dataclasses.dataclass, application: 'app.Application',
                 **params) -> dataclasses.dataclass:
+
     def on_postgres_error(_metric_name: str, exc: Exception) -> None:
         LOGGER.error('Failed to execute query for %s with params %r: %s',
                      model.__class__.__name__, params, exc)
@@ -412,6 +413,7 @@ async def _load_collection(model: dataclasses.dataclass,
                            obj_id: int,
                            application: 'app.Application') \
         -> list[dataclasses.dataclass]:
+
     def on_postgres_error(_metric_name: str, exc: Exception) -> None:
         LOGGER.error('Failed to execute query for collection %s: %s', obj_id,
                      exc)
@@ -438,6 +440,7 @@ async def operations_log(ops_log_id: int,
 
 
 async def project(project_id: int, application: 'app.Application') -> Project:
+
     def on_postgres_error(_metric_name: str, exc: Exception) -> None:
         LOGGER.error('Failed to execute query for project %s: %s', project_id,
                      exc)
@@ -469,12 +472,18 @@ async def project(project_id: int, application: 'app.Application') -> Project:
             values.update({
                 'namespace': results[0],
                 'project_type': results[1],
-                'facts': {value.name: value.value
-                          for value in results[2]},
-                'links': {value.link_type: value.url
-                          for value in results[3]},
-                'urls': {value.environment: value.url
-                         for value in results[4]},
+                'facts': {
+                    value.name: value.value
+                    for value in results[2]
+                },
+                'links': {
+                    value.link_type: value.url
+                    for value in results[3]
+                },
+                'urls': {
+                    value.environment: value.url
+                    for value in results[4]
+                },
                 'identifiers': {
                     value.integration_name: value.external_id
                     for value in results[5]

--- a/imbi/openapi.py
+++ b/imbi/openapi.py
@@ -18,6 +18,7 @@ LOGGER = logging.getLogger(__name__)
 
 
 class EMailFormatter:
+
     @staticmethod
     def validate(value) -> bool:
         return validators.email(value)
@@ -28,6 +29,7 @@ class EMailFormatter:
 
 
 class ISO8601Formatter:
+
     @staticmethod
     def validate(value) -> bool:
         try:
@@ -42,6 +44,7 @@ class ISO8601Formatter:
 
 
 class URIFormatter:
+
     @staticmethod
     def validate(value) -> bool:
         return validators.url(value, validate_scheme=lambda _: True)

--- a/imbi/opensearch/__init__.py
+++ b/imbi/opensearch/__init__.py
@@ -20,6 +20,7 @@ ModelType = typing.TypeVar('ModelType')
 
 
 class SupportsIndexDocumentById(typing.Protocol):
+
     async def index_document_by_id(self, doc_id: int) -> bool:
         ...
 

--- a/imbi/opensearch/operations_log.py
+++ b/imbi/opensearch/operations_log.py
@@ -83,6 +83,7 @@ class OperationsLogIndex(opensearch.SearchIndex[models.OperationsLog]):
 
 
 class RequestHandlerMixin:
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.search_index = OperationsLogIndex(self.application)

--- a/imbi/opensearch/project.py
+++ b/imbi/opensearch/project.py
@@ -194,6 +194,7 @@ class ProjectIndex(imbi.opensearch.SearchIndex[models.Project]):
 
 
 class RequestHandlerMixin:
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.search_index = ProjectIndex(self.application)

--- a/imbi/pkgfiles.py
+++ b/imbi/pkgfiles.py
@@ -13,6 +13,7 @@ LOGGER = logging.getLogger(__name__)
 
 class TemplateLoader(template.BaseLoader):
     """A template loader that loads from Python package data."""
+
     def __init__(self, debug=False, **kwargs):
         """Create a new instance of the loader, respecting the debug flag
         so that when set, templates are not cached, since changing templates

--- a/imbi/semver.py
+++ b/imbi/semver.py
@@ -77,6 +77,7 @@ class VersionRange(abc.Container[semantic_version.Version]):
 
 class ExactRange(VersionRange):
     """Exact matches only"""
+
     def __init__(self, spec: str, /) -> None:
         super().__init__(spec, constraint_cls=semantic_version.SimpleSpec)
         self.version = semantic_version.Version.coerce(spec)

--- a/imbi/server.py
+++ b/imbi/server.py
@@ -114,6 +114,7 @@ def load_configuration(config: str, debug: bool) -> typing.Tuple[dict, dict]:
 
     log_config = config.get('logging', DEFAULT_LOG_CONFIG)
 
+    actions = config.get('actions', {})
     automations = config.get('automations', {})
     automations_grafana = automations.get('grafana', {})
     if automations_grafana.get('url') \
@@ -173,6 +174,7 @@ def load_configuration(config: str, debug: bool) -> typing.Tuple[dict, dict]:
             encryption_key = encoded_key.encode()
 
     settings = {
+        'actions': actions,
         'automations': {
             'github': automations_github,
             'gitlab': automations_gitlab,

--- a/imbi/session.py
+++ b/imbi/session.py
@@ -21,6 +21,7 @@ DEFAULT_POOL_SIZE = 5
 
 class Session:
     """Session object manages session state and the user object."""
+
     def __init__(self, handler: web.RequestHandler) -> None:
         self._handler = handler
         self.authenticated = False

--- a/imbi/slugify.py
+++ b/imbi/slugify.py
@@ -18,6 +18,7 @@ Slug = typing.Annotated[str,
 
 
 class InvalidSlugError(errors.BadRequest):
+
     def __init__(self, slug_type: str, invalid_slugs: set[int | str]) -> None:
         super().__init__('Invalid %s slug(s): %r',
                          slug_type,
@@ -51,6 +52,7 @@ def decode_path_slug(slug_or_id: str) -> tuple[int | None] | tuple[None | str]:
 
 class IdSlugMapping:
     """Maps between IDs and slugs"""
+
     def __init__(self, slug_to_id: dict[str, int] | None = None) -> None:
         self._slug_to_id: dict[str, int] = {}
         if slug_to_id:

--- a/imbi/stats.py
+++ b/imbi/stats.py
@@ -19,6 +19,7 @@ class Stats:
     collector.
 
     """
+
     def __init__(self, client: aioredis.Redis):
         """Create a new instance of the Stats class"""
         self._client = client

--- a/imbi/templates/openapi.yaml
+++ b/imbi/templates/openapi.yaml
@@ -1220,12 +1220,14 @@ paths:
                 records:
                   summary: Multiple environment records
                   value:
-                    - name: testing
+                    - name: Testing
+                      slug: testing
                       description: |
                         The testing environment reflects the state of HEAD state of the
                         master branch in our Git Repositories for all projects
                       icon_class: fab fa-aws
-                    - name: staging
+                    - name: Staging
+                      slug: staging
                       description: |
                         The staging environment reflects tagged project releases that are
                         intended to be to deployed to production
@@ -1239,12 +1241,14 @@ paths:
                 records:
                   summary: Multiple environment records
                   value:
-                    - name: testing
+                    - name: Testing
+                      slug: testing
                       description: |
                         The testing environment reflects the state of HEAD state of the
                         master branch in our Git Repositories for all projects
                       icon_class: fab fa-aws
-                    - name: staging
+                    - name: Staging
+                      slug: staging
                       description: |
                         The staging environment reflects tagged project releases that are
                         intended to be to deployed to production
@@ -1266,6 +1270,9 @@ paths:
                 name:
                   description: The display name for a environment
                   type: string
+                slug:
+                  description: URL-safe environment identifier
+                  type: string
                 description:
                   description: A description of the environment
                   type: string
@@ -1275,13 +1282,15 @@ paths:
                   type: string
               required:
                 - name
+                - slug
                 - icon_class
               additionalProperties: false
             examples:
               record:
                 summary: A full environment record
                 value:
-                  name: testing
+                  name: Testing
+                  slug: testing
                   description: |
                     The testing environment reflects the state of HEAD state of the
                     master branch in our Git Repositories for all projects
@@ -1293,7 +1302,8 @@ paths:
               record:
                 summary: A full environment record
                 value:
-                  name: testing
+                  name: Testing
+                  slug: testing
                   description: |
                     The testing environment reflects the state of HEAD state of the
                     master branch in our Git Repositories for all projects
@@ -1382,6 +1392,119 @@ paths:
         schema:
           type: string
           pattern: '[\w_]+'
+  /github/auth:
+    get:
+      description: |
+        This endpoint is invoked during the GitHub authorization flow for a specific user.
+        It exchanges the code for an access/refresh token pair and stores them in the database
+        for future use.
+      summary: GitHub OAuth 2 callback
+      security: []
+      tags:
+        - Integrations
+      parameters:
+        - name: code
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: state
+          in: query
+          required: false
+          schema:
+            type: string
+      responses:
+        '302':
+          description: Redirect back to profile
+  '/github/projects/{project_id}/tags':
+    get:
+      description: Retrieve GitHub tags for a project's repository
+      summary: Available GitHub tags
+      tags:
+        - Integrations
+        - Projects
+      parameters:
+        - name: project_id
+          in: path
+          description: Unique project identifier
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: List of available tags
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+              examples:
+                tags:
+                  summary: Example tags
+                  value:
+                    - v1.0.0
+                    - v1.1.0
+                    - v2.0.0
+        '400':
+          description: Invalid project ID
+        '404':
+          description: Project not found or GitHub not configured
+        '500':
+          description: GitHub integration is not available/configured
+  '/github/projects/{project_id}/deployments':
+    post:
+      description: Create a GitHub deployment for a project
+      summary: Create GitHub deployment
+      tags:
+        - Integrations
+        - Projects
+      parameters:
+        - name: project_id
+          in: path
+          description: Unique project identifier
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        description: Deployment parameters
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                ref:
+                  type: string
+                  description: 'Git ref to deploy (tag, branch, or SHA)'
+                environment:
+                  type: string
+                  description: Target environment name
+              required:
+                - ref
+                - environment
+            examples:
+              deployment:
+                summary: Deploy a tag to production
+                value:
+                  ref: v1.2.3
+                  environment: Production
+      responses:
+        '201':
+          description: Deployment created successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+        '400':
+          description: Invalid request or environment not configured for project
+        '404':
+          description: Project not found or GitHub not configured
+        '500':
+          description: Failed to create GitHub deployment
   /gitlab/auth:
     get:
       description: |

--- a/imbi/transcoders.py
+++ b/imbi/transcoders.py
@@ -6,6 +6,7 @@ from sprockets.mixins.mediatype import handlers, transcoders
 
 
 def parse_form_body(data) -> dict:
+
     def translate_value(v):
         if not v:
             return None
@@ -36,6 +37,7 @@ def parse_form_body(data) -> dict:
 
 
 class DecimalMixin:
+
     def dump_object(self, obj):
         if isinstance(obj, decimal.Decimal):
             return float(obj)
@@ -43,6 +45,7 @@ class DecimalMixin:
 
 
 class PydanticMixin:
+
     def dump_object(self, obj):
         if isinstance(obj, pydantic.BaseModel):
             return obj.model_dump(mode='json')
@@ -59,6 +62,7 @@ class MsgPackTranscoder(DecimalMixin, PydanticMixin,
 
 
 class HTMLTranscoder(transcoders.JSONTranscoder):
+
     def __init__(self, content_type='text/html', default_encoding='utf-8'):
         super().__init__(content_type, default_encoding)
         self.dump_options = {
@@ -85,6 +89,7 @@ class HTMLTranscoder(transcoders.JSONTranscoder):
 
 
 class FormTranscoder(handlers.TextContentHandler):
+
     def __init__(self):
         super().__init__('application/x-www-form-urlencoded',
                          dumps=self.dumps,

--- a/setup.cfg
+++ b/setup.cfg
@@ -68,7 +68,7 @@ install_requires =
     opensearch-py[async]>=1,<2
     packaging>=24,<25
     pycurl
-    pydantic==2.6.1
+    pydantic>=2.11.9,<3
     python-ulid>=1,<2
     pyyaml
     semantic-version>=2.10,<3

--- a/setup.cfg
+++ b/setup.cfg
@@ -80,7 +80,7 @@ install_requires =
     tornado==6.1
     tornado-problem-details>=0.0.6,<1
     tornado_openapi3>=1.1.2,<2
-    typing-extensions>=4.9,<4.10
+    typing-extensions>=4.9,<5
     u-msgpack-python>=2.1,<3
     validators
     yapf==0.31.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -104,7 +104,7 @@ sentry =
 testing =
     bandit==1.6.2
     coverage==5.0.4
-    flake8==3.7.9
+    flake8==7.3.0
     flake8-comprehensions==3.2.2
     flake8-deprecated==1.3
     flake8-import-order==0.18.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -111,7 +111,7 @@ testing =
     flake8-quotes==3.0.0
     flake8-rst-docstrings==0.0.13
     flake8-tuple==0.4.1
-    pre-commit==2.20.0
+    pre-commit==4.3.0
 
 [entry_points]
 bandit.formatters =

--- a/setup.cfg
+++ b/setup.cfg
@@ -105,7 +105,7 @@ testing =
     bandit==1.6.2
     coverage==5.0.4
     flake8==7.3.0
-    flake8-comprehensions==3.2.2
+    flake8-comprehensions==3.17.0
     flake8-deprecated==1.3
     flake8-import-order==0.18.1
     flake8-quotes==3.0.0

--- a/tests/automations/test_context.py
+++ b/tests/automations/test_context.py
@@ -21,6 +21,7 @@ class AnyInstanceOf:
            AnyInstanceOf(automations.AutomationContext))
 
     """
+
     def __init__(self, cls: type) -> None:
         self.expected_class = cls
 
@@ -31,6 +32,7 @@ class AnyInstanceOf:
 
 
 class FakeAutomation:
+
     def __init__(self) -> None:
         self.integration_name = str(uuid.uuid4())
         self.slug = str(uuid.uuid4())
@@ -45,6 +47,7 @@ class FakeAutomation:
 
 
 class AutomationContextTests(unittest.IsolatedAsyncioTestCase):
+
     def setUp(self) -> None:
         super().setUp()
         self.application = unittest.mock.Mock(spec=app.Application)
@@ -153,7 +156,9 @@ class AutomationContextTests(unittest.IsolatedAsyncioTestCase):
         autos[-1].callback.assert_not_awaited()
 
     async def test_using_context_from_within_action(self) -> None:
+
         class Automation(FakeAutomation):
+
             def __init__(self, side_effect: Exception | None = None) -> None:
                 super().__init__()
                 self.action.side_effect = side_effect
@@ -178,6 +183,7 @@ class AutomationContextTests(unittest.IsolatedAsyncioTestCase):
         autos[0].callback.assert_called_once_with(self.context, error)
 
     async def test_state_storage(self) -> None:
+
         async def writer(ctx: automations.AutomationContext,
                          _auto: models.Automation) -> None:
             ctx[self.test_state_storage] = 'hello'
@@ -196,6 +202,7 @@ class AutomationContextTests(unittest.IsolatedAsyncioTestCase):
 
 
 class RunAutomationsTests(unittest.IsolatedAsyncioTestCase):
+
     def setUp(self) -> None:
         super().setUp()
         self.application = unittest.mock.Mock(spec=app.Application)
@@ -295,6 +302,7 @@ class RunAutomationsTests(unittest.IsolatedAsyncioTestCase):
 
 
 class QueryRunnerTests(unittest.IsolatedAsyncioTestCase):
+
     async def test(self) -> None:
         runner = automations.query_runner(
             unittest.mock.sentinel.metric_name,

--- a/tests/base.py
+++ b/tests/base.py
@@ -199,6 +199,7 @@ class TestCaseWithReset(TestCase):
                                 method='POST',
                                 json_body={
                                     'name': str(uuid.uuid4()),
+                                    'slug': str(uuid.uuid4()),
                                     'description': str(uuid.uuid4()),
                                     'icon_class': 'fas fa-blind'
                                 })

--- a/tests/endpoints/test_activity_feed.py
+++ b/tests/endpoints/test_activity_feed.py
@@ -61,6 +61,7 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
         )
 
     def test_pagination(self):
+
         def now() -> str:
             return datetime.datetime.now(datetime.timezone.utc).isoformat()
 

--- a/tests/endpoints/test_environments.py
+++ b/tests/endpoints/test_environments.py
@@ -15,6 +15,7 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
     def test_environment_lifecycle(self):
         record = {
             'name': str(uuid.uuid4()),
+            'slug': str(uuid.uuid4()),
             'description': str(uuid.uuid4()),
             'icon_class': 'fas fa-blind'
         }
@@ -89,11 +90,16 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
         self.assertEqual(result.code, 404)
 
     def test_create_with_missing_fields(self):
-        record = {'name': str(uuid.uuid4()), 'icon_class': 'fas fa-blind'}
+        record = {
+            'name': str(uuid.uuid4()),
+            'slug': str(uuid.uuid4()),
+            'icon_class': 'fas fa-blind'
+        }
         result = self.fetch('/environments', method='POST', json_body=record)
         self.assertEqual(result.code, 200)
         new_value = json.loads(result.body.decode('utf-8'))
         self.assertEqual(new_value['name'], record['name'])
+        self.assertEqual(new_value['slug'], record['slug'])
         self.assertIsNone(new_value['description'])
         self.assertIsNotNone(new_value['icon_class'])
 

--- a/tests/endpoints/test_metrics.py
+++ b/tests/endpoints/test_metrics.py
@@ -2,6 +2,7 @@ from tests import base
 
 
 class AsyncHTTPTestCase(base.TestCase):
+
     def test_status_ok(self):
         response = self.fetch('/metrics')
         self.assertEqual(response.code, 200)

--- a/tests/endpoints/test_namespaces.py
+++ b/tests/endpoints/test_namespaces.py
@@ -14,8 +14,8 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
 
     def test_namespace_lifecycle(self):
         record = {
-            field:
-            namespaces.CollectionRequestHandler.DEFAULTS.get(field, None)
+            field: namespaces.CollectionRequestHandler.DEFAULTS.get(
+                field, None)
             for field in namespaces.CollectionRequestHandler.FIELDS
             if field != namespaces.CollectionRequestHandler.ID_KEY
         }

--- a/tests/endpoints/test_notification_processing.py
+++ b/tests/endpoints/test_notification_processing.py
@@ -466,6 +466,7 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
 
 
 class EdgeTests(unittest.TestCase):
+
     def test_json_pointer_validation(self) -> None:
         Adapter = pydantic.TypeAdapter(common.JsonPointer)
         with self.assertRaises(TypeError):

--- a/tests/endpoints/test_permissions.py
+++ b/tests/endpoints/test_permissions.py
@@ -15,6 +15,7 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
 
 
 class AsyncHTTPUnauthorizedTestCase(base.TestCaseWithReset):
+
     def test_permission_values(self):
         result = self.fetch('/permissions')
         self.assertEqual(result.code, 403)

--- a/tests/endpoints/test_project_types.py
+++ b/tests/endpoints/test_project_types.py
@@ -14,8 +14,8 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
 
     def test_project_type_lifecycle(self):
         record = {
-            field:
-            project_types.CollectionRequestHandler.DEFAULTS.get(field, None)
+            field: project_types.CollectionRequestHandler.DEFAULTS.get(
+                field, None)
             for field in project_types.CollectionRequestHandler.FIELDS
             if field != project_types.CollectionRequestHandler.ID_KEY
         }

--- a/tests/endpoints/test_status.py
+++ b/tests/endpoints/test_status.py
@@ -2,6 +2,7 @@ from tests import base
 
 
 class AsyncHTTPTestCase(base.TestCase):
+
     def test_status_ok(self):
         response = self.fetch('/status')
         self.assertEqual(response.code, 200)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -4,6 +4,7 @@ from tests import base
 
 
 class EncryptionTestCase(base.TestCase):
+
     def test_lifecycle(self):
         value = str(uuid.uuid4())
         encrypted = self._app.encrypt_value(value)
@@ -11,6 +12,7 @@ class EncryptionTestCase(base.TestCase):
 
 
 class PasswordHashingTestCase(base.TestCase):
+
     def test_that_password_hashes_include_algorithm(self):
         hashed = self._app.hash_password('my password')
         self.assertTrue(

--- a/tests/test_cors.py
+++ b/tests/test_cors.py
@@ -11,6 +11,7 @@ from imbi import cors
 
 
 class OriginTests(unittest.TestCase):
+
     def test_defaults(self):
         origins = cors.Origins()
         self.assertTrue(origins.allow_any)
@@ -30,6 +31,7 @@ class OriginTests(unittest.TestCase):
 
 
 class ConfigTests(unittest.TestCase):
+
     def test_default_configuration(self):
         cfg = cors.CORSConfig()
         self.assertTrue(cfg.allow_credentials)
@@ -98,6 +100,7 @@ class ConfigTests(unittest.TestCase):
 
 
 class RequestProcessingTestCase(unittest.TestCase):
+
     def setUp(self) -> None:
         super().setUp()
         self.request = httputil.HTTPServerRequest(
@@ -113,6 +116,7 @@ class RequestProcessingTestCase(unittest.TestCase):
 
 
 class PreflightProcessingTests(RequestProcessingTestCase):
+
     def setUp(self) -> None:
         super().setUp()
         self.cors_processor = cors.CORSProcessor(
@@ -188,6 +192,7 @@ class PreflightProcessingTests(RequestProcessingTestCase):
 
 
 class RequestProcessingTests(RequestProcessingTestCase):
+
     def setUp(self) -> None:
         super().setUp()
         self.request.method = 'DELETE'
@@ -240,7 +245,9 @@ class RequestProcessingTests(RequestProcessingTestCase):
 
 
 class MixinTests(unittest.IsolatedAsyncioTestCase):
+
     class Handler(cors.CORSMixin):
+
         def delete(self) -> None:
             self.set_status(204)
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -6,6 +6,7 @@ from imbi import errors
 
 
 class DefaultFunctionalityTests(unittest.TestCase):
+
     def test_that_error_url_can_be_configured(self):
         saved_error_url = errors.ERROR_URL
         try:
@@ -59,6 +60,7 @@ class DefaultFunctionalityTests(unittest.TestCase):
 
 
 class SpecificErrorBehaviorTests(unittest.TestCase):
+
     def test_item_not_found_default_title(self):
         err = errors.ItemNotFound()
         self.assertEqual('Item not found', err.document['title'])

--- a/tests/test_keychain.py
+++ b/tests/test_keychain.py
@@ -7,12 +7,14 @@ import imbi.keychain
 
 
 class KeychainCreationTests(unittest.TestCase):
+
     def test_that_32_byte_key_is_required(self):
         with self.assertRaises(ValueError):
             imbi.keychain.Keychain(b'not 32 bytes')
 
 
 class PasswordHashingTests(unittest.TestCase):
+
     def setUp(self):
         super().setUp()
         self.key = b'some thirty-two character secret'
@@ -25,6 +27,7 @@ class PasswordHashingTests(unittest.TestCase):
 
 
 class EncryptionTests(unittest.TestCase):
+
     def setUp(self):
         super().setUp()
         self.key = b'some thirty-two character secret'

--- a/tests/test_ldap.py
+++ b/tests/test_ldap.py
@@ -9,6 +9,7 @@ LDAP_PASSWORD = 'password'
 
 
 class ClientTestCase(base.TestCase):
+
     @staticmethod
     def get_user_dn(conn):
         result = conn.extend.standard.who_am_i()

--- a/tests/test_pagerduty_client.py
+++ b/tests/test_pagerduty_client.py
@@ -187,6 +187,7 @@ class PagerDutyProjectCreationTests(PagerDutyClientTestCase):
 
 
 class PagerDutyProjectDeletionTests(PagerDutyClientTestCase):
+
     def test_removing_service(self) -> None:
         self.run_until_complete(self.client.remove_service('some-service-id'))
         self.http_fetch_mock.assert_awaited_once_with(

--- a/tests/test_semver.py
+++ b/tests/test_semver.py
@@ -9,6 +9,7 @@ from imbi import semver
 
 
 class VersionCheckingTests(unittest.TestCase):
+
     def verify_range(self, spec: str, in_range: abc.Iterable[str],
                      out_of_range: abc.Iterable[str]) -> None:
         ver_range = semver.parse_semver_range(spec)
@@ -68,6 +69,7 @@ class VersionCheckingTests(unittest.TestCase):
 
 
 class VersionRangeErrorHandlingTests(unittest.TestCase):
+
     def test_that_empty_spec_is_rejected(self) -> None:
         with self.assertRaises(ValueError):
             semver.ExactRange('')
@@ -90,6 +92,7 @@ class VersionRangeErrorHandlingTests(unittest.TestCase):
 
 
 class PydanticModelTests(unittest.TestCase):
+
     def setUp(self) -> None:
         super().setUp()
         self.adapter = pydantic.TypeAdapter(semver.VersionRange)
@@ -107,6 +110,7 @@ class PydanticModelTests(unittest.TestCase):
 
 
 class UtilityFunctionTests(unittest.TestCase):
+
     def test_equality(self) -> None:
         self.assertEqual(semver.VersionRange('1'), semver.VersionRange('1'))
         self.assertNotEqual(semver.VersionRange('1'), '1')

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -33,6 +33,7 @@ class ConfigurationTestCase(unittest.TestCase):
 
 
 class LoadConfigurationTests(ConfigurationTestCase):
+
     def test_missing_configuration_file(self):
         with self.assertRaises(SystemExit):
             server.load_configuration(str(uuid.uuid4()), False)
@@ -67,6 +68,7 @@ class LoadConfigurationTests(ConfigurationTestCase):
 
 
 class SentryConfigurationTests(ConfigurationTestCase):
+
     def test_that_default_is_enabled(self):
         yaml.dump(self.config, self.temp_file)
         config, _ = server.load_configuration(self.temp_file.name, False)
@@ -86,6 +88,7 @@ class SentryConfigurationTests(ConfigurationTestCase):
 
 
 class GitLabConfiguratTests(ConfigurationTestCase):
+
     def test_that_default_is_disabled(self):
         yaml.dump(self.config, self.temp_file)
         config, _ = server.load_configuration(self.temp_file.name, False)

--- a/tests/test_timestamp.py
+++ b/tests/test_timestamp.py
@@ -7,6 +7,7 @@ from imbi import timestamp
 
 
 class TimestampTests(unittest.TestCase):
+
     def test_format_and_parse(self):
         expectation = '2016-08-26 13:46:34-04:00'
         parsed = timestamp.parse(expectation)

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -8,6 +8,7 @@ from tests import base
 
 
 class GroupTestCase(unittest.TestCase):
+
     def test_as_dict(self):
         name = str(uuid.uuid4())
         permissions = [str(uuid.uuid4()), str(uuid.uuid4())]


### PR DESCRIPTION
This:
 - fixes local dev with some dependency updates, which included a flake8 update and linting the repo
 - adds support for generic project action support, for now, only creating GitHub deployments
 - updates endpoints for the new `slug` column on namespaces. This is used making requests to the GitHub API
 - adds GitHub endpoints:
   - view refs on a GitHub repo
   - create a new deployment