### PR TITLE
Add Release endpoints and deployment-edge tracking

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -217,4 +217,4 @@ url = "https://pypi.org/simple"
 default = true
 
 [tool.uv.sources]
-imbi-common = { git = "https://github.com/AWeber-Imbi/imbi-common.git", rev = "feature/releases" }
+imbi-common = { git = "https://github.com/AWeber-Imbi/imbi-common.git", rev = "main" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -217,4 +217,4 @@ url = "https://pypi.org/simple"
 default = true
 
 [tool.uv.sources]
-imbi-common = { git = "https://github.com/AWeber-Imbi/imbi-common.git", rev = "main" }
+imbi-common = { git = "https://github.com/AWeber-Imbi/imbi-common.git", rev = "feature/releases" }

--- a/src/imbi_api/endpoints/organizations.py
+++ b/src/imbi_api/endpoints/organizations.py
@@ -18,6 +18,7 @@ from .link_definitions import link_definitions_router
 from .operations_log import operations_log_project_router
 from .project_types import project_types_router
 from .projects import projects_router
+from .releases import releases_router
 from .teams import teams_router
 from .third_party_services import third_party_services_router
 from .webhooks import project_services_router, webhooks_router
@@ -59,6 +60,10 @@ organizations_router.include_router(
 organizations_router.include_router(
     operations_log_project_router,
     prefix='/{org_slug}/projects/{project_id}/operations-log',
+)
+organizations_router.include_router(
+    releases_router,
+    prefix='/{org_slug}/projects/{project_id}/releases',
 )
 organizations_router.include_router(
     project_services_router,

--- a/src/imbi_api/endpoints/releases.py
+++ b/src/imbi_api/endpoints/releases.py
@@ -1,0 +1,714 @@
+"""Release CRUD and deployment-edge endpoints.
+
+Releases are identified by a per-project ``version`` string. The
+``Release`` node is connected to its ``Project`` via an incoming
+``HAS_RELEASE`` edge and to every ``Environment`` it has been
+deployed to via a ``DEPLOYED_TO`` edge carrying an append-only
+``deployments`` history.
+
+"""
+
+import datetime
+import json
+import logging
+import typing
+
+import fastapi
+import nanoid
+import pydantic
+from imbi_common import graph, models, versioning
+from imbi_common import settings as common_settings
+
+from imbi_api import patch as json_patch
+from imbi_api.auth import permissions
+
+LOGGER = logging.getLogger(__name__)
+
+releases_router = fastapi.APIRouter(tags=['Releases'])
+
+
+_DEPLOYMENT_STATUS = typing.Literal[
+    'pending',
+    'in_progress',
+    'success',
+    'failed',
+    'rolled_back',
+]
+
+
+# -- Request / Response models ------------------------------------------
+
+
+class ReleaseCreate(pydantic.BaseModel):
+    """Request body for creating a release."""
+
+    model_config = pydantic.ConfigDict(extra='forbid')
+
+    version: str
+    title: str
+    description: str | None = None
+    links: list[models.ReleaseLink] = []
+    created_by: str | None = None
+
+
+class ReleaseUpdate(pydantic.BaseModel):
+    """JSON Patch-compatible release shape.
+
+    Only ``title``, ``description``, and ``links`` may be patched;
+    ``version`` / ``id`` / timestamps / project are read-only.
+    """
+
+    model_config = pydantic.ConfigDict(extra='forbid')
+
+    title: str | None = None
+    description: str | None = None
+    links: list[models.ReleaseLink] | None = None
+
+
+class ReleaseResponse(pydantic.BaseModel):
+    """Response body for a release."""
+
+    id: str
+    project_id: str
+    version: str
+    title: str
+    description: str | None = None
+    links: list[models.ReleaseLink] = []
+    created_at: datetime.datetime
+    updated_at: datetime.datetime | None = None
+    created_by: str
+
+    @pydantic.field_validator('links', mode='before')
+    @classmethod
+    def _parse_links(cls, value: typing.Any) -> typing.Any:
+        if isinstance(value, str):
+            return json.loads(value)
+        return value
+
+
+class DeploymentEventInput(pydantic.BaseModel):
+    """Request body for recording a deployment event."""
+
+    model_config = pydantic.ConfigDict(extra='forbid')
+
+    status: _DEPLOYMENT_STATUS
+    note: str | None = None
+
+
+class ReleaseEnvironmentRef(pydantic.BaseModel):
+    """Minimal environment identity returned on edge responses."""
+
+    slug: str
+    name: str
+
+
+class ReleaseEnvironmentEdgeResponse(pydantic.BaseModel):
+    """Response body for a release/environment deployment edge."""
+
+    environment: ReleaseEnvironmentRef
+    deployments: list[models.DeploymentEvent] = []
+    current_status: _DEPLOYMENT_STATUS | None = None
+
+
+# -- Helpers ------------------------------------------------------------
+
+
+_RELEASE_READONLY_PATHS: frozenset[str] = frozenset(
+    [
+        '/id',
+        '/version',
+        '/project_id',
+        '/created_at',
+        '/updated_at',
+        '/created_by',
+    ]
+)
+
+
+def _version_format() -> versioning.VersionFormat:
+    """Return the active configured release version format."""
+    return common_settings.Releases().version_format
+
+
+def _serialize_links(
+    links: list[models.ReleaseLink] | list[dict[str, typing.Any]],
+) -> str:
+    """Serialize a list of release links to a JSON string for storage."""
+    out: list[dict[str, typing.Any]] = []
+    for link in links:
+        if isinstance(link, models.ReleaseLink):
+            out.append(link.model_dump(mode='json'))
+        else:
+            out.append(models.ReleaseLink(**link).model_dump(mode='json'))
+    return json.dumps(out)
+
+
+def _parse_deployments(
+    raw: typing.Any,
+) -> list[models.DeploymentEvent]:
+    """Parse the JSON-encoded ``deployments`` edge property."""
+    if not raw:
+        return []
+    data = json.loads(raw) if isinstance(raw, str) else raw
+    if not isinstance(data, list):
+        return []
+    items: list[typing.Any] = data  # type: ignore[assignment]
+    return [models.DeploymentEvent.model_validate(e) for e in items]
+
+
+def _release_to_response(
+    data: dict[str, typing.Any],
+    project_id: str,
+) -> ReleaseResponse:
+    """Build a ``ReleaseResponse`` from a parsed release node dict."""
+    raw_links: typing.Any = data.get('links') or []
+    if isinstance(raw_links, str):
+        raw_links = json.loads(raw_links)
+    return ReleaseResponse.model_validate(
+        {
+            'id': data['id'],
+            'project_id': project_id,
+            'version': data['version'],
+            'title': data['title'],
+            'description': data.get('description'),
+            'links': raw_links,
+            'created_at': data['created_at'],
+            'updated_at': data.get('updated_at'),
+            'created_by': data['created_by'],
+        }
+    )
+
+
+async def _project_exists(
+    db: graph.Graph,
+    org_slug: str,
+    project_id: str,
+) -> bool:
+    """Return True when the project exists in the given organization."""
+    query: typing.LiteralString = """
+    MATCH (p:Project {{id: {project_id}}})
+          -[:OWNED_BY]->(:Team)
+          -[:BELONGS_TO]->(:Organization {{slug: {org_slug}}})
+    RETURN p.id AS id
+    """
+    rows = await db.execute(
+        query,
+        {'project_id': project_id, 'org_slug': org_slug},
+        ['id'],
+    )
+    return bool(rows)
+
+
+async def _fetch_release(
+    db: graph.Graph,
+    org_slug: str,
+    project_id: str,
+    version: str,
+) -> dict[str, typing.Any] | None:
+    """Fetch a release node by project and version."""
+    query: typing.LiteralString = """
+    MATCH (p:Project {{id: {project_id}}})
+          -[:OWNED_BY]->(:Team)
+          -[:BELONGS_TO]->(:Organization {{slug: {org_slug}}})
+    MATCH (p)-[:HAS_RELEASE]->(r:Release {{version: {version}}})
+    RETURN r{{.*}} AS release
+    """
+    rows = await db.execute(
+        query,
+        {
+            'project_id': project_id,
+            'org_slug': org_slug,
+            'version': version,
+        },
+        ['release'],
+    )
+    if not rows:
+        return None
+    return typing.cast(
+        dict[str, typing.Any], graph.parse_agtype(rows[0]['release'])
+    )
+
+
+# -- Endpoints ----------------------------------------------------------
+
+
+@releases_router.post('/', status_code=201, response_model=ReleaseResponse)
+async def create_release(
+    org_slug: str,
+    project_id: str,
+    data: ReleaseCreate,
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('project:write'),
+        ),
+    ],
+) -> ReleaseResponse:
+    """Create a new release for a project."""
+    try:
+        version = versioning.validate_version(data.version, _version_format())
+    except ValueError as e:
+        raise fastapi.HTTPException(status_code=422, detail=str(e)) from e
+
+    if not await _project_exists(db, org_slug, project_id):
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail=f'Project {project_id!r} not found',
+        )
+
+    # Per-project version uniqueness pre-check.
+    existing_query: typing.LiteralString = """
+    MATCH (p:Project {{id: {project_id}}})
+          -[:HAS_RELEASE]->(r:Release {{version: {version}}})
+    RETURN r.id AS id
+    """
+    existing = await db.execute(
+        existing_query,
+        {'project_id': project_id, 'version': version},
+        ['id'],
+    )
+    if existing:
+        raise fastapi.HTTPException(
+            status_code=409,
+            detail=(
+                f'Release {version!r} already exists'
+                f' for project {project_id!r}'
+            ),
+        )
+
+    # Spec calls for ``auth.user.username``; the User model uses
+    # ``email`` as the principal identity (no ``username`` field).
+    # ``principal_name`` returns the user's email or the service
+    # account's slug — matching the convention used by opslog.
+    created_by = data.created_by or auth.principal_name
+    now = datetime.datetime.now(datetime.UTC)
+    props: dict[str, typing.Any] = {
+        'id': nanoid.generate(),
+        'version': version,
+        'title': data.title,
+        'description': data.description,
+        'links': _serialize_links(data.links),
+        'created_by': created_by,
+        'created_at': now.isoformat(),
+        'updated_at': now.isoformat(),
+    }
+
+    create_query: typing.LiteralString = """
+    MATCH (p:Project {{id: {project_id}}})
+    CREATE (r:Release {{
+        id: {id},
+        version: {version},
+        title: {title},
+        description: {description},
+        links: {links},
+        created_by: {created_by},
+        created_at: {created_at},
+        updated_at: {updated_at}
+    }})
+    CREATE (p)-[:HAS_RELEASE]->(r)
+    RETURN r{{.*}} AS release
+    """
+    rows = await db.execute(
+        create_query,
+        {'project_id': project_id, **props},
+        ['release'],
+    )
+    if not rows:
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail=f'Project {project_id!r} not found',
+        )
+    release_data = graph.parse_agtype(rows[0]['release'])
+    return _release_to_response(release_data, project_id)
+
+
+@releases_router.get('/', response_model=list[ReleaseResponse])
+async def list_releases(
+    org_slug: str,
+    project_id: str,
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('project:read'),
+        ),
+    ],
+) -> list[ReleaseResponse]:
+    """List all releases for a project, newest first."""
+    del auth
+    query: typing.LiteralString = """
+    MATCH (p:Project {{id: {project_id}}})
+          -[:OWNED_BY]->(:Team)
+          -[:BELONGS_TO]->(:Organization {{slug: {org_slug}}})
+    MATCH (p)-[:HAS_RELEASE]->(r:Release)
+    RETURN r{{.*}} AS release
+    ORDER BY r.created_at DESC
+    """
+    rows = await db.execute(
+        query,
+        {'project_id': project_id, 'org_slug': org_slug},
+        ['release'],
+    )
+    return [
+        _release_to_response(graph.parse_agtype(r['release']), project_id)
+        for r in rows
+    ]
+
+
+@releases_router.get('/{version}', response_model=ReleaseResponse)
+async def get_release(
+    org_slug: str,
+    project_id: str,
+    version: str,
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('project:read'),
+        ),
+    ],
+) -> ReleaseResponse:
+    """Get a single release by version."""
+    del auth
+    data = await _fetch_release(db, org_slug, project_id, version)
+    if data is None:
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail=(
+                f'Release {version!r} for project {project_id!r} not found'
+            ),
+        )
+    return _release_to_response(data, project_id)
+
+
+@releases_router.patch('/{version}', response_model=ReleaseResponse)
+async def patch_release(
+    org_slug: str,
+    project_id: str,
+    version: str,
+    operations: list[json_patch.PatchOperation],
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('project:write'),
+        ),
+    ],
+) -> ReleaseResponse:
+    """Apply a JSON Patch (RFC 6902) to a release."""
+    del auth
+    data = await _fetch_release(db, org_slug, project_id, version)
+    if data is None:
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail=(
+                f'Release {version!r} for project {project_id!r} not found'
+            ),
+        )
+
+    raw_links: typing.Any = data.get('links') or []
+    if isinstance(raw_links, str):
+        raw_links = json.loads(raw_links)
+    patchable: dict[str, typing.Any] = {
+        'title': data['title'],
+        'description': data.get('description'),
+        'links': raw_links,
+    }
+
+    patched = json_patch.apply_patch(
+        patchable, operations, _RELEASE_READONLY_PATHS
+    )
+
+    try:
+        update = ReleaseUpdate(**patched)
+    except pydantic.ValidationError as e:
+        LOGGER.warning('Validation error patching release: %s', e)
+        raise fastapi.HTTPException(
+            status_code=400,
+            detail=f'Validation error: {e.errors()}',
+        ) from e
+
+    now = datetime.datetime.now(datetime.UTC)
+    # ``patched`` is the post-JSON-Patch document — treat it as the
+    # source of truth rather than the ``ReleaseUpdate`` view so that
+    # explicit nulls (e.g. ``remove`` of ``/description``) survive.
+    merged_title = patched.get('title') or data['title']
+    merged_description = patched.get('description')
+    merged_links_raw = patched.get('links', raw_links)
+    serialized_links = _serialize_links(merged_links_raw)
+    del update
+
+    update_query: typing.LiteralString = """
+    MATCH (p:Project {{id: {project_id}}})
+          -[:HAS_RELEASE]->(r:Release {{version: {version}}})
+    SET r.title = {title},
+        r.description = {description},
+        r.links = {links},
+        r.updated_at = {updated_at}
+    RETURN r{{.*}} AS release
+    """
+    rows = await db.execute(
+        update_query,
+        {
+            'project_id': project_id,
+            'version': version,
+            'title': merged_title,
+            'description': merged_description,
+            'links': serialized_links,
+            'updated_at': now.isoformat(),
+        },
+        ['release'],
+    )
+    if not rows:
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail=(
+                f'Release {version!r} for project {project_id!r} not found'
+            ),
+        )
+    release_data = graph.parse_agtype(rows[0]['release'])
+    return _release_to_response(release_data, project_id)
+
+
+# -- Deployment edge ----------------------------------------------------
+
+
+async def _fetch_deployment_edge(
+    db: graph.Graph,
+    org_slug: str,
+    project_id: str,
+    version: str,
+    env_slug: str,
+) -> tuple[dict[str, typing.Any] | None, list[models.DeploymentEvent]]:
+    """Fetch environment and any existing DEPLOYED_TO edge."""
+    query: typing.LiteralString = """
+    MATCH (p:Project {{id: {project_id}}})
+          -[:HAS_RELEASE]->(r:Release {{version: {version}}})
+    MATCH (e:Environment {{slug: {env_slug}}})
+          -[:BELONGS_TO]->(:Organization {{slug: {org_slug}}})
+    OPTIONAL MATCH (r)-[d:DEPLOYED_TO]->(e)
+    RETURN e{{.slug, .name}} AS env,
+           CASE WHEN d IS NULL THEN null ELSE d.deployments END
+               AS deployments
+    """
+    rows = await db.execute(
+        query,
+        {
+            'project_id': project_id,
+            'version': version,
+            'env_slug': env_slug,
+            'org_slug': org_slug,
+        },
+        ['env', 'deployments'],
+    )
+    if not rows:
+        return None, []
+    env = graph.parse_agtype(rows[0]['env'])
+    deployments = _parse_deployments(
+        graph.parse_agtype(rows[0]['deployments'])
+    )
+    return env, deployments
+
+
+def _edge_to_response(
+    env: dict[str, typing.Any],
+    deployments: list[models.DeploymentEvent],
+) -> ReleaseEnvironmentEdgeResponse:
+    """Build an edge response with derived ``current_status``."""
+    return ReleaseEnvironmentEdgeResponse(
+        environment=ReleaseEnvironmentRef(slug=env['slug'], name=env['name']),
+        deployments=deployments,
+        current_status=deployments[-1].status if deployments else None,
+    )
+
+
+@releases_router.post(
+    '/{version}/environments/{env_slug}',
+    response_model=ReleaseEnvironmentEdgeResponse,
+)
+async def record_deployment(
+    org_slug: str,
+    project_id: str,
+    version: str,
+    env_slug: str,
+    data: DeploymentEventInput,
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('project:write'),
+        ),
+    ],
+) -> ReleaseEnvironmentEdgeResponse:
+    """Record a deployment event for a release in an environment."""
+    del auth
+    release = await _fetch_release(db, org_slug, project_id, version)
+    if release is None:
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail=(
+                f'Release {version!r} for project {project_id!r} not found'
+            ),
+        )
+
+    env, existing = await _fetch_deployment_edge(
+        db, org_slug, project_id, version, env_slug
+    )
+    if env is None:
+        raise fastapi.HTTPException(
+            status_code=422,
+            detail=(
+                f'Environment {env_slug!r} not found in'
+                f' organization {org_slug!r}'
+            ),
+        )
+
+    event = models.DeploymentEvent(
+        timestamp=datetime.datetime.now(datetime.UTC),
+        status=data.status,
+        note=data.note,
+    )
+    deployments = [*existing, event]
+    serialized = json.dumps(
+        [e.model_dump(mode='json') for e in deployments],
+    )
+
+    if existing:
+        set_query: typing.LiteralString = """
+        MATCH (:Project {{id: {project_id}}})
+              -[:HAS_RELEASE]->(r:Release {{version: {version}}})
+        MATCH (r)-[d:DEPLOYED_TO]->(:Environment {{slug: {env_slug}}})
+        SET d.deployments = {deployments}
+        RETURN d.deployments AS deployments
+        """
+        await db.execute(
+            set_query,
+            {
+                'project_id': project_id,
+                'version': version,
+                'env_slug': env_slug,
+                'deployments': serialized,
+            },
+            ['deployments'],
+        )
+    else:
+        create_query: typing.LiteralString = """
+        MATCH (:Project {{id: {project_id}}})
+              -[:HAS_RELEASE]->(r:Release {{version: {version}}})
+        MATCH (e:Environment {{slug: {env_slug}}})
+              -[:BELONGS_TO]->(:Organization {{slug: {org_slug}}})
+        CREATE (r)-[d:DEPLOYED_TO {{deployments: {deployments}}}]->(e)
+        RETURN d.deployments AS deployments
+        """
+        await db.execute(
+            create_query,
+            {
+                'project_id': project_id,
+                'version': version,
+                'env_slug': env_slug,
+                'org_slug': org_slug,
+                'deployments': serialized,
+            },
+            ['deployments'],
+        )
+
+    return _edge_to_response(env, deployments)
+
+
+@releases_router.get(
+    '/{version}/environments',
+    response_model=list[ReleaseEnvironmentEdgeResponse],
+)
+async def list_deployment_edges(
+    org_slug: str,
+    project_id: str,
+    version: str,
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('project:read'),
+        ),
+    ],
+) -> list[ReleaseEnvironmentEdgeResponse]:
+    """List every environment edge for a release."""
+    del auth
+    release = await _fetch_release(db, org_slug, project_id, version)
+    if release is None:
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail=(
+                f'Release {version!r} for project {project_id!r} not found'
+            ),
+        )
+
+    query: typing.LiteralString = """
+    MATCH (p:Project {{id: {project_id}}})
+          -[:OWNED_BY]->(:Team)
+          -[:BELONGS_TO]->(:Organization {{slug: {org_slug}}})
+    MATCH (p)-[:HAS_RELEASE]->(r:Release {{version: {version}}})
+    MATCH (r)-[d:DEPLOYED_TO]->(e:Environment)
+    RETURN e{{.slug, .name}} AS env, d.deployments AS deployments
+    ORDER BY e.slug
+    """
+    rows = await db.execute(
+        query,
+        {
+            'project_id': project_id,
+            'org_slug': org_slug,
+            'version': version,
+        },
+        ['env', 'deployments'],
+    )
+    results: list[ReleaseEnvironmentEdgeResponse] = []
+    for row in rows:
+        env = graph.parse_agtype(row['env'])
+        if not env:
+            continue
+        deployments = _parse_deployments(
+            graph.parse_agtype(row['deployments'])
+        )
+        results.append(_edge_to_response(env, deployments))
+    return results
+
+
+@releases_router.get(
+    '/{version}/environments/{env_slug}',
+    response_model=ReleaseEnvironmentEdgeResponse,
+)
+async def get_deployment_edge(
+    org_slug: str,
+    project_id: str,
+    version: str,
+    env_slug: str,
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('project:read'),
+        ),
+    ],
+) -> ReleaseEnvironmentEdgeResponse:
+    """Get a single deployment edge by environment slug."""
+    del auth
+    release = await _fetch_release(db, org_slug, project_id, version)
+    if release is None:
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail=(
+                f'Release {version!r} for project {project_id!r} not found'
+            ),
+        )
+    env, deployments = await _fetch_deployment_edge(
+        db, org_slug, project_id, version, env_slug
+    )
+    if env is None or not deployments:
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail=(
+                f'Deployment edge for release {version!r} in'
+                f' environment {env_slug!r} not found'
+            ),
+        )
+    return _edge_to_response(env, deployments)

