### PR TITLE
feat: operations log CRUD endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .*
 /build
 /dist
+/docs/superpowers
 /public
 /site
 VERSION

--- a/src/imbi_api/auth/seed.py
+++ b/src/imbi_api/auth/seed.py
@@ -202,6 +202,31 @@ STANDARD_PERMISSIONS: list[tuple[str, str, str, str]] = [
         'delete',
         'Delete service accounts',
     ),
+    # Operations log management
+    (
+        'operations_log:create',
+        'operations_log',
+        'create',
+        'Create operations log entries',
+    ),
+    (
+        'operations_log:read',
+        'operations_log',
+        'read',
+        'View operations log entries',
+    ),
+    (
+        'operations_log:update',
+        'operations_log',
+        'update',
+        'Update operations log entries',
+    ),
+    (
+        'operations_log:delete',
+        'operations_log',
+        'delete',
+        'Delete operations log entries',
+    ),
 ]
 
 # Default role definitions

--- a/src/imbi_api/auth/seed.py
+++ b/src/imbi_api/auth/seed.py
@@ -275,6 +275,7 @@ DEFAULT_ROLES: list[tuple[str, str, str, int, list[str]]] = [
             'blueprint:read',
             'environment:read',
             'link_definition:read',
+            'operations_log:read',
             'project:read',
             'project_type:read',
             'organization:read',

--- a/src/imbi_api/endpoints/__init__.py
+++ b/src/imbi_api/endpoints/__init__.py
@@ -6,6 +6,7 @@ from .auth import auth_router
 from .blueprints import blueprint_router
 from .client_credentials import client_credentials_router
 from .mfa import mfa_router
+from .operations_log import operations_log_router
 from .organizations import organizations_router
 from .roles import roles_router
 from .sa_api_keys import sa_api_keys_router
@@ -21,6 +22,7 @@ routers: list[fastapi.APIRouter] = [
     blueprint_router,
     client_credentials_router,
     mfa_router,
+    operations_log_router,
     organizations_router,
     roles_router,
     sa_api_keys_router,

--- a/src/imbi_api/endpoints/operations_log.py
+++ b/src/imbi_api/endpoints/operations_log.py
@@ -153,3 +153,37 @@ async def create_operation_log(
 
     await _insert_row(_model_to_row(entry))
     return _row_to_response(entry.model_dump(mode='json'))
+
+
+_SINGLE_ENTRY_SQL: typing.Final[str] = (
+    'SELECT * FROM operations_log FINAL '
+    'WHERE id = {id:String} AND is_deleted = 0 LIMIT 1'
+)
+
+
+async def _fetch_current(
+    entry_id: str,
+) -> dict[str, typing.Any] | None:
+    """Fetch the current (non-deleted) row for an entry id."""
+    rows = await clickhouse.query(_SINGLE_ENTRY_SQL, {'id': entry_id})
+    return rows[0] if rows else None
+
+
+@operations_log_router.get('/{entry_id}')
+async def get_operation_log(
+    entry_id: str,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('operations_log:read'),
+        ),
+    ],
+) -> dict[str, typing.Any]:
+    """Get a single operations log entry."""
+    row = await _fetch_current(entry_id)
+    if row is None:
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail=f'Operations log entry {entry_id!r} not found',
+        )
+    return _row_to_response(row)

--- a/src/imbi_api/endpoints/operations_log.py
+++ b/src/imbi_api/endpoints/operations_log.py
@@ -42,7 +42,6 @@ READONLY_PATHS: frozenset[str] = frozenset(
         '/occurred_at',
         '/recorded_at',
         '/recorded_by',
-        '/_row_version',
         '/row_version',
         '/is_deleted',
     ]
@@ -155,8 +154,9 @@ async def create_operation_log(
     if entry.performed_by is None:
         entry.performed_by = entry.recorded_by
 
-    await _insert_row(_model_to_row(entry))
-    return _row_to_response(entry.model_dump(mode='json'))
+    row = _model_to_row(entry)
+    await _insert_row(row)
+    return _row_to_response(fastapi.encoders.jsonable_encoder(row))
 
 
 _SINGLE_ENTRY_SQL: typing.Final[str] = (
@@ -173,13 +173,13 @@ async def _fetch_current(
     return rows[0] if rows else None
 
 
-_FILTER_FIELDS: tuple[tuple[str, str], ...] = (
-    ('project_id', 'String'),
-    ('project_slug', 'String'),
-    ('environment_slug', 'String'),
-    ('entry_type', 'String'),
-    ('ticket_slug', 'String'),
-    ('performed_by', 'String'),
+_FILTER_FIELDS: tuple[str, ...] = (
+    'project_id',
+    'project_slug',
+    'environment_slug',
+    'entry_type',
+    'ticket_slug',
+    'performed_by',
 )
 
 
@@ -244,16 +244,16 @@ async def _list_impl(
     clauses: list[str] = ['is_deleted = 0']
     params: dict[str, typing.Any] = {}
 
-    # Forced filters win; merge them first.
-    all_filters: dict[str, str | None] = dict(query_filters or {})
-    for key, value in (forced_filters or {}).items():
-        all_filters[key] = value
+    all_filters: dict[str, str | None] = {
+        **(query_filters or {}),
+        **(forced_filters or {}),
+    }
 
-    for field, ch_type in _FILTER_FIELDS:
-        filter_value = all_filters.get(field)
-        if filter_value is not None:
-            clauses.append(f'{field} = {{{field}:{ch_type}}}')
-            params[field] = filter_value
+    for field in _FILTER_FIELDS:
+        value = all_filters.get(field)
+        if value is not None:
+            clauses.append(f'{field} = {{{field}:String}}')
+            params[field] = value
 
     if since is not None:
         params['since'] = _parse_iso(since, 'since')
@@ -357,7 +357,7 @@ async def list_project_operation_logs(
     until: str | None = None,
 ) -> fastapi.Response:
     """List operations log entries for a specific project."""
-    del org_slug  # only used for URL scoping; not a filter column
+    del org_slug
     return await _list_impl(
         request=request,
         limit=limit,
@@ -413,8 +413,6 @@ async def patch_operation_log(
             detail=f'Operations log entry {entry_id!r} not found',
         )
 
-    # Build patch target dict: rename _row_version -> row_version for
-    # model validation, and drop is_deleted (readonly in API).
     target = dict(current)
     target['row_version'] = target.pop('_row_version')
     target.pop('is_deleted', None)
@@ -430,7 +428,6 @@ async def patch_operation_log(
             detail=f'Validation error: {e.errors()}',
         ) from e
 
-    # Preserve identity; bump version; keep tombstone false.
     entry.id = entry_id
     entry.occurred_at = current['occurred_at']
     entry.recorded_at = current['recorded_at']
@@ -439,8 +436,9 @@ async def patch_operation_log(
     entry.row_version = int(current['_row_version']) + 1
     entry.is_deleted = False
 
-    await _insert_row(_model_to_row(entry))
-    return _row_to_response(entry.model_dump(mode='json'))
+    row = _model_to_row(entry)
+    await _insert_row(row)
+    return _row_to_response(fastapi.encoders.jsonable_encoder(row))
 
 
 @operations_log_router.delete('/{entry_id}', status_code=204)

--- a/src/imbi_api/endpoints/operations_log.py
+++ b/src/imbi_api/endpoints/operations_log.py
@@ -25,6 +25,7 @@ import nanoid
 import pydantic
 from imbi_common import clickhouse, models
 
+from imbi_api import patch as json_patch
 from imbi_api.auth import permissions
 
 LOGGER = logging.getLogger(__name__)
@@ -323,3 +324,52 @@ async def get_operation_log(
             detail=f'Operations log entry {entry_id!r} not found',
         )
     return _row_to_response(row)
+
+
+@operations_log_router.patch('/{entry_id}')
+async def patch_operation_log(
+    entry_id: str,
+    operations: list[json_patch.PatchOperation],
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('operations_log:update'),
+        ),
+    ],
+) -> dict[str, typing.Any]:
+    """Apply a JSON Patch to an operations log entry."""
+    current = await _fetch_current(entry_id)
+    if current is None:
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail=f'Operations log entry {entry_id!r} not found',
+        )
+
+    # Build patch target dict: rename _row_version -> row_version for
+    # model validation, and drop is_deleted (readonly in API).
+    target = dict(current)
+    target['row_version'] = target.pop('_row_version')
+    target.pop('is_deleted', None)
+
+    patched = json_patch.apply_patch(target, operations, READONLY_PATHS)
+
+    try:
+        entry = models.OperationLog.model_validate(patched)
+    except pydantic.ValidationError as e:
+        LOGGER.warning('Validation error patching opslog entry: %s', e)
+        raise fastapi.HTTPException(
+            status_code=400,
+            detail=f'Validation error: {e.errors()}',
+        ) from e
+
+    # Preserve identity; bump version; keep tombstone false.
+    entry.id = entry_id
+    entry.occurred_at = current['occurred_at']
+    entry.recorded_at = current['recorded_at']
+    entry.recorded_by = current['recorded_by']
+    entry.project_id = current['project_id']
+    entry.row_version = int(current['_row_version']) + 1
+    entry.is_deleted = False
+
+    await _insert_row(_model_to_row(entry))
+    return _row_to_response(entry.model_dump(mode='json'))

--- a/src/imbi_api/endpoints/operations_log.py
+++ b/src/imbi_api/endpoints/operations_log.py
@@ -373,3 +373,29 @@ async def patch_operation_log(
 
     await _insert_row(_model_to_row(entry))
     return _row_to_response(entry.model_dump(mode='json'))
+
+
+@operations_log_router.delete('/{entry_id}', status_code=204)
+async def delete_operation_log(
+    entry_id: str,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('operations_log:delete'),
+        ),
+    ],
+) -> fastapi.Response:
+    """Soft-delete an operations log entry (tombstone insert)."""
+    current = await _fetch_current(entry_id)
+    if current is None:
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail=f'Operations log entry {entry_id!r} not found',
+        )
+
+    tombstone = dict(current)
+    tombstone['_row_version'] = int(current['_row_version']) + 1
+    tombstone['is_deleted'] = 1
+
+    await _insert_row(tombstone)
+    return fastapi.Response(status_code=204)

--- a/src/imbi_api/endpoints/operations_log.py
+++ b/src/imbi_api/endpoints/operations_log.py
@@ -16,8 +16,11 @@ import base64
 import datetime
 import logging
 import typing
+import urllib.parse
 
 import fastapi
+import fastapi.encoders
+import fastapi.responses
 import nanoid
 import pydantic
 from imbi_common import clickhouse, models
@@ -167,6 +170,139 @@ async def _fetch_current(
     """Fetch the current (non-deleted) row for an entry id."""
     rows = await clickhouse.query(_SINGLE_ENTRY_SQL, {'id': entry_id})
     return rows[0] if rows else None
+
+
+_FILTER_FIELDS: tuple[tuple[str, str], ...] = (
+    ('project_id', 'String'),
+    ('project_slug', 'String'),
+    ('environment_slug', 'String'),
+    ('entry_type', 'String'),
+    ('ticket_slug', 'String'),
+    ('performed_by', 'String'),
+)
+
+
+def _parse_iso(value: str, field_name: str) -> datetime.datetime:
+    try:
+        parsed = datetime.datetime.fromisoformat(value)
+    except ValueError as err:
+        raise fastapi.HTTPException(
+            status_code=400,
+            detail=f'Invalid ISO timestamp for {field_name!r}',
+        ) from err
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=datetime.UTC)
+    return parsed.astimezone(datetime.UTC)
+
+
+def _build_link_header(
+    request: fastapi.Request,
+    next_cursor: str | None,
+) -> str:
+    url = request.url
+    base_params = {
+        k: v for k, v in request.query_params.multi_items() if k != 'cursor'
+    }
+
+    def _url_with(params: dict[str, str]) -> str:
+        scheme_host_path = f'{url.scheme}://{url.netloc}{url.path}'
+        if not params:
+            return scheme_host_path
+        return f'{scheme_host_path}?{urllib.parse.urlencode(params)}'
+
+    links = [f'<{_url_with(base_params)}>; rel="first"']
+    if next_cursor is not None:
+        next_params = dict(base_params)
+        next_params['cursor'] = next_cursor
+        links.append(f'<{_url_with(next_params)}>; rel="next"')
+    return ', '.join(links)
+
+
+@operations_log_router.get('/')
+async def list_operation_logs(
+    request: fastapi.Request,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('operations_log:read'),
+        ),
+    ],
+    limit: int = DEFAULT_LIMIT,
+    cursor: str | None = None,
+    project_id: str | None = None,
+    project_slug: str | None = None,
+    environment_slug: str | None = None,
+    entry_type: str | None = None,
+    ticket_slug: str | None = None,
+    performed_by: str | None = None,
+    since: str | None = None,
+    until: str | None = None,
+) -> fastapi.Response:
+    """List operations log entries (newest first, keyset paginated)."""
+    if limit < 1 or limit > MAX_LIMIT:
+        raise fastapi.HTTPException(
+            status_code=400,
+            detail=f'limit must be 1..{MAX_LIMIT}',
+        )
+
+    clauses: list[str] = ['is_deleted = 0']
+    params: dict[str, typing.Any] = {}
+
+    filters: dict[str, str | None] = {
+        'project_id': project_id,
+        'project_slug': project_slug,
+        'environment_slug': environment_slug,
+        'entry_type': entry_type,
+        'ticket_slug': ticket_slug,
+        'performed_by': performed_by,
+    }
+    for field, ch_type in _FILTER_FIELDS:
+        value = filters.get(field)
+        if value is not None:
+            clauses.append(f'{field} = {{{field}:{ch_type}}}')
+            params[field] = value
+
+    if since is not None:
+        params['since'] = _parse_iso(since, 'since')
+        clauses.append('occurred_at >= {since:DateTime64(3)}')
+    if until is not None:
+        params['until'] = _parse_iso(until, 'until')
+        clauses.append('occurred_at < {until:DateTime64(3)}')
+
+    if cursor is not None:
+        decoded = _decode_cursor(cursor)
+        if decoded is None:
+            raise fastapi.HTTPException(
+                status_code=400, detail='Invalid cursor'
+            )
+        cursor_ts, cursor_id = decoded
+        params['cursor_ts'] = cursor_ts
+        params['cursor_id'] = cursor_id
+        clauses.append(
+            '(occurred_at, id) < '
+            '({cursor_ts:DateTime64(3)}, {cursor_id:String})'
+        )
+
+    where = ' AND '.join(clauses)
+    sql: str = (
+        'SELECT * FROM operations_log FINAL WHERE '  # noqa: S608
+        + where
+        + f' ORDER BY occurred_at DESC, id DESC LIMIT {limit + 1}'
+    )
+
+    rows = await clickhouse.query(sql, params)
+    next_cursor: str | None = None
+    if len(rows) > limit:
+        rows.pop()
+        last = rows[-1]
+        next_cursor = _encode_cursor(last['occurred_at'], last['id'])
+
+    body = [_row_to_response(r) for r in rows]
+    response = fastapi.responses.JSONResponse(
+        fastapi.encoders.jsonable_encoder(body)
+    )
+    response.headers['Link'] = _build_link_header(request, next_cursor)
+    return response
 
 
 @operations_log_router.get('/{entry_id}')

