### PR TITLE
Rename project dependencies to relationships with direction

### DIFF
--- a/src/imbi_api/endpoints/projects.py
+++ b/src/imbi_api/endpoints/projects.py
@@ -906,7 +906,8 @@ async def list_project_relationships(
     ORDER BY CASE direction WHEN 'inbound' THEN 0
                             WHEN 'outbound' THEN 1
                             ELSE 2 END,
-             other.name
+             other.name,
+             other.id
     """
     records = await db.execute(
         query,

--- a/src/imbi_api/endpoints/projects.py
+++ b/src/imbi_api/endpoints/projects.py
@@ -819,6 +819,105 @@ async def get_project(
     return ProjectResponse.model_validate(result)
 
 
+class ProjectRelationshipSummary(pydantic.BaseModel):
+    """Summary of the project on the other end of an edge."""
+
+    id: str
+    name: str
+    slug: str
+    namespace: str | None = None
+    project_type: str | None = None
+
+
+class ProjectRelationship(pydantic.BaseModel):
+    """A single DEPENDS_ON edge touching the project."""
+
+    direction: typing.Literal['inbound', 'outbound']
+    type: typing.Literal['depends_on'] = 'depends_on'
+    project: ProjectRelationshipSummary
+
+
+class ProjectRelationshipsResponse(pydantic.BaseModel):
+    """Wrapped list of relationships."""
+
+    relationships: list[ProjectRelationship]
+
+
+@projects_router.get('/{project_id}/relationships')
+async def list_project_relationships(
+    org_slug: str,
+    project_id: str,
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('project:read'),
+        ),
+    ],
+) -> ProjectRelationshipsResponse:
+    """List every DEPENDS_ON edge touching the project.
+
+    Returns both inbound and outbound edges in a flat list with a
+    ``direction`` field. Rows are sorted inbound first, then by
+    the related project's name.
+    """
+    query: typing.LiteralString = """
+    MATCH (p:Project {{id: {project_id}}})
+          -[:OWNED_BY]->(:Team)
+          -[:BELONGS_TO]->(:Organization {{slug: {org_slug}}})
+    WITH p, true AS project_exists
+    OPTIONAL MATCH (p)-[r:DEPENDS_ON]-(other:Project)
+          -[:OWNED_BY]->(:Team)
+          -[:BELONGS_TO]->(otherOrg:Organization)
+    OPTIONAL MATCH (other)-[:TYPE]->(pt:ProjectType)
+    WITH p, project_exists, r, other, otherOrg,
+         collect(pt.slug)[0] AS pt_slug,
+         CASE WHEN r IS NULL THEN null
+              WHEN startNode(r) = p THEN 'outbound'
+              ELSE 'inbound'
+         END AS direction
+    RETURN project_exists,
+           direction,
+           CASE WHEN other IS NULL THEN null
+                ELSE other{{.id, .name, .slug,
+                           namespace: otherOrg.slug,
+                           project_type: pt_slug}}
+           END AS other
+    ORDER BY CASE direction WHEN 'inbound' THEN 0
+                            WHEN 'outbound' THEN 1
+                            ELSE 2 END,
+             other.name
+    """
+    records = await db.execute(
+        query,
+        {
+            'project_id': project_id,
+            'org_slug': org_slug,
+        },
+        ['project_exists', 'direction', 'other'],
+    )
+    if not records:
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail=f'Project {project_id!r} not found',
+        )
+    relationships: list[ProjectRelationship] = []
+    for record in records:
+        direction = graph.parse_agtype(record['direction'])
+        other = graph.parse_agtype(record['other'])
+        if not direction or not other:
+            continue
+        relationships.append(
+            ProjectRelationship(
+                direction=direction,
+                project=ProjectRelationshipSummary.model_validate(other),
+            ),
+        )
+    return ProjectRelationshipsResponse(
+        relationships=relationships,
+    )
+
+
 @projects_router.put('/{project_id}')
 async def update_project(
     org_slug: str,

--- a/src/imbi_api/endpoints/projects.py
+++ b/src/imbi_api/endpoints/projects.py
@@ -886,8 +886,9 @@ async def list_project_relationships(
           -[:OWNED_BY]->(:Team)
           -[:BELONGS_TO]->(otherOrg:Organization)
     OPTIONAL MATCH (other)-[:TYPE]->(pt:ProjectType)
+    WITH p, project_exists, r, other, otherOrg, pt
+    ORDER BY pt.slug
     WITH p, project_exists, r, other, otherOrg,
-         // Picks an arbitrary type when the project has multiple
          collect(pt.slug)[0] AS pt_slug,
          collect(pt.icon)[0] AS pt_icon,
          CASE WHEN r IS NULL THEN null

--- a/src/imbi_api/endpoints/projects.py
+++ b/src/imbi_api/endpoints/projects.py
@@ -106,6 +106,16 @@ class ProjectUpdate(pydantic.BaseModel):
     identifiers: dict[str, int | str] | None = None
 
 
+class ProjectRelationships(pydantic.BaseModel):
+    """Typed relationship links and counts for a project."""
+
+    team: models.RelationshipLink
+    environments: models.RelationshipLink
+    href: str
+    outbound_count: int = 0
+    inbound_count: int = 0
+
+
 class ProjectResponse(pydantic.BaseModel):
     """Response body for a project."""
 
@@ -123,7 +133,7 @@ class ProjectResponse(pydantic.BaseModel):
     environments: list[EnvironmentRef] = []
     links: dict[str, pydantic.AnyUrl] = {}
     identifiers: dict[str, int | str] = {}
-    relationships: dict[str, typing.Any] | None = None
+    relationships: ProjectRelationships | None = None
 
     @pydantic.field_validator(
         'links',
@@ -567,7 +577,12 @@ async def create_project(
 
     project_data = graph.parse_agtype(records[0]['project'])
     _flatten_edge_props(project_data)
-    result = _add_relationships(project_data, org_slug)
+    result = _add_relationships(
+        project_data,
+        org_slug,
+        graph.parse_agtype(records[0]['outbound_count']),
+        graph.parse_agtype(records[0]['inbound_count']),
+    )
     return ProjectResponse.model_validate(result)
 
 

--- a/src/imbi_api/endpoints/projects.py
+++ b/src/imbi_api/endpoints/projects.py
@@ -827,6 +827,7 @@ class ProjectRelationshipSummary(pydantic.BaseModel):
     slug: str
     namespace: str | None = None
     project_type: str | None = None
+    project_type_icon: str | None = None
 
 
 class ProjectRelationship(pydantic.BaseModel):
@@ -873,6 +874,7 @@ async def list_project_relationships(
     WITH p, project_exists, r, other, otherOrg,
          // Picks an arbitrary type when the project has multiple
          collect(pt.slug)[0] AS pt_slug,
+         collect(pt.icon)[0] AS pt_icon,
          CASE WHEN r IS NULL THEN null
               WHEN startNode(r) = p THEN 'outbound'
               ELSE 'inbound'
@@ -882,7 +884,8 @@ async def list_project_relationships(
            CASE WHEN other IS NULL THEN null
                 ELSE other{{.id, .name, .slug,
                            namespace: otherOrg.slug,
-                           project_type: pt_slug}}
+                           project_type: pt_slug,
+                           project_type_icon: pt_icon}}
            END AS other
     ORDER BY CASE direction WHEN 'inbound' THEN 0
                             WHEN 'outbound' THEN 1

--- a/src/imbi_api/endpoints/projects.py
+++ b/src/imbi_api/endpoints/projects.py
@@ -871,6 +871,7 @@ async def list_project_relationships(
           -[:BELONGS_TO]->(otherOrg:Organization)
     OPTIONAL MATCH (other)-[:TYPE]->(pt:ProjectType)
     WITH p, project_exists, r, other, otherOrg,
+         // Picks an arbitrary type when the project has multiple
          collect(pt.slug)[0] AS pt_slug,
          CASE WHEN r IS NULL THEN null
               WHEN startNode(r) = p THEN 'outbound'

--- a/src/imbi_api/endpoints/projects.py
+++ b/src/imbi_api/endpoints/projects.py
@@ -123,8 +123,7 @@ class ProjectResponse(pydantic.BaseModel):
     environments: list[EnvironmentRef] = []
     links: dict[str, pydantic.AnyUrl] = {}
     identifiers: dict[str, int | str] = {}
-    relationships: dict[str, models.RelationshipLink] | None = None
-    dependency_uris: list[str] = []
+    relationships: dict[str, typing.Any] | None = None
 
     @pydantic.field_validator(
         'links',
@@ -323,7 +322,8 @@ def _flatten_edge_props(
 def _add_relationships(
     project: dict[str, typing.Any],
     org_slug: str,
-    dependency_count: int = 0,
+    outbound_count: int = 0,
+    inbound_count: int = 0,
 ) -> dict[str, typing.Any]:
     """Attach relationships sub-object to a project dict."""
     project_id = project.get('id') or ''
@@ -339,10 +339,9 @@ def _add_relationships(
             f'{base}/environments',
             len(project.get('environments') or []),
         ),
-        'dependencies': relationship_link(
-            f'{base}/dependencies',
-            dependency_count,
-        ),
+        'href': f'{base}/relationships',
+        'outbound_count': outbound_count,
+        'inbound_count': inbound_count,
     }
     return project
 
@@ -362,27 +361,18 @@ _RETURN_FRAGMENT: typing.LiteralString = """
                      sort_order: coalesce(env.sort_order, 0),
                      _edge: properties(d),
                      organization: o{{.*}}}}) AS envs
