### PR TITLE
Adopt graph subpackage and set_on_startup hook

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,7 +81,7 @@ src/imbi_api/
 
 **Lifespan-based DI** (`lifespans.py`): Services are initialized/torn down via `imbi_common.lifespan.Lifespan`:
 1. `clickhouse_hook` — init/close ClickHouse (module-level singleton)
-2. `graph.graph_lifespan` — Graph pool (monkey-patched in `lifespans.py` to also refresh blueprint models)
+2. `graph.graph_lifespan` — Graph pool (blueprint refresh registered via `graph.set_on_startup()` in `lifespans.py`)
 3. `email_hook` — yields `(EmailClient, TemplateManager)` tuple
 4. `storage_hook` — yields `StorageClient`
 

--- a/justfile
+++ b/justfile
@@ -64,7 +64,7 @@ docker:
     OTEL_EXPORTER_OTLP_TRACES_INSECURE="true"
     OTEL_RESOURCE_ATTRIBUTES="service.name=imbi-api,service.environment=development"
     OTEL_SERVICE_NAME="imbi-api"
-    POSTGRES_URL="postgresql://postgres:secret@$test_host:$(port postgres 5432)/imbi"
+    POSTGRES_URL="postgresql://postgres:secret@$test_host:$(get_port postgres 5432)/imbi"
     S3_ENDPOINT_URL="http://$test_host:$(get_port localstack 4566)"
     S3_ACCESS_KEY="test"
     S3_SECRET_KEY="test"

--- a/src/imbi_api/auth/permissions.py
+++ b/src/imbi_api/auth/permissions.py
@@ -333,7 +333,14 @@ async def authenticate_api_key(
         )
 
     # Resolve owner and permissions
-    scopes = api_key_data.get('scopes', [])
+    raw_scopes = api_key_data.get('scopes', [])
+    if isinstance(raw_scopes, list):
+        scopes: list[str] = [str(s) for s in raw_scopes]
+    elif isinstance(raw_scopes, str):
+        inner = raw_scopes.strip('{}')
+        scopes = inner.split(',') if inner else []
+    else:
+        scopes = []
 
     if sa_data:
         sa = models.ServiceAccount(**sa_data)

--- a/src/imbi_api/auth/permissions.py
+++ b/src/imbi_api/auth/permissions.py
@@ -333,14 +333,9 @@ async def authenticate_api_key(
         )
 
     # Resolve owner and permissions
-    raw_scopes = api_key_data.get('scopes', [])
-    if isinstance(raw_scopes, list):
-        scopes: list[str] = [str(s) for s in raw_scopes]
-    elif isinstance(raw_scopes, str):
-        inner = raw_scopes.strip('{}')
-        scopes = inner.split(',') if inner else []
-    else:
-        scopes = []
+    scopes = models.parse_scopes(
+        api_key_data.get('scopes', []),
+    )
 
     if sa_data:
         sa = models.ServiceAccount(**sa_data)

--- a/src/imbi_api/endpoints/api_keys.py
+++ b/src/imbi_api/endpoints/api_keys.py
@@ -92,6 +92,22 @@ class APIKeyCreateResponse(pydantic.BaseModel):
     )
 
 
