### PR TITLE
Fix webhook rule creation: work around Apache AGE FOREACH and UNWIND defects

### DIFF
--- a/src/imbi_api/domain/models.py
+++ b/src/imbi_api/domain/models.py
@@ -890,7 +890,7 @@ class WebhookResponse(pydantic.BaseModel):
         """Build a WebhookResponse from a graph query record."""
         webhook = graph.parse_agtype(record['webhook'])
 
-        raw_rules = record.get('rules', [])
+        raw_rules = graph.parse_agtype(record.get('rules')) or []
         rules: list[WebhookRuleResponse] = []
         for r in raw_rules:
             if r is not None:

--- a/src/imbi_api/domain/models.py
+++ b/src/imbi_api/domain/models.py
@@ -895,7 +895,7 @@ class WebhookResponse(pydantic.BaseModel):
         )
         rules: list[WebhookRuleResponse] = []
         for r in raw_rules:
-            if r is not None:
+            if r:
                 raw_config: str = r.get('handler_config', '{}')
                 config: dict[str, typing.Any] | list[typing.Any]
                 try:

--- a/src/imbi_api/domain/models.py
+++ b/src/imbi_api/domain/models.py
@@ -890,11 +890,13 @@ class WebhookResponse(pydantic.BaseModel):
         """Build a WebhookResponse from a graph query record."""
         webhook = graph.parse_agtype(record['webhook'])
 
-        raw_rules = graph.parse_agtype(record.get('rules')) or []
+        raw_rules: list[dict[str, typing.Any] | None] = (
+            graph.parse_agtype(record.get('rules')) or []
+        )
         rules: list[WebhookRuleResponse] = []
         for r in raw_rules:
             if r is not None:
-                raw_config = r.get('handler_config', '{}')
+                raw_config: str = r.get('handler_config', '{}')
                 config: dict[str, typing.Any] | list[typing.Any]
                 try:
                     config = json.loads(raw_config) if raw_config else {}
@@ -902,8 +904,8 @@ class WebhookResponse(pydantic.BaseModel):
                     config = {}
                 rules.append(
                     WebhookRuleResponse(
-                        filter_expression=r['filter_expression'],
-                        handler=r['handler'],
+                        filter_expression=str(r['filter_expression']),
+                        handler=str(r['handler']),
                         handler_config=config,
                     )
                 )

