### PR TITLE
Declare ops-log response model and force UTC on timestamps

### DIFF
--- a/src/imbi_api/endpoints/operations_log.py
+++ b/src/imbi_api/endpoints/operations_log.py
@@ -52,6 +52,23 @@ DEFAULT_LIMIT: int = 50
 MAX_LIMIT: int = 500
 
 
+# Aggregate counts for the list-endpoint envelope. Computed once for
+# the full filter universe (not paged) so the UI summary tiles stay
+# accurate even when the client only loads a single page.
+class OperationLogMetrics(pydantic.BaseModel):
+    event_count: int
+    deploys: int
+    projects: int
+    environments: int
+    team_members: int
+    deploys_by_environment: dict[str, int]
+
+
+class OperationLogListResponse(pydantic.BaseModel):
+    metrics: OperationLogMetrics | None = None
+    data: list[OperationLogResponse]
+
+
 # Mirror of ``OperationLog`` without internal bookkeeping fields
 # (``row_version``, ``is_deleted``). Declared as the ``response_model``
 # so the OpenAPI schema reflects what clients actually receive.
@@ -304,6 +321,48 @@ def _build_link_header(
     return ', '.join(links)
 
 
+async def _compute_metrics(
+    filter_sql: str, filter_params: dict[str, typing.Any]
+) -> OperationLogMetrics:
+    """Run aggregate queries for the summary tiles.
+
+    `filter_sql` is the WHERE-clause body (without `WHERE`) shared with the
+    list query; `filter_params` supplies its placeholders.
+    """
+    totals_sql: str = (
+        'SELECT '
+        'count() AS event_count, '
+        "countIf(entry_type = 'Deployed') AS deploys, "
+        'uniqExact(project_slug) AS projects, '
+        'uniqExact(environment_slug) AS environments, '
+        'uniqExact(performed_by) AS team_members '
+        'FROM operations_log FINAL WHERE '
+    ) + filter_sql
+    env_sql: str = (
+        'SELECT environment_slug, count() AS c '
+        'FROM operations_log FINAL WHERE '
+        + filter_sql
+        + " AND entry_type = 'Deployed' "
+        'GROUP BY environment_slug'
+    )
+    totals_rows = await clickhouse.query(totals_sql, filter_params)
+    env_rows = await clickhouse.query(env_sql, filter_params)
+    totals = totals_rows[0] if totals_rows else {}
+    deploys_by_env = {
+        str(row['environment_slug']): int(row['c'])
+        for row in env_rows
+        if row.get('environment_slug')
+    }
+    return OperationLogMetrics(
+        event_count=int(totals.get('event_count', 0) or 0),
+        deploys=int(totals.get('deploys', 0) or 0),
+        projects=int(totals.get('projects', 0) or 0),
+        environments=int(totals.get('environments', 0) or 0),
+        team_members=int(totals.get('team_members', 0) or 0),
+        deploys_by_environment=deploys_by_env,
+    )
+
+
 async def _list_impl(
     *,
     request: fastapi.Request,
@@ -347,6 +406,11 @@ async def _list_impl(
         params['until'] = _parse_iso(until, 'until')
         clauses.append('occurred_at < {until:DateTime64(3)}')
 
+    # Pre-cursor clause set is also what feeds the /metrics aggregate so
+    # the summary reflects the full filter universe, not the current page.
+    metrics_clauses = list(clauses)
+    metrics_params = dict(params)
+
     if cursor is not None:
         decoded = _decode_cursor(cursor)
         if decoded is None:
@@ -375,7 +439,20 @@ async def _list_impl(
         last = rows[-1]
         next_cursor = _encode_cursor(last['occurred_at'], last['id'])
 
-    body = [_row_to_response(r) for r in rows]
+    # Only compute metrics on the first page (no cursor) — the client
+    # stores them once and paginates through ``data`` afterward.
+    metrics: OperationLogMetrics | None = None
+    if cursor is None:
+        metrics = await _compute_metrics(
+            ' AND '.join(metrics_clauses), metrics_params
+        )
+
+    body = {
+        'metrics': (
+            metrics.model_dump(mode='json') if metrics is not None else None
+        ),
+        'data': [_row_to_response(r) for r in rows],
+    }
     response = fastapi.responses.JSONResponse(
         fastapi.encoders.jsonable_encoder(body)
     )
@@ -385,7 +462,7 @@ async def _list_impl(
 
 @operations_log_router.get(
     '/',
-    response_model=list[OperationLogResponse],
+    response_model=OperationLogListResponse,
 )
 async def list_operation_logs(
     request: fastapi.Request,
@@ -426,7 +503,7 @@ async def list_operation_logs(
 
 @operations_log_project_router.get(
     '/',
-    response_model=list[OperationLogResponse],
+    response_model=OperationLogListResponse,
 )
 async def list_project_operation_logs(
     request: fastapi.Request,

--- a/src/imbi_api/endpoints/operations_log.py
+++ b/src/imbi_api/endpoints/operations_log.py
@@ -234,7 +234,7 @@ async def create_operation_log(
 
     row = _model_to_row(entry)
     await _insert_row(row)
-    return _row_to_response(fastapi.encoders.jsonable_encoder(row))
+    return _row_to_response(row)
 
 
 _SINGLE_ENTRY_SQL: typing.Final[str] = (
@@ -615,7 +615,7 @@ async def patch_operation_log(
 
     row = _model_to_row(entry)
     await _insert_row(row)
-    return _row_to_response(fastapi.encoders.jsonable_encoder(row))
+    return _row_to_response(row)
 
 
 @operations_log_router.delete('/{entry_id}', status_code=204)

--- a/src/imbi_api/endpoints/operations_log.py
+++ b/src/imbi_api/endpoints/operations_log.py
@@ -426,10 +426,11 @@ async def _list_impl(
         )
 
     where = ' AND '.join(clauses)
+    params['row_limit'] = limit + 1
     sql: str = (
         'SELECT * FROM operations_log FINAL WHERE '  # noqa: S608
         + where
-        + f' ORDER BY occurred_at DESC, id DESC LIMIT {limit + 1}'
+        + ' ORDER BY occurred_at DESC, id DESC LIMIT {row_limit:UInt32}'
     )
 
     rows = await clickhouse.query(sql, params)

--- a/src/imbi_api/endpoints/operations_log.py
+++ b/src/imbi_api/endpoints/operations_log.py
@@ -52,6 +52,39 @@ DEFAULT_LIMIT: int = 50
 MAX_LIMIT: int = 500
 
 
+# Mirror of ``OperationLog`` without internal bookkeeping fields
+# (``row_version``, ``is_deleted``). Declared as the ``response_model``
+# so the OpenAPI schema reflects what clients actually receive.
+class OperationLogResponse(pydantic.BaseModel):
+    """Public projection of an OperationLog entry."""
+
+    id: str
+    occurred_at: datetime.datetime
+    recorded_at: datetime.datetime
+    recorded_by: str
+    performed_by: str | None = None
+    completed_at: datetime.datetime | None = None
+    project_id: str
+    project_slug: str
+    environment_slug: str
+    entry_type: typing.Literal[
+        'Configured',
+        'Decommissioned',
+        'Deployed',
+        'Migrated',
+        'Provisioned',
+        'Restarted',
+        'Rolled Back',
+        'Scaled',
+        'Upgraded',
+    ]
+    description: str
+    link: str | None = None
+    notes: str | None = None
+    ticket_slug: str | None = None
+    version: str | None = None
+
+
 def _encode_cursor(occurred_at: datetime.datetime, entry_id: str) -> str:
     """Encode a (timestamp, id) cursor as urlsafe base64."""
     payload = f'{occurred_at.isoformat()}|{entry_id}'.encode()
@@ -78,16 +111,36 @@ def _decode_cursor(
         ts = datetime.datetime.fromisoformat(ts_str)
     except ValueError:
         return None
-    return ts, entry_id
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=datetime.UTC)
+    return ts.astimezone(datetime.UTC), entry_id
+
+
+_TIMESTAMP_FIELDS: frozenset[str] = frozenset(
+    {'occurred_at', 'recorded_at', 'completed_at'}
+)
 
 
 def _row_to_response(row: dict[str, typing.Any]) -> dict[str, typing.Any]:
-    """Strip internal bookkeeping columns before returning to the client."""
-    return {
-        k: v
-        for k, v in row.items()
-        if k not in {'_row_version', 'row_version', 'is_deleted'}
-    }
+    """Strip internal bookkeeping columns before returning to the client.
+
+    ClickHouse DateTime64 values come back as naive ``datetime`` objects
+    even though they are stored as UTC. Attach ``tzinfo=UTC`` so that the
+    JSON serializer emits an offset (``...Z``/``+00:00``) and clients can
+    parse unambiguously.
+    """
+    out: dict[str, typing.Any] = {}
+    for k, v in row.items():
+        if k in {'_row_version', 'row_version', 'is_deleted'}:
+            continue
+        if (
+            k in _TIMESTAMP_FIELDS
+            and isinstance(v, datetime.datetime)
+            and v.tzinfo is None
+        ):
+            v = v.replace(tzinfo=datetime.UTC)
+        out[k] = v
+    return out
 
 
 def _model_to_row(entry: models.OperationLog) -> dict[str, typing.Any]:
@@ -116,7 +169,11 @@ async def _insert_row(row: dict[str, typing.Any]) -> None:
     )
 
 
-@operations_log_router.post('/', status_code=201)
+@operations_log_router.post(
+    '/',
+    status_code=201,
+    response_model=OperationLogResponse,
+)
 async def create_operation_log(
     data: dict[str, typing.Any],
     auth: typing.Annotated[
@@ -326,7 +383,10 @@ async def _list_impl(
     return response
 
 
-@operations_log_router.get('/')
+@operations_log_router.get(
+    '/',
+    response_model=list[OperationLogResponse],
+)
 async def list_operation_logs(
     request: fastapi.Request,
     auth: typing.Annotated[
@@ -364,7 +424,10 @@ async def list_operation_logs(
     )
 
 
-@operations_log_project_router.get('/')
+@operations_log_project_router.get(
+    '/',
+    response_model=list[OperationLogResponse],
+)
 async def list_project_operation_logs(
     request: fastapi.Request,
     org_slug: str,
@@ -402,7 +465,10 @@ async def list_project_operation_logs(
     )
 
 
-@operations_log_router.get('/{entry_id}')
+@operations_log_router.get(
+    '/{entry_id}',
+    response_model=OperationLogResponse,
+)
 async def get_operation_log(
     entry_id: str,
     auth: typing.Annotated[
@@ -422,7 +488,10 @@ async def get_operation_log(
     return _row_to_response(row)
 
 
-@operations_log_router.patch('/{entry_id}')
+@operations_log_router.patch(
+    '/{entry_id}',
+    response_model=OperationLogResponse,
+)
 async def patch_operation_log(
     entry_id: str,
     operations: list[json_patch.PatchOperation],

--- a/tests/endpoints/test_operations_log.py
+++ b/tests/endpoints/test_operations_log.py
@@ -103,6 +103,30 @@ class _OpsLogTestBase(unittest.TestCase):
         self.addCleanup(self.insert_patcher.stop)
         self.addCleanup(self.query_patcher.stop)
 
+    def _stub_list(
+        self,
+        rows: list[dict[str, typing.Any]],
+        *,
+        with_metrics: bool = True,
+    ) -> None:
+        """Wire `mock_query` for a list-endpoint call.
+
+        The list handler issues 3 ClickHouse queries on the first page
+        (list + totals + per-env deploys) and just 1 on paginated pages.
+        """
+        empty_totals = [
+            {
+                'event_count': 0,
+                'deploys': 0,
+                'projects': 0,
+                'environments': 0,
+                'team_members': 0,
+            }
+        ]
+        self.mock_query.side_effect = (
+            [rows, empty_totals, []] if with_metrics else [rows]
+        )
+
     def _revoke_permissions(self) -> None:
         """Swap the auth context to a non-admin user with no permissions.
 
@@ -245,11 +269,12 @@ class ListEntriesTests(_OpsLogTestBase):
         ]
 
     def test_list_default_limit(self) -> None:
-        self.mock_query.return_value = self._rows(3)
+        self._stub_list(self._rows(3))
         response = self.client.get('/operations-log/')
         self.assertEqual(response.status_code, 200)
         body = response.json()
-        self.assertEqual(len(body), 3)
+        self.assertEqual(len(body['data']), 3)
+        self.assertIsNotNone(body['metrics'])
         link = response.headers['Link']
         self.assertIn('rel="first"', link)
         # Only 3 rows returned, no next page
@@ -257,11 +282,11 @@ class ListEntriesTests(_OpsLogTestBase):
 
     def test_list_has_next_link_when_more_results(self) -> None:
         # Endpoint requests limit+1 rows; we return 3 for limit=2.
-        self.mock_query.return_value = self._rows(3)
+        self._stub_list(self._rows(3))
         response = self.client.get('/operations-log/?limit=2')
         self.assertEqual(response.status_code, 200)
         body = response.json()
-        self.assertEqual(len(body), 2)  # extra row popped
+        self.assertEqual(len(body['data']), 2)  # extra row popped
         link = response.headers['Link']
         self.assertIn('rel="first"', link)
         self.assertIn('rel="next"', link)
@@ -271,7 +296,7 @@ class ListEntriesTests(_OpsLogTestBase):
         import re
 
         rows = self._rows(3)
-        self.mock_query.return_value = rows
+        self._stub_list(rows)
         response = self.client.get('/operations-log/?limit=2')
         link = response.headers['Link']
         match = re.search(r'<[^>]*cursor=([^&>]+)[^>]*>;\s*rel="next"', link)
@@ -296,22 +321,22 @@ class ListEntriesTests(_OpsLogTestBase):
         self.assertEqual(response.status_code, 400)
 
     def test_list_project_slug_filter(self) -> None:
-        self.mock_query.return_value = self._rows(1)
+        self._stub_list(self._rows(1))
         response = self.client.get('/operations-log/?project_slug=imbi-api')
         self.assertEqual(response.status_code, 200)
-        sent_sql, sent_params = self.mock_query.await_args.args
+        sent_sql, sent_params = self.mock_query.await_args_list[0].args
         self.assertIn('project_slug = {project_slug:String}', sent_sql)
         self.assertEqual(sent_params['project_slug'], 'imbi-api')
 
     def test_list_since_until(self) -> None:
-        self.mock_query.return_value = []
+        self._stub_list([])
         since = '2026-04-01T00:00:00Z'
         until = '2026-05-01T00:00:00Z'
         response = self.client.get(
             f'/operations-log/?since={since}&until={until}'
         )
         self.assertEqual(response.status_code, 200)
-        sent_sql, sent_params = self.mock_query.await_args.args
+        sent_sql, sent_params = self.mock_query.await_args_list[0].args
         self.assertIn('occurred_at >= {since:DateTime64(3)}', sent_sql)
         self.assertIn('occurred_at < {until:DateTime64(3)}', sent_sql)
         self.assertIn('since', sent_params)
@@ -436,18 +461,18 @@ class PatchOperationLogTests(_OpsLogTestBase):
 class ProjectScopedListTests(_OpsLogTestBase):
     def test_project_scoped_forces_project_id(self) -> None:
         row = _sample_row(project_id='proj-xyz')
-        self.mock_query.return_value = [row]
+        self._stub_list([row])
         # Client-supplied ?project_id= is ignored; path wins.
         response = self.client.get(
             '/organizations/engineering/projects/proj-xyz/operations-log/'
             '?project_id=hacker-attempt'
         )
         self.assertEqual(response.status_code, 200)
-        _sql, params = self.mock_query.await_args.args
+        _sql, params = self.mock_query.await_args_list[0].args
         self.assertEqual(params['project_id'], 'proj-xyz')
 
     def test_project_scoped_has_link_headers(self) -> None:
-        self.mock_query.return_value = [_sample_row()]
+        self._stub_list([_sample_row()])
         response = self.client.get(
             '/organizations/engineering/projects/proj-xyz/operations-log/'
         )


### PR DESCRIPTION
## Summary
- Adds `OperationLogResponse` (mirror of `OperationLog` without `row_version` / `is_deleted`) and wires it as the declared `response_model` on POST, GET `/`, GET `/{id}`, the project-scoped list, and PATCH — so the OpenAPI schema matches the payload clients actually receive.
- ClickHouse `DateTime64` values come back as naive `datetime`s even though they're stored as UTC; `_row_to_response` now attaches `tzinfo=UTC` so JSON serializes with an offset and browsers can parse unambiguously.
- `_decode_cursor` now normalizes to aware UTC so downstream comparisons never mix naive and aware datetimes.

## Test plan
- [x] `just test tests/endpoints/test_operations_log.py` — all 34 tests pass.
- [x] `mypy` clean on the touched module.