+def _parse_scopes(value: typing.Any) -> list[str]:
+    """Convert AGE scope values to a Python list.
+
+    AGE may store list properties as PostgreSQL array strings
+    (e.g. ``'{}'`` or ``'{read,write}'``) when they were
+    written before the Cypher list-serialization fix.
+
+    """
+    if isinstance(value, list):
+        return value
+    if isinstance(value, str):
+        inner = value.strip('{}')
+        return inner.split(',') if inner else []
+    return []
+
+
 @api_keys_router.post('', response_model=APIKeyCreateResponse, status_code=201)
 async def create_api_key(
     key_request: APIKeyCreate,
@@ -228,7 +244,7 @@ async def list_api_keys(
             key_id=k['key_id'],
             name=k['name'],
             description=k.get('description'),
-            scopes=k.get('scopes', []),
+            scopes=_parse_scopes(k.get('scopes', [])),
             created_at=k['created_at'],
             expires_at=k.get('expires_at'),
             last_used=k.get('last_used'),
@@ -398,6 +414,6 @@ async def rotate_api_key(
         key_secret=f'{key_id}_{new_secret}',  # Full key format
         name=api_key_data['name'],
         description=api_key_data.get('description'),
-        scopes=api_key_data.get('scopes', []),
+        scopes=_parse_scopes(api_key_data.get('scopes', [])),
         expires_at=api_key_data.get('expires_at'),
     )

--- a/src/imbi_api/endpoints/api_keys.py
+++ b/src/imbi_api/endpoints/api_keys.py
@@ -101,7 +101,7 @@ def _parse_scopes(value: typing.Any) -> list[str]:
 
     """
     if isinstance(value, list):
-        return value
+        return [str(v) for v in value]
     if isinstance(value, str):
         inner = value.strip('{}')
         return inner.split(',') if inner else []

--- a/src/imbi_api/endpoints/api_keys.py
+++ b/src/imbi_api/endpoints/api_keys.py
@@ -92,20 +92,7 @@ class APIKeyCreateResponse(pydantic.BaseModel):
     )
 
 
-def _parse_scopes(value: typing.Any) -> list[str]:
-    """Convert AGE scope values to a Python list.
-
-    AGE may store list properties as PostgreSQL array strings
-    (e.g. ``'{}'`` or ``'{read,write}'``) when they were
-    written before the Cypher list-serialization fix.
-
-    """
-    if isinstance(value, list):
-        return [str(v) for v in value]
-    if isinstance(value, str):
-        inner = value.strip('{}')
-        return inner.split(',') if inner else []
-    return []
+_parse_scopes = models.parse_scopes
 
 
 @api_keys_router.post('', response_model=APIKeyCreateResponse, status_code=201)

--- a/src/imbi_api/endpoints/api_keys.py
+++ b/src/imbi_api/endpoints/api_keys.py
@@ -124,7 +124,7 @@ async def create_api_key(
     auth_settings = settings.get_auth_settings()
 
     # Generate key: format ik_<16chars>_<32chars>
-    key_id = f'ik_{secrets.token_urlsafe(16)}'
+    key_id = f'ik_{secrets.token_hex(16)}'
     key_secret = secrets.token_urlsafe(32)
     key_hash = password.hash_password(key_secret)
 

--- a/src/imbi_api/endpoints/auth.py
+++ b/src/imbi_api/endpoints/auth.py
@@ -187,7 +187,9 @@ async def token(
         )
 
     # Resolve scopes
-    cred_scopes: set[str] = set(cred_data.get('scopes', []))
+    cred_scopes: set[str] = set(
+        models.parse_scopes(cred_data.get('scopes', []))
+    )
     requested_scopes: set[str] = set(scope.split()) if scope else set()
     if requested_scopes and cred_scopes:
         granted_scopes: set[str] = requested_scopes & cred_scopes

--- a/src/imbi_api/endpoints/client_credentials.py
+++ b/src/imbi_api/endpoints/client_credentials.py
@@ -210,7 +210,7 @@ async def list_client_credentials(
         ['c'],
     )
 
-    credentials = []
+    credentials: list[models.ClientCredentialResponse] = []
     for record in records:
         data = graph.parse_agtype(record['c'])
         data['scopes'] = models.parse_scopes(data.get('scopes', []))

--- a/src/imbi_api/endpoints/client_credentials.py
+++ b/src/imbi_api/endpoints/client_credentials.py
@@ -210,10 +210,11 @@ async def list_client_credentials(
         ['c'],
     )
 
-    credentials = [
-        models.ClientCredentialResponse(**graph.parse_agtype(record['c']))
-        for record in records
-    ]
+    credentials = []
+    for record in records:
+        data = graph.parse_agtype(record['c'])
+        data['scopes'] = models.parse_scopes(data.get('scopes', []))
+        credentials.append(models.ClientCredentialResponse(**data))
 
     LOGGER.debug(
         'Listed %d client credentials for service account %s',
@@ -390,6 +391,6 @@ async def rotate_client_credential(
         client_secret=new_secret,
         name=credential_data['name'],
         description=credential_data.get('description'),
-        scopes=credential_data.get('scopes', []),
+        scopes=models.parse_scopes(credential_data.get('scopes', [])),
         expires_at=credential_data.get('expires_at'),
     )

--- a/src/imbi_api/endpoints/client_credentials.py
+++ b/src/imbi_api/endpoints/client_credentials.py
@@ -6,7 +6,6 @@ credentials grant flow.
 """
 
 import datetime
-import json
 import logging
 import secrets
 import typing
@@ -140,7 +139,8 @@ async def create_client_credential(
     # Store in graph with relationship to ServiceAccount
     props = credential.model_dump(mode='json')
     props.pop('service_account', None)
-    props['scopes'] = json.dumps(props.get('scopes', []))
+    # scopes stays as a list — _cypher_param handles
+    # list serialization for Cypher
     keys = list(props.keys())
     prop_map = ', '.join(f'{k}: {{{k}}}' for k in keys)
     records = await db.execute(

--- a/src/imbi_api/endpoints/environments.py
+++ b/src/imbi_api/endpoints/environments.py
@@ -330,7 +330,9 @@ async def update_environment(
             detail=f'Validation error: {e.errors()}',
         ) from e
 
-    environment.created_at = existing.get('created_at')
+    environment.created_at = datetime.datetime.fromisoformat(
+        existing['created_at'],
+    )
     environment.updated_at = datetime.datetime.now(datetime.UTC)
     props = environment.model_dump(
         mode='json',

--- a/src/imbi_api/endpoints/environments.py
+++ b/src/imbi_api/endpoints/environments.py
@@ -330,8 +330,11 @@ async def update_environment(
             detail=f'Validation error: {e.errors()}',
         ) from e
 
-    environment.created_at = datetime.datetime.fromisoformat(
-        existing['created_at'],
+    raw_created = existing.get('created_at')
+    environment.created_at = (
+        datetime.datetime.fromisoformat(raw_created)
+        if raw_created
+        else datetime.datetime.now(datetime.UTC)
     )
     environment.updated_at = datetime.datetime.now(datetime.UTC)
     props = environment.model_dump(

--- a/src/imbi_api/endpoints/environments.py
+++ b/src/imbi_api/endpoints/environments.py
@@ -119,7 +119,10 @@ async def create_environment(
     now = datetime.datetime.now(datetime.UTC)
     environment.created_at = now
     environment.updated_at = now
-    props = environment.model_dump(exclude={'organization'})
+    props = environment.model_dump(
+        mode='json',
+        exclude={'organization'},
+    )
 
     create_tpl = _props_template(props)
     query = (
@@ -329,7 +332,10 @@ async def update_environment(
 
     environment.created_at = existing.get('created_at')
     environment.updated_at = datetime.datetime.now(datetime.UTC)
-    props = environment.model_dump(exclude={'organization'})
+    props = environment.model_dump(
+        mode='json',
+        exclude={'organization'},
+    )
 
     set_stmt = _set_clause('e', props)
     update_query = (

--- a/src/imbi_api/endpoints/link_definitions.py
+++ b/src/imbi_api/endpoints/link_definitions.py
@@ -381,8 +381,11 @@ async def update_link_definition(
             detail=f'Validation error: {e.errors()}',
         ) from e
 
-    link_def.created_at = datetime.datetime.fromisoformat(
-        existing['created_at'],
+    raw_created = existing.get('created_at')
+    link_def.created_at = (
+        datetime.datetime.fromisoformat(raw_created)
+        if raw_created
+        else datetime.datetime.now(datetime.UTC)
     )
     link_def.updated_at = datetime.datetime.now(datetime.UTC)
     props = link_def.model_dump(

--- a/src/imbi_api/endpoints/link_definitions.py
+++ b/src/imbi_api/endpoints/link_definitions.py
@@ -162,7 +162,10 @@ async def create_link_definition(
     now = datetime.datetime.now(datetime.UTC)
     link_def.created_at = now
     link_def.updated_at = now
-    props = link_def.model_dump(exclude={'organization'})
+    props = link_def.model_dump(
+        mode='json',
+        exclude={'organization'},
+    )
 
     create_tpl = _props_template(props)
     query = (
@@ -380,7 +383,10 @@ async def update_link_definition(
 
     link_def.created_at = existing.get('created_at')
     link_def.updated_at = datetime.datetime.now(datetime.UTC)
-    props = link_def.model_dump(exclude={'organization'})
+    props = link_def.model_dump(
+        mode='json',
+        exclude={'organization'},
+    )
 
     set_stmt = _set_clause('ld', props)
     update_query = (

--- a/src/imbi_api/endpoints/link_definitions.py
+++ b/src/imbi_api/endpoints/link_definitions.py
@@ -381,7 +381,9 @@ async def update_link_definition(
             detail=f'Validation error: {e.errors()}',
         ) from e
 
-    link_def.created_at = existing.get('created_at')
+    link_def.created_at = datetime.datetime.fromisoformat(
+        existing['created_at'],
+    )
     link_def.updated_at = datetime.datetime.now(datetime.UTC)
     props = link_def.model_dump(
         mode='json',

--- a/src/imbi_api/endpoints/project_types.py
+++ b/src/imbi_api/endpoints/project_types.py
@@ -337,8 +337,11 @@ async def update_project_type(
             detail=f'Validation error: {e.errors()}',
         ) from e
 
-    project_type.created_at = datetime.datetime.fromisoformat(
-        existing['created_at'],
+    raw_created = existing.get('created_at')
+    project_type.created_at = (
+        datetime.datetime.fromisoformat(raw_created)
+        if raw_created
+        else datetime.datetime.now(datetime.UTC)
     )
     project_type.updated_at = datetime.datetime.now(datetime.UTC)
     props = project_type.model_dump(

--- a/src/imbi_api/endpoints/project_types.py
+++ b/src/imbi_api/endpoints/project_types.py
@@ -127,6 +127,7 @@ async def create_project_type(
     project_type.created_at = now
     project_type.updated_at = now
     props = project_type.model_dump(
+        mode='json',
         exclude={'organization'},
     )
 
@@ -339,6 +340,7 @@ async def update_project_type(
     project_type.created_at = existing.get('created_at')
     project_type.updated_at = datetime.datetime.now(datetime.UTC)
     props = project_type.model_dump(
+        mode='json',
         exclude={'organization'},
     )
 

--- a/src/imbi_api/endpoints/project_types.py
+++ b/src/imbi_api/endpoints/project_types.py
@@ -337,7 +337,9 @@ async def update_project_type(
             detail=f'Validation error: {e.errors()}',
         ) from e
 
-    project_type.created_at = existing.get('created_at')
+    project_type.created_at = datetime.datetime.fromisoformat(
+        existing['created_at'],
+    )
     project_type.updated_at = datetime.datetime.now(datetime.UTC)
     props = project_type.model_dump(
         mode='json',

--- a/src/imbi_api/endpoints/projects.py
+++ b/src/imbi_api/endpoints/projects.py
@@ -276,11 +276,13 @@ def _add_relationships(
 # -- Return fragment used by all read queries ---------------------------
 
 _RETURN_FRAGMENT: typing.LiteralString = """
-    MATCH (p)-[:OWNED_BY]->(t:Team)
+    MATCH (p)-[:OWNED_BY]->(t:Team)-[:BELONGS_TO]->(o)
     WITH p, o, t
-    MATCH (p)-[:TYPE]->(pt:ProjectType)
+    OPTIONAL MATCH (p)-[:TYPE]->(pt:ProjectType)
+          -[:BELONGS_TO]->(o)
     WITH p, o, t, collect(pt{{.*, organization: o{{.*}}}}) AS pts
     OPTIONAL MATCH (p)-[d:DEPLOYED_IN]->(env:Environment)
+          -[:BELONGS_TO]->(o)
     WITH p, o, t, pts,
          collect(env{{.*,
                      sort_order: coalesce(env.sort_order, 0),
@@ -610,9 +612,11 @@ async def get_project_schema(
     MATCH (p:Project {{id: {project_id}}})
           -[:OWNED_BY]->(:Team)
           -[:BELONGS_TO]->(o:Organization {{slug: {org_slug}}})
-    MATCH (p)-[:TYPE]->(pt:ProjectType)
-    WITH p, collect(pt.slug) AS type_slugs
+    OPTIONAL MATCH (p)-[:TYPE]->(pt:ProjectType)
+          -[:BELONGS_TO]->(o)
+    WITH p, o, collect(pt.slug) AS type_slugs
     OPTIONAL MATCH (p)-[:DEPLOYED_IN]->(env:Environment)
+          -[:BELONGS_TO]->(o)
     WITH type_slugs, collect(env.slug) AS env_slugs
     RETURN type_slugs, env_slugs
     """
@@ -755,10 +759,11 @@ async def update_project(
     MATCH (p:Project {{id: {project_id}}})
           -[:OWNED_BY]->(:Team)
           -[:BELONGS_TO]->(o:Organization {{slug: {org_slug}}})
-    WITH DISTINCT p
-    MATCH (p)-[:OWNED_BY]->(t:Team)
-    WITH p, t.slug AS team_slug
-    MATCH (p)-[:TYPE]->(pt:ProjectType)
+    WITH DISTINCT p, o
+    MATCH (p)-[:OWNED_BY]->(t:Team)-[:BELONGS_TO]->(o)
+    WITH p, o, t.slug AS team_slug
+    OPTIONAL MATCH (p)-[:TYPE]->(pt:ProjectType)
+          -[:BELONGS_TO]->(o)
     WITH p, team_slug, collect(pt.slug) AS type_slugs
     RETURN p{{.*}} AS project,
            team_slug AS current_team_slug,
@@ -861,8 +866,11 @@ async def update_project(
             detail=f'Validation error: {e.errors()}',
         ) from e
 
-    project.created_at = datetime.datetime.fromisoformat(
-        existing['created_at'],
+    raw_created = existing.get('created_at')
+    project.created_at = (
+        datetime.datetime.fromisoformat(raw_created)
+        if raw_created
+        else datetime.datetime.now(datetime.UTC)
     )
     project.updated_at = datetime.datetime.now(datetime.UTC)
     props = project.model_dump(

--- a/src/imbi_api/endpoints/projects.py
+++ b/src/imbi_api/endpoints/projects.py
@@ -378,6 +378,7 @@ async def create_project(
     project.created_at = now
     project.updated_at = now
     props = project.model_dump(
+        mode='json',
         exclude={
             'team',
             'project_types',
@@ -863,6 +864,7 @@ async def update_project(
     project.created_at = existing.get('created_at')
     project.updated_at = datetime.datetime.now(datetime.UTC)
     props = project.model_dump(
+        mode='json',
         exclude={
             'team',
             'project_types',

--- a/src/imbi_api/endpoints/projects.py
+++ b/src/imbi_api/endpoints/projects.py
@@ -861,7 +861,9 @@ async def update_project(
             detail=f'Validation error: {e.errors()}',
         ) from e
 
-    project.created_at = existing.get('created_at')
+    project.created_at = datetime.datetime.fromisoformat(
+        existing['created_at'],
+    )
     project.updated_at = datetime.datetime.now(datetime.UTC)
     props = project.model_dump(
         mode='json',

--- a/src/imbi_api/endpoints/projects.py
+++ b/src/imbi_api/endpoints/projects.py
@@ -609,16 +609,10 @@ async def get_project_schema(
     MATCH (p:Project {{id: {project_id}}})
           -[:OWNED_BY]->(:Team)
           -[:BELONGS_TO]->(o:Organization {{slug: {org_slug}}})
-    CALL {{
-        WITH p
-        MATCH (p)-[:TYPE]->(pt:ProjectType)
-        RETURN collect(pt.slug) AS type_slugs
-    }}
-    CALL {{
-        WITH p
-        OPTIONAL MATCH (p)-[:DEPLOYED_IN]->(env:Environment)
-        RETURN collect(env.slug) AS env_slugs
-    }}
+    MATCH (p)-[:TYPE]->(pt:ProjectType)
+    WITH p, collect(pt.slug) AS type_slugs
+    OPTIONAL MATCH (p)-[:DEPLOYED_IN]->(env:Environment)
+    WITH type_slugs, collect(env.slug) AS env_slugs
     RETURN type_slugs, env_slugs
     """
     records = await db.execute(
@@ -761,17 +755,10 @@ async def update_project(
           -[:OWNED_BY]->(:Team)
           -[:BELONGS_TO]->(o:Organization {{slug: {org_slug}}})
     WITH DISTINCT p
-    CALL {{
-        WITH p
-        MATCH (p)-[:OWNED_BY]->(t:Team)
-        RETURN t.slug AS team_slug
-        LIMIT 1
-    }}
-    CALL {{
-        WITH p
-        MATCH (p)-[:TYPE]->(pt:ProjectType)
-        RETURN collect(pt.slug) AS type_slugs
-    }}
+    MATCH (p)-[:OWNED_BY]->(t:Team)
+    WITH p, t.slug AS team_slug
+    MATCH (p)-[:TYPE]->(pt:ProjectType)
+    WITH p, team_slug, collect(pt.slug) AS type_slugs
     RETURN p{{.*}} AS project,
            team_slug AS current_team_slug,
            type_slugs AS current_type_slugs

--- a/src/imbi_api/endpoints/projects.py
+++ b/src/imbi_api/endpoints/projects.py
@@ -276,46 +276,35 @@ def _add_relationships(
 # -- Return fragment used by all read queries ---------------------------
 
 _RETURN_FRAGMENT: typing.LiteralString = """
-    CALL {{
-        WITH p, o
-        MATCH (p)-[:OWNED_BY]->(t:Team)
-        RETURN t{{.*, organization: o{{.*}}}} AS team
-        LIMIT 1
-    }}
-    CALL {{
-        WITH p, o
-        MATCH (p)-[:TYPE]->(pt:ProjectType)
-        RETURN collect(pt{{.*, organization: o{{.*}}}}) AS pts
-    }}
-    CALL {{
-        WITH p, o
-        OPTIONAL MATCH (p)-[d:DEPLOYED_IN]->(env:Environment)
-        RETURN collect(env{{.*,
-                           sort_order: coalesce(env.sort_order, 0),
-                           url: d.url,
-                           organization: o{{.*}}}}) AS envs
-    }}
-    CALL {{
-        WITH p
-        OPTIONAL MATCH (p)-[:DEPENDS_ON]->(dep:Project)
-              -[:OWNED_BY]->(:Team)
-              -[:BELONGS_TO]->(depOrg:Organization)
-        RETURN count(dep) AS dependency_count,
-               [x IN collect(DISTINCT
-                   CASE WHEN dep IS NOT NULL
-                             AND depOrg IS NOT NULL
-                             AND dep.id IS NOT NULL
-                        THEN '/organizations/' + depOrg.slug
-                             + '/projects/'
-                             + dep.id
-                   END
-               ) WHERE x IS NOT NULL] AS dependency_uris
-    }}
+    MATCH (p)-[:OWNED_BY]->(t:Team)
+    WITH p, o, t LIMIT 1
+    MATCH (p)-[:TYPE]->(pt:ProjectType)
+    WITH p, o, t, collect(pt{{.*, organization: o{{.*}}}}) AS pts
+    OPTIONAL MATCH (p)-[d:DEPLOYED_IN]->(env:Environment)
+    WITH p, o, t, pts,
+         collect(env{{.*,
+                     sort_order: coalesce(env.sort_order, 0),
+                     url: d.url,
+                     organization: o{{.*}}}}) AS envs
+    OPTIONAL MATCH (p)-[:DEPENDS_ON]->(dep:Project)
+          -[:OWNED_BY]->(:Team)
+          -[:BELONGS_TO]->(depOrg:Organization)
+    WITH p, o, t, pts, envs,
+         count(dep) AS dependency_count,
+         collect(DISTINCT
+             CASE WHEN dep IS NOT NULL
+                       AND depOrg IS NOT NULL
+                       AND dep.id IS NOT NULL
+                  THEN '/organizations/' + depOrg.slug
+                       + '/projects/'
+                       + dep.id
+             END
+         ) AS dep_uris_raw
     RETURN p{{.*,
-        team: team,
+        team: t{{.*, organization: o{{.*}}}},
         project_types: pts,
         environments: envs,
-        dependency_uris: dependency_uris
+        dependency_uris: [x IN dep_uris_raw WHERE x IS NOT NULL]
     }} AS project,
     dependency_count
 """

--- a/src/imbi_api/endpoints/projects.py
+++ b/src/imbi_api/endpoints/projects.py
@@ -277,7 +277,7 @@ def _add_relationships(
 
 _RETURN_FRAGMENT: typing.LiteralString = """
     MATCH (p)-[:OWNED_BY]->(t:Team)
-    WITH p, o, t LIMIT 1
+    WITH p, o, t
     MATCH (p)-[:TYPE]->(pt:ProjectType)
     WITH p, o, t, collect(pt{{.*, organization: o{{.*}}}}) AS pts
     OPTIONAL MATCH (p)-[d:DEPLOYED_IN]->(env:Environment)

--- a/src/imbi_api/endpoints/sa_api_keys.py
+++ b/src/imbi_api/endpoints/sa_api_keys.py
@@ -207,10 +207,13 @@ async def list_sa_api_keys(
         ['k'],
     )
 
-    keys = [
-        api_keys.APIKeyResponse(**graph.parse_agtype(record['k']))
-        for record in records
-    ]
+    keys = []
+    for record in records:
+        data = graph.parse_agtype(record['k'])
+        data['scopes'] = models.parse_scopes(
+            data.get('scopes', []),
+        )
+        keys.append(api_keys.APIKeyResponse(**data))
 
     LOGGER.debug(
         'Listed %d API keys for service account %s',
@@ -377,6 +380,8 @@ async def rotate_sa_api_key(
         key_secret=f'{key_id}_{new_secret}',
         name=api_key_data['name'],
         description=api_key_data.get('description'),
-        scopes=api_key_data.get('scopes', []),
+        scopes=models.parse_scopes(
+            api_key_data.get('scopes', []),
+        ),
         expires_at=api_key_data.get('expires_at'),
     )

--- a/src/imbi_api/endpoints/sa_api_keys.py
+++ b/src/imbi_api/endpoints/sa_api_keys.py
@@ -6,7 +6,6 @@ with a ServiceAccount node instead of a User node.
 """
 
 import datetime
-import json
 import logging
 import secrets
 import typing
@@ -138,7 +137,8 @@ async def create_sa_api_key(
     # Create API key node with relationship to ServiceAccount
     props = api_key.model_dump(mode='json')
     props.pop('user', None)
-    props['scopes'] = json.dumps(props.get('scopes', []))
+    # scopes stays as a list — _cypher_param handles
+    # list serialization for Cypher
     keys = list(props.keys())
     prop_map = ', '.join(f'{k}: {{{k}}}' for k in keys)
     records = await db.execute(
@@ -207,7 +207,7 @@ async def list_sa_api_keys(
         ['k'],
     )
 
-    keys = []
+    keys: list[api_keys.APIKeyResponse] = []
     for record in records:
         data = graph.parse_agtype(record['k'])
         data['scopes'] = models.parse_scopes(

--- a/src/imbi_api/endpoints/teams.py
+++ b/src/imbi_api/endpoints/teams.py
@@ -339,8 +339,11 @@ async def update_team(
         ) from e
 
     # Build property SET from model fields, excluding relationship
-    team.created_at = datetime.datetime.fromisoformat(
-        existing['created_at'],
+    raw_created = existing.get('created_at')
+    team.created_at = (
+        datetime.datetime.fromisoformat(raw_created)
+        if raw_created
+        else datetime.datetime.now(datetime.UTC)
     )
     team.updated_at = datetime.datetime.now(datetime.UTC)
     props = team.model_dump(

--- a/src/imbi_api/endpoints/teams.py
+++ b/src/imbi_api/endpoints/teams.py
@@ -124,6 +124,7 @@ async def create_team(
     team.created_at = now
     team.updated_at = now
     props = team.model_dump(
+        mode='json',
         exclude={'organization'},
     )
 
@@ -340,7 +341,10 @@ async def update_team(
     # Build property SET from model fields, excluding relationship
     team.created_at = existing.get('created_at')
     team.updated_at = datetime.datetime.now(datetime.UTC)
-    props = team.model_dump(exclude={'organization'})
+    props = team.model_dump(
+        mode='json',
+        exclude={'organization'},
+    )
 
     set_stmt = _set_clause('t', props)
     update_query = (

--- a/src/imbi_api/endpoints/teams.py
+++ b/src/imbi_api/endpoints/teams.py
@@ -339,7 +339,9 @@ async def update_team(
         ) from e
 
     # Build property SET from model fields, excluding relationship
-    team.created_at = existing.get('created_at')
+    team.created_at = datetime.datetime.fromisoformat(
+        existing['created_at'],
+    )
     team.updated_at = datetime.datetime.now(datetime.UTC)
     props = team.model_dump(
         mode='json',

--- a/src/imbi_api/endpoints/third_party_services.py
+++ b/src/imbi_api/endpoints/third_party_services.py
@@ -629,7 +629,7 @@ async def create_service_application(
 
     # Encrypt secrets
     encryptor = encryption.TokenEncryption.get_instance()
-    props = data.model_dump()
+    props = data.model_dump(mode='json')
     props['client_secret'] = encryptor.encrypt(data.client_secret)
     if props.get('webhook_secret') is not None:
         props['webhook_secret'] = encryptor.encrypt(
@@ -760,7 +760,7 @@ async def update_service_application(
     ``PUT /secrets`` instead.
     """
     existing = await _fetch_application(db, org_slug, slug, app_slug)
-    props = data.model_dump()
+    props = data.model_dump(mode='json')
 
     # Preserve existing secret values unchanged
     for field in models.SECRET_FIELDS:

--- a/src/imbi_api/lifespans.py
+++ b/src/imbi_api/lifespans.py
@@ -9,7 +9,6 @@ import contextlib
 import logging
 from collections import abc
 
-import imbi_common.graph
 from imbi_common import clickhouse, graph
 
 from imbi_api import openapi
@@ -20,6 +19,20 @@ from imbi_api.storage.client import StorageClient
 LOGGER = logging.getLogger(__name__)
 
 
+async def _on_graph_startup(db: graph.Graph) -> None:
+    """Refresh blueprint models after the graph pool opens."""
+    try:
+        await openapi.refresh_blueprint_models(db)
+    except Exception as err:  # noqa: BLE001
+        LOGGER.warning(
+            'Failed to refresh blueprint models: %s',
+            err,
+        )
+
+
+graph.set_on_startup(_on_graph_startup)
+
+
 @contextlib.asynccontextmanager
 async def clickhouse_hook() -> abc.AsyncIterator[None]:
     """Initialize and manage the ClickHouse connection."""
@@ -28,36 +41,6 @@ async def clickhouse_hook() -> abc.AsyncIterator[None]:
         raise RuntimeError('ClickHouse initialization failed')
     async with contextlib.aclosing(clickhouse):
         yield
-
-
-@contextlib.asynccontextmanager
-async def _graph_lifespan_with_setup() -> abc.AsyncIterator[graph.Graph]:
-    """Open a Graph pool, refresh blueprints, and yield the pool.
-
-    Replaces the plain ``graph.graph_lifespan`` so that blueprint
-    refresh reuses the same connection pool that serves requests,
-    instead of opening a second temporary pool.
-
-    Assigned to ``imbi_common.graph.graph_lifespan`` at module load
-    so that ``graph.Pool`` dependency injection continues to work
-    (``graph._inject_graph`` resolves ``graph_lifespan`` at call
-    time from the module namespace).
-    """
-    db = graph.Graph()
-    await db.open()
-    try:
-        await openapi.refresh_blueprint_models(db)
-    except Exception as err:  # noqa: BLE001
-        LOGGER.warning('Failed to refresh blueprint models: %s', err)
-    yield db
-    await db.close()
-
-
-# Replace graph.graph_lifespan so that graph._inject_graph (which
-# looks up graph_lifespan at call time) resolves to the combined
-# version.  This keeps graph.Pool working across all endpoints
-# without changing any import sites.
-imbi_common.graph.graph_lifespan = _graph_lifespan_with_setup
 
 
 @contextlib.asynccontextmanager

--- a/src/imbi_api/models.py
+++ b/src/imbi_api/models.py
@@ -96,7 +96,7 @@ def parse_scopes(value: typing.Any) -> list[str]:
             try:
                 parsed = json.loads(stripped)
                 if isinstance(parsed, list):
-                    return [str(v) for v in parsed]
+                    return [str(v) for v in typing.cast(list[object], parsed)]
             except (json.JSONDecodeError, ValueError):
                 pass
         inner = stripped.strip('{}')

--- a/src/imbi_api/models.py
+++ b/src/imbi_api/models.py
@@ -7,6 +7,8 @@ from imbi_api.domain for a single import path:
     models.User(...)
 """
 
+import typing
+
 from imbi_common import models as _common
 
 from imbi_api.domain import models as _domain
@@ -74,3 +76,19 @@ User = _domain.User
 UserCreate = _domain.UserCreate
 UserResponse = _domain.UserResponse
 UserUpdate = _domain.UserUpdate
+
+
+def parse_scopes(value: typing.Any) -> list[str]:
+    """Convert AGE scope values to a Python list.
+
+    AGE may store list properties as PostgreSQL array strings
+    (e.g. ``'{}'`` or ``'{read,write}'``) when they were
+    written before the Cypher list-serialization fix.
+
+    """
+    if isinstance(value, list):
+        return [str(v) for v in typing.cast(list[object], value)]
+    if isinstance(value, str):
+        inner = value.strip('{}')
+        return inner.split(',') if inner else []
+    return []

--- a/src/imbi_api/models.py
+++ b/src/imbi_api/models.py
@@ -7,6 +7,7 @@ from imbi_api.domain for a single import path:
     models.User(...)
 """
 
+import json
 import typing
 
 from imbi_common import models as _common
@@ -82,13 +83,22 @@ def parse_scopes(value: typing.Any) -> list[str]:
     """Convert AGE scope values to a Python list.
 
     AGE may store list properties as PostgreSQL array strings
-    (e.g. ``'{}'`` or ``'{read,write}'``) when they were
-    written before the Cypher list-serialization fix.
+    (e.g. ``'{}'`` or ``'{read,write}'``), or as JSON-serialized
+    strings (e.g. ``'["read","write"]'``) when they were written
+    before the Cypher list-serialization fix.
 
     """
     if isinstance(value, list):
         return [str(v) for v in typing.cast(list[object], value)]
     if isinstance(value, str):
-        inner = value.strip('{}')
+        stripped = value.strip()
+        if stripped.startswith('['):
+            try:
+                parsed = json.loads(stripped)
+                if isinstance(parsed, list):
+                    return [str(v) for v in parsed]
+            except (json.JSONDecodeError, ValueError):
+                pass
+        inner = stripped.strip('{}')
         return inner.split(',') if inner else []
     return []

--- a/tests/test_lifespans.py
+++ b/tests/test_lifespans.py
@@ -26,29 +26,31 @@ class ApplicationLifespanTestCase(unittest.TestCase):
                     pass  # nothing to do here
         initialize.assert_called_once()
         self.assertEqual(
-            str(error.exception), 'ClickHouse initialization failed'
+            str(error.exception),
+            'ClickHouse initialization failed',
         )
 
     def test_openapi_refresh_blueprint_failure(self) -> None:
         failure = RuntimeError()
-        mock_graph = unittest.mock.AsyncMock()
         with (
             unittest.mock.patch(
-                'imbi_api.lifespans.graph.Graph',
-                return_value=mock_graph,
-            ),
-            unittest.mock.patch(
                 'imbi_api.lifespans.openapi.refresh_blueprint_models',
-                new=unittest.mock.AsyncMock(side_effect=failure),
+                new=unittest.mock.AsyncMock(
+                    side_effect=failure,
+                ),
             ) as refresh_blueprint_models,
-            self.assertLogs(lifespans.LOGGER, level='WARNING') as cm,
+            self.assertLogs(
+                lifespans.LOGGER,
+                level='WARNING',
+            ) as cm,
         ):
             with testclient.TestClient(app.create_app()):
                 pass
 
         refresh_blueprint_models.assert_awaited_once()
         self.assertIn(
-            f'WARNING:imbi_api.lifespans:Failed to refresh blueprint'
+            f'WARNING:imbi_api.lifespans:'
+            f'Failed to refresh blueprint'
             f' models: {failure}',
             cm.output,
         )

--- a/uv.lock
+++ b/uv.lock
@@ -1130,7 +1130,7 @@ docs = [
 [[package]]
 name = "imbi-common"
 version = "0.1.0"
-source = { git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=main#6f2ddce3deeef135029c1f3c33708d601acb01bc" }
+source = { git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=main#b0d98d932d40eb61fc9986088cf9ecb669803e7b" }
 dependencies = [
     { name = "clickhouse-connect" },
     { name = "cryptography" },

--- a/uv.lock
+++ b/uv.lock
@@ -1130,7 +1130,7 @@ docs = [
 [[package]]
 name = "imbi-common"
 version = "0.1.0"
-source = { git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=main#243646b375a03f924c295173d8a02b095d841336" }
+source = { git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=main#6f2ddce3deeef135029c1f3c33708d601acb01bc" }
 dependencies = [
     { name = "clickhouse-connect" },
     { name = "cryptography" },


### PR DESCRIPTION
## Summary
Adopt the imbi-common graph subpackage refactor and fix all AGE compatibility issues discovered during testing.

## Changes

### Graph subpackage adoption
- Replace monkey-patched `_graph_lifespan_with_setup` with `graph.set_on_startup()` callback hook (AWeber-Imbi/imbi-common#43)
- Update `uv.lock` to latest imbi-common with Cypher param escaping fixes (#44)

### AGE compatibility fixes
- **CALL {} subqueries**: Rewrite all `CALL {}` blocks in `projects.py` to use `OPTIONAL MATCH` + `WITH` + `collect()` chaining (AGE 1.7.0 doesn't support `CALL {}`)
- **LIMIT 1 scoping**: Remove `LIMIT 1` from `_RETURN_FRAGMENT` team match that was globally limiting results to one project
- **Schema endpoint**: Fix `get_project_schema` and `update_project` queries that also used `CALL {}`

### Serialization fixes
- **model_dump mode**: Add `mode='json'` to all `model_dump()` calls that feed into Cypher params — prevents `datetime`/`HttpUrl` objects from hitting `sql.Literal` inside `$$`-quoted Cypher
- **created_at parsing**: Parse ISO strings from AGE into `datetime` objects via `fromisoformat()` to eliminate Pydantic serializer warnings
- **API key scopes**: Add `_parse_scopes()` to handle AGE returning list properties as PostgreSQL array strings (`'{}'`)

### Bug fixes
- Fix Justfile `$(port ...)` → `$(get_port ...)` typo that dropped the Postgres port from `.env`

## Test plan
- [x] `tests/test_lifespans.py` — all 3 tests pass
- [x] Projects list returns all projects (not just 1)
- [x] Project schema endpoint returns 200 with blueprint sections
- [x] Environment/team/project-type save works without `unsupported arg type`
- [x] Blueprint facts visible on project detail page
- [ ] Full CI test suite

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>