--- a/src/imbi_api/endpoints/releases.py
+++ b/src/imbi_api/endpoints/releases.py
@@ -433,7 +433,10 @@ async def patch_release(
     # ``patched`` is the post-JSON-Patch document — treat it as the
     # source of truth rather than the ``ReleaseUpdate`` view so that
     # explicit nulls (e.g. ``remove`` of ``/description``) survive.
-    merged_title = patched.get('title') or data['title']
+    # Use key presence, not truthiness, so explicit empty strings
+    # (``replace /title ""``) are persisted rather than silently
+    # reverted to the old value.
+    merged_title = patched['title'] if 'title' in patched else data['title']
     merged_description = patched.get('description')
     merged_links_raw = patched.get('links', raw_links)
     serialized_links = _serialize_links(merged_links_raw)

--- a/src/imbi_api/models.py
+++ b/src/imbi_api/models.py
@@ -23,6 +23,7 @@ __all__ = [  # pyright: ignore[reportUnsupportedDunderAll]
 Blueprint = _common.Blueprint
 BlueprintAssignment = _common.BlueprintAssignment
 BlueprintEdge = _common.BlueprintEdge
+DeploymentEvent = _common.DeploymentEvent
 Environment = _common.Environment
 LinkDefinition = _common.LinkDefinition
 Node = _common.Node
@@ -30,6 +31,9 @@ Organization = _common.Organization
 Project = _common.Project
 ProjectType = _common.ProjectType
 RelationshipLink = _common.RelationshipLink
+Release = _common.Release
+ReleaseDeploymentEdge = _common.ReleaseDeploymentEdge
+ReleaseLink = _common.ReleaseLink
 Schema = _common.Schema
 Team = _common.Team
 

--- a/tests/endpoints/test_releases.py
+++ b/tests/endpoints/test_releases.py
@@ -1,0 +1,561 @@
+"""Tests for release CRUD and deployment-edge endpoints."""
+
+import datetime
+import json
+import typing
+import unittest
+from unittest import mock
+
+import fastapi.testclient
+from imbi_common import graph
+
+from imbi_api import app, models
+
+PROJECT_ID = 'proj123nanoid'
+RELEASE_ID = 'rel456nanoid'
+ORG = 'engineering'
+
+
+def _release_row(**overrides: typing.Any) -> dict[str, typing.Any]:
+    data: dict[str, typing.Any] = {
+        'id': RELEASE_ID,
+        'version': '1.2.3',
+        'title': 'Initial release',
+        'description': None,
+        'links': json.dumps([]),
+        'created_by': 'alice@example.com',
+        'created_at': '2026-04-20T12:00:00+00:00',
+        'updated_at': '2026-04-20T12:00:00+00:00',
+    }
+    data.update(overrides)
+    return data
+
+
+class _ReleasesTestBase(unittest.TestCase):
+    """Shared setup mounting release endpoints with admin auth."""
+
+    permissions_granted: typing.ClassVar[set[str]] = {
+        'project:read',
+        'project:write',
+    }
+
+    def setUp(self) -> None:
+        from imbi_api.auth import permissions
+
+        self.test_app = app.create_app()
+
+        self.admin_user = models.User(
+            email='alice@example.com',
+            display_name='Alice',
+            password_hash='$argon2id$hashed',
+            is_active=True,
+            is_admin=True,
+            is_service_account=False,
+            created_at=datetime.datetime.now(datetime.UTC),
+        )
+        self.auth_context = permissions.AuthContext(
+            user=self.admin_user,
+            session_id='test-session',
+            auth_method='jwt',
+            permissions=self.permissions_granted,
+        )
+
+        async def _current_user() -> permissions.AuthContext:
+            return self.auth_context
+
+        self.test_app.dependency_overrides[permissions.get_current_user] = (
+            _current_user
+        )
+
+        self.mock_db = mock.AsyncMock(spec=graph.Graph)
+        self.test_app.dependency_overrides[graph._inject_graph] = (
+            lambda: self.mock_db
+        )
+        self.client = fastapi.testclient.TestClient(self.test_app)
+        self.addCleanup(self.client.close)
+
+    def _url(self, tail: str = '') -> str:
+        base = f'/organizations/{ORG}/projects/{PROJECT_ID}/releases'
+        return f'{base}{tail}'
+
+
+class CreateReleaseTestCase(_ReleasesTestBase):
+    """POST /releases/"""
+
+    def test_create_success(self) -> None:
+        self.mock_db.execute.side_effect = [
+            [{'id': PROJECT_ID}],  # project_exists
+            [],  # version uniqueness check
+            [{'release': _release_row()}],  # create
+        ]
+
+        with (
+            mock.patch(
+                'imbi_common.graph.parse_agtype',
+                side_effect=lambda x: x,
+            ),
+            mock.patch(
+                'imbi_api.endpoints.releases.nanoid.generate',
+                return_value=RELEASE_ID,
+            ),
+        ):
+            response = self.client.post(
+                self._url('/'),
+                json={
+                    'version': '1.2.3',
+                    'title': 'Initial release',
+                    'description': 'First cut',
+                    'links': [
+                        {
+                            'type': 'github_release',
+                            'url': 'https://example.com/r/1.2.3',
+                        }
+                    ],
+                },
+            )
+
+        self.assertEqual(response.status_code, 201)
+        body = response.json()
+        self.assertEqual(body['version'], '1.2.3')
+        self.assertEqual(body['project_id'], PROJECT_ID)
+        self.assertEqual(body['id'], RELEASE_ID)
+        self.assertEqual(body['created_by'], 'alice@example.com')
+
+    def test_create_with_explicit_created_by(self) -> None:
+        self.mock_db.execute.side_effect = [
+            [{'id': PROJECT_ID}],
+            [],
+            [{'release': _release_row(created_by='deploy-bot')}],
+        ]
+        with (
+            mock.patch(
+                'imbi_common.graph.parse_agtype',
+                side_effect=lambda x: x,
+            ),
+            mock.patch(
+                'imbi_api.endpoints.releases.nanoid.generate',
+                return_value=RELEASE_ID,
+            ),
+        ):
+            response = self.client.post(
+                self._url('/'),
+                json={
+                    'version': '1.2.3',
+                    'title': 'Initial release',
+                    'created_by': 'deploy-bot',
+                },
+            )
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.json()['created_by'], 'deploy-bot')
+
+    def test_create_invalid_semver(self) -> None:
+        response = self.client.post(
+            self._url('/'),
+            json={'version': 'not.a.version', 'title': 'x'},
+        )
+        self.assertEqual(response.status_code, 422)
+        self.assertIn('semver', response.json()['detail'].lower())
+
+    def test_create_project_not_found(self) -> None:
+        self.mock_db.execute.side_effect = [[]]  # project_exists -> no rows
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            response = self.client.post(
+                self._url('/'),
+                json={'version': '1.0.0', 'title': 'x'},
+            )
+        self.assertEqual(response.status_code, 404)
+
+    def test_create_duplicate_version_same_project(self) -> None:
+        self.mock_db.execute.side_effect = [
+            [{'id': PROJECT_ID}],
+            [{'id': RELEASE_ID}],  # duplicate
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            response = self.client.post(
+                self._url('/'),
+                json={'version': '1.2.3', 'title': 'x'},
+            )
+        self.assertEqual(response.status_code, 409)
+
+    def test_create_cross_project_duplicate_ok(self) -> None:
+        """Uniqueness is per-project: another project may reuse 1.2.3."""
+        self.mock_db.execute.side_effect = [
+            [{'id': PROJECT_ID}],
+            [],  # no existing release under THIS project
+            [{'release': _release_row()}],
+        ]
+        with (
+            mock.patch(
+                'imbi_common.graph.parse_agtype',
+                side_effect=lambda x: x,
+            ),
+            mock.patch(
+                'imbi_api.endpoints.releases.nanoid.generate',
+                return_value=RELEASE_ID,
+            ),
+        ):
+            response = self.client.post(
+                self._url('/'),
+                json={'version': '1.2.3', 'title': 'x'},
+            )
+        self.assertEqual(response.status_code, 201)
+
+    def test_create_commitish_format_rejects_semver(self) -> None:
+        """With version_format=commitish the semver regex is rejected."""
+        with mock.patch(
+            'imbi_api.endpoints.releases.common_settings.Releases'
+        ) as mock_releases:
+            mock_releases.return_value.version_format = 'commitish'
+            response = self.client.post(
+                self._url('/'),
+                json={'version': '1.2.3', 'title': 'x'},
+            )
+            self.assertEqual(response.status_code, 422)
+            self.assertIn('commitish', response.json()['detail'].lower())
+
+    def test_create_commitish_valid_sha(self) -> None:
+        self.mock_db.execute.side_effect = [
+            [{'id': PROJECT_ID}],
+            [],
+            [{'release': _release_row(version='abc1234')}],
+        ]
+        with (
+            mock.patch(
+                'imbi_common.graph.parse_agtype',
+                side_effect=lambda x: x,
+            ),
+            mock.patch(
+                'imbi_api.endpoints.releases.nanoid.generate',
+                return_value=RELEASE_ID,
+            ),
+            mock.patch(
+                'imbi_api.endpoints.releases.common_settings.Releases'
+            ) as mock_releases,
+        ):
+            mock_releases.return_value.version_format = 'commitish'
+            response = self.client.post(
+                self._url('/'),
+                json={'version': 'abc1234', 'title': 'x'},
+            )
+        self.assertEqual(response.status_code, 201)
+
+
+class ListGetReleaseTestCase(_ReleasesTestBase):
+    """GET list / get single / 404."""
+
+    def test_list_releases(self) -> None:
+        self.mock_db.execute.return_value = [
+            {'release': _release_row(version='1.0.0', id='a')},
+            {'release': _release_row(version='1.1.0', id='b')},
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            response = self.client.get(self._url('/'))
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(len(data), 2)
+        self.assertEqual(data[0]['version'], '1.0.0')
+        self.assertEqual(data[0]['project_id'], PROJECT_ID)
+
+    def test_get_release_success(self) -> None:
+        self.mock_db.execute.return_value = [{'release': _release_row()}]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            response = self.client.get(self._url('/1.2.3'))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()['version'], '1.2.3')
+
+    def test_get_release_not_found(self) -> None:
+        self.mock_db.execute.return_value = []
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            response = self.client.get(self._url('/9.9.9'))
+        self.assertEqual(response.status_code, 404)
+
+
+class PatchReleaseTestCase(_ReleasesTestBase):
+    """PATCH /releases/{version}"""
+
+    def test_patch_title(self) -> None:
+        self.mock_db.execute.side_effect = [
+            [{'release': _release_row()}],
+            [{'release': _release_row(title='Updated')}],
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            response = self.client.patch(
+                self._url('/1.2.3'),
+                json=[
+                    {'op': 'replace', 'path': '/title', 'value': 'Updated'},
+                ],
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()['title'], 'Updated')
+
+    def test_patch_description_and_links(self) -> None:
+        self.mock_db.execute.side_effect = [
+            [{'release': _release_row()}],
+            [
+                {
+                    'release': _release_row(
+                        description='New desc',
+                        links=json.dumps(
+                            [
+                                {
+                                    'type': 'github_release',
+                                    'url': 'https://example.com/',
+                                    'label': None,
+                                }
+                            ]
+                        ),
+                    )
+                }
+            ],
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            response = self.client.patch(
+                self._url('/1.2.3'),
+                json=[
+                    {
+                        'op': 'replace',
+                        'path': '/description',
+                        'value': 'New desc',
+                    },
+                    {
+                        'op': 'replace',
+                        'path': '/links',
+                        'value': [
+                            {
+                                'type': 'github_release',
+                                'url': 'https://example.com/',
+                            }
+                        ],
+                    },
+                ],
+            )
+        self.assertEqual(response.status_code, 200)
+        body = response.json()
+        self.assertEqual(body['description'], 'New desc')
+        self.assertEqual(len(body['links']), 1)
+
+    def test_patch_readonly_version(self) -> None:
+        self.mock_db.execute.side_effect = [[{'release': _release_row()}]]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            response = self.client.patch(
+                self._url('/1.2.3'),
+                json=[
+                    {'op': 'replace', 'path': '/version', 'value': '2.0.0'},
+                ],
+            )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('read-only', response.json()['detail'])
+
+    def test_patch_unknown_path(self) -> None:
+        self.mock_db.execute.side_effect = [[{'release': _release_row()}]]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            response = self.client.patch(
+                self._url('/1.2.3'),
+                json=[
+                    {'op': 'replace', 'path': '/bogus', 'value': 'x'},
+                ],
+            )
+        self.assertEqual(response.status_code, 400)
+
+    def test_patch_not_found(self) -> None:
+        self.mock_db.execute.return_value = []
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            response = self.client.patch(
+                self._url('/1.2.3'),
+                json=[
+                    {'op': 'replace', 'path': '/title', 'value': 'x'},
+                ],
+            )
+        self.assertEqual(response.status_code, 404)
+
+
+class DeploymentEdgeTestCase(_ReleasesTestBase):
+    """POST / GET deployment edges."""
+
+    def _env(self, slug: str = 'production') -> dict[str, typing.Any]:
+        return {'slug': slug, 'name': slug.title()}
+
+    def test_record_deployment_creates_edge(self) -> None:
+        self.mock_db.execute.side_effect = [
+            [{'release': _release_row()}],  # _fetch_release
+            # _fetch_deployment_edge: env exists, no edge
+            [{'env': self._env(), 'deployments': None}],
+            [{'deployments': None}],  # create_query
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            response = self.client.post(
+                self._url('/1.2.3/environments/production'),
+                json={'status': 'pending'},
+            )
+        self.assertEqual(response.status_code, 200)
+        body = response.json()
+        self.assertEqual(body['environment']['slug'], 'production')
+        self.assertEqual(len(body['deployments']), 1)
+        self.assertEqual(body['deployments'][0]['status'], 'pending')
+        self.assertEqual(body['current_status'], 'pending')
+
+    def test_record_deployment_appends(self) -> None:
+        existing = [
+            {
+                'timestamp': '2026-04-20T10:00:00+00:00',
+                'status': 'pending',
+                'note': None,
+            }
+        ]
+        self.mock_db.execute.side_effect = [
+            [{'release': _release_row()}],
+            [
+                {
+                    'env': self._env(),
+                    'deployments': json.dumps(existing),
+                }
+            ],
+            [{'deployments': None}],
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            response = self.client.post(
+                self._url('/1.2.3/environments/production'),
+                json={'status': 'success', 'note': 'rolled out'},
+            )
+        self.assertEqual(response.status_code, 200)
+        body = response.json()
+        self.assertEqual(len(body['deployments']), 2)
+        self.assertEqual(body['current_status'], 'success')
+
+    def test_record_deployment_env_missing(self) -> None:
+        self.mock_db.execute.side_effect = [
+            [{'release': _release_row()}],
+            [],  # env not found
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            response = self.client.post(
+                self._url('/1.2.3/environments/ghost'),
+                json={'status': 'pending'},
+            )
+        self.assertEqual(response.status_code, 422)
+
+    def test_record_deployment_release_missing(self) -> None:
+        self.mock_db.execute.side_effect = [[]]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            response = self.client.post(
+                self._url('/9.9.9/environments/production'),
+                json={'status': 'pending'},
+            )
+        self.assertEqual(response.status_code, 404)
+
+    def test_list_deployment_edges(self) -> None:
+        deployments = json.dumps(
+            [
+                {
+                    'timestamp': '2026-04-20T10:00:00+00:00',
+                    'status': 'success',
+                    'note': None,
+                }
+            ]
+        )
+        self.mock_db.execute.side_effect = [
+            [{'release': _release_row()}],
+            [
+                {
+                    'env': self._env('production'),
+                    'deployments': deployments,
+                },
+                {
+                    'env': self._env('staging'),
+                    'deployments': deployments,
+                },
+            ],
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            response = self.client.get(
+                self._url('/1.2.3/environments'),
+            )
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(len(data), 2)
+        self.assertEqual(data[0]['current_status'], 'success')
+
+    def test_get_single_edge_404_when_no_edge(self) -> None:
+        self.mock_db.execute.side_effect = [
+            [{'release': _release_row()}],
+            # env exists but no edge
+            [{'env': self._env(), 'deployments': None}],
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            response = self.client.get(
+                self._url('/1.2.3/environments/production'),
+            )
+        self.assertEqual(response.status_code, 404)
+
+    def test_get_single_edge_success(self) -> None:
+        deployments = json.dumps(
+            [
+                {
+                    'timestamp': '2026-04-20T10:00:00+00:00',
+                    'status': 'success',
+                    'note': None,
+                }
+            ]
+        )
+        self.mock_db.execute.side_effect = [
+            [{'release': _release_row()}],
+            [{'env': self._env(), 'deployments': deployments}],
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            response = self.client.get(
+                self._url('/1.2.3/environments/production'),
+            )
+        self.assertEqual(response.status_code, 200)
+        body = response.json()
+        self.assertEqual(body['current_status'], 'success')

--- a/tests/endpoints/test_releases.py
+++ b/tests/endpoints/test_releases.py
@@ -355,6 +355,29 @@ class PatchReleaseTestCase(_ReleasesTestBase):
         self.assertEqual(body['description'], 'New desc')
         self.assertEqual(len(body['links']), 1)
 
+    def test_patch_title_to_empty_string(self) -> None:
+        """Explicit empty-string patches of ``title`` must persist."""
+        self.mock_db.execute.side_effect = [
+            [{'release': _release_row()}],
+            [{'release': _release_row(title='')}],
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            response = self.client.patch(
+                self._url('/1.2.3'),
+                json=[
+                    {'op': 'replace', 'path': '/title', 'value': ''},
+                ],
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()['title'], '')
+        # Confirm the SET clause received the empty string, not the old
+        # title — i.e. the fix for truthiness-vs-presence is effective.
+        update_call = self.mock_db.execute.await_args_list[1]
+        self.assertEqual(update_call.args[1]['title'], '')
+
     def test_patch_readonly_version(self) -> None:
         self.mock_db.execute.side_effect = [[{'release': _release_row()}]]
         with mock.patch(

--- a/uv.lock
+++ b/uv.lock
@@ -897,7 +897,7 @@ requires-dist = [
     { name = "fastapi" },
     { name = "filetype" },
     { name = "httpx", specifier = ">=0.28.1" },
-    { name = "imbi-common", extras = ["databases", "server"], git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=main" },
+    { name = "imbi-common", extras = ["databases", "server"], git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=feature%2Freleases" },
     { name = "jinja2" },
     { name = "jsonpatch", specifier = ">=1.33" },
     { name = "nanoid", specifier = ">=2.0.0" },
@@ -944,7 +944,7 @@ docs = [
 [[package]]
 name = "imbi-common"
 version = "0.1.0"
-source = { git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=main#f54395f2b75ce4c31f7cc5c60db4ad655c73794b" }
+source = { git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=feature%2Freleases#4fd575aa609b9cad4df7ba60013f5a333fd6f4bf" }
 dependencies = [
     { name = "cryptography" },
     { name = "jsonschema-models" },

--- a/uv.lock
+++ b/uv.lock
@@ -944,7 +944,7 @@ docs = [
 [[package]]
 name = "imbi-common"
 version = "0.1.0"
-source = { git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=feature%2Freleases#4fd575aa609b9cad4df7ba60013f5a333fd6f4bf" }
+source = { git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=feature%2Freleases#cc093a46457b30a198e4c24372785bf4038b4735" }
 dependencies = [
     { name = "cryptography" },
     { name = "jsonschema-models" },

--- a/uv.lock
+++ b/uv.lock
@@ -897,7 +897,7 @@ requires-dist = [
     { name = "fastapi" },
     { name = "filetype" },
     { name = "httpx", specifier = ">=0.28.1" },
-    { name = "imbi-common", extras = ["databases", "server"], git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=feature%2Freleases" },
+    { name = "imbi-common", extras = ["databases", "server"], git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=main" },
     { name = "jinja2" },
     { name = "jsonpatch", specifier = ">=1.33" },
     { name = "nanoid", specifier = ">=2.0.0" },
@@ -944,7 +944,7 @@ docs = [
 [[package]]
 name = "imbi-common"
 version = "0.1.0"
-source = { git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=feature%2Freleases#cc093a46457b30a198e4c24372785bf4038b4735" }
+source = { git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=main#b6ae276c61164c96b69580a40059c5e9a8916d7f" }
 dependencies = [
     { name = "cryptography" },
     { name = "jsonschema-models" },


### PR DESCRIPTION
## Summary

- Wires up the Release CRUD endpoints plus deployment-edge tracking at
  `/organizations/{org_slug}/projects/{project_id}/releases`, consuming
  the Release layer introduced in `imbi-common` PR #57.
- Pins `imbi-common` to the `feature/releases` branch (commit `4fd575a`)
  until that PR lands on `main`; will be rebumped to `main` once
  `AWeber-Imbi/imbi-common#57` merges.

## Problem

Imbi has no first-class concept of a release. Operations-log entries
carry a free-form `version` string, but we cannot yet answer "what was
deployed where, when, by whom?" without guessing. The new Release node
in `imbi-common` gives us identity, and the `DEPLOYED_TO` edge gives
us an append-only deployment history per environment.

## Solution

New `src/imbi_api/endpoints/releases.py` mounted by `organizations.py`
under `/organizations/{org_slug}/projects/{project_id}/releases`:

| Method | Path | Behavior |
|---|---|---|
| `POST`  | `/` | Create a release (validates version against `config.releases.version_format`, per-project uniqueness, 409 on conflict) |
| `GET`   | `/` | List releases, newest first |
| `GET`   | `/{version}` | Fetch a single release |
| `PATCH` | `/{version}` | RFC 6902 JSON Patch on `title`/`description`/`links`; `version`, `id`, `project_id`, timestamps and `created_by` are read-only |
| `POST`  | `/{version}/environments/{env_slug}` | Upsert `DEPLOYED_TO` edge and append a new `DeploymentEvent` to its `deployments` list |
| `GET`   | `/{version}/environments` | List every edge with derived `current_status` |
| `GET`   | `/{version}/environments/{env_slug}` | Fetch one edge; 404 if env exists but edge does not |

### Design decisions / judgment calls

- **Permissions.** `auth/seed.py` defines no release-specific
  permissions, so per the PRD fallback, writes use `project:write` and
  reads use `project:read`. If release-specific permissions are added
  later, a one-line swap.
- **`created_by` default.** The PRD says "default to
  `auth.user.username`", but `models.User` has no `username` field
  (`email` is the principal identity). Used `auth.principal_name`
  instead, which matches the convention in `endpoints/operations_log.py`.
  Noted in a source comment.
- **Cypher deployment-edge upsert.** Two separate Cypher statements
  (OPTIONAL MATCH for existing, then `CREATE` or `SET`) per the PRD's
  explicit guidance to avoid AGE's buggy `MERGE`-with-edge-props path.
- **Patch semantics.** Treat the post-patch document (not the
  `ReleaseUpdate` view) as the source of truth on merge so explicit
  `remove` operations (e.g. clearing `description`) are preserved.
- **Response-model project_id.** Derived from the URL path rather than
  traversing back to the project in Cypher; the edge target is
  implicit in the URL.

## Test plan

- [x] `just lint` passes (ruff, tombi, mypy, basedpyright).
- [x] `just test tests/endpoints/test_releases.py` — 23 tests pass.
- [x] `just test` — 936 passed, 1 skipped (unchanged from main).
- [x] `uv run python -c "from imbi_common import models, versioning; print(models.Release, versioning.validate_version)"` resolves.
- [ ] After `AWeber-Imbi/imbi-common#57` merges, rebump
      `imbi-common` rev to `main` in `pyproject.toml` + `uv.lock` and
      push an update to this PR before merging.

## Blocked on

- **`AWeber-Imbi/imbi-common#57`** — must merge first. This PR pins to
  the branch head intentionally; the final commit before merging here
  will move the rev back to `main`.