### PR TITLE
Add PUT endpoint for setting project relationships

### DIFF
--- a/src/imbi_api/endpoints/projects.py
+++ b/src/imbi_api/endpoints/projects.py
@@ -859,6 +859,81 @@ class ProjectRelationshipsResponse(pydantic.BaseModel):
     relationships: list[ProjectRelationship]
 
 
+class ProjectRelationshipsUpdate(pydantic.BaseModel):
+    """Request body for replacing outbound DEPENDS_ON edges."""
+
+    depends_on: list[str] = pydantic.Field(
+        description='Project IDs that this project depends on.',
+    )
+
+
+_RELATIONSHIPS_QUERY: typing.LiteralString = """
+    MATCH (p:Project {{id: {project_id}}})
+          -[:OWNED_BY]->(:Team)
+          -[:BELONGS_TO]->(:Organization {{slug: {org_slug}}})
+    WITH p
+    OPTIONAL MATCH (p)-[r:DEPENDS_ON]-(other:Project)
+          -[:OWNED_BY]->(:Team)
+          -[:BELONGS_TO]->(otherOrg:Organization)
+    OPTIONAL MATCH (other)-[:TYPE]->(pt:ProjectType)
+    WITH p, r, other, otherOrg, pt
+    ORDER BY pt.slug
+    WITH p, r, other, otherOrg,
+         collect(pt.slug)[0] AS pt_slug,
+         collect(pt.icon)[0] AS pt_icon,
+         CASE WHEN r IS NULL THEN null
+              WHEN startNode(r) = p THEN 'outbound'
+              ELSE 'inbound'
+         END AS direction
+    RETURN direction,
+           CASE WHEN other IS NULL THEN null
+                ELSE other{{.id, .name, .slug,
+                           namespace: otherOrg.slug,
+                           project_type: pt_slug,
+                           project_type_icon: pt_icon}}
+           END AS other
+    ORDER BY CASE direction WHEN 'inbound' THEN 0
+                            WHEN 'outbound' THEN 1
+                            ELSE 2 END,
+             other.name,
+             other.id
+"""
+
+
+async def _fetch_relationships(
+    db: graph.Pool,
+    project_id: str,
+    org_slug: str,
+) -> list[ProjectRelationship]:
+    """Fetch all DEPENDS_ON edges for a project, sorted inbound-first."""
+    records = await db.execute(
+        _RELATIONSHIPS_QUERY,
+        {'project_id': project_id, 'org_slug': org_slug},
+        ['direction', 'other'],
+    )
+    relationships: list[ProjectRelationship] = []
+    for record in records:
+        direction = graph.parse_agtype(record['direction'])
+        other = graph.parse_agtype(record['other'])
+        if not direction or not other:
+            continue
+        relationships.append(
+            ProjectRelationship(
+                direction=direction,
+                project=ProjectRelationshipSummary.model_validate(other),
+            ),
+        )
+    return relationships
+
+
+_PROJECT_EXISTS_QUERY: typing.LiteralString = """
+    MATCH (p:Project {{id: {project_id}}})
+          -[:OWNED_BY]->(:Team)
+          -[:BELONGS_TO]->(:Organization {{slug: {org_slug}}})
+    RETURN p.id AS id
+"""
+
+
 @projects_router.get('/{project_id}/relationships')
 async def list_project_relationships(
     org_slug: str,
@@ -877,65 +952,107 @@ async def list_project_relationships(
     ``direction`` field. Rows are sorted inbound first, then by
     the related project's name.
     """
-    query: typing.LiteralString = """
-    MATCH (p:Project {{id: {project_id}}})
-          -[:OWNED_BY]->(:Team)
-          -[:BELONGS_TO]->(:Organization {{slug: {org_slug}}})
-    WITH p, true AS project_exists
-    OPTIONAL MATCH (p)-[r:DEPENDS_ON]-(other:Project)
-          -[:OWNED_BY]->(:Team)
-          -[:BELONGS_TO]->(otherOrg:Organization)
-    OPTIONAL MATCH (other)-[:TYPE]->(pt:ProjectType)
-    WITH p, project_exists, r, other, otherOrg, pt
-    ORDER BY pt.slug
-    WITH p, project_exists, r, other, otherOrg,
-         collect(pt.slug)[0] AS pt_slug,
-         collect(pt.icon)[0] AS pt_icon,
-         CASE WHEN r IS NULL THEN null
-              WHEN startNode(r) = p THEN 'outbound'
-              ELSE 'inbound'
-         END AS direction
-    RETURN project_exists,
-           direction,
-           CASE WHEN other IS NULL THEN null
-                ELSE other{{.id, .name, .slug,
-                           namespace: otherOrg.slug,
-                           project_type: pt_slug,
-                           project_type_icon: pt_icon}}
-           END AS other
-    ORDER BY CASE direction WHEN 'inbound' THEN 0
-                            WHEN 'outbound' THEN 1
-                            ELSE 2 END,
-             other.name,
-             other.id
-    """
-    records = await db.execute(
-        query,
-        {
-            'project_id': project_id,
-            'org_slug': org_slug,
-        },
-        ['project_exists', 'direction', 'other'],
+    exists = await db.execute(
+        _PROJECT_EXISTS_QUERY,
+        {'project_id': project_id, 'org_slug': org_slug},
+        ['id'],
     )
-    if not records:
+    if not exists:
         raise fastapi.HTTPException(
             status_code=404,
             detail=f'Project {project_id!r} not found',
         )
-    relationships: list[ProjectRelationship] = []
-    for record in records:
-        direction = graph.parse_agtype(record['direction'])
-        other = graph.parse_agtype(record['other'])
-        if not direction or not other:
-            continue
-        relationships.append(
-            ProjectRelationship(
-                direction=direction,
-                project=ProjectRelationshipSummary.model_validate(other),
-            ),
-        )
     return ProjectRelationshipsResponse(
-        relationships=relationships,
+        relationships=await _fetch_relationships(db, project_id, org_slug),
+    )
+
+
+@projects_router.put('/{project_id}/relationships')
+async def set_project_relationships(
+    org_slug: str,
+    project_id: str,
+    data: ProjectRelationshipsUpdate,
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('project:write'),
+        ),
+    ],
+) -> ProjectRelationshipsResponse:
+    """Replace the outbound DEPENDS_ON edges for a project.
+
+    Deletes all existing outbound DEPENDS_ON edges and creates new
+    ones for each project ID in ``depends_on``.  Self-references
+    are silently ignored.
+    """
+    target_ids = list(
+        dict.fromkeys(tid for tid in data.depends_on if tid != project_id)
+    )
+
+    exists = await db.execute(
+        _PROJECT_EXISTS_QUERY,
+        {'project_id': project_id, 'org_slug': org_slug},
+        ['id'],
+    )
+    if not exists:
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail=f'Project {project_id!r} not found',
+        )
+
+    if target_ids:
+        validate_query: typing.LiteralString = """
+        UNWIND {target_ids} AS tid
+        OPTIONAL MATCH (t:Project {{id: tid}})
+        RETURN tid, t IS NOT NULL AS found
+        """
+        records = await db.execute(
+            validate_query,
+            {'target_ids': target_ids},
+            ['tid', 'found'],
+        )
+        missing = [
+            graph.parse_agtype(r['tid'])
+            for r in records
+            if not graph.parse_agtype(r['found'])
+        ]
+        if missing:
+            raise fastapi.HTTPException(
+                status_code=422,
+                detail=(f'Project ID(s) not found: {sorted(missing)!r}'),
+            )
+
+    if target_ids:
+        mutate_query: typing.LiteralString = """
+        MATCH (p:Project {{id: {project_id}}})
+        OPTIONAL MATCH (p)-[old:DEPENDS_ON]->(:Project)
+        DELETE old
+        WITH DISTINCT p
+        UNWIND {target_ids} AS tid
+        MATCH (target:Project {{id: tid}})
+        CREATE (p)-[:DEPENDS_ON]->(target)
+        """
+        await db.execute(
+            mutate_query,
+            {
+                'project_id': project_id,
+                'target_ids': target_ids,
+            },
+        )
+    else:
+        delete_query: typing.LiteralString = """
+        MATCH (p:Project {{id: {project_id}}})
+        OPTIONAL MATCH (p)-[old:DEPENDS_ON]->(:Project)
+        DELETE old
+        """
+        await db.execute(
+            delete_query,
+            {'project_id': project_id},
+        )
+
+    return ProjectRelationshipsResponse(
+        relationships=await _fetch_relationships(db, project_id, org_slug),
     )
 
 

--- a/tests/endpoints/test_projects.py
+++ b/tests/endpoints/test_projects.py
@@ -777,8 +777,10 @@ class ProjectEndpointsTestCase(unittest.TestCase):
         self.assertIn('not found', response.json()['detail'])
 
 
-class ProjectRelationshipsEndpointTestCase(unittest.TestCase):
-    """Tests for GET /projects/{id}/relationships."""
+class _RelationshipsTestBase(unittest.TestCase):
+    """Shared setup for relationship endpoint tests."""
+
+    _permissions: typing.ClassVar[set[str]] = set()
 
     def setUp(self) -> None:
         from imbi_api.auth import permissions
@@ -798,7 +800,7 @@ class ProjectRelationshipsEndpointTestCase(unittest.TestCase):
             user=self.admin_user,
             session_id='test-session',
             auth_method='jwt',
-            permissions={'project:read'},
+            permissions=self._permissions,
         )
 
         async def mock_get_current_user():
@@ -814,6 +816,9 @@ class ProjectRelationshipsEndpointTestCase(unittest.TestCase):
         )
         self.client = TestClient(self.test_app)
 
+    def _url(self, pid: str = PROJECT_ID) -> str:
+        return f'/organizations/engineering/projects/{pid}/relationships'
+
     def _summary(self, **overrides: typing.Any) -> dict:
         data = {
             'id': 'dep1',
@@ -826,10 +831,17 @@ class ProjectRelationshipsEndpointTestCase(unittest.TestCase):
         data.update(overrides)
         return data
 
+
+class ProjectRelationshipsEndpointTestCase(_RelationshipsTestBase):
+    """Tests for GET /projects/{id}/relationships."""
+
+    _permissions: typing.ClassVar[set[str]] = {'project:read'}
+
     def test_empty(self) -> None:
         """Returns an empty list when the project has no edges."""
-        self.mock_db.execute.return_value = [
-            {'project_exists': True, 'direction': None, 'other': None}
+        self.mock_db.execute.side_effect = [
+            [{'id': PROJECT_ID}],
+            [{'direction': None, 'other': None}],
         ]
 
         with mock.patch(
@@ -846,22 +858,22 @@ class ProjectRelationshipsEndpointTestCase(unittest.TestCase):
 
     def test_mixed_directions(self) -> None:
         """Returns inbound and outbound rows, inbound sorted first."""
-        self.mock_db.execute.return_value = [
-            {
-                'project_exists': True,
-                'direction': 'inbound',
-                'other': self._summary(id='in1', name='Inbound A'),
-            },
-            {
-                'project_exists': True,
-                'direction': 'inbound',
-                'other': self._summary(id='in2', name='Inbound B'),
-            },
-            {
-                'project_exists': True,
-                'direction': 'outbound',
-                'other': self._summary(id='out1', name='Outbound A'),
-            },
+        self.mock_db.execute.side_effect = [
+            [{'id': PROJECT_ID}],
+            [
+                {
+                    'direction': 'inbound',
+                    'other': self._summary(id='in1', name='Inbound A'),
+                },
+                {
+                    'direction': 'inbound',
+                    'other': self._summary(id='in2', name='Inbound B'),
+                },
+                {
+                    'direction': 'outbound',
+                    'other': self._summary(id='out1', name='Outbound A'),
+                },
+            ],
         ]
 
         with mock.patch(
@@ -912,8 +924,9 @@ class ProjectRelationshipsEndpointTestCase(unittest.TestCase):
         sibling projects that share a name across namespaces sort
         deterministically across repeated requests.
         """
-        self.mock_db.execute.return_value = [
-            {'project_exists': True, 'direction': None, 'other': None}
+        self.mock_db.execute.side_effect = [
+            [{'id': PROJECT_ID}],
+            [{'direction': None, 'other': None}],
         ]
 
         with mock.patch(
@@ -926,8 +939,8 @@ class ProjectRelationshipsEndpointTestCase(unittest.TestCase):
             )
 
         self.assertEqual(response.status_code, 200)
-        self.mock_db.execute.assert_called_once()
-        query = self.mock_db.execute.call_args.args[0]
+        # Fetch query is the second call (first is exists check)
+        query = self.mock_db.execute.call_args_list[1].args[0]
         normalized = ' '.join(query.split())
         self.assertIn(
             'ORDER BY CASE direction',
@@ -941,3 +954,148 @@ class ProjectRelationshipsEndpointTestCase(unittest.TestCase):
             'so ordering is stable when multiple related projects share a '
             'name across namespaces',
         )
+
+
+class SetProjectRelationshipsTestCase(_RelationshipsTestBase):
+    """Tests for PUT /projects/{id}/relationships."""
+
+    _permissions: typing.ClassVar[set[str]] = {'project:write'}
+
+    def test_set_depends_on(self) -> None:
+        """Replaces outbound edges and returns updated list."""
+        # exists, validate, mutate (delete+create), fetch
+        self.mock_db.execute.side_effect = [
+            [{'id': PROJECT_ID}],
+            [{'tid': 'target1', 'found': True}],
+            [],
+            [
+                {
+                    'direction': 'outbound',
+                    'other': self._summary(id='target1', name='Target One'),
+                },
+            ],
+        ]
+
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            response = self.client.put(
+                self._url(),
+                json={'depends_on': ['target1']},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        rels = response.json()['relationships']
+        self.assertEqual(len(rels), 1)
+        self.assertEqual(rels[0]['direction'], 'outbound')
+        self.assertEqual(rels[0]['project']['id'], 'target1')
+        self.assertEqual(rels[0]['type'], 'depends_on')
+
+    def test_clear_depends_on(self) -> None:
+        """Empty list removes all outbound edges."""
+        self.mock_db.execute.side_effect = [
+            [{'id': PROJECT_ID}],
+            [],
+            [{'direction': None, 'other': None}],
+        ]
+
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            response = self.client.put(
+                self._url(),
+                json={'depends_on': []},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {'relationships': []})
+
+    def test_project_not_found(self) -> None:
+        """Returns 404 when source project does not exist."""
+        self.mock_db.execute.return_value = []
+
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            response = self.client.put(
+                self._url('missing'),
+                json={'depends_on': ['target1']},
+            )
+
+        self.assertEqual(response.status_code, 404)
+        self.assertIn('not found', response.json()['detail'])
+
+    def test_target_not_found(self) -> None:
+        """Returns 422 when a target project ID does not exist."""
+        self.mock_db.execute.side_effect = [
+            [{'id': PROJECT_ID}],
+            [
+                {'tid': 'good', 'found': True},
+                {'tid': 'bad', 'found': False},
+            ],
+        ]
+
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            response = self.client.put(
+                self._url(),
+                json={'depends_on': ['good', 'bad']},
+            )
+
+        self.assertEqual(response.status_code, 422)
+        self.assertIn('bad', response.json()['detail'])
+
+    def test_self_reference_ignored(self) -> None:
+        """Self-references are silently dropped."""
+        self.mock_db.execute.side_effect = [
+            [{'id': PROJECT_ID}],
+            [],
+            [{'direction': None, 'other': None}],
+        ]
+
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            response = self.client.put(
+                self._url(),
+                json={'depends_on': [PROJECT_ID]},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {'relationships': []})
+
+    def test_duplicates_deduplicated(self) -> None:
+        """Duplicate IDs in depends_on are collapsed."""
+        # exists, validate, mutate (delete+create), fetch
+        self.mock_db.execute.side_effect = [
+            [{'id': PROJECT_ID}],
+            [{'tid': 'dup', 'found': True}],
+            [],
+            [
+                {
+                    'direction': 'outbound',
+                    'other': self._summary(id='dup', name='Dup'),
+                },
+            ],
+        ]
+
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            response = self.client.put(
+                self._url(),
+                json={'depends_on': ['dup', 'dup', 'dup']},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        # Validate only unique targets were sent to the DB
+        validate_call = self.mock_db.execute.call_args_list[1]
+        validate_params = validate_call.args[1]
+        self.assertEqual(validate_params['target_ids'], ['dup'])

--- a/tests/endpoints/test_projects.py
+++ b/tests/endpoints/test_projects.py
@@ -787,17 +787,17 @@ class _RelationshipsTestBase(unittest.TestCase):
 
         self.test_app = app.create_app()
 
-        self.admin_user = models.User(
-            email='admin@example.com',
-            display_name='Admin User',
+        self.test_user = models.User(
+            email='user@example.com',
+            display_name='Test User',
             password_hash='$argon2id$hashed',
             is_active=True,
-            is_admin=True,
+            is_admin=False,
             is_service_account=False,
             created_at=datetime.datetime.now(datetime.UTC),
         )
         self.auth_context = permissions.AuthContext(
-            user=self.admin_user,
+            user=self.test_user,
             session_id='test-session',
             auth_method='jwt',
             permissions=self._permissions,


### PR DESCRIPTION
## Summary
- Implements `PUT /organizations/{org}/projects/{id}/relationships` accepting `{ depends_on: string[] }` to declaratively replace outbound DEPENDS_ON edges
- Validates target project existence (422 with missing IDs), deduplicates, silently drops self-references
- Returns the full relationship list (inbound + outbound) matching the GET response shape

## Refactoring
- Extracts `_RELATIONSHIPS_QUERY`, `_PROJECT_EXISTS_QUERY`, and `_fetch_relationships()` helper shared between GET and PUT handlers
- Introduces `_RelationshipsTestBase` to deduplicate test setup across GET and PUT test classes

## Test plan
- [x] Unit tests: set depends_on, clear depends_on, 404 source, 422 missing target, self-reference filtering, duplicate deduplication
- [x] All 29 project endpoint tests pass
- [x] Pre-commit hooks pass (ruff, mypy, format)
- [x] Manual testing against Okteto dev environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)