### PR TITLE
Bump imbi-common to pick up Project.identifiers field

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -944,7 +944,7 @@ docs = [
 [[package]]
 name = "imbi-common"
 version = "0.1.0"
-source = { git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=main#f96a0a0a8051ba293a48e0ddb3fd1960a76fd09a" }
+source = { git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=main#f54395f2b75ce4c31f7cc5c60db4ad655c73794b" }
 dependencies = [
     { name = "cryptography" },
     { name = "jsonschema-models" },


### PR DESCRIPTION
## Summary

- Bumps the pinned `imbi-common` commit so imbi-api picks up
  [imbi-common#56](https://github.com/AWeber-Imbi/imbi-common/pull/56),
  which adds `identifiers: dict[str, int | str | pydantic.AnyUrl] = {}`
  to `models.Project`.

## Problem

`PATCH /organizations/{org}/projects/{id}` with
`[{"op":"replace","path":"/identifiers","value":{...}}]` returned 200
but the change did not persist — the next `GET` showed the previous
identifiers.

Root cause: `_execute_project_update` builds the update query from
`project.model_dump(...)` where `project` is an instance of
`dynamic_model` (a subclass of `models.Project`). `Project` had no
`identifiers` field and `GraphModel` sets `extra='ignore'`, so the
kwarg was silently dropped. `props` therefore never contained
`identifiers`, the Cypher `SET` clause never touched `p.identifiers`,
and the row kept its old value. The same defect quietly swallowed
`identifiers` on project creation.

## Solution

Pin to the imbi-common commit that adds the field
(`f54395f2b75ce4c31f7cc5c60db4ad655c73794b`). No code changes needed
in imbi-api — the endpoint already references `data.identifiers` and
serializes the dict to JSON before writing.

## Test plan

- [ ] `PATCH /organizations/{org}/projects/{id}` with a `replace` on
  `/identifiers` persists the new map; subsequent `GET` returns it.
- [ ] `POST /organizations/{org}/projects/` with `identifiers` in the
  body persists the identifiers.
- [ ] `just test` passes.