--- a/src/imbi_api/endpoints/operations_log.py
+++ b/src/imbi_api/endpoints/operations_log.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import base64
 import datetime
 import logging
+import threading
 import typing
 import urllib.parse
 
@@ -176,17 +177,28 @@ async def _fetch_current(
     return rows[0] if rows else None
 
 
+_row_version_lock = threading.Lock()
+_row_version_last: int = 0
+
+
 def _next_row_version(current_version: int) -> int:
     """Return a strictly-increasing ``_row_version`` value.
 
     ClickHouse ``ReplacingMergeTree`` requires the version column to
     strictly increase per key to guarantee deterministic last-write-wins
-    replacement. Concurrent writers that both compute ``current + 1``
-    would collide, so we use millisecond-precision wall time and fall
-    back to ``current + 1`` if the clock somehow doesn't advance.
+    replacement. We combine millisecond-precision wall time with a
+    process-wide monotonic guard so two concurrent writers observing the
+    same ``current_version`` in the same millisecond still produce
+    distinct, strictly-increasing versions; the result is also kept
+    greater than ``current_version`` to remain safe against any
+    older/current values already in ClickHouse.
     """
+    global _row_version_last
     now_ms = int(datetime.datetime.now(datetime.UTC).timestamp() * 1000)
-    return max(now_ms, current_version + 1)
+    with _row_version_lock:
+        candidate = max(now_ms, _row_version_last + 1, current_version + 1)
+        _row_version_last = candidate
+        return candidate
 
 
 _FILTER_FIELDS: tuple[str, ...] = (

--- a/src/imbi_api/endpoints/operations_log.py
+++ b/src/imbi_api/endpoints/operations_log.py
@@ -145,7 +145,10 @@ async def create_operation_log(
             **payload,
         )
     except pydantic.ValidationError as e:
-        LOGGER.warning('Validation error creating opslog entry: %s', e)
+        LOGGER.warning(
+            'Validation error creating opslog entry on fields=%s',
+            [tuple(err['loc']) for err in e.errors()],
+        )
         raise fastapi.HTTPException(
             status_code=400,
             detail=f'Validation error: {e.errors()}',
@@ -171,6 +174,19 @@ async def _fetch_current(
     """Fetch the current (non-deleted) row for an entry id."""
     rows = await clickhouse.query(_SINGLE_ENTRY_SQL, {'id': entry_id})
     return rows[0] if rows else None
+
+
+def _next_row_version(current_version: int) -> int:
+    """Return a strictly-increasing ``_row_version`` value.
+
+    ClickHouse ``ReplacingMergeTree`` requires the version column to
+    strictly increase per key to guarantee deterministic last-write-wins
+    replacement. Concurrent writers that both compute ``current + 1``
+    would collide, so we use millisecond-precision wall time and fall
+    back to ``current + 1`` if the clock somehow doesn't advance.
+    """
+    now_ms = int(datetime.datetime.now(datetime.UTC).timestamp() * 1000)
+    return max(now_ms, current_version + 1)
 
 
 _FILTER_FIELDS: tuple[str, ...] = (
@@ -422,7 +438,10 @@ async def patch_operation_log(
     try:
         entry = models.OperationLog.model_validate(patched)
     except pydantic.ValidationError as e:
-        LOGGER.warning('Validation error patching opslog entry: %s', e)
+        LOGGER.warning(
+            'Validation error patching opslog entry on fields=%s',
+            [tuple(err['loc']) for err in e.errors()],
+        )
         raise fastapi.HTTPException(
             status_code=400,
             detail=f'Validation error: {e.errors()}',
@@ -433,7 +452,7 @@ async def patch_operation_log(
     entry.recorded_at = current['recorded_at']
     entry.recorded_by = current['recorded_by']
     entry.project_id = current['project_id']
-    entry.row_version = int(current['_row_version']) + 1
+    entry.row_version = _next_row_version(int(current['_row_version']))
     entry.is_deleted = False
 
     row = _model_to_row(entry)
@@ -460,7 +479,7 @@ async def delete_operation_log(
         )
 
     tombstone = dict(current)
-    tombstone['_row_version'] = int(current['_row_version']) + 1
+    tombstone['_row_version'] = _next_row_version(int(current['_row_version']))
     tombstone['is_deleted'] = 1
 
     await _insert_row(tombstone)

--- a/src/imbi_api/endpoints/operations_log.py
+++ b/src/imbi_api/endpoints/operations_log.py
@@ -14,8 +14,17 @@ from __future__ import annotations
 
 import base64
 import datetime
+import logging
+import typing
 
 import fastapi
+import nanoid
+import pydantic
+from imbi_common import clickhouse, models
+
+from imbi_api.auth import permissions
+
+LOGGER = logging.getLogger(__name__)
 
 operations_log_router = fastapi.APIRouter(
     prefix='/operations-log', tags=['Operations Log']
@@ -66,3 +75,81 @@ def _decode_cursor(
     except ValueError:
         return None
     return ts, entry_id
+
+
+def _row_to_response(row: dict[str, typing.Any]) -> dict[str, typing.Any]:
+    """Strip internal bookkeeping columns before returning to the client."""
+    return {
+        k: v
+        for k, v in row.items()
+        if k not in {'_row_version', 'row_version', 'is_deleted'}
+    }
+
+
+def _model_to_row(entry: models.OperationLog) -> dict[str, typing.Any]:
+    """Build the ClickHouse row dict from a validated model.
+
+    Uses by_alias=True so the ``_row_version`` column name is emitted
+    instead of the Python field name ``row_version``. ``is_deleted`` is
+    coerced to UInt8 (0/1) for the ClickHouse UInt8 column.
+    """
+    dumped = entry.model_dump(by_alias=True, mode='python')
+    dumped['is_deleted'] = 1 if entry.is_deleted else 0
+    return dumped
+
+
+async def _insert_row(row: dict[str, typing.Any]) -> None:
+    """Insert a single row into operations_log.
+
+    Calls the class method directly with explicit column names/values
+    because the module-level ``clickhouse.insert`` wrapper only accepts
+    pydantic models and loses the alias during serialization.
+    """
+    await clickhouse.client.Clickhouse.get_instance().insert(
+        'operations_log',
+        [list(row.values())],
+        list(row.keys()),
+    )
+
+
+@operations_log_router.post('/', status_code=201)
+async def create_operation_log(
+    data: dict[str, typing.Any],
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('operations_log:create'),
+        ),
+    ],
+) -> dict[str, typing.Any]:
+    """Create a new operations log entry."""
+    payload = dict(data)
+    for server_field in (
+        'id',
+        'recorded_at',
+        'recorded_by',
+        '_row_version',
+        'row_version',
+        'is_deleted',
+    ):
+        payload.pop(server_field, None)
+
+    try:
+        entry = models.OperationLog(
+            id=nanoid.generate(),
+            recorded_at=datetime.datetime.now(datetime.UTC),
+            recorded_by=auth.principal_name,
+            **payload,
+        )
+    except pydantic.ValidationError as e:
+        LOGGER.warning('Validation error creating opslog entry: %s', e)
+        raise fastapi.HTTPException(
+            status_code=400,
+            detail=f'Validation error: {e.errors()}',
+        ) from e
+
+    if entry.performed_by is None:
+        entry.performed_by = entry.recorded_by
+
+    await _insert_row(_model_to_row(entry))
+    return _row_to_response(entry.model_dump(mode='json'))

--- a/src/imbi_api/endpoints/operations_log.py
+++ b/src/imbi_api/endpoints/operations_log.py
@@ -1,0 +1,68 @@
+"""Operations log CRUD endpoints.
+
+Writes and the non-project-scoped reads are on the top-level
+``operations_log_router``. The project-scoped collection GET lives on
+``operations_log_project_router``, which is mounted under
+``/organizations/{org_slug}/projects/{project_id}``.
+
+All reads use ``FINAL`` plus ``WHERE is_deleted = 0`` so that the
+``ReplacingMergeTree`` dedupes to the latest version and tombstones
+are hidden.
+"""
+
+from __future__ import annotations
+
+import base64
+import datetime
+
+import fastapi
+
+operations_log_router = fastapi.APIRouter(
+    prefix='/operations-log', tags=['Operations Log']
+)
+operations_log_project_router = fastapi.APIRouter(tags=['Operations Log'])
+
+READONLY_PATHS: frozenset[str] = frozenset(
+    [
+        '/id',
+        '/project_id',
+        '/occurred_at',
+        '/recorded_at',
+        '/recorded_by',
+        '/_row_version',
+        '/row_version',
+        '/is_deleted',
+    ]
+)
+
+DEFAULT_LIMIT: int = 50
+MAX_LIMIT: int = 500
+
+
+def _encode_cursor(occurred_at: datetime.datetime, entry_id: str) -> str:
+    """Encode a (timestamp, id) cursor as urlsafe base64."""
+    payload = f'{occurred_at.isoformat()}|{entry_id}'.encode()
+    return base64.urlsafe_b64encode(payload).rstrip(b'=').decode('ascii')
+
+
+def _decode_cursor(
+    cursor: str,
+) -> tuple[datetime.datetime, str] | None:
+    """Decode a cursor string. Return None for any malformed input."""
+    if not cursor:
+        return None
+    padding = '=' * (-len(cursor) % 4)
+    try:
+        raw = base64.urlsafe_b64decode(cursor + padding).decode('utf-8')
+    except (ValueError, UnicodeDecodeError):
+        return None
+    if '|' not in raw:
+        return None
+    ts_str, _, entry_id = raw.partition('|')
+    if not entry_id:
+        return None
+    try:
+        ts = datetime.datetime.fromisoformat(ts_str)
+    except ValueError:
+        return None
+    return ts, entry_id

--- a/src/imbi_api/endpoints/operations_log.py
+++ b/src/imbi_api/endpoints/operations_log.py
@@ -219,27 +219,22 @@ def _build_link_header(
     return ', '.join(links)
 
 
-@operations_log_router.get('/')
-async def list_operation_logs(
+async def _list_impl(
+    *,
     request: fastapi.Request,
-    auth: typing.Annotated[
-        permissions.AuthContext,
-        fastapi.Depends(
-            permissions.require_permission('operations_log:read'),
-        ),
-    ],
     limit: int = DEFAULT_LIMIT,
     cursor: str | None = None,
-    project_id: str | None = None,
-    project_slug: str | None = None,
-    environment_slug: str | None = None,
-    entry_type: str | None = None,
-    ticket_slug: str | None = None,
-    performed_by: str | None = None,
+    forced_filters: dict[str, str] | None = None,
+    query_filters: dict[str, str | None] | None = None,
     since: str | None = None,
     until: str | None = None,
 ) -> fastapi.Response:
-    """List operations log entries (newest first, keyset paginated)."""
+    """Core implementation for listing operations log entries.
+
+    ``forced_filters`` are applied unconditionally (e.g. project_id from the
+    URL path). ``query_filters`` come from query-string parameters and are
+    applied only when non-None.
+    """
     if limit < 1 or limit > MAX_LIMIT:
         raise fastapi.HTTPException(
             status_code=400,
@@ -249,19 +244,16 @@ async def list_operation_logs(
     clauses: list[str] = ['is_deleted = 0']
     params: dict[str, typing.Any] = {}
 
-    filters: dict[str, str | None] = {
-        'project_id': project_id,
-        'project_slug': project_slug,
-        'environment_slug': environment_slug,
-        'entry_type': entry_type,
-        'ticket_slug': ticket_slug,
-        'performed_by': performed_by,
-    }
+    # Forced filters win; merge them first.
+    all_filters: dict[str, str | None] = dict(query_filters or {})
+    for key, value in (forced_filters or {}).items():
+        all_filters[key] = value
+
     for field, ch_type in _FILTER_FIELDS:
-        value = filters.get(field)
-        if value is not None:
+        filter_value = all_filters.get(field)
+        if filter_value is not None:
             clauses.append(f'{field} = {{{field}:{ch_type}}}')
-            params[field] = value
+            params[field] = filter_value
 
     if since is not None:
         params['since'] = _parse_iso(since, 'since')
@@ -304,6 +296,82 @@ async def list_operation_logs(
     )
     response.headers['Link'] = _build_link_header(request, next_cursor)
     return response
+
+
+@operations_log_router.get('/')
+async def list_operation_logs(
+    request: fastapi.Request,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('operations_log:read'),
+        ),
+    ],
+    limit: int = DEFAULT_LIMIT,
+    cursor: str | None = None,
+    project_id: str | None = None,
+    project_slug: str | None = None,
+    environment_slug: str | None = None,
+    entry_type: str | None = None,
+    ticket_slug: str | None = None,
+    performed_by: str | None = None,
+    since: str | None = None,
+    until: str | None = None,
+) -> fastapi.Response:
+    """List operations log entries (newest first, keyset paginated)."""
+    return await _list_impl(
+        request=request,
+        limit=limit,
+        cursor=cursor,
+        query_filters={
+            'project_id': project_id,
+            'project_slug': project_slug,
+            'environment_slug': environment_slug,
+            'entry_type': entry_type,
+            'ticket_slug': ticket_slug,
+            'performed_by': performed_by,
+        },
+        since=since,
+        until=until,
+    )
+
+
+@operations_log_project_router.get('/')
+async def list_project_operation_logs(
+    request: fastapi.Request,
+    org_slug: str,
+    project_id: str,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('operations_log:read'),
+        ),
+    ],
+    limit: int = DEFAULT_LIMIT,
+    cursor: str | None = None,
+    environment_slug: str | None = None,
+    entry_type: str | None = None,
+    ticket_slug: str | None = None,
+    performed_by: str | None = None,
+    since: str | None = None,
+    until: str | None = None,
+) -> fastapi.Response:
+    """List operations log entries for a specific project."""
+    del org_slug  # only used for URL scoping; not a filter column
+    return await _list_impl(
+        request=request,
+        limit=limit,
+        cursor=cursor,
+        forced_filters={'project_id': project_id},
+        query_filters={
+            'environment_slug': environment_slug,
+            'entry_type': entry_type,
+            'ticket_slug': ticket_slug,
+            'performed_by': performed_by,
+        },
+        since=since,
+        until=until,
+    )
 
 
 @operations_log_router.get('/{entry_id}')

--- a/src/imbi_api/endpoints/organizations.py
+++ b/src/imbi_api/endpoints/organizations.py
@@ -15,6 +15,7 @@ from imbi_api.relationships import relationship_link
 
 from .environments import environments_router
 from .link_definitions import link_definitions_router
+from .operations_log import operations_log_project_router
 from .project_types import project_types_router
 from .projects import projects_router
 from .teams import teams_router
@@ -54,6 +55,10 @@ organizations_router.include_router(
 organizations_router.include_router(
     webhooks_router,
     prefix='/{org_slug}/webhooks',
+)
+organizations_router.include_router(
+    operations_log_project_router,
+    prefix='/{org_slug}/projects/{project_id}/operations-log',
 )
 organizations_router.include_router(
     project_services_router,

--- a/tests/auth/test_seed.py
+++ b/tests/auth/test_seed.py
@@ -330,3 +330,13 @@ class CheckIfSeededTestCase(unittest.IsolatedAsyncioTestCase):
         is_seeded = await seed.check_if_seeded(mock_db)
 
         self.assertFalse(is_seeded)
+
+
+class StandardPermissionsTests(unittest.TestCase):
+    """Tests for the STANDARD_PERMISSIONS catalogue."""
+
+    def test_operations_log_permissions_present(self) -> None:
+        slugs = {perm[0] for perm in seed.STANDARD_PERMISSIONS}
+        for action in ('create', 'read', 'update', 'delete'):
+            with self.subTest(action=action):
+                self.assertIn(f'operations_log:{action}', slugs)

--- a/tests/endpoints/test_operations_log.py
+++ b/tests/endpoints/test_operations_log.py
@@ -498,6 +498,44 @@ class PatchOperationLogTests(_OpsLogTestBase):
         self.assertEqual(response.status_code, 403)
 
 
+class ProjectScopedListTests(_OpsLogTestBase):
+    def test_project_scoped_forces_project_id(self) -> None:
+        row = _sample_row(project_id='proj-xyz')
+        self.mock_query.return_value = [row]
+        # Client-supplied ?project_id= is ignored; path wins.
+        response = self.client.get(
+            '/organizations/engineering/projects/proj-xyz/operations-log/'
+            '?project_id=hacker-attempt'
+        )
+        self.assertEqual(response.status_code, 200)
+        _sql, params = self.mock_query.await_args.args
+        self.assertEqual(params['project_id'], 'proj-xyz')
+
+    def test_project_scoped_has_link_headers(self) -> None:
+        self.mock_query.return_value = [_sample_row()]
+        response = self.client.get(
+            '/organizations/engineering/projects/proj-xyz/operations-log/'
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('rel="first"', response.headers['Link'])
+
+    def test_project_scoped_forbidden_without_permission(self) -> None:
+        self.auth_context.user = api_models.User(
+            email='bob@example.com',
+            display_name='Bob',
+            password_hash='$argon2id$hash',
+            is_active=True,
+            is_admin=False,
+            is_service_account=False,
+            created_at=datetime.datetime.now(datetime.UTC),
+        )
+        self.auth_context.permissions = set()
+        response = self.client.get(
+            '/organizations/engineering/projects/proj-xyz/operations-log/'
+        )
+        self.assertEqual(response.status_code, 403)
+
+
 class DeleteOperationLogTests(_OpsLogTestBase):
     def test_delete_204(self) -> None:
         self.mock_query.return_value = [_sample_row()]

--- a/tests/endpoints/test_operations_log.py
+++ b/tests/endpoints/test_operations_log.py
@@ -1,0 +1,34 @@
+"""Tests for operations log endpoints."""
+
+import datetime
+import unittest
+
+from imbi_api.endpoints import operations_log
+
+
+class CursorCodecTests(unittest.TestCase):
+    def test_round_trip(self) -> None:
+        ts = datetime.datetime(
+            2026, 4, 17, 14, 22, 31, 412000, tzinfo=datetime.UTC
+        )
+        entry_id = 'V1StGXR8_Z5jdHi6B-myT'
+        encoded = operations_log._encode_cursor(ts, entry_id)
+        self.assertIsInstance(encoded, str)
+        decoded = operations_log._decode_cursor(encoded)
+        self.assertIsNotNone(decoded)
+        assert decoded is not None
+        decoded_ts, decoded_id = decoded
+        self.assertEqual(decoded_ts, ts)
+        self.assertEqual(decoded_id, entry_id)
+
+    def test_decode_malformed_returns_none(self) -> None:
+        self.assertIsNone(operations_log._decode_cursor('!!!not-base64!!!'))
+
+    def test_decode_wrong_format_returns_none(self) -> None:
+        import base64
+
+        payload = base64.urlsafe_b64encode(b'missing-separator').decode()
+        self.assertIsNone(operations_log._decode_cursor(payload))
+
+    def test_decode_empty_string_returns_none(self) -> None:
+        self.assertIsNone(operations_log._decode_cursor(''))

--- a/tests/endpoints/test_operations_log.py
+++ b/tests/endpoints/test_operations_log.py
@@ -106,7 +106,9 @@ class _OpsLogTestBase(unittest.IsolatedAsyncioTestCase):
         """Swap the auth context to a non-admin user with no permissions.
 
         Admin users bypass ``require_permission``, so tests that exercise
-        403 responses need a regular user.
+        403 responses need a regular user. The existing ``_current_user``
+        override closes over ``self`` and picks up the new context on
+        its next call.
         """
         self.auth_context = api_permissions.AuthContext(
             user=api_models.User(
@@ -122,13 +124,6 @@ class _OpsLogTestBase(unittest.IsolatedAsyncioTestCase):
             auth_method='jwt',
             permissions=set(),
         )
-
-        async def _current_user() -> api_permissions.AuthContext:
-            return self.auth_context
-
-        self.test_app.dependency_overrides[
-            api_permissions.get_current_user
-        ] = _current_user
 
 
 class CursorCodecTests(unittest.TestCase):
@@ -390,7 +385,7 @@ class PatchOperationLogTests(_OpsLogTestBase):
         self._setup_existing()
         response = self.client.patch(
             '/operations-log/entry-abc',
-            json=[{'op': 'replace', 'path': '/_row_version', 'value': 99}],
+            json=[{'op': 'replace', 'path': '/row_version', 'value': 99}],
         )
         self.assertEqual(response.status_code, 400)
 

--- a/tests/endpoints/test_operations_log.py
+++ b/tests/endpoints/test_operations_log.py
@@ -395,6 +395,7 @@ class PatchOperationLogTests(_OpsLogTestBase):
         self.assertEqual(body['description'], 'Rolled out v2.4.1')
         self.mock_insert.assert_awaited_once()
         # Check that the insert carried a bumped _row_version
+        assert self.mock_insert.await_args is not None
         args, _kwargs = self.mock_insert.await_args
         # args = (table, values, column_names)
         column_names = args[2]
@@ -542,6 +543,7 @@ class DeleteOperationLogTests(_OpsLogTestBase):
         response = self.client.delete('/operations-log/entry-abc')
         self.assertEqual(response.status_code, 204)
         self.mock_insert.assert_awaited_once()
+        assert self.mock_insert.await_args is not None
         args, _kwargs = self.mock_insert.await_args
         column_names = args[2]
         values = args[1][0]

--- a/tests/endpoints/test_operations_log.py
+++ b/tests/endpoints/test_operations_log.py
@@ -356,7 +356,7 @@ class PatchOperationLogTests(_OpsLogTestBase):
         column_names = args[2]
         values = args[1][0]
         columns = dict(zip(column_names, values, strict=True))
-        self.assertEqual(columns['_row_version'], 2)
+        self.assertGreater(columns['_row_version'], 1)
         self.assertEqual(columns['id'], 'entry-abc')
 
     def test_patch_readonly_id_is_400(self) -> None:
@@ -474,7 +474,7 @@ class DeleteOperationLogTests(_OpsLogTestBase):
         row = dict(zip(column_names, values, strict=True))
         self.assertEqual(row['id'], 'entry-abc')
         self.assertEqual(row['is_deleted'], 1)
-        self.assertEqual(row['_row_version'], 2)
+        self.assertGreater(row['_row_version'], 1)
 
     def test_delete_idempotent_after_tombstone(self) -> None:
         # First delete: row exists.

--- a/tests/endpoints/test_operations_log.py
+++ b/tests/endpoints/test_operations_log.py
@@ -102,6 +102,34 @@ class _OpsLogTestBase(unittest.IsolatedAsyncioTestCase):
         self.addCleanup(self.insert_patcher.stop)
         self.addCleanup(self.query_patcher.stop)
 
+    def _revoke_permissions(self) -> None:
+        """Swap the auth context to a non-admin user with no permissions.
+
+        Admin users bypass ``require_permission``, so tests that exercise
+        403 responses need a regular user.
+        """
+        self.auth_context = api_permissions.AuthContext(
+            user=api_models.User(
+                email='bob@example.com',
+                display_name='Bob',
+                password_hash='$argon2id$hash',
+                is_active=True,
+                is_admin=False,
+                is_service_account=False,
+                created_at=datetime.datetime.now(datetime.UTC),
+            ),
+            session_id='test-session',
+            auth_method='jwt',
+            permissions=set(),
+        )
+
+        async def _current_user() -> api_permissions.AuthContext:
+            return self.auth_context
+
+        self.test_app.dependency_overrides[
+            api_permissions.get_current_user
+        ] = _current_user
+
 
 class CursorCodecTests(unittest.TestCase):
     def test_round_trip(self) -> None:
@@ -173,29 +201,7 @@ class PostOperationLogTests(_OpsLogTestBase):
         self.assertEqual(response.status_code, 400)
 
     def test_create_forbidden_without_permission(self) -> None:
-        non_admin = api_models.User(
-            email='bob@example.com',
-            display_name='Bob',
-            password_hash='$argon2id$hash',
-            is_active=True,
-            is_admin=False,
-            is_service_account=False,
-            created_at=datetime.datetime.now(datetime.UTC),
-        )
-        self.auth_context = api_permissions.AuthContext(
-            user=non_admin,
-            session_id='test-session',
-            auth_method='jwt',
-            permissions=set(),
-        )
-
-        async def _current_user() -> api_permissions.AuthContext:
-            return self.auth_context
-
-        self.test_app.dependency_overrides[
-            api_permissions.get_current_user
-        ] = _current_user
-
+        self._revoke_permissions()
         response = self.client.post(
             '/operations-log/', json=self._valid_body()
         )
@@ -225,29 +231,7 @@ class GetSingleEntryTests(_OpsLogTestBase):
         self.assertEqual(response.status_code, 404)
 
     def test_get_forbidden_without_permission(self) -> None:
-        non_admin = api_models.User(
-            email='bob@example.com',
-            display_name='Bob',
-            password_hash='$argon2id$hash',
-            is_active=True,
-            is_admin=False,
-            is_service_account=False,
-            created_at=datetime.datetime.now(datetime.UTC),
-        )
-        self.auth_context = api_permissions.AuthContext(
-            user=non_admin,
-            session_id='test-session',
-            auth_method='jwt',
-            permissions=set(),
-        )
-
-        async def _current_user() -> api_permissions.AuthContext:
-            return self.auth_context
-
-        self.test_app.dependency_overrides[
-            api_permissions.get_current_user
-        ] = _current_user
-
+        self._revoke_permissions()
         response = self.client.get('/operations-log/entry-abc')
         self.assertEqual(response.status_code, 403)
         self.mock_query.assert_not_awaited()
@@ -342,29 +326,7 @@ class ListEntriesTests(_OpsLogTestBase):
         self.assertEqual(response.status_code, 400)
 
     def test_list_forbidden_without_permission(self) -> None:
-        non_admin = api_models.User(
-            email='bob@example.com',
-            display_name='Bob',
-            password_hash='$argon2id$hash',
-            is_active=True,
-            is_admin=False,
-            is_service_account=False,
-            created_at=datetime.datetime.now(datetime.UTC),
-        )
-        self.auth_context = api_permissions.AuthContext(
-            user=non_admin,
-            session_id='test-session',
-            auth_method='jwt',
-            permissions=set(),
-        )
-
-        async def _current_user() -> api_permissions.AuthContext:
-            return self.auth_context
-
-        self.test_app.dependency_overrides[
-            api_permissions.get_current_user
-        ] = _current_user
-
+        self._revoke_permissions()
         response = self.client.get('/operations-log/')
         self.assertEqual(response.status_code, 403)
         self.mock_query.assert_not_awaited()
@@ -394,10 +356,8 @@ class PatchOperationLogTests(_OpsLogTestBase):
         body = response.json()
         self.assertEqual(body['description'], 'Rolled out v2.4.1')
         self.mock_insert.assert_awaited_once()
-        # Check that the insert carried a bumped _row_version
         assert self.mock_insert.await_args is not None
         args, _kwargs = self.mock_insert.await_args
-        # args = (table, values, column_names)
         column_names = args[2]
         values = args[1][0]
         columns = dict(zip(column_names, values, strict=True))
@@ -463,29 +423,7 @@ class PatchOperationLogTests(_OpsLogTestBase):
         self.assertEqual(response.status_code, 404)
 
     def test_patch_forbidden_without_permission(self) -> None:
-        non_admin = api_models.User(
-            email='bob@example.com',
-            display_name='Bob',
-            password_hash='$argon2id$hash',
-            is_active=True,
-            is_admin=False,
-            is_service_account=False,
-            created_at=datetime.datetime.now(datetime.UTC),
-        )
-        self.auth_context = api_permissions.AuthContext(
-            user=non_admin,
-            session_id='test-session',
-            auth_method='jwt',
-            permissions=set(),
-        )
-
-        async def _current_user() -> api_permissions.AuthContext:
-            return self.auth_context
-
-        self.test_app.dependency_overrides[
-            api_permissions.get_current_user
-        ] = _current_user
-
+        self._revoke_permissions()
         response = self.client.patch(
             '/operations-log/entry-abc',
             json=[
@@ -521,16 +459,7 @@ class ProjectScopedListTests(_OpsLogTestBase):
         self.assertIn('rel="first"', response.headers['Link'])
 
     def test_project_scoped_forbidden_without_permission(self) -> None:
-        self.auth_context.user = api_models.User(
-            email='bob@example.com',
-            display_name='Bob',
-            password_hash='$argon2id$hash',
-            is_active=True,
-            is_admin=False,
-            is_service_account=False,
-            created_at=datetime.datetime.now(datetime.UTC),
-        )
-        self.auth_context.permissions = set()
+        self._revoke_permissions()
         response = self.client.get(
             '/organizations/engineering/projects/proj-xyz/operations-log/'
         )
@@ -569,28 +498,6 @@ class DeleteOperationLogTests(_OpsLogTestBase):
         self.assertEqual(response.status_code, 404)
 
     def test_delete_forbidden_without_permission(self) -> None:
-        non_admin = api_models.User(
-            email='bob@example.com',
-            display_name='Bob',
-            password_hash='$argon2id$hash',
-            is_active=True,
-            is_admin=False,
-            is_service_account=False,
-            created_at=datetime.datetime.now(datetime.UTC),
-        )
-        self.auth_context = api_permissions.AuthContext(
-            user=non_admin,
-            session_id='test-session',
-            auth_method='jwt',
-            permissions=set(),
-        )
-
-        async def _current_user() -> api_permissions.AuthContext:
-            return self.auth_context
-
-        self.test_app.dependency_overrides[
-            api_permissions.get_current_user
-        ] = _current_user
-
+        self._revoke_permissions()
         response = self.client.delete('/operations-log/entry-abc')
         self.assertEqual(response.status_code, 403)

--- a/tests/endpoints/test_operations_log.py
+++ b/tests/endpoints/test_operations_log.py
@@ -201,3 +201,53 @@ class PostOperationLogTests(_OpsLogTestBase):
         )
         self.assertEqual(response.status_code, 403)
         self.mock_insert.assert_not_awaited()
+
+
+class GetSingleEntryTests(_OpsLogTestBase):
+    def test_get_returns_200(self) -> None:
+        self.mock_query.return_value = [_sample_row()]
+
+        response = self.client.get('/operations-log/entry-abc')
+        self.assertEqual(response.status_code, 200)
+        body = response.json()
+        self.assertEqual(body['id'], 'entry-abc')
+        self.assertEqual(body['entry_type'], 'Deployed')
+        self.assertNotIn('_row_version', body)
+        self.assertNotIn('is_deleted', body)
+        self.mock_query.assert_awaited_once()
+        sent_sql = self.mock_query.await_args.args[0]
+        self.assertIn('FINAL', sent_sql)
+        self.assertIn('is_deleted = 0', sent_sql)
+
+    def test_get_not_found(self) -> None:
+        self.mock_query.return_value = []
+        response = self.client.get('/operations-log/missing-id')
+        self.assertEqual(response.status_code, 404)
+
+    def test_get_forbidden_without_permission(self) -> None:
+        non_admin = api_models.User(
+            email='bob@example.com',
+            display_name='Bob',
+            password_hash='$argon2id$hash',
+            is_active=True,
+            is_admin=False,
+            is_service_account=False,
+            created_at=datetime.datetime.now(datetime.UTC),
+        )
+        self.auth_context = api_permissions.AuthContext(
+            user=non_admin,
+            session_id='test-session',
+            auth_method='jwt',
+            permissions=set(),
+        )
+
+        async def _current_user() -> api_permissions.AuthContext:
+            return self.auth_context
+
+        self.test_app.dependency_overrides[
+            api_permissions.get_current_user
+        ] = _current_user
+
+        response = self.client.get('/operations-log/entry-abc')
+        self.assertEqual(response.status_code, 403)
+        self.mock_query.assert_not_awaited()

--- a/tests/endpoints/test_operations_log.py
+++ b/tests/endpoints/test_operations_log.py
@@ -496,3 +496,61 @@ class PatchOperationLogTests(_OpsLogTestBase):
             ],
         )
         self.assertEqual(response.status_code, 403)
+
+
+class DeleteOperationLogTests(_OpsLogTestBase):
+    def test_delete_204(self) -> None:
+        self.mock_query.return_value = [_sample_row()]
+        response = self.client.delete('/operations-log/entry-abc')
+        self.assertEqual(response.status_code, 204)
+        self.mock_insert.assert_awaited_once()
+        args, _kwargs = self.mock_insert.await_args
+        column_names = args[2]
+        values = args[1][0]
+        row = dict(zip(column_names, values, strict=True))
+        self.assertEqual(row['id'], 'entry-abc')
+        self.assertEqual(row['is_deleted'], 1)
+        self.assertEqual(row['_row_version'], 2)
+
+    def test_delete_idempotent_after_tombstone(self) -> None:
+        # First delete: row exists.
+        self.mock_query.return_value = [_sample_row()]
+        first = self.client.delete('/operations-log/entry-abc')
+        self.assertEqual(first.status_code, 204)
+
+        # Second delete: tombstoned rows are invisible due to is_deleted = 0.
+        self.mock_query.return_value = []
+        second = self.client.delete('/operations-log/entry-abc')
+        self.assertEqual(second.status_code, 404)
+
+    def test_delete_not_found(self) -> None:
+        self.mock_query.return_value = []
+        response = self.client.delete('/operations-log/missing')
+        self.assertEqual(response.status_code, 404)
+
+    def test_delete_forbidden_without_permission(self) -> None:
+        non_admin = api_models.User(
+            email='bob@example.com',
+            display_name='Bob',
+            password_hash='$argon2id$hash',
+            is_active=True,
+            is_admin=False,
+            is_service_account=False,
+            created_at=datetime.datetime.now(datetime.UTC),
+        )
+        self.auth_context = api_permissions.AuthContext(
+            user=non_admin,
+            session_id='test-session',
+            auth_method='jwt',
+            permissions=set(),
+        )
+
+        async def _current_user() -> api_permissions.AuthContext:
+            return self.auth_context
+
+        self.test_app.dependency_overrides[
+            api_permissions.get_current_user
+        ] = _current_user
+
+        response = self.client.delete('/operations-log/entry-abc')
+        self.assertEqual(response.status_code, 403)

--- a/tests/endpoints/test_operations_log.py
+++ b/tests/endpoints/test_operations_log.py
@@ -1,9 +1,106 @@
 """Tests for operations log endpoints."""
 
 import datetime
+import typing
 import unittest
+from unittest import mock
 
+from fastapi import testclient
+from imbi_common import clickhouse as imbi_clickhouse
+
+from imbi_api import app
+from imbi_api import models as api_models
+from imbi_api.auth import permissions as api_permissions
 from imbi_api.endpoints import operations_log
+
+ALL_OPSLOG_PERMS: set[str] = {
+    'operations_log:create',
+    'operations_log:read',
+    'operations_log:update',
+    'operations_log:delete',
+}
+
+
+def _sample_row(**overrides: typing.Any) -> dict[str, typing.Any]:
+    """Return a dict matching the ClickHouse row shape for an opslog entry."""
+    base: dict[str, typing.Any] = {
+        'id': 'entry-abc',
+        'occurred_at': datetime.datetime(
+            2026, 4, 17, 14, 22, 31, 412000, tzinfo=datetime.UTC
+        ),
+        'recorded_at': datetime.datetime(
+            2026, 4, 17, 14, 22, 33, 1000, tzinfo=datetime.UTC
+        ),
+        'recorded_by': 'alice@example.com',
+        'performed_by': 'alice@example.com',
+        'completed_at': None,
+        'project_id': 'proj-xyz',
+        'project_slug': 'imbi-api',
+        'environment_slug': 'production',
+        'entry_type': 'Deployed',
+        'description': 'Rolled out v2.4.0',
+        'link': None,
+        'notes': None,
+        'ticket_slug': None,
+        'version': '2.4.0',
+        '_row_version': 1,
+        'is_deleted': 0,
+    }
+    base.update(overrides)
+    return base
+
+
+class _OpsLogTestBase(unittest.IsolatedAsyncioTestCase):
+    """Shared setup for operations-log endpoint tests."""
+
+    permissions_granted: set[str] = ALL_OPSLOG_PERMS
+
+    def setUp(self) -> None:
+        self.test_app = app.create_app()
+        self.admin = api_models.User(
+            email='alice@example.com',
+            display_name='Alice',
+            password_hash='$argon2id$hash',
+            is_active=True,
+            is_admin=True,
+            is_service_account=False,
+            created_at=datetime.datetime.now(datetime.UTC),
+        )
+        self.auth_context = api_permissions.AuthContext(
+            user=self.admin,
+            session_id='test-session',
+            auth_method='jwt',
+            permissions=self.permissions_granted,
+        )
+
+        async def _current_user() -> api_permissions.AuthContext:
+            return self.auth_context
+
+        self.test_app.dependency_overrides[
+            api_permissions.get_current_user
+        ] = _current_user
+
+        self.client = testclient.TestClient(self.test_app)
+
+        # Patch ClickHouse:
+        #   * query() is the module-level wrapper used for reads; returns
+        #     list[dict].
+        #   * insert is the class method Clickhouse.insert called directly
+        #     with explicit column names/values (the module-level wrapper
+        #     only accepts pydantic models and strips the alias).
+        self.insert_patcher = mock.patch.object(
+            imbi_clickhouse.client.Clickhouse,
+            'insert',
+            new_callable=mock.AsyncMock,
+        )
+        self.query_patcher = mock.patch(
+            'imbi_common.clickhouse.query',
+            new_callable=mock.AsyncMock,
+        )
+        self.mock_insert = self.insert_patcher.start()
+        self.mock_query = self.query_patcher.start()
+        self.addCleanup(self.insert_patcher.stop)
+        self.addCleanup(self.query_patcher.stop)
 
 
 class CursorCodecTests(unittest.TestCase):
@@ -32,3 +129,75 @@ class CursorCodecTests(unittest.TestCase):
 
     def test_decode_empty_string_returns_none(self) -> None:
         self.assertIsNone(operations_log._decode_cursor(''))
+
+
+class PostOperationLogTests(_OpsLogTestBase):
+    def _valid_body(self) -> dict[str, typing.Any]:
+        return {
+            'project_id': 'proj-xyz',
+            'project_slug': 'imbi-api',
+            'environment_slug': 'production',
+            'entry_type': 'Deployed',
+            'description': 'Rolled out v2.4.0',
+        }
+
+    def test_create_minimum_body_returns_201(self) -> None:
+        response = self.client.post(
+            '/operations-log/', json=self._valid_body()
+        )
+        self.assertEqual(response.status_code, 201)
+        body = response.json()
+        self.assertEqual(body['entry_type'], 'Deployed')
+        self.assertEqual(body['project_slug'], 'imbi-api')
+        # Server-stamped fields
+        self.assertIsNotNone(body['id'])
+        self.assertIsNotNone(body['recorded_at'])
+        self.assertEqual(body['recorded_by'], 'alice@example.com')
+        self.assertEqual(body['performed_by'], 'alice@example.com')
+        # Internal fields excluded
+        self.assertNotIn('_row_version', body)
+        self.assertNotIn('row_version', body)
+        self.assertNotIn('is_deleted', body)
+        self.mock_insert.assert_awaited_once()
+
+    def test_create_with_explicit_performed_by(self) -> None:
+        body = self._valid_body() | {'performed_by': 'ci-bot'}
+        response = self.client.post('/operations-log/', json=body)
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.json()['performed_by'], 'ci-bot')
+
+    def test_create_validation_error(self) -> None:
+        body = self._valid_body()
+        del body['entry_type']
+        response = self.client.post('/operations-log/', json=body)
+        self.assertEqual(response.status_code, 400)
+
+    def test_create_forbidden_without_permission(self) -> None:
+        non_admin = api_models.User(
+            email='bob@example.com',
+            display_name='Bob',
+            password_hash='$argon2id$hash',
+            is_active=True,
+            is_admin=False,
+            is_service_account=False,
+            created_at=datetime.datetime.now(datetime.UTC),
+        )
+        self.auth_context = api_permissions.AuthContext(
+            user=non_admin,
+            session_id='test-session',
+            auth_method='jwt',
+            permissions=set(),
+        )
+
+        async def _current_user() -> api_permissions.AuthContext:
+            return self.auth_context
+
+        self.test_app.dependency_overrides[
+            api_permissions.get_current_user
+        ] = _current_user
+
+        response = self.client.post(
+            '/operations-log/', json=self._valid_body()
+        )
+        self.assertEqual(response.status_code, 403)
+        self.mock_insert.assert_not_awaited()

--- a/tests/endpoints/test_operations_log.py
+++ b/tests/endpoints/test_operations_log.py
@@ -251,3 +251,120 @@ class GetSingleEntryTests(_OpsLogTestBase):
         response = self.client.get('/operations-log/entry-abc')
         self.assertEqual(response.status_code, 403)
         self.mock_query.assert_not_awaited()
+
+
+class ListEntriesTests(_OpsLogTestBase):
+    def _rows(self, count: int) -> list[dict[str, typing.Any]]:
+        base_ts = datetime.datetime(2026, 4, 17, 14, 0, 0, tzinfo=datetime.UTC)
+        return [
+            _sample_row(
+                id=f'entry-{i:03d}',
+                occurred_at=base_ts - datetime.timedelta(minutes=i),
+            )
+            for i in range(count)
+        ]
+
+    def test_list_default_limit(self) -> None:
+        self.mock_query.return_value = self._rows(3)
+        response = self.client.get('/operations-log/')
+        self.assertEqual(response.status_code, 200)
+        body = response.json()
+        self.assertEqual(len(body), 3)
+        link = response.headers['Link']
+        self.assertIn('rel="first"', link)
+        # Only 3 rows returned, no next page
+        self.assertNotIn('rel="next"', link)
+
+    def test_list_has_next_link_when_more_results(self) -> None:
+        # Endpoint requests limit+1 rows; we return 3 for limit=2.
+        self.mock_query.return_value = self._rows(3)
+        response = self.client.get('/operations-log/?limit=2')
+        self.assertEqual(response.status_code, 200)
+        body = response.json()
+        self.assertEqual(len(body), 2)  # extra row popped
+        link = response.headers['Link']
+        self.assertIn('rel="first"', link)
+        self.assertIn('rel="next"', link)
+        self.assertIn('cursor=', link)
+
+    def test_list_next_cursor_round_trip(self) -> None:
+        import re
+
+        rows = self._rows(3)
+        self.mock_query.return_value = rows
+        response = self.client.get('/operations-log/?limit=2')
+        link = response.headers['Link']
+        match = re.search(r'<[^>]*cursor=([^&>]+)[^>]*>;\s*rel="next"', link)
+        assert match is not None, link
+        cursor = match.group(1)
+        decoded = operations_log._decode_cursor(cursor)
+        self.assertIsNotNone(decoded)
+        assert decoded is not None
+        ts, entry_id = decoded
+        # Second row in newest-first order is index 1 of the requested 2.
+        self.assertEqual(entry_id, rows[1]['id'])
+        self.assertEqual(ts, rows[1]['occurred_at'])
+
+    def test_list_invalid_cursor(self) -> None:
+        response = self.client.get('/operations-log/?cursor=!!!bad!!!')
+        self.assertEqual(response.status_code, 400)
+
+    def test_list_limit_out_of_range(self) -> None:
+        response = self.client.get('/operations-log/?limit=0')
+        self.assertEqual(response.status_code, 400)
+        response = self.client.get('/operations-log/?limit=501')
+        self.assertEqual(response.status_code, 400)
+
+    def test_list_project_slug_filter(self) -> None:
+        self.mock_query.return_value = self._rows(1)
+        response = self.client.get('/operations-log/?project_slug=imbi-api')
+        self.assertEqual(response.status_code, 200)
+        sent_sql, sent_params = self.mock_query.await_args.args
+        self.assertIn('project_slug = {project_slug:String}', sent_sql)
+        self.assertEqual(sent_params['project_slug'], 'imbi-api')
+
+    def test_list_since_until(self) -> None:
+        self.mock_query.return_value = []
+        since = '2026-04-01T00:00:00Z'
+        until = '2026-05-01T00:00:00Z'
+        response = self.client.get(
+            f'/operations-log/?since={since}&until={until}'
+        )
+        self.assertEqual(response.status_code, 200)
+        sent_sql, sent_params = self.mock_query.await_args.args
+        self.assertIn('occurred_at >= {since:DateTime64(3)}', sent_sql)
+        self.assertIn('occurred_at < {until:DateTime64(3)}', sent_sql)
+        self.assertIn('since', sent_params)
+        self.assertIn('until', sent_params)
+
+    def test_list_invalid_since(self) -> None:
+        response = self.client.get('/operations-log/?since=not-a-date')
+        self.assertEqual(response.status_code, 400)
+
+    def test_list_forbidden_without_permission(self) -> None:
+        non_admin = api_models.User(
+            email='bob@example.com',
+            display_name='Bob',
+            password_hash='$argon2id$hash',
+            is_active=True,
+            is_admin=False,
+            is_service_account=False,
+            created_at=datetime.datetime.now(datetime.UTC),
+        )
+        self.auth_context = api_permissions.AuthContext(
+            user=non_admin,
+            session_id='test-session',
+            auth_method='jwt',
+            permissions=set(),
+        )
+
+        async def _current_user() -> api_permissions.AuthContext:
+            return self.auth_context
+
+        self.test_app.dependency_overrides[
+            api_permissions.get_current_user
+        ] = _current_user
+
+        response = self.client.get('/operations-log/')
+        self.assertEqual(response.status_code, 403)
+        self.mock_query.assert_not_awaited()

--- a/tests/endpoints/test_operations_log.py
+++ b/tests/endpoints/test_operations_log.py
@@ -368,3 +368,131 @@ class ListEntriesTests(_OpsLogTestBase):
         response = self.client.get('/operations-log/')
         self.assertEqual(response.status_code, 403)
         self.mock_query.assert_not_awaited()
+
+
+class PatchOperationLogTests(_OpsLogTestBase):
+    def _setup_existing(
+        self, **overrides: typing.Any
+    ) -> dict[str, typing.Any]:
+        row = _sample_row(**overrides)
+        self.mock_query.return_value = [row]
+        return row
+
+    def test_patch_replace_description(self) -> None:
+        self._setup_existing()
+        response = self.client.patch(
+            '/operations-log/entry-abc',
+            json=[
+                {
+                    'op': 'replace',
+                    'path': '/description',
+                    'value': 'Rolled out v2.4.1',
+                }
+            ],
+        )
+        self.assertEqual(response.status_code, 200)
+        body = response.json()
+        self.assertEqual(body['description'], 'Rolled out v2.4.1')
+        self.mock_insert.assert_awaited_once()
+        # Check that the insert carried a bumped _row_version
+        args, _kwargs = self.mock_insert.await_args
+        # args = (table, values, column_names)
+        column_names = args[2]
+        values = args[1][0]
+        columns = dict(zip(column_names, values, strict=True))
+        self.assertEqual(columns['_row_version'], 2)
+        self.assertEqual(columns['id'], 'entry-abc')
+
+    def test_patch_readonly_id_is_400(self) -> None:
+        self._setup_existing()
+        response = self.client.patch(
+            '/operations-log/entry-abc',
+            json=[{'op': 'replace', 'path': '/id', 'value': 'x'}],
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_patch_readonly_occurred_at_is_400(self) -> None:
+        self._setup_existing()
+        response = self.client.patch(
+            '/operations-log/entry-abc',
+            json=[
+                {
+                    'op': 'replace',
+                    'path': '/occurred_at',
+                    'value': '2020-01-01T00:00:00Z',
+                }
+            ],
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_patch_readonly_row_version_is_400(self) -> None:
+        self._setup_existing()
+        response = self.client.patch(
+            '/operations-log/entry-abc',
+            json=[{'op': 'replace', 'path': '/_row_version', 'value': 99}],
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_patch_test_op_failure_is_422(self) -> None:
+        self._setup_existing()
+        response = self.client.patch(
+            '/operations-log/entry-abc',
+            json=[
+                {
+                    'op': 'test',
+                    'path': '/description',
+                    'value': 'something else',
+                }
+            ],
+        )
+        self.assertEqual(response.status_code, 422)
+
+    def test_patch_not_found(self) -> None:
+        self.mock_query.return_value = []
+        response = self.client.patch(
+            '/operations-log/missing',
+            json=[
+                {
+                    'op': 'replace',
+                    'path': '/description',
+                    'value': 'x',
+                }
+            ],
+        )
+        self.assertEqual(response.status_code, 404)
+
+    def test_patch_forbidden_without_permission(self) -> None:
+        non_admin = api_models.User(
+            email='bob@example.com',
+            display_name='Bob',
+            password_hash='$argon2id$hash',
+            is_active=True,
+            is_admin=False,
+            is_service_account=False,
+            created_at=datetime.datetime.now(datetime.UTC),
+        )
+        self.auth_context = api_permissions.AuthContext(
+            user=non_admin,
+            session_id='test-session',
+            auth_method='jwt',
+            permissions=set(),
+        )
+
+        async def _current_user() -> api_permissions.AuthContext:
+            return self.auth_context
+
+        self.test_app.dependency_overrides[
+            api_permissions.get_current_user
+        ] = _current_user
+
+        response = self.client.patch(
+            '/operations-log/entry-abc',
+            json=[
+                {
+                    'op': 'replace',
+                    'path': '/description',
+                    'value': 'x',
+                }
+            ],
+        )
+        self.assertEqual(response.status_code, 403)

--- a/tests/endpoints/test_operations_log.py
+++ b/tests/endpoints/test_operations_log.py
@@ -50,7 +50,7 @@ def _sample_row(**overrides: typing.Any) -> dict[str, typing.Any]:
     return base
 
 
-class _OpsLogTestBase(unittest.IsolatedAsyncioTestCase):
+class _OpsLogTestBase(unittest.TestCase):
     """Shared setup for operations-log endpoint tests."""
 
     permissions_granted: set[str] = ALL_OPSLOG_PERMS
@@ -81,6 +81,7 @@ class _OpsLogTestBase(unittest.IsolatedAsyncioTestCase):
         ] = _current_user
 
         self.client = testclient.TestClient(self.test_app)
+        self.addCleanup(self.client.close)
 
         # Patch ClickHouse:
         #   * query() is the module-level wrapper used for reads; returns

--- a/uv.lock
+++ b/uv.lock
@@ -495,7 +495,7 @@ wheels = [
 
 [[package]]
 name = "clickhouse-connect"
-version = "0.10.0"
+version = "0.12.0rc1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -504,32 +504,37 @@ dependencies = [
     { name = "urllib3" },
     { name = "zstandard" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7b/fd/f8bea1157d40f117248dcaa9abdbf68c729513fcf2098ab5cb4aa58768b8/clickhouse_connect-0.10.0.tar.gz", hash = "sha256:a0256328802c6e5580513e197cef7f9ba49a99fc98e9ba410922873427569564", size = 104753, upload-time = "2025-11-14T20:31:00.947Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/45/f48c80d3a06fa14b3b0915c4b5dc6c4f065735b97a95c06d76f972f685e4/clickhouse_connect-0.12.0rc1.tar.gz", hash = "sha256:2411ee79c15625643633b3d1c8776ff596276d3abb952e317d7bdbc6e8d8a54e", size = 132165, upload-time = "2026-02-12T19:27:58.524Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9e/59/fadbbf64f4c6496cd003a0a3c9223772409a86d0eea9d4ff45d2aa88aabf/clickhouse_connect-0.10.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b090c7d8e602dd084b2795265cd30610461752284763d9ad93a5d619a0e0ff21", size = 276401, upload-time = "2025-11-14T20:30:07.469Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/e3/781f9970f2ef202410f0d64681e42b2aecd0010097481a91e4df186a36c7/clickhouse_connect-0.10.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b8a708d38b81dcc8c13bb85549c904817e304d2b7f461246fed2945524b7a31b", size = 268193, upload-time = "2025-11-14T20:30:08.503Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/e0/64ab66b38fce762b77b5203a4fcecc603595f2a2361ce1605fc7bb79c835/clickhouse_connect-0.10.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3646fc9184a5469b95cf4a0846e6954e6e9e85666f030a5d2acae58fa8afb37e", size = 1123810, upload-time = "2025-11-14T20:30:09.62Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/03/19121aecf11a30feaf19049be96988131798c54ac6ba646a38e5faecaa0a/clickhouse_connect-0.10.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fe7e6be0f40a8a77a90482944f5cc2aa39084c1570899e8d2d1191f62460365b", size = 1153409, upload-time = "2025-11-14T20:30:10.855Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/ee/63870fd8b666c6030393950ad4ee76b7b69430f5a49a5d3fa32a70b11942/clickhouse_connect-0.10.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:88b4890f13163e163bf6fa61f3a013bb974c95676853b7a4e63061faf33911ac", size = 1104696, upload-time = "2025-11-14T20:30:12.187Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/bc/fcd8da1c4d007ebce088783979c495e3d7360867cfa8c91327ed235778f5/clickhouse_connect-0.10.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6286832cc79affc6fddfbf5563075effa65f80e7cd1481cf2b771ce317c67d08", size = 1156389, upload-time = "2025-11-14T20:30:13.385Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/33/7cb99cc3fc503c23fd3a365ec862eb79cd81c8dc3037242782d709280fa9/clickhouse_connect-0.10.0-cp312-cp312-win32.whl", hash = "sha256:92b8b6691a92d2613ee35f5759317bd4be7ba66d39bf81c4deed620feb388ca6", size = 243682, upload-time = "2025-11-14T20:30:14.52Z" },
-    { url = "https://files.pythonhosted.org/packages/48/5c/12eee6a1f5ecda2dfc421781fde653c6d6ca6f3080f24547c0af40485a5a/clickhouse_connect-0.10.0-cp312-cp312-win_amd64.whl", hash = "sha256:1159ee2c33e7eca40b53dda917a8b6a2ed889cb4c54f3d83b303b31ddb4f351d", size = 262790, upload-time = "2025-11-14T20:30:15.555Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/4a/197abf4d74c914cd11aff644c954f754562546a35015de466592a778f388/clickhouse_connect-0.10.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f927722c5e054cf833a4112cf82d633e37d3b329f01e232754cc2678be268020", size = 273670, upload-time = "2025-11-14T20:30:16.883Z" },
-    { url = "https://files.pythonhosted.org/packages/33/ec/5503e235b9588d178ad7777f0a6c61ede9cdfa1dfae1be08beaf18fe336b/clickhouse_connect-0.10.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:ef58f431e2ef3c2a91a6d5535484186f2f57f50eff791410548b17017563784b", size = 265346, upload-time = "2025-11-14T20:30:18.154Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/83/5bc991215540b9c12c95452783b6b59e074d71391324d2a934c2e25a8afe/clickhouse_connect-0.10.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:40b7cf86d016ae6c6c3af6a7b5786f41c18632bfbc9e58d0c4a21a4c5d50c674", size = 1104945, upload-time = "2025-11-14T20:30:19.35Z" },
-    { url = "https://files.pythonhosted.org/packages/67/74/93442c805f4ed7ad831ef412c7b94c3df492494fa49f30fa77ed8fd8673a/clickhouse_connect-0.10.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:51193dc39f4169b0dd6da13003bbea60527dea92eb2408aecae7f1fb4ad2c5a4", size = 1137413, upload-time = "2025-11-14T20:30:20.932Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/9c/c885d6a726e35e489d874da8a592f0b6b0ac4d5f132e1126466c3143f263/clickhouse_connect-0.10.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:b3e393dd95bcce02307f558f6aee53bf2a1bfc83f13030c9b4e47b2045de293f", size = 1086490, upload-time = "2025-11-14T20:30:22.195Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/a5/0980c9cb8ad13174840abcf31a085f3e5bb4026efb9271e4c757c40110ab/clickhouse_connect-0.10.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:bd6e1870df82dd57a47bc2a2a6f39c57da8aee43cc291a44d04babfdec5986dc", size = 1140722, upload-time = "2025-11-14T20:30:23.446Z" },
-    { url = "https://files.pythonhosted.org/packages/12/6f/716e12a0e9a174dc3e422846a4e2f0ee73bcfc1f47b93bb02cf3d155bf0b/clickhouse_connect-0.10.0-cp313-cp313-win32.whl", hash = "sha256:d69b3f55a3a2f5414db7bed45afcca940e78ce1867cf5cc0c202f7be21cf48e9", size = 242997, upload-time = "2025-11-14T20:30:24.626Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/70/d0148812bec753767be39d528cffa48e7510718fb75fd2cf2b4dfdb24f37/clickhouse_connect-0.10.0-cp313-cp313-win_amd64.whl", hash = "sha256:5fa4f3763d46b90dc28b1f38eba8de83fbf6c9928f071dd66074e7d6de80e21b", size = 261840, upload-time = "2025-11-14T20:30:25.686Z" },
-    { url = "https://files.pythonhosted.org/packages/46/1d/1f21be2e27c189d7a1f9a86e099fbb250722b1b43458265d324c39c8bba0/clickhouse_connect-0.10.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:8a4f20ea756e0c019e06a51d23f41edf1f0c260615e0572cb7ab0f696dfec91c", size = 273810, upload-time = "2025-11-14T20:30:26.748Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/e6/d1507e7adfcdf523daab15e175dcf304033469f93c529478f61ec8bfe85c/clickhouse_connect-0.10.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:7fbdba6b414d52e21cccb23545e3562873318a898247e9b7108aec019911f1b4", size = 266318, upload-time = "2025-11-14T20:30:28.057Z" },
-    { url = "https://files.pythonhosted.org/packages/40/e8/4d27676fb370cf3133f19703db962cd7146c1471896a95bea35d3340e6b1/clickhouse_connect-0.10.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:19cb3af95721013a0f8e88276277e23e960b08f7c14613a325a14c418207f54f", size = 1103459, upload-time = "2025-11-14T20:30:29.482Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/71/5d36414244ae59e5212f612e4b765a6bbde5b3bc559b4cbf95986b2e58b1/clickhouse_connect-0.10.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1246137a53fb270d4bb8b51e56816d5b3f5cc595a5b2d281393308a34d8a5f43", size = 1128321, upload-time = "2025-11-14T20:30:30.71Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/46/e35f16c3262dee9c3e5e8877f3c619eecf537caf7079cc9f2278506bc068/clickhouse_connect-0.10.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:5b20b3f8f93743f4dcc61dc2bd9e5c374de1e57d4a601f48e46dd06d2d4f7b97", size = 1085862, upload-time = "2025-11-14T20:30:32.294Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/90/6e9f52ff48fa1216c817d4a37a85eac2fe75785bd33e812149bbcd753f86/clickhouse_connect-0.10.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e32ef05046558928728d577ff6e053495cb5bf870e1f61fd2ea0c980587fefb7", size = 1134685, upload-time = "2025-11-14T20:30:33.664Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/74/2e9231c183c67d42398f44acf239da83f85aba5793046914ca6a66db57a9/clickhouse_connect-0.10.0-cp314-cp314-win32.whl", hash = "sha256:28f2666e59bf478461693e10e84acaa9a7e32b427d2d3d72843fd7e0a7415a77", size = 246958, upload-time = "2025-11-14T20:30:34.906Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/47/716fc7f481d850d649cac2bf9a74e64658e1ff1e98c449691d5ca87d4a90/clickhouse_connect-0.10.0-cp314-cp314-win_amd64.whl", hash = "sha256:93bf4869d27d9e86469f8fa4f0f27a618e4e63a970c3084f531c0d4706efba49", size = 266059, upload-time = "2025-11-14T20:30:35.999Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/68/b0cd083f453da233471ddd67149fd25696574a6d80273111a58191b5d45e/clickhouse_connect-0.12.0rc1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:26e68b31b2fb47bdd5af5c49664fc5b408317c28eec30e5ee8ebdf469f957f86", size = 306272, upload-time = "2026-02-12T19:26:52.45Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/84/c022fd4663e4726396857b8f8027c035da5343fb78dd83bdfcd81519e7bb/clickhouse_connect-0.12.0rc1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1c1b0a217279cb51e65e8c8c4ef7c49e240ab3f01f78413502c584a41af8ad4d", size = 298063, upload-time = "2026-02-12T19:26:53.702Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/b2/9e6cdda1bb7dbc383a2b628fd61fa5da9f26939e6d0bfc1ddca3cdabda6a/clickhouse_connect-0.12.0rc1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d43e24ff1275c8efaa041b7c29bde65cda65809826e8be52d74e425777bd863a", size = 1153686, upload-time = "2026-02-12T19:26:55.025Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/55/c9a46684f3f2071828e60e95096fa82d739ce48cfe072e6eb304420e5be9/clickhouse_connect-0.12.0rc1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:210170a9c41cc11e112a5145c45c3474166c8a6707f9a1fc0192c87d6f90638b", size = 1183281, upload-time = "2026-02-12T19:26:56.335Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/b4/4cbd204b5d7ae53db8ec42e6e099c2b1e7b29d451ad939b3b39295332ea4/clickhouse_connect-0.12.0rc1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:6573f739a85e228e8f850185c2ea2290879d0a7ec0ffb450b663b4ac18cae87a", size = 1134572, upload-time = "2026-02-12T19:26:57.667Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8c/94e2ec0c50ceaca8652f384d84eb3df6134e90d2ece3b28707c2f4dc2b76/clickhouse_connect-0.12.0rc1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:90b0aa8d6a34164e3e8e04a7bb3388254d49afa93682035f870dc877d03bd287", size = 1186264, upload-time = "2026-02-12T19:26:59.008Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/9e/9c0f572569436603be34968f7aa93507198619f77da031c18d22eb30adf2/clickhouse_connect-0.12.0rc1-cp312-cp312-win32.whl", hash = "sha256:6d93e7982e622f2adcd79a168aa21962fe004cfbe7413164e9c71609e8f8a318", size = 273731, upload-time = "2026-02-12T19:27:00.345Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/d7/2731ae93b8de4e5ce9da4a9af8454a701ff7c79e076217357f986bb92ba1/clickhouse_connect-0.12.0rc1-cp312-cp312-win_amd64.whl", hash = "sha256:91781ac42326f99ff156cc705e55a2d77930689163a6f94167ae9f4b93ed804e", size = 292804, upload-time = "2026-02-12T19:27:02.04Z" },
+    { url = "https://files.pythonhosted.org/packages/66/62/1356695ca154ee109b9047cbd3ce021ab470be2718d89a9f22fcd5ea2744/clickhouse_connect-0.12.0rc1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:23560754a88c3ca4072f1e1982b3c99212d7a2a8678e1769e6094fea8ab37278", size = 303541, upload-time = "2026-02-12T19:27:03.313Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/53/7f0658b7da70b4ee95a21f0e354180d386fe3b6d7df24c84ce9d2d595a86/clickhouse_connect-0.12.0rc1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:12eeb961062f2ba5bfb44f707f4f23b0e47a1a876d78e0da5e1e74e98e3b3b4b", size = 295212, upload-time = "2026-02-12T19:27:05.3Z" },
+    { url = "https://files.pythonhosted.org/packages/85/1a/840a0989fd294388018d786733d5312249b5dcdfa233f27bf15bc69b0433/clickhouse_connect-0.12.0rc1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:687aa7f24d32347b4b0293cf428c51a32709cb7bdea3d2a9b5af3b3c7bf76cbf", size = 1134820, upload-time = "2026-02-12T19:27:07.163Z" },
+    { url = "https://files.pythonhosted.org/packages/79/c7/4c792fea36501485f7113e22fe202666488228397ccba53dd18397c89337/clickhouse_connect-0.12.0rc1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:14f99ff8b31b159548de7b5f5970b2a466cc2a84315397ba4e60b6fa5779c3af", size = 1167287, upload-time = "2026-02-12T19:27:09.273Z" },
+    { url = "https://files.pythonhosted.org/packages/33/2f/49afd15a1c587637054a57c5aec444b273488a7c877801f4c9ebbde096b0/clickhouse_connect-0.12.0rc1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:717088e1457575c3d720315a8123058573eda69b67a86866b885503e1b8d0376", size = 1116366, upload-time = "2026-02-12T19:27:10.665Z" },
+    { url = "https://files.pythonhosted.org/packages/11/47/b488931a4e859d60ab25bdfe10bf782e6f660bb1b2c228c2cfdb6bc4472f/clickhouse_connect-0.12.0rc1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:c59e7adf0c27c2af71678f96996a09f04780f643238744ad2b209e8824df4b03", size = 1170598, upload-time = "2026-02-12T19:27:12.269Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/42/852d80d02f2749556d5ed888a32fd407b59014b183f565a1694c83ac9898/clickhouse_connect-0.12.0rc1-cp313-cp313-win32.whl", hash = "sha256:8eca7d27c40342f66ae7adf5995658ecd0a94669909be125fdf9ff9eb14ee396", size = 273036, upload-time = "2026-02-12T19:27:13.714Z" },
+    { url = "https://files.pythonhosted.org/packages/84/de/ec0c8a1a64bc2307721547487cc3c79d6effc11015308e34105c74dbfffa/clickhouse_connect-0.12.0rc1-cp313-cp313-win_amd64.whl", hash = "sha256:1e6256c8d4a3635db0e3fcf3f75770f1ee39263bda6d78f43b7c9bc1b2b0ea30", size = 291862, upload-time = "2026-02-12T19:27:15.021Z" },
+    { url = "https://files.pythonhosted.org/packages/69/62/022f2962e3b81a9386edaa81de37ec27de45fd86b0340c19dd770a1f139b/clickhouse_connect-0.12.0rc1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:e4f388a657f00fb396a3902153e3560193223a1f089dd7132ce5887b4c494112", size = 303670, upload-time = "2026-02-12T19:27:16.751Z" },
+    { url = "https://files.pythonhosted.org/packages/65/6b/d221d923ccf33bd335fedf92ee386defdda86584490a3fb79fed6ff23400/clickhouse_connect-0.12.0rc1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:b6fd7c4f3f951d3408181009d977c10df302c5a0571adcca147b296e22e292f2", size = 296187, upload-time = "2026-02-12T19:27:19.223Z" },
+    { url = "https://files.pythonhosted.org/packages/af/70/3239bf69b7a98c68f20cb8697bb548ca5c0f48351c55e98e222ed111b3b2/clickhouse_connect-0.12.0rc1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b0b3abb4616c1fcb7cd757797dcfa99e9b62eb70cb8b9e9127903d660947509b", size = 1133333, upload-time = "2026-02-12T19:27:20.658Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/a9/424e49b315f3defa31517807dae608621d8cd6bb4698c79a16b9a9578d90/clickhouse_connect-0.12.0rc1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f9bdb801bd2c312319a7e1ce380982cfba6fd08d7d4ad2ce81c69984c78032e2", size = 1158195, upload-time = "2026-02-12T19:27:22.101Z" },
+    { url = "https://files.pythonhosted.org/packages/81/cf/9edc5e79da5f36c39ce3b101372791708766c130d964e7ba1ba8f125d722/clickhouse_connect-0.12.0rc1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:fd9f73cb4673647082e331d1e3a0974286ebe9c3c200586ca71bf4d0e37ed56b", size = 1115736, upload-time = "2026-02-12T19:27:23.731Z" },
+    { url = "https://files.pythonhosted.org/packages/95/81/902bfc46126e95f85943851684cb019d41dba862cec2ccd0d31cd9801fc0/clickhouse_connect-0.12.0rc1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:abfbacd6bdb4f06c57447acb27c6a94f32dbb5887ccdc547504a72ddf79a3774", size = 1164557, upload-time = "2026-02-12T19:27:25.257Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/22/48f66a0e0cd7fa72dad8dec16132b4fbd14f87671e6e8f8e08ee502aeced/clickhouse_connect-0.12.0rc1-cp314-cp314-win32.whl", hash = "sha256:c211c9a792df958dd2ac74db3a2732d97822d97d9ae30ba0cf38161d44c12778", size = 276868, upload-time = "2026-02-12T19:27:26.572Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/f6/31f29883b397176f30435b973444c8b0cd6452e5955a30e20aff7b35b45e/clickhouse_connect-0.12.0rc1-cp314-cp314-win_amd64.whl", hash = "sha256:e6e2fb5618bb9c6c498fed431a12bcac12617b4c3b56c247836f7c5ce6f5b15d", size = 295970, upload-time = "2026-02-12T19:27:27.868Z" },
+]
+
+[package.optional-dependencies]
+async = [
+    { name = "aiohttp" },
 ]
 
 [[package]]
@@ -1161,7 +1166,7 @@ docs = [
 [[package]]
 name = "imbi-common"
 version = "0.1.0"
-source = { git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=main#7b0586eae23be567fe1656027ae83cde0803f109" }
+source = { git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=main#f96a0a0a8051ba293a48e0ddb3fd1960a76fd09a" }
 dependencies = [
     { name = "cryptography" },
     { name = "jsonschema-models" },
@@ -1177,7 +1182,7 @@ dependencies = [
 
 [package.optional-dependencies]
 databases = [
-    { name = "clickhouse-connect" },
+    { name = "clickhouse-connect", extra = ["async"] },
     { name = "fastembed" },
     { name = "pgvector" },
     { name = "psycopg", extra = ["binary", "pool"] },


### PR DESCRIPTION
## Summary

Adds CRUD endpoints for the operations log. Backed by the `operations_log` ClickHouse table in `imbi-common` (moved to `ReplacingMergeTree(_row_version)` in AWeber-Imbi/imbi-common#51 so PATCH and DELETE are cheap re-inserts).

| Method | Path | Permission |
|---|---|---|
| POST   | `/operations-log/`                                                        | `operations_log:create` |
| GET    | `/operations-log/`                                                        | `operations_log:read`   |
| GET    | `/operations-log/{entry_id}`                                              | `operations_log:read`   |
| PATCH  | `/operations-log/{entry_id}` (JSON Patch, RFC 6902)                       | `operations_log:update` |
| DELETE | `/operations-log/{entry_id}` (soft delete via `is_deleted` tombstone)     | `operations_log:delete` |
| GET    | `/organizations/{org_slug}/projects/{project_id}/operations-log/`         | `operations_log:read`   |

## Problem

The opslog foundation (model + schema) landed in `imbi-common` without HTTP endpoints. Operators and CI systems had no way to record or query deploys, scaling events, or other operational history.

## Solution

- **Writes**: POST inserts a new row with `_row_version=1`; PATCH re-inserts with a bumped version after applying a JSON Patch; DELETE re-inserts the existing row with `is_deleted=1`. `ReplacingMergeTree` dedupes on merge; all reads filter `WHERE is_deleted = 0` so deletes are visible immediately.
- **PATCH read-only paths**: `/id`, `/project_id`, `/occurred_at`, `/recorded_at`, `/recorded_by`, `/row_version`, `/is_deleted`. `/occurred_at` is locked because the table partitions on `toYYYYMM(occurred_at)` — mutating it across months would strand old versions in a different partition.
- **Reads**: collection endpoints are keyset-paginated (newest first) with RFC 5988 `Link` headers (`rel="first"`, `rel="next"`). Filters: `project_id`, `project_slug`, `environment_slug`, `entry_type`, `ticket_slug`, `performed_by`, `since`, `until`.
- **Project-nested collection**: URL-path `project_id` always overrides any client-supplied `?project_id=` query parameter.
- **Permissions**: four new `operations_log:{create,read,update,delete}` permissions seeded in `auth/seed.py`; admin inherits them via the existing expansion.

## Test plan

- [x] 34 unit tests across cursor codec, POST, GET single, GET list (filters + pagination + Link headers), PATCH (readonly + test-op), DELETE (idempotency), project-nested GET, and six `403 forbidden` cases (via a shared `_revoke_permissions` helper).
- [x] `just lint` clean
- [x] `just test` clean (902 passing, coverage 90.30%)
- [ ] End-to-end ClickHouse round-trip to verify the schema migration on a real cluster — deferred to deploy/QA.

## Commits

Squashed summary:

```
b30bc49 chore(deps): refresh imbi-common lock to f96a0a0
b0114f5 refactor(opslog): tighten test helper and fix misleading readonly test
17a046d refactor(opslog): simplify after code review
3c7235c test(opslog): narrow await_args type for basedpyright
b6c4b0e feat(opslog): GET .../projects/{project_id}/operations-log/
00f0c21 feat(opslog): DELETE /operations-log/{entry_id}
102cad6 feat(opslog): PATCH /operations-log/{entry_id} via JSON Patch
5e9d312 feat(opslog): GET /operations-log/ with filters and Link pagination
8dc7934 feat(opslog): GET /operations-log/{entry_id}
eab31b1 feat(opslog): POST /operations-log/
5fe2230 feat(opslog): add module scaffold and cursor codec
615aa58 feat(auth): seed operations_log permissions
40b4602 chore: ignore local docs/superpowers planning artifacts
```