--- a/src/imbi_api/endpoints/projects.py
+++ b/src/imbi_api/endpoints/projects.py
@@ -321,9 +321,13 @@ def _flatten_edge_props(
     projections (collect(node{...}) when OPTIONAL MATCH found nothing).
     """
     raw_pts: list[typing.Any] = project.get('project_types') or []
-    project['project_types'] = [pt for pt in raw_pts if pt]
+    project['project_types'] = [
+        pt for pt in raw_pts if isinstance(pt, dict) and pt
+    ]
     raw_envs: list[typing.Any] = project.get('environments') or []
-    envs: list[dict[str, typing.Any]] = [e for e in raw_envs if e]
+    envs: list[dict[str, typing.Any]] = [
+        e for e in raw_envs if isinstance(e, dict) and e
+    ]
     project['environments'] = envs
     for env in envs:
         raw_edge = env.pop('_edge', None)

--- a/src/imbi_api/endpoints/projects.py
+++ b/src/imbi_api/endpoints/projects.py
@@ -316,8 +316,17 @@ def _flatten_edge_props(
     top-level environment dict so they appear as peer fields.
     Protected environment keys are excluded to prevent
     accidental overwrites.
+
+    Also strips empty dicts that AGE can inject via null map
+    projections (collect(node{...}) when OPTIONAL MATCH found nothing).
     """
-    envs: list[dict[str, typing.Any]] = project.get('environments') or []
+    project['project_types'] = [
+        pt for pt in (project.get('project_types') or []) if pt
+    ]
+    envs: list[dict[str, typing.Any]] = [
+        e for e in (project.get('environments') or []) if e
+    ]
+    project['environments'] = envs
     for env in envs:
         raw_edge = env.pop('_edge', None)
         if raw_edge:
@@ -364,14 +373,18 @@ _RETURN_FRAGMENT: typing.LiteralString = """
     WITH p, o, t
     OPTIONAL MATCH (p)-[:TYPE]->(pt:ProjectType)
           -[:BELONGS_TO]->(o)
-    WITH p, o, t, collect(pt{{.*, organization: o{{.*}}}}) AS pts
+    WITH p, o, t, collect(CASE WHEN pt IS NOT NULL
+                          THEN pt{{.*, organization: o{{.*}}}}
+                          END) AS pts
     OPTIONAL MATCH (p)-[d:DEPLOYED_IN]->(env:Environment)
           -[:BELONGS_TO]->(o)
     WITH p, o, t, pts,
-         collect(env{{.*,
-                     sort_order: coalesce(env.sort_order, 0),
-                     _edge: properties(d),
-                     organization: o{{.*}}}}) AS envs
+         collect(CASE WHEN env IS NOT NULL
+                 THEN env{{.*,
+                          sort_order: coalesce(env.sort_order, 0),
+                          _edge: properties(d),
+                          organization: o{{.*}}}}
+                 END) AS envs
     OPTIONAL MATCH (p)-[:DEPENDS_ON]->(out:Project)
     WITH p, o, t, pts, envs, count(out) AS outbound_count
     OPTIONAL MATCH (p)<-[:DEPENDS_ON]-(in_:Project)

--- a/src/imbi_api/endpoints/projects.py
+++ b/src/imbi_api/endpoints/projects.py
@@ -320,12 +320,10 @@ def _flatten_edge_props(
     Also strips empty dicts that AGE can inject via null map
     projections (collect(node{...}) when OPTIONAL MATCH found nothing).
     """
-    project['project_types'] = [
-        pt for pt in (project.get('project_types') or []) if pt
-    ]
-    envs: list[dict[str, typing.Any]] = [
-        e for e in (project.get('environments') or []) if e
-    ]
+    raw_pts: list[typing.Any] = project.get('project_types') or []
+    project['project_types'] = [pt for pt in raw_pts if pt]
+    raw_envs: list[typing.Any] = project.get('environments') or []
+    envs: list[dict[str, typing.Any]] = [e for e in raw_envs if e]
     project['environments'] = envs
     for env in envs:
         raw_edge = env.pop('_edge', None)

--- a/src/imbi_api/endpoints/third_party_services.py
+++ b/src/imbi_api/endpoints/third_party_services.py
@@ -524,7 +524,9 @@ async def list_service_webhooks(
           -[:BELONGS_TO]->(o:Organization {{slug: {org_slug}}})
     MATCH (w)-[:BELONGS_TO]->(o)
     OPTIONAL MATCH (r:WebhookRule)-[:ACTIONS]->(w)
-    With w, tps, impl,
+    WITH w, tps, impl, r
+    ORDER BY r.ordinal
+    WITH w, tps, impl,
          collect(CASE WHEN r IS NOT NULL
                  THEN r{{.filter_expression, .handler,
                         .handler_config, .ordinal}}

--- a/src/imbi_api/endpoints/third_party_services.py
+++ b/src/imbi_api/endpoints/third_party_services.py
@@ -525,9 +525,10 @@ async def list_service_webhooks(
     MATCH (w)-[:BELONGS_TO]->(o)
     OPTIONAL MATCH (r:WebhookRule)-[:ACTIONS]->(w)
     With w, tps, impl,
-         collect(r{{
-                .filter_expression, .handler,
-                .handler_config, .ordinal}})
+         collect(CASE WHEN r IS NOT NULL
+                 THEN r{{.filter_expression, .handler,
+                        .handler_config, .ordinal}}
+                 END)
             AS all_rules
     RETURN w{{.*}} AS webhook,
            tps{{.*}} AS tps,

--- a/src/imbi_api/endpoints/webhooks.py
+++ b/src/imbi_api/endpoints/webhooks.py
@@ -48,81 +48,57 @@ def _set_clause(
     return f'SET {assignments}'
 
 
-def _rules_template(
+def _rules_create_clauses(
     rules: list[dict[str, str | int]],
 ) -> tuple[str, dict[str, typing.Any]]:
-    """Build an inline Cypher list of maps for webhook rules.
+    """Build CREATE clauses for webhook rules.
 
-    Returns a tuple of (template_fragment, params_dict) where
-    the template uses indexed placeholders and the params dict
-    maps those keys to scalar values.
-
+    Returns (cypher_fragment, params_dict). The fragment
+    contains one CREATE pair per rule using unique variable
+    names (rule_0, rule_1, …) so AGE never sees UNWIND-
+    driven row multiplication or WITH DISTINCT after CREATE.
     """
     if not rules:
-        return '[]', {}
-    maps: list[str] = []
+        return '', {}
+    clauses: list[str] = []
     params: dict[str, typing.Any] = {}
     for i, rule in enumerate(rules):
-        maps.append(
-            f'{{{{filter_expression: {{rule_{i}_fe}},'
-            f' handler: {{rule_{i}_handler}},'
-            f' handler_config: {{rule_{i}_hc}},'
-            f' ordinal: {{rule_{i}_ord}}}}}}'
+        n = str(i)
+        clauses.append(
+            ' CREATE (rule_' + n + ':WebhookRule'
+            ' {{filter_expression: {rule_' + n + '_fe},'
+            ' handler: {rule_' + n + '_handler},'
+            ' handler_config: {rule_' + n + '_hc},'
+            ' ordinal: {rule_' + n + '_ord}}})'
+            ' CREATE (rule_' + n + ')-[:ACTIONS]->(w)'
         )
-        params[f'rule_{i}_fe'] = rule['filter_expression']
-        params[f'rule_{i}_handler'] = rule['handler']
-        params[f'rule_{i}_hc'] = rule['handler_config']
-        params[f'rule_{i}_ord'] = rule['ordinal']
-    return '[' + ', '.join(maps) + ']', params
+        params['rule_' + n + '_fe'] = rule['filter_expression']
+        params['rule_' + n + '_handler'] = rule['handler']
+        params['rule_' + n + '_hc'] = rule['handler_config']
+        params['rule_' + n + '_ord'] = rule['ordinal']
+    return ''.join(clauses), params
 
 
-def _rule_unwind(rules_tpl: str) -> str:
-    """Build the UNWIND + FOREACH clause for rule creation."""
-    return (
-        f' UNWIND CASE WHEN size({rules_tpl}) = 0'
-        f' THEN [null] ELSE {rules_tpl}'
-        ' END AS rule_data'
-        ' FOREACH (_ IN CASE WHEN rule_data IS NOT NULL'
-        ' THEN [1] ELSE [] END |'
-        ' CREATE (r:WebhookRule'
-        ' {{{{filter_expression:'
-        ' rule_data.filter_expression,'
-        ' handler: rule_data.handler,'
-        ' handler_config: rule_data.handler_config,'
-        ' ordinal: rule_data.ordinal}}}})'
-        ' CREATE (r)-[:ACTIONS]->(w))'
-    )
-
-
-_RULE_RETURN_TPS: typing.LiteralString = (
-    ' WITH DISTINCT w, tps, impl'
-    ' OPTIONAL MATCH (r:WebhookRule)-[:ACTIONS]->(w)'
-    ' WITH w, tps, impl, r'
-    ' ORDER BY r.ordinal'
-    ' WITH w, tps, impl,'
-    ' collect(r{{.filter_expression, .handler,'
-    ' .handler_config, .ordinal}}) AS rules'
-    ' RETURN w{{.*}} AS webhook,'
-    ' tps{{.*}} AS tps,'
-    ' impl.identifier_selector AS identifier_selector,'
-    ' [x IN rules | x {{.filter_expression,'
-    ' .handler, .handler_config}}] AS rules'
-)
-
-_RULE_RETURN_NO_TPS: typing.LiteralString = (
-    ' WITH DISTINCT w'
-    ' OPTIONAL MATCH (r:WebhookRule)-[:ACTIONS]->(w)'
-    ' WITH w, r'
-    ' ORDER BY r.ordinal'
-    ' WITH w,'
-    ' collect(r{{.filter_expression, .handler,'
-    ' .handler_config, .ordinal}}) AS rules'
-    ' RETURN w{{.*}} AS webhook,'
-    ' null AS tps,'
-    ' null AS identifier_selector,'
-    ' [x IN rules | x {{.filter_expression,'
-    ' .handler, .handler_config}}] AS rules'
-)
+_FETCH_WEBHOOK_QUERY: typing.LiteralString = """
+MATCH (w:Webhook {{slug: {slug}}})
+      -[:BELONGS_TO]->(o:Organization {{slug: {org_slug}}})
+OPTIONAL MATCH (w)-[impl:IMPLEMENTED_BY]->(tps:ThirdPartyService)
+OPTIONAL MATCH (r:WebhookRule)-[:ACTIONS]->(w)
+WITH w, tps, impl, r
+ORDER BY r.ordinal
+WITH w, tps, impl,
+     collect(r{{
+            .filter_expression, .handler,
+            .handler_config, .ordinal}})
+        AS all_rules
+RETURN w{{.*}} AS webhook,
+       tps{{.*}} AS tps,
+       impl.identifier_selector AS identifier_selector,
+       [x IN all_rules
+        | x {{.filter_expression, .handler,
+              .handler_config}}]
+           AS rules
+"""
 
 
 webhooks_router = fastapi.APIRouter(tags=['Webhooks'])
@@ -168,11 +144,10 @@ async def create_webhook(
                 'ordinal': idx,
             }
         )
-    rules_tpl, rules_params = _rules_template(rule_dicts)
-    unwind = _rule_unwind(rules_tpl)
+    rule_clauses, rules_params = _rules_create_clauses(rule_dicts)
 
     if data.third_party_service_slug:
-        query: str = (
+        write_query: str = (
             'MATCH (o:Organization {{slug: {org_slug}}})'
             ' MATCH (tps:ThirdPartyService'
             ' {{slug: {tps_slug}}})-[:BELONGS_TO]->(o)'
@@ -181,9 +156,10 @@ async def create_webhook(
             ' CREATE (w)-[impl:IMPLEMENTED_BY]->(tps)'
             ' SET impl.identifier_selector'
             ' = {identifier_selector}'
-            ' WITH w, tps, o, impl' + unwind + _RULE_RETURN_TPS
+            + rule_clauses
+            + ' RETURN w.slug AS slug'
         )
-        params: dict[str, typing.Any] = {
+        write_params: dict[str, typing.Any] = {
             'org_slug': org_slug,
             'tps_slug': data.third_party_service_slug,
             **props,
@@ -191,23 +167,24 @@ async def create_webhook(
             **rules_params,
         }
     else:
-        query = (
+        write_query = (
             'MATCH (o:Organization {{slug: {org_slug}}})'
             f' CREATE (w:Webhook {create_tpl})'
             ' CREATE (w)-[:BELONGS_TO]->(o)'
-            ' WITH w, o' + unwind + _RULE_RETURN_NO_TPS
+            + rule_clauses
+            + ' RETURN w.slug AS slug'
         )
-        params = {
+        write_params = {
             'org_slug': org_slug,
             **props,
             **rules_params,
         }
 
     try:
-        records = await db.execute(
-            query,
-            params,
-            ['webhook', 'tps', 'identifier_selector', 'rules'],
+        write_records = await db.execute(
+            write_query,
+            write_params,
+            ['slug'],
         )
     except psycopg.errors.UniqueViolation as e:
         raise fastapi.HTTPException(
@@ -219,12 +196,17 @@ async def create_webhook(
             ),
         ) from e
 
-    if not records:
+    if not write_records:
         raise fastapi.HTTPException(
             status_code=404,
             detail=f'Organization {org_slug!r} not found',
         )
 
+    records = await db.execute(
+        _FETCH_WEBHOOK_QUERY,
+        {'slug': data.slug, 'org_slug': org_slug},
+        ['webhook', 'tps', 'identifier_selector', 'rules'],
+    )
     return models.WebhookResponse.from_graph_record(records[0])
 
 
@@ -386,12 +368,11 @@ async def update_webhook(
                 'ordinal': idx,
             }
         )
-    rules_tpl, rules_params = _rules_template(rule_dicts)
-    unwind = _rule_unwind(rules_tpl)
+    rule_clauses, rules_params = _rules_create_clauses(rule_dicts)
 
     # Delete old rules and IMPLEMENTED_BY, then recreate
     if data.third_party_service_slug:
-        query: str = (
+        write_query: str = (
             'MATCH (w:Webhook {{slug: {old_slug}}})'
             ' -[:BELONGS_TO]->(o:Organization'
             ' {{slug: {org_slug}}})'
@@ -409,7 +390,8 @@ async def update_webhook(
             ' CREATE (w)-[impl:IMPLEMENTED_BY]->(tps)'
             ' SET impl.identifier_selector'
             ' = {identifier_selector}'
-            ' WITH w, tps, impl' + unwind + _RULE_RETURN_TPS
+            + rule_clauses
+            + ' RETURN w.slug AS slug'
         )
         params: dict[str, typing.Any] = {
             'old_slug': slug,
@@ -420,7 +402,7 @@ async def update_webhook(
             **rules_params,
         }
     else:
-        query = (
+        write_query = (
             'MATCH (w:Webhook {{slug: {old_slug}}})'
             ' -[:BELONGS_TO]->(o:Organization'
             ' {{slug: {org_slug}}})'
@@ -432,8 +414,7 @@ async def update_webhook(
             ' (w)-[old_impl:IMPLEMENTED_BY]->()'
             ' DELETE old_impl'
             ' WITH DISTINCT w'
-            f' {set_clause}'
-            ' WITH w' + unwind + _RULE_RETURN_NO_TPS
+            f' {set_clause}' + rule_clauses + ' RETURN w.slug AS slug'
         )
         params = {
             'old_slug': slug,
@@ -443,10 +424,10 @@ async def update_webhook(
         }
 
     try:
-        records = await db.execute(
-            query,
+        write_records = await db.execute(
+            write_query,
             params,
-            ['webhook', 'tps', 'identifier_selector', 'rules'],
+            ['slug'],
         )
     except psycopg.errors.UniqueViolation as e:
         raise fastapi.HTTPException(
@@ -458,12 +439,17 @@ async def update_webhook(
             ),
         ) from e
 
-    if not records:
+    if not write_records:
         raise fastapi.HTTPException(
             status_code=404,
             detail=f'Webhook with slug {slug!r} not found',
         )
 
+    records = await db.execute(
+        _FETCH_WEBHOOK_QUERY,
+        {'slug': data.slug, 'org_slug': org_slug},
+        ['webhook', 'tps', 'identifier_selector', 'rules'],
+    )
     return models.WebhookResponse.from_graph_record(records[0])
 
 
@@ -481,29 +467,8 @@ async def patch_webhook(
     ],
 ) -> models.WebhookResponse:
     """Partially update a webhook using JSON Patch (RFC 6902)."""
-    check_query: typing.LiteralString = """
-    MATCH (w:Webhook {{slug: {slug}}})
-          -[:BELONGS_TO]->(o:Organization {{slug: {org_slug}}})
-    OPTIONAL MATCH (w)-[impl:IMPLEMENTED_BY]->
-                   (tps:ThirdPartyService)
-    OPTIONAL MATCH (r:WebhookRule)-[:ACTIONS]->(w)
-    WITH w, tps, impl, r
-    ORDER BY r.ordinal
-    WITH w, tps, impl,
-         collect(r{{
-                .filter_expression, .handler,
-                .handler_config, .ordinal}})
-            AS all_rules
-    RETURN w{{.*}} AS webhook,
-           tps{{.*}} AS tps,
-           impl.identifier_selector AS identifier_selector,
-           [x IN all_rules
-            | x {{.filter_expression, .handler,
-                  .handler_config}}]
-               AS rules
-    """
     existing = await db.execute(
-        check_query,
+        _FETCH_WEBHOOK_QUERY,
         {'slug': slug, 'org_slug': org_slug},
         ['webhook', 'tps', 'identifier_selector', 'rules'],
     )
@@ -597,11 +562,10 @@ async def patch_webhook(
                 'ordinal': idx,
             }
         )
-    rules_tpl, rules_params = _rules_template(rule_dicts)
-    unwind = _rule_unwind(rules_tpl)
+    rule_clauses, rules_params = _rules_create_clauses(rule_dicts)
 
     if data.third_party_service_slug:
-        query: str = (
+        write_query: str = (
             'MATCH (w:Webhook {{slug: {old_slug}}})'
             ' -[:BELONGS_TO]->(o:Organization'
             ' {{slug: {org_slug}}})'
@@ -619,7 +583,8 @@ async def patch_webhook(
             ' CREATE (w)-[impl:IMPLEMENTED_BY]->(tps)'
             ' SET impl.identifier_selector'
             ' = {identifier_selector}'
-            ' WITH w, tps, impl' + unwind + _RULE_RETURN_TPS
+            + rule_clauses
+            + ' RETURN w.slug AS slug'
         )
         params: dict[str, typing.Any] = {
             'old_slug': slug,
@@ -630,7 +595,7 @@ async def patch_webhook(
             **rules_params,
         }
     else:
-        query = (
+        write_query = (
             'MATCH (w:Webhook {{slug: {old_slug}}})'
             ' -[:BELONGS_TO]->(o:Organization'
             ' {{slug: {org_slug}}})'
@@ -642,8 +607,7 @@ async def patch_webhook(
             ' (w)-[old_impl:IMPLEMENTED_BY]->()'
             ' DELETE old_impl'
             ' WITH DISTINCT w'
-            f' {set_clause}'
-            ' WITH w' + unwind + _RULE_RETURN_NO_TPS
+            f' {set_clause}' + rule_clauses + ' RETURN w.slug AS slug'
         )
         params = {
             'old_slug': slug,
@@ -653,10 +617,10 @@ async def patch_webhook(
         }
 
     try:
-        records = await db.execute(
-            query,
+        write_records = await db.execute(
+            write_query,
             params,
-            ['webhook', 'tps', 'identifier_selector', 'rules'],
+            ['slug'],
         )
     except psycopg.errors.UniqueViolation as e:
         raise fastapi.HTTPException(
@@ -668,12 +632,17 @@ async def patch_webhook(
             ),
         ) from e
 
-    if not records:
+    if not write_records:
         raise fastapi.HTTPException(
             status_code=404,
             detail=f'Webhook with slug {slug!r} not found',
         )
 
+    records = await db.execute(
+        _FETCH_WEBHOOK_QUERY,
+        {'slug': data.slug, 'org_slug': org_slug},
+        ['webhook', 'tps', 'identifier_selector', 'rules'],
+    )
     return models.WebhookResponse.from_graph_record(records[0])
 
 

--- a/src/imbi_api/endpoints/webhooks.py
+++ b/src/imbi_api/endpoints/webhooks.py
@@ -87,9 +87,10 @@ OPTIONAL MATCH (r:WebhookRule)-[:ACTIONS]->(w)
 WITH w, tps, impl, r
 ORDER BY r.ordinal
 WITH w, tps, impl,
-     collect(r{{
-            .filter_expression, .handler,
-            .handler_config, .ordinal}})
+     collect(CASE WHEN r IS NOT NULL
+             THEN r{{.filter_expression, .handler,
+                    .handler_config, .ordinal}}
+             END)
         AS all_rules
 RETURN w{{.*}} AS webhook,
        tps{{.*}} AS tps,
@@ -231,9 +232,10 @@ async def list_webhooks(
     WITH w, tps, impl, r
     ORDER BY r.ordinal
     WITH w, tps, impl,
-         collect(r{{
-                .filter_expression, .handler,
-                .handler_config, .ordinal}})
+         collect(CASE WHEN r IS NOT NULL
+                 THEN r{{.filter_expression, .handler,
+                        .handler_config, .ordinal}}
+                 END)
             AS all_rules
     RETURN w{{.*}} AS webhook,
            tps{{.*}} AS tps,
@@ -274,9 +276,10 @@ async def get_webhook(
     WITH w, tps, impl, r
     ORDER BY r.ordinal
     WITH w, tps, impl,
-         collect(r{{
-                .filter_expression, .handler,
-                .handler_config, .ordinal}})
+         collect(CASE WHEN r IS NOT NULL
+                 THEN r{{.filter_expression, .handler,
+                        .handler_config, .ordinal}}
+                 END)
             AS all_rules
     RETURN w{{.*}} AS webhook,
            tps{{.*}} AS tps,

--- a/tests/endpoints/test_webhooks.py
+++ b/tests/endpoints/test_webhooks.py
@@ -363,6 +363,7 @@ class WebhookEndpointsTestCase(unittest.TestCase):
         self.mock_db.execute.side_effect = [
             fetch_result,
             update_result,
+            [updated],
         ]
 
         payload = dict(self.webhook_update_json)
@@ -497,6 +498,7 @@ class WebhookEndpointsTestCase(unittest.TestCase):
         self.mock_db.execute.side_effect = [
             [existing_record],
             [updated_record],
+            [updated_record],
         ]
 
         with (
@@ -560,6 +562,7 @@ class WebhookEndpointsTestCase(unittest.TestCase):
         self.mock_db.execute.side_effect = [
             [existing_record],
             [updated_record],
+            [updated_record],
         ]
 
         with (
@@ -600,6 +603,7 @@ class WebhookEndpointsTestCase(unittest.TestCase):
 
         self.mock_db.execute.side_effect = [
             [existing_record],
+            [updated_record],
             [updated_record],
         ]
 
@@ -649,6 +653,7 @@ class WebhookEndpointsTestCase(unittest.TestCase):
 
         self.mock_db.execute.side_effect = [
             [existing_record],
+            [updated_record],
             [updated_record],
         ]
 
@@ -704,6 +709,7 @@ class WebhookEndpointsTestCase(unittest.TestCase):
 
         self.mock_db.execute.side_effect = [
             [existing_record],
+            [updated_record],
             [updated_record],
         ]
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -586,3 +586,125 @@ class ExistsInModelTestCase(unittest.TestCase):
         )
         self.assertEqual(obj.third_party_service_name, 'GitHub')
         self.assertIsNone(obj.canonical_link)
+
+
+class WebhookResponseFromGraphRecordTestCase(unittest.TestCase):
+    """Tests for WebhookResponse.from_graph_record.
+
+    Apache AGE returns [{}] (a list containing one empty map) instead
+    of [] when collect() is used with a map projection on a node that
+    was NULL due to an OPTIONAL MATCH with no results.  This is an AGE
+    quirk: standard Cypher map projection on a NULL node returns NULL
+    (which collect() skips), but AGE returns {}.
+
+    These tests verify that from_graph_record produces an empty rules
+    list in all the forms the database can return "no rules".
+    """
+
+    def _minimal_record(
+        self,
+        **overrides: object,
+    ) -> dict[str, object]:
+        record: dict[str, object] = {
+            'webhook': {
+                'name': 'Test Webhook',
+                'slug': 'test-webhook',
+                'notification_path': '/webhooks/test',
+            },
+            'tps': None,
+            'identifier_selector': None,
+            'rules': '[]',
+        }
+        record.update(overrides)
+        return record
+
+    def test_age_empty_map_projection_gives_no_rules(self) -> None:
+        """AGE bug: collect(r{...}) with no rows returns '[{}]' not '[]'."""
+        record = self._minimal_record(rules='[{}]')
+        response = domain_models.WebhookResponse.from_graph_record(record)
+        self.assertEqual(response.rules, [])
+
+    def test_age_multiple_empty_maps_gives_no_rules(self) -> None:
+        """Defensive: multiple empty maps are all filtered out."""
+        record = self._minimal_record(rules='[{}, {}]')
+        response = domain_models.WebhookResponse.from_graph_record(record)
+        self.assertEqual(response.rules, [])
+
+    def test_empty_rules_json_string(self) -> None:
+        record = self._minimal_record(rules='[]')
+        response = domain_models.WebhookResponse.from_graph_record(record)
+        self.assertEqual(response.rules, [])
+
+    def test_none_rules(self) -> None:
+        record = self._minimal_record(rules=None)
+        response = domain_models.WebhookResponse.from_graph_record(record)
+        self.assertEqual(response.rules, [])
+
+    def test_missing_rules_key(self) -> None:
+        record = self._minimal_record()
+        del record['rules']  # type: ignore[arg-type]
+        response = domain_models.WebhookResponse.from_graph_record(record)
+        self.assertEqual(response.rules, [])
+
+    def test_empty_python_list(self) -> None:
+        """parse_agtype passes lists through unchanged."""
+        record = self._minimal_record(rules=[])
+        response = domain_models.WebhookResponse.from_graph_record(record)
+        self.assertEqual(response.rules, [])
+
+    def test_python_list_with_empty_dict(self) -> None:
+        """parse_agtype passes [{}] through; from_graph_record filters it."""
+        record = self._minimal_record(rules=[{}])
+        response = domain_models.WebhookResponse.from_graph_record(record)
+        self.assertEqual(response.rules, [])
+
+    def test_with_one_rule(self) -> None:
+        record = self._minimal_record(
+            rules=[
+                {
+                    'filter_expression': '$.action == "push"',
+                    'handler': 'my.module.handle_push',
+                    'handler_config': '{"branch": "main"}',
+                },
+            ],
+        )
+        response = domain_models.WebhookResponse.from_graph_record(record)
+        self.assertEqual(len(response.rules), 1)
+        self.assertEqual(response.rules[0].handler, 'my.module.handle_push')
+        self.assertEqual(
+            response.rules[0].handler_config,
+            {'branch': 'main'},
+        )
+
+    def test_rule_with_missing_handler_config(self) -> None:
+        """handler_config absent in rule defaults to {}."""
+        record = self._minimal_record(
+            rules=[
+                {
+                    'filter_expression': '$.action',
+                    'handler': 'my.handler',
+                },
+            ],
+        )
+        response = domain_models.WebhookResponse.from_graph_record(record)
+        self.assertEqual(response.rules[0].handler_config, {})
+
+    def test_with_tps_and_identifier_selector(self) -> None:
+        record = self._minimal_record(
+            tps={'name': 'GitHub', 'slug': 'github'},
+            identifier_selector='$.repository.full_name',
+        )
+        response = domain_models.WebhookResponse.from_graph_record(record)
+        self.assertIsNotNone(response.third_party_service)
+        assert response.third_party_service is not None
+        self.assertEqual(response.third_party_service['slug'], 'github')
+        self.assertEqual(
+            response.identifier_selector,
+            '$.repository.full_name',
+        )
+
+    def test_without_tps(self) -> None:
+        record = self._minimal_record(tps=None, identifier_selector=None)
+        response = domain_models.WebhookResponse.from_graph_record(record)
+        self.assertIsNone(response.third_party_service)
+        self.assertIsNone(response.identifier_selector)


### PR DESCRIPTION
## Summary

- Apache AGE does not support the `FOREACH` Cypher keyword ([apache/age#2381](https://github.com/apache/age/issues/2381)), causing a `SyntaxError` on every webhook creation request
- AGE also has a bug where `UNWIND` followed by `CREATE` marks newly created vertices as deleted ([apache/age#2389](https://github.com/apache/age/issues/2389)), making any UNWIND-based workaround non-viable
- Replace `_rules_template` + `_rule_unwind` + UNWIND/FOREACH with `_rules_create_clauses()`, which emits one inline `CREATE (rule_N:WebhookRule {...}) CREATE (rule_N)-[:ACTIONS]->(w)` per rule using unique numbered variable names — no row multiplication, no AGE multi-row bug
- Fix `WebhookResponse.from_graph_record()`: the `rules` column returned by AGE is a raw agtype string; it must be passed through `parse_agtype()` before iteration (was causing `AttributeError: 'str' object has no attribute 'get'`)
- Refactor all three write endpoints (`create_webhook`, `update_webhook`, `patch_webhook`) to use a write-then-read pattern: the write query returns only `w.slug`, then a shared `_FETCH_WEBHOOK_QUERY` fetches the full response
- Fix a third AGE defect: map projection on a NULL node (`r{.field, ...}` when `r IS NULL`) returns `{}` instead of `NULL` ([apache/age#2391](https://github.com/apache/age/issues/2391)), so `collect(r{...})` yields `[{}]` instead of `[]` when no rules exist — wrap every `collect(node{...})` over an `OPTIONAL MATCH` in `CASE WHEN node IS NOT NULL THEN node{...} END` so `collect()` receives `NULL` values it skips; also tighten the Python guard from `if r is not None` to `if r` as a second line of defence; same fix applied to `project_types` and `environments` in the projects query

## Test plan

- [ ] POST `/organizations/{slug}/webhooks/` with one or more rules → 201 with rules in response
- [ ] GET `/organizations/{slug}/webhooks/{webhook_slug}` → correct JSON including rules in ordinal order
- [ ] PUT `/organizations/{slug}/webhooks/{webhook_slug}` (update with modified rules) → 200 with updated rules
- [ ] PATCH `/organizations/{slug}/webhooks/{webhook_slug}` → 200
- [ ] POST with zero rules → 201 with **empty** rules list (not `[{}]`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)