-    OPTIONAL MATCH (p)-[:DEPENDS_ON]->(dep:Project)
-          -[:OWNED_BY]->(:Team)
-          -[:BELONGS_TO]->(depOrg:Organization)
-    WITH p, o, t, pts, envs,
-         count(dep) AS dependency_count,
-         collect(DISTINCT
-             CASE WHEN dep IS NOT NULL
-                       AND depOrg IS NOT NULL
-                       AND dep.id IS NOT NULL
-                  THEN '/organizations/' + depOrg.slug
-                       + '/projects/'
-                       + dep.id
-             END
-         ) AS dep_uris_raw
+    OPTIONAL MATCH (p)-[:DEPENDS_ON]->(out:Project)
+    WITH p, o, t, pts, envs, count(out) AS outbound_count
+    OPTIONAL MATCH (p)<-[:DEPENDS_ON]-(in_:Project)
+    WITH p, o, t, pts, envs, outbound_count,
+         count(in_) AS inbound_count
     RETURN p{{.*,
         team: t{{.*, organization: o{{.*}}}},
         project_types: pts,
-        environments: envs,
-        dependency_uris: [x IN dep_uris_raw WHERE x IS NOT NULL]
+        environments: envs
     }} AS project,
-    dependency_count
+    outbound_count,
+    inbound_count
 """
 
 
@@ -557,7 +547,7 @@ async def create_project(
                 **props,
                 **env_params,
             },
-            ['project', 'dependency_count'],
+            ['project', 'outbound_count', 'inbound_count'],
         )
     except psycopg.errors.UniqueViolation as e:
         raise fastapi.HTTPException(
@@ -618,7 +608,7 @@ async def list_projects(
             'org_slug': org_slug,
             'project_type': project_type,
         },
-        ['project', 'dependency_count'],
+        ['project', 'outbound_count', 'inbound_count'],
     )
     for record in records:
         project_data = graph.parse_agtype(record['project'])
@@ -626,7 +616,8 @@ async def list_projects(
         proj = _add_relationships(
             project_data,
             org_slug,
-            graph.parse_agtype(record['dependency_count']),
+            graph.parse_agtype(record['outbound_count']),
+            graph.parse_agtype(record['inbound_count']),
         )
         results.append(
             ProjectResponse.model_validate(proj),
@@ -809,7 +800,7 @@ async def get_project(
             'project_id': project_id,
             'org_slug': org_slug,
         },
-        ['project', 'dependency_count'],
+        ['project', 'outbound_count', 'inbound_count'],
     )
 
     if not records:
@@ -822,7 +813,8 @@ async def get_project(
     result = _add_relationships(
         project_data,
         org_slug,
-        graph.parse_agtype(records[0]['dependency_count']),
+        graph.parse_agtype(records[0]['outbound_count']),
+        graph.parse_agtype(records[0]['inbound_count']),
     )
     return ProjectResponse.model_validate(result)
 
@@ -1118,7 +1110,7 @@ async def update_project(
                 ),
                 **new_env_params,
             },
-            ['project', 'dependency_count'],
+            ['project', 'outbound_count', 'inbound_count'],
         )
     except psycopg.errors.UniqueViolation as e:
         raise fastapi.HTTPException(
@@ -1137,7 +1129,8 @@ async def update_project(
     result = _add_relationships(
         project_data,
         org_slug,
-        graph.parse_agtype(updated[0]['dependency_count']),
+        graph.parse_agtype(updated[0]['outbound_count']),
+        graph.parse_agtype(updated[0]['inbound_count']),
     )
     return ProjectResponse.model_validate(result)
 

--- a/tests/endpoints/test_projects.py
+++ b/tests/endpoints/test_projects.py
@@ -775,3 +775,122 @@ class ProjectEndpointsTestCase(unittest.TestCase):
 
         self.assertEqual(response.status_code, 404)
         self.assertIn('not found', response.json()['detail'])
+
+
+class ProjectRelationshipsEndpointTestCase(unittest.TestCase):
+    """Tests for GET /projects/{id}/relationships."""
+
+    def setUp(self) -> None:
+        from imbi_api.auth import permissions
+
+        self.test_app = app.create_app()
+
+        self.admin_user = models.User(
+            email='admin@example.com',
+            display_name='Admin User',
+            password_hash='$argon2id$hashed',
+            is_active=True,
+            is_admin=True,
+            is_service_account=False,
+            created_at=datetime.datetime.now(datetime.UTC),
+        )
+        self.auth_context = permissions.AuthContext(
+            user=self.admin_user,
+            session_id='test-session',
+            auth_method='jwt',
+            permissions={'project:read'},
+        )
+
+        async def mock_get_current_user():
+            return self.auth_context
+
+        self.test_app.dependency_overrides[permissions.get_current_user] = (
+            mock_get_current_user
+        )
+
+        self.mock_db = mock.AsyncMock(spec=graph.Graph)
+        self.test_app.dependency_overrides[graph._inject_graph] = (
+            lambda: self.mock_db
+        )
+        self.client = TestClient(self.test_app)
+
+    def _summary(self, **overrides: typing.Any) -> dict:
+        data = {
+            'id': 'dep1',
+            'name': 'Dep One',
+            'slug': 'dep-one',
+            'namespace': 'engineering',
+            'project_type': 'api-service',
+        }
+        data.update(overrides)
+        return data
+
+    def test_empty(self) -> None:
+        """Returns an empty list when the project has no edges."""
+        self.mock_db.execute.return_value = [
+            {'project_exists': True, 'direction': None, 'other': None}
+        ]
+
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            response = self.client.get(
+                f'/organizations/engineering/projects/{PROJECT_ID}'
+                '/relationships'
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {'relationships': []})
+
+    def test_mixed_directions(self) -> None:
+        """Returns inbound and outbound rows, inbound sorted first."""
+        self.mock_db.execute.return_value = [
+            {
+                'project_exists': True,
+                'direction': 'outbound',
+                'other': self._summary(id='out1', name='Outbound A'),
+            },
+            {
+                'project_exists': True,
+                'direction': 'inbound',
+                'other': self._summary(id='in1', name='Inbound A'),
+            },
+            {
+                'project_exists': True,
+                'direction': 'inbound',
+                'other': self._summary(id='in2', name='Inbound B'),
+            },
+        ]
+
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            response = self.client.get(
+                f'/organizations/engineering/projects/{PROJECT_ID}'
+                '/relationships'
+            )
+
+        self.assertEqual(response.status_code, 200)
+        rels = response.json()['relationships']
+        self.assertEqual(len(rels), 3)
+        for entry in rels:
+            self.assertEqual(entry['type'], 'depends_on')
+            self.assertIn(entry['direction'], ('inbound', 'outbound'))
+            self.assertIn('project', entry)
+
+    def test_not_found(self) -> None:
+        """Returns 404 when the project does not exist."""
+        self.mock_db.execute.return_value = []
+
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            response = self.client.get(
+                '/organizations/engineering/projects/missing/relationships'
+            )
+
+        self.assertEqual(response.status_code, 404)
+        self.assertIn('not found', response.json()['detail'])

--- a/tests/endpoints/test_projects.py
+++ b/tests/endpoints/test_projects.py
@@ -385,7 +385,7 @@ class ProjectEndpointsTestCase(unittest.TestCase):
             {
                 'project': self._project_data(),
                 'outbound_count': 5,
-                'inbound_count': 0,
+                'inbound_count': 2,
             },
         ]
 
@@ -401,7 +401,7 @@ class ProjectEndpointsTestCase(unittest.TestCase):
         data = response.json()
         self.assertEqual(data['slug'], 'my-api')
         self.assertEqual(data['relationships']['outbound_count'], 5)
-        self.assertEqual(data['relationships']['inbound_count'], 0)
+        self.assertEqual(data['relationships']['inbound_count'], 2)
 
     def test_get_not_found(self) -> None:
         """Test retrieving nonexistent project."""

--- a/tests/endpoints/test_projects.py
+++ b/tests/endpoints/test_projects.py
@@ -821,6 +821,7 @@ class ProjectRelationshipsEndpointTestCase(unittest.TestCase):
             'slug': 'dep-one',
             'namespace': 'engineering',
             'project_type': 'api-service',
+            'project_type_icon': 'aws-lambda',
         }
         data.update(overrides)
         return data
@@ -885,6 +886,11 @@ class ProjectRelationshipsEndpointTestCase(unittest.TestCase):
             self.assertEqual(entry['type'], 'depends_on')
             self.assertEqual(entry['project']['project_type'], 'api-service')
             self.assertEqual(entry['project']['namespace'], 'engineering')
+
+        self.assertEqual(
+            rels[0]['project']['project_type_icon'],
+            'aws-lambda',
+        )
 
     def test_not_found(self) -> None:
         """Returns 404 when the project does not exist."""

--- a/tests/endpoints/test_projects.py
+++ b/tests/endpoints/test_projects.py
@@ -906,3 +906,38 @@ class ProjectRelationshipsEndpointTestCase(unittest.TestCase):
 
         self.assertEqual(response.status_code, 404)
         self.assertIn('not found', response.json()['detail'])
+
+    def test_order_by_has_stable_tiebreaker(self) -> None:
+        """ORDER BY must include a unique tie-breaker after other.name so
+        sibling projects that share a name across namespaces sort
+        deterministically across repeated requests.
+        """
+        self.mock_db.execute.return_value = [
+            {'project_exists': True, 'direction': None, 'other': None}
+        ]
+
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            response = self.client.get(
+                f'/organizations/engineering/projects/{PROJECT_ID}'
+                '/relationships'
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.mock_db.execute.assert_called_once()
+        query = self.mock_db.execute.call_args.args[0]
+        normalized = ' '.join(query.split())
+        self.assertIn(
+            'ORDER BY CASE direction',
+            normalized,
+            'expected relationships query to sort by direction first',
+        )
+        self.assertIn(
+            'other.name, other.id',
+            normalized,
+            'expected other.id tie-breaker after other.name in ORDER BY '
+            'so ordering is stable when multiple related projects share a '
+            'name across namespaces',
+        )

--- a/tests/endpoints/test_projects.py
+++ b/tests/endpoints/test_projects.py
@@ -91,7 +91,6 @@ class ProjectEndpointsTestCase(unittest.TestCase):
                 },
             ],
             'environments': [],
-            'dependency_uris': [],
         }
         data.update(overrides)
         return data
@@ -109,7 +108,8 @@ class ProjectEndpointsTestCase(unittest.TestCase):
             [
                 {
                     'project': record,
-                    'dependency_count': 0,
+                    'outbound_count': 0,
+                    'inbound_count': 0,
                 },
             ],
         ]
@@ -175,7 +175,8 @@ class ProjectEndpointsTestCase(unittest.TestCase):
             [
                 {
                     'project': record,
-                    'dependency_count': 0,
+                    'outbound_count': 0,
+                    'inbound_count': 0,
                 },
             ],
         ]
@@ -345,7 +346,8 @@ class ProjectEndpointsTestCase(unittest.TestCase):
         self.mock_db.execute.return_value = [
             {
                 'project': self._project_data(),
-                'dependency_count': 3,
+                'outbound_count': 3,
+                'inbound_count': 0,
             },
             {
                 'project': self._project_data(
@@ -353,7 +355,8 @@ class ProjectEndpointsTestCase(unittest.TestCase):
                     name='My Consumer',
                     slug='my-consumer',
                 ),
-                'dependency_count': 0,
+                'outbound_count': 0,
+                'inbound_count': 0,
             },
         ]
 
@@ -371,10 +374,8 @@ class ProjectEndpointsTestCase(unittest.TestCase):
         self.assertEqual(len(data), 2)
         self.assertEqual(data[0]['slug'], 'my-api')
         rels = data[0]['relationships']
-        self.assertEqual(
-            rels['dependencies']['count'],
-            3,
-        )
+        self.assertEqual(rels['outbound_count'], 3)
+        self.assertEqual(rels['inbound_count'], 0)
 
     # -- Get -----------------------------------------------------------
 
@@ -383,7 +384,8 @@ class ProjectEndpointsTestCase(unittest.TestCase):
         self.mock_db.execute.return_value = [
             {
                 'project': self._project_data(),
-                'dependency_count': 5,
+                'outbound_count': 5,
+                'inbound_count': 0,
             },
         ]
 
@@ -398,10 +400,8 @@ class ProjectEndpointsTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         data = response.json()
         self.assertEqual(data['slug'], 'my-api')
-        self.assertEqual(
-            data['relationships']['dependencies']['count'],
-            5,
-        )
+        self.assertEqual(data['relationships']['outbound_count'], 5)
+        self.assertEqual(data['relationships']['inbound_count'], 0)
 
     def test_get_not_found(self) -> None:
         """Test retrieving nonexistent project."""
@@ -438,7 +438,8 @@ class ProjectEndpointsTestCase(unittest.TestCase):
             [
                 {
                     'project': updated,
-                    'dependency_count': 0,
+                    'outbound_count': 0,
+                    'inbound_count': 0,
                 },
             ],
         ]
@@ -493,7 +494,8 @@ class ProjectEndpointsTestCase(unittest.TestCase):
             [
                 {
                     'project': updated,
-                    'dependency_count': 0,
+                    'outbound_count': 0,
+                    'inbound_count': 0,
                 },
             ],
         ]
@@ -626,7 +628,8 @@ class ProjectEndpointsTestCase(unittest.TestCase):
             [
                 {
                     'project': updated,
-                    'dependency_count': 0,
+                    'outbound_count': 0,
+                    'inbound_count': 0,
                 },
             ],
         ]

--- a/tests/endpoints/test_projects.py
+++ b/tests/endpoints/test_projects.py
@@ -848,11 +848,6 @@ class ProjectRelationshipsEndpointTestCase(unittest.TestCase):
         self.mock_db.execute.return_value = [
             {
                 'project_exists': True,
-                'direction': 'outbound',
-                'other': self._summary(id='out1', name='Outbound A'),
-            },
-            {
-                'project_exists': True,
                 'direction': 'inbound',
                 'other': self._summary(id='in1', name='Inbound A'),
             },
@@ -860,6 +855,11 @@ class ProjectRelationshipsEndpointTestCase(unittest.TestCase):
                 'project_exists': True,
                 'direction': 'inbound',
                 'other': self._summary(id='in2', name='Inbound B'),
+            },
+            {
+                'project_exists': True,
+                'direction': 'outbound',
+                'other': self._summary(id='out1', name='Outbound A'),
             },
         ]
 
@@ -875,10 +875,16 @@ class ProjectRelationshipsEndpointTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         rels = response.json()['relationships']
         self.assertEqual(len(rels), 3)
+        self.assertEqual(rels[0]['direction'], 'inbound')
+        self.assertEqual(rels[0]['project']['id'], 'in1')
+        self.assertEqual(rels[1]['direction'], 'inbound')
+        self.assertEqual(rels[1]['project']['id'], 'in2')
+        self.assertEqual(rels[2]['direction'], 'outbound')
+        self.assertEqual(rels[2]['project']['id'], 'out1')
         for entry in rels:
             self.assertEqual(entry['type'], 'depends_on')
-            self.assertIn(entry['direction'], ('inbound', 'outbound'))
-            self.assertIn('project', entry)
+            self.assertEqual(entry['project']['project_type'], 'api-service')
+            self.assertEqual(entry['project']['namespace'], 'engineering')
 
     def test_not_found(self) -> None:
         """Returns 404 when the project does not exist."""


### PR DESCRIPTION
## Summary

Renames the user-facing "dependencies" concept to "relationships" across the API, exposing both inbound and outbound `DEPENDS_ON` edges with explicit direction metadata. The AGE edge label `DEPENDS_ON` is unchanged; this is a naming and presentation change.

## Problem

The project response shape previously exposed a nested `relationships.dependencies` link and a flat `dependency_uris` array, which only surfaced outbound edges. Callers had no first-class view of "projects that depend on this one," and had to resolve `dependency_uris` separately to render anything useful.

## Solution

- Replace `relationships.dependencies` with a flat `relationships` object: `{ href, inbound_count, outbound_count }`.
- Drop `dependency_uris`.
- Add `GET /organizations/{org}/projects/{id}/relationships` returning `{ relationships: [{ direction, type, project }] }` — one flat list with explicit direction, sorted inbound first then by related project name.
- Include `project_type_icon` on each related project so the UI can render per-type icons without a second roundtrip.
- Keep `DEPENDS_ON` edge label unchanged; no database migration.

## Commits

- Split `dependency_count` into `outbound_count`/`inbound_count` in read queries and response model
- Assert non-zero inbound in tests to guard against argument swaps
- Add `GET /projects/{id}/relationships` endpoint with direction derived from `startNode(r)`
- Strengthen sort-order test and document the arbitrary `pt.slug` pick
- Add `project_type_icon` to relationship summaries

## Test plan

- [x] 22 project endpoint tests pass (19 existing, updated for new shape; 3 new for `/relationships`)
- [x] Full suite: 813 passed, 1 skipped, 90.08% coverage
- [x] Lint (ruff, basedpyright, mypy) clean
- [ ] Smoke test in Okteto against real graph data once UI PR is merged together

Spec: [2026-04-13-dependencies-to-relationships-design.md](https://github.com/AWeber-Imbi/imbi/blob/main/docs/superpowers/specs/2026-04-13-dependencies-to-relationships-design.md) (orchestrator repo)

Companion PR: AWeber-Imbi/imbi-ui PR (to be linked after creation)