### PR TITLE
Add Valkey service to local dev environment

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -50,3 +50,13 @@ services:
       POSTGRES_DB: imbi
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
+
+  valkey:
+    image: valkey/valkey:8-alpine
+    ports:
+      - "6379"
+    healthcheck:
+      test: ["CMD-SHELL", "valkey-cli ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 10

--- a/justfile
+++ b/justfile
@@ -71,6 +71,7 @@ docker:
     S3_SECRET_KEY="test"
     S3_BUCKET="imbi-uploads"
     S3_REGION="us-east-1"
+    VALKEY_URL="redis://$test_host:$(get_port valkey 6379)"
     EOF
 
 [doc("Run tests")]


### PR DESCRIPTION
## Summary
Add Valkey (Redis-compatible key-value store) to the local development Docker Compose stack.

## Problem
The local dev stack has no Valkey/Redis service, so `VALKEY_URL` is never set when running `just serve` or `just test`. Any code path that depends on Valkey will fail to start or error at runtime.

## Solution
- Add `valkey/valkey:8-alpine` to `compose.yaml` with a dynamic port mapping and healthcheck
- Append `VALKEY_URL="redis://$test_host:$(get_port valkey 6379)"` to the `.env` generated by the `docker` recipe in `justfile`

## Impact
`VALKEY_URL` is now automatically available in `.env` after running `just docker`, `just serve`, or `just test`. No changes to application code or configuration.