### PR TITLE
Fix project PATCH: list params, blueprint extras, AGE FOREACH

### DIFF
--- a/src/imbi_api/endpoints/projects.py
+++ b/src/imbi_api/endpoints/projects.py
@@ -262,7 +262,7 @@ async def _validate_env_slugs(
         env_check,
         {
             'org_slug': org_slug,
-            'env_slugs': json.dumps(env_slugs),
+            'env_slugs': env_slugs,
         },
         ['env_slug', 'found'],
     )
@@ -480,7 +480,7 @@ async def create_project(
         validate_query,
         {
             'org_slug': org_slug,
-            'pt_slugs': json.dumps(data.project_type_slugs),
+            'pt_slugs': data.project_type_slugs,
         },
         ['pt_slug', 'found'],
     )
@@ -552,9 +552,7 @@ async def create_project(
             {
                 'org_slug': org_slug,
                 'team_slug': data.team_slug,
-                'pt_slugs': json.dumps(
-                    data.project_type_slugs,
-                ),
+                'pt_slugs': data.project_type_slugs,
                 **props,
                 **env_params,
             },
@@ -1099,7 +1097,7 @@ async def _validate_update_refs(
             pt_check,
             {
                 'org_slug': org_slug,
-                'pt_slugs': json.dumps(data.project_type_slugs),
+                'pt_slugs': data.project_type_slugs,
             },
             ['pt_slug', 'found'],
         )
@@ -1166,16 +1164,15 @@ def _build_update_clauses(
             ' OPTIONAL MATCH'
             ' (p)-[old_env:DEPLOYED_IN]->(:Environment)'
             ' DELETE old_env'
-            ' WITH DISTINCT p, o'
-            f' UNWIND CASE WHEN size({new_env_tpl}) = 0'
-            f' THEN [null] ELSE {new_env_tpl}'
-            ' END AS entry'
-            ' OPTIONAL MATCH (e:Environment'
-            ' {{slug: entry.slug}})-[:BELONGS_TO]->(o)'
-            ' FOREACH (_ IN CASE WHEN e IS NOT NULL'
-            ' THEN [1] ELSE [] END |'
-            ' CREATE (p)-[:DEPLOYED_IN' + new_edge_props_tpl + ']->(e))'
         )
+        if new_env_entries:
+            rel_clauses += (
+                ' WITH DISTINCT p, o'
+                f' UNWIND {new_env_tpl} AS entry'
+                ' MATCH (e:Environment'
+                ' {{slug: entry.slug}})-[:BELONGS_TO]->(o)'
+                ' CREATE (p)-[:DEPLOYED_IN' + new_edge_props_tpl + ']->(e)'
+            )
 
     return rel_clauses, new_env_params
 
@@ -1343,9 +1340,7 @@ async def _execute_project_update(
                 'org_slug': org_slug,
                 **props,
                 'new_team_slug': data.team_slug or '',
-                'new_type_slugs': json.dumps(
-                    data.project_type_slugs or [],
-                ),
+                'new_type_slugs': data.project_type_slugs or [],
                 **new_env_params,
             },
             ['project', 'outbound_count', 'inbound_count'],
@@ -1519,6 +1514,12 @@ async def patch_project(
             }
             current_environments[env_slug] = edge_props
 
+    base_fields = set(ProjectUpdate.model_fields)
+    extras = {
+        k: v
+        for k, v in project_data.items()
+        if k not in base_fields and k not in _RESERVED_FIELDS
+    }
     patchable: dict[str, typing.Any] = {
         'name': project_data.get('name', ''),
         'slug': project_data.get('slug', ''),
@@ -1529,6 +1530,7 @@ async def patch_project(
         'environments': current_environments,
         'links': parsed_links,
         'identifiers': parsed_identifiers,
+        **extras,
     }
 
     patched = json_patch.apply_patch(patchable, operations)


### PR DESCRIPTION
## Summary
Fix three bugs that caused `PATCH /organizations/{org}/projects/{id}` to fail with 422 / 400 / 500 when editing a project that has project types, blueprint-extended fields, or environments.

## Problem
A trivial PATCH (`[{\"op\":\"replace\",\"path\":\"/slug\",\"value\":\"accounts\"}]`) against an existing project surfaced three independent defects:

1. **422 `Project type slug(s) not found: ['[\"apis\"]']`** — `_validate_update_refs` (and `_validate_env_slugs`, `create_project`, `_execute_project_update`) wrapped list parameters in `json.dumps(...)` before handing them to `db.execute`. But `imbi_common.graph.client._cypher_param` already serializes lists into Cypher list literals; wrapping first turns the list into a quoted Cypher **string**, so `UNWIND '[\"apis\"]'` yields the raw JSON as the sole iteration and every existing project-type slug is reported missing.
2. **400 `Invalid patch: can't replace a non-existent object 'configuration_system'`** — `patch_project` built its `patchable` document only from the fixed `ProjectUpdate` base fields, so blueprint-defined extras (e.g. `/configuration_system`) didn't exist in the doc and `jsonpatch` raised `JsonPatchConflict`.
3. **500 `syntax error at or near \"FOREACH\"`** — with Bug 1 cleared, the request reached the env-rebind block in `_build_update_clauses`, which chained `OPTIONAL MATCH (e:Environment …) FOREACH (_ IN CASE WHEN e IS NOT NULL …)`. AGE's Cypher parser rejects this — even with an intervening `WITH`.

## Solution
- Remove the `json.dumps(...)` wrappers from every list parameter handed to `db.execute` in `projects.py` (`_validate_env_slugs`, `_validate_update_refs`, `create_project` validate+main queries, `_execute_project_update`).
- Seed the PATCH `patchable` document with every non-reserved extra key from `project_data`, matching how `_execute_project_update` already layers extras via `data.model_extra`.
- Rewrite the env-rebind block to avoid `FOREACH` and the `UNWIND CASE WHEN size(…)=0 THEN [null]` trick. `_validate_env_slugs` already guarantees each slug exists, so a required `MATCH` + straight `CREATE` suffices, and the empty-envs case is branched in Python rather than in Cypher. Mirrors the pattern the project-types rel_clauses already use.

## Impact
- Project PATCH and PUT now work against projects with types / blueprint fields / envs. No behavior change for projects without those.
- `create_project` keeps its existing `OPTIONAL MATCH + FOREACH` pattern for project types and environments. Not touched because no failure has been reported against it and the scope here is the PATCH break. Worth watching — if AGE also rejects it under write-heavy queries, we'll refactor similarly in a follow-up.
- Env rebind is now a simpler two-step (DELETE old, CREATE new) instead of one combined UNWIND+FOREACH. Same transactional guarantees (single Cypher statement).

## Testing
- `just lint` clean (ruff, basedpyright, mypy, pre-commit hooks).
- `uv run pytest tests/endpoints/test_projects.py tests/test_patch.py` — 45 passed.
- `uv run pytest` full suite — 902 passed, 1 skipped.
- Unit tests mock `db.execute`, so real AGE verification happens on your next PATCH against the live instance; if the FOREACH fix is still insufficient we'll have a fresh traceback to work from.