### PR TITLE
Refactor: extract shared Cypher helpers, token issuance, and batch seeding

### DIFF
--- a/src/imbi_api/app.py
+++ b/src/imbi_api/app.py
@@ -1,6 +1,7 @@
 import fastapi
 from fastapi.middleware import cors
 from imbi_common import graph, lifespan
+from uvicorn.middleware import proxy_headers
 
 from imbi_api import endpoints, lifespans, openapi, settings, version
 from imbi_api.middleware import rate_limit
@@ -32,6 +33,15 @@ def create_app() -> fastapi.FastAPI:
         allow_methods=['*'],
         allow_headers=['authorization'],
     )
+
+    # Honor X-Forwarded-For from trusted proxies so rate limiting keys
+    # on the real client IP rather than the proxy address. Skipped
+    # when forwarded_allow_ips is empty (dev/no-proxy deployments).
+    if server_config.forwarded_allow_ips:
+        app.add_middleware(
+            proxy_headers.ProxyHeadersMiddleware,
+            trusted_hosts=server_config.forwarded_allow_ips,
+        )
 
     # Phase 5: Setup rate limiting middleware
     rate_limit.setup_rate_limiting(app)

--- a/src/imbi_api/auth/seed.py
+++ b/src/imbi_api/auth/seed.py
@@ -291,129 +291,89 @@ DEFAULT_ROLES: list[tuple[str, str, str, int, list[str]]] = [
 
 
 async def seed_permissions(db: graph.Graph) -> int:
-    """
-    Seed standard permissions into the database.
+    """Seed standard permissions in a single batched query."""
+    maps: list[str] = []
+    params: dict[str, typing.Any] = {}
+    for i, (name, resource_type, action, description) in enumerate(
+        STANDARD_PERMISSIONS
+    ):
+        maps.append(
+            f'{{{{name: {{p_n_{i}}}, resource_type: {{p_rt_{i}}},'
+            f' action: {{p_a_{i}}}, description: {{p_d_{i}}}}}}}'
+        )
+        params[f'p_n_{i}'] = name
+        params[f'p_rt_{i}'] = resource_type
+        params[f'p_a_{i}'] = action
+        params[f'p_d_{i}'] = description
 
-    Uses MERGE to make the operation idempotent - running multiple
-    times will not create duplicates.
-
-    Parameters:
-        db: Graph database connection.
-
-    Returns:
-        int: Number of permissions created (not updated).
-    """
+    query: str = (
+        'UNWIND [' + ', '.join(maps) + '] AS perm '
+        'OPTIONAL MATCH (existing:Permission {{name: perm.name}}) '
+        'WITH perm, existing '
+        'MERGE (p:Permission {{name: perm.name}}) '
+        'SET p.resource_type = perm.resource_type, '
+        'p.action = perm.action, '
+        'p.description = perm.description '
+        'RETURN sum(CASE WHEN existing IS NULL THEN 1 ELSE 0 END) '
+        'AS created'
+    )
+    records = await db.execute(query, params, columns=['created'])
     created_count = 0
-
-    for name, resource_type, action, description in STANDARD_PERMISSIONS:
-        # Check if the permission already exists
-        check_query = (
-            'OPTIONAL MATCH (existing:Permission '
-            '{{name: {name}}}) '
-            'RETURN existing IS NULL AS is_new'
-        )
-        check_records = await db.execute(
-            check_query,
-            {'name': name},
-            columns=['is_new'],
-        )
-        is_new = False
-        if check_records:
-            raw = graph.parse_agtype(check_records[0].get('is_new'))
-            is_new = bool(raw)
-
-        # Merge the permission node
-        merge_query = (
-            'MERGE (p:Permission {{name: {name}}}) '
-            'SET p.resource_type = {resource_type}, '
-            'p.action = {action}, '
-            'p.description = {description} '
-            'RETURN p'
-        )
-        await db.execute(
-            merge_query,
-            {
-                'name': name,
-                'resource_type': resource_type,
-                'action': action,
-                'description': description,
-            },
-        )
-
-        if is_new:
-            created_count += 1
-
+    if records:
+        raw = graph.parse_agtype(records[0].get('created'))
+        created_count = int(raw or 0)
     LOGGER.info('Seeded %d permissions', created_count)
     return created_count
 
 
 async def seed_default_roles(db: graph.Graph) -> int:
-    """
-    Seed default roles (admin, developer, readonly) into the
-    database.
+    """Seed default roles and GRANTS edges in a single batched query."""
+    role_maps: list[str] = []
+    grant_maps: list[str] = []
+    params: dict[str, typing.Any] = {}
+    for i, (
+        slug,
+        name,
+        description,
+        priority,
+        permission_names,
+    ) in enumerate(DEFAULT_ROLES):
+        role_maps.append(
+            f'{{{{slug: {{r_s_{i}}}, name: {{r_n_{i}}},'
+            f' description: {{r_d_{i}}}, priority: {{r_p_{i}}}}}}}'
+        )
+        params[f'r_s_{i}'] = slug
+        params[f'r_n_{i}'] = name
+        params[f'r_d_{i}'] = description
+        params[f'r_p_{i}'] = priority
+        for j, perm_name in enumerate(permission_names):
+            grant_maps.append(
+                f'{{{{slug: {{r_s_{i}}}, perm: {{g_{i}_{j}}}}}}}'
+            )
+            params[f'g_{i}_{j}'] = perm_name
 
-    Uses MERGE to make the operation idempotent.
-
-    Parameters:
-        db: Graph database connection.
-
-    Returns:
-        int: Number of roles created (not updated).
-    """
+    query: str = (
+        'UNWIND [' + ', '.join(role_maps) + '] AS role '
+        'OPTIONAL MATCH (existing:Role {{slug: role.slug}}) '
+        'WITH role, existing '
+        'MERGE (r:Role {{slug: role.slug}}) '
+        'SET r.name = role.name, '
+        'r.description = role.description, '
+        'r.priority = role.priority, '
+        'r.is_system = true '
+        'WITH sum(CASE WHEN existing IS NULL THEN 1 ELSE 0 END) '
+        'AS created '
+        'UNWIND [' + ', '.join(grant_maps) + '] AS grant '
+        'MATCH (gr:Role {{slug: grant.slug}}), '
+        '(gp:Permission {{name: grant.perm}}) '
+        'MERGE (gr)-[:GRANTS]->(gp) '
+        'RETURN created LIMIT 1'
+    )
+    records = await db.execute(query, params, columns=['created'])
     created_count = 0
-
-    for slug, name, description, priority, permission_names in DEFAULT_ROLES:
-        # Check if the role already exists
-        check_query = (
-            'OPTIONAL MATCH (existing:Role {{slug: {slug}}}) '
-            'RETURN existing IS NULL AS is_new'
-        )
-        check_records = await db.execute(
-            check_query,
-            {'slug': slug},
-            columns=['is_new'],
-        )
-        is_new = False
-        if check_records:
-            raw = graph.parse_agtype(check_records[0].get('is_new'))
-            is_new = bool(raw)
-
-        # Merge the role node
-        merge_query = (
-            'MERGE (r:Role {{slug: {slug}}}) '
-            'SET r.name = {name}, '
-            'r.description = {description}, '
-            'r.priority = {priority}, '
-            'r.is_system = {is_system} '
-            'RETURN r'
-        )
-        await db.execute(
-            merge_query,
-            {
-                'slug': slug,
-                'name': name,
-                'description': description,
-                'priority': priority,
-                'is_system': True,
-            },
-        )
-
-        if is_new:
-            created_count += 1
-
-        # Grant permissions to role
-        for perm_name in permission_names:
-            perm_query = (
-                'MATCH (r:Role {{slug: {slug}}}), '
-                '(p:Permission {{name: {perm_name}}}) '
-                'MERGE (r)-[g:GRANTS]->(p) '
-                'RETURN g'
-            )
-            await db.execute(
-                perm_query,
-                {'slug': slug, 'perm_name': perm_name},
-            )
-
+    if records:
+        raw = graph.parse_agtype(records[0].get('created'))
+        created_count = int(raw or 0)
     LOGGER.info('Seeded %d default roles', created_count)
     return created_count
 

--- a/src/imbi_api/auth/seed.py
+++ b/src/imbi_api/auth/seed.py
@@ -327,7 +327,13 @@ async def seed_permissions(db: graph.Graph) -> int:
 
 
 async def seed_default_roles(db: graph.Graph) -> int:
-    """Seed default roles and GRANTS edges in a single batched query."""
+    """Seed default roles and GRANTS edges in a single batched query.
+
+    Must run after ``seed_permissions``: the second UNWIND below does a
+    ``MATCH (gp:Permission {{name: grant.perm}})`` that will silently
+    produce no GRANTS edges if any referenced permission is missing.
+    ``bootstrap_auth_system`` enforces this ordering.
+    """
     role_maps: list[str] = []
     grant_maps: list[str] = []
     params: dict[str, typing.Any] = {}

--- a/src/imbi_api/auth/sessions.py
+++ b/src/imbi_api/auth/sessions.py
@@ -6,7 +6,6 @@ concurrent session limits, and tracking session activity.
 
 import datetime
 import logging
-import typing
 
 from imbi_common import graph
 
@@ -36,45 +35,25 @@ async def enforce_session_limit(
     query = (
         'MATCH (u:User {{email: {email}}})'
         '<-[:SESSION_FOR]-(s:Session) '
-        'RETURN s.session_id, s.last_activity '
-        'ORDER BY s.last_activity DESC'
+        'WITH s ORDER BY s.last_activity DESC SKIP {limit} '
+        'DETACH DELETE s '
+        'RETURN count(s) AS removed'
     )
     records = await db.execute(
         query,
-        {'email': email},
-        columns=['session_id', 'last_activity'],
+        {
+            'email': email,
+            'limit': auth_settings.max_concurrent_sessions,
+        },
+        columns=['removed'],
     )
+    raw = graph.parse_agtype(records[0].get('removed') if records else None)
+    removed = raw if isinstance(raw, int) else 0
 
-    sessions: list[dict[str, typing.Any]] = []
-    for record in records:
-        sessions.append(
-            {
-                'session_id': graph.parse_agtype(record.get('session_id')),
-                'last_activity': graph.parse_agtype(
-                    record.get('last_activity')
-                ),
-            }
-        )
-
-    if len(sessions) > auth_settings.max_concurrent_sessions:
-        # Remove oldest sessions (those beyond the limit)
-        sessions_to_remove: list[dict[str, typing.Any]] = sessions[
-            auth_settings.max_concurrent_sessions :
-        ]
-        for s in sessions_to_remove:
-            delete_query = (
-                'MATCH (s:Session '
-                '{{session_id: {session_id}}}) '
-                'DETACH DELETE s'
-            )
-            await db.execute(
-                delete_query,
-                {'session_id': s['session_id']},
-            )
-
+    if removed > 0:
         LOGGER.info(
             'Removed %d old sessions for user %s',
-            len(sessions_to_remove),
+            removed,
             email,
         )
 

--- a/src/imbi_api/auth/tokens.py
+++ b/src/imbi_api/auth/tokens.py
@@ -25,12 +25,6 @@ class PrincipalNotFoundError(Exception):
     """Raised when no principal node matches the given id."""
 
 
-_USER_CHECK: typing.LiteralString = (
-    'MATCH (p:User {{email: {principal_id}}}) RETURN p LIMIT 1'
-)
-_SERVICE_ACCOUNT_CHECK: typing.LiteralString = (
-    'MATCH (p:ServiceAccount {{slug: {principal_id}}}) RETURN p LIMIT 1'
-)
 _USER_CREATE: typing.LiteralString = (
     'MATCH (p:User {{email: {principal_id}}}) '
     'CREATE (at:TokenMetadata {{'
@@ -46,7 +40,8 @@ _USER_CREATE: typing.LiteralString = (
     'issued_at: {issued_at}, '
     'expires_at: {refresh_exp}, '
     'revoked: false'
-    '}})-[:ISSUED_TO]->(p)'
+    '}})-[:ISSUED_TO]->(p) '
+    'RETURN count(p) AS principal_count'
 )
 _SERVICE_ACCOUNT_CREATE: typing.LiteralString = (
     'MATCH (p:ServiceAccount {{slug: {principal_id}}}) '
@@ -63,14 +58,13 @@ _SERVICE_ACCOUNT_CREATE: typing.LiteralString = (
     'issued_at: {issued_at}, '
     'expires_at: {refresh_exp}, '
     'revoked: false'
-    '}})-[:ISSUED_TO]->(p)'
+    '}})-[:ISSUED_TO]->(p) '
+    'RETURN count(p) AS principal_count'
 )
 
-_PRINCIPAL_QUERIES: dict[
-    PrincipalType, tuple[typing.LiteralString, typing.LiteralString]
-] = {
-    'user': (_USER_CHECK, _USER_CREATE),
-    'service_account': (_SERVICE_ACCOUNT_CHECK, _SERVICE_ACCOUNT_CREATE),
+_PRINCIPAL_QUERIES: dict[PrincipalType, typing.LiteralString] = {
+    'user': _USER_CREATE,
+    'service_account': _SERVICE_ACCOUNT_CREATE,
 }
 
 
@@ -92,6 +86,14 @@ async def issue_token_pair(
 ) -> tuple[str, str, dict[str, typing.Any]]:
     """Mint an access+refresh pair and persist TokenMetadata nodes.
 
+    The MATCH/CREATE runs in a single Cypher statement and returns
+    the number of principals matched. Zero matches means no
+    ``TokenMetadata``/``ISSUED_TO`` row was written, so the
+    freshly-signed tokens are discarded by raising
+    ``PrincipalNotFoundError``. This keeps the check atomic with the
+    write (avoiding the TOCTOU gap of a separate existence query)
+    and fails closed if a principal is removed mid-flight.
+
     Args:
         db: Graph database connection.
         principal_type: ``'user'`` or ``'service_account'``.
@@ -106,26 +108,10 @@ async def issue_token_pair(
 
     Raises:
         PrincipalNotFoundError: No principal matched ``principal_id``.
-            Raised before any JWT is signed so tokens are never issued
-            without a corresponding ``TokenMetadata``/``ISSUED_TO`` row.
+            No JWT is returned when this is raised.
 
     """
-    check_query, create_query = _PRINCIPAL_QUERIES[principal_type]
-
-    existing = await db.execute(
-        check_query,
-        {'principal_id': principal_id},
-        columns=['p'],
-    )
-    if not existing:
-        LOGGER.warning(
-            'issue_token_pair: no %s matching %r',
-            principal_type,
-            principal_id,
-        )
-        raise PrincipalNotFoundError(
-            f'No {principal_type} found for {principal_id!r}'
-        )
+    create_query = _PRINCIPAL_QUERIES[principal_type]
 
     access_token = core.create_access_token(
         principal_id,
@@ -149,7 +135,7 @@ async def issue_token_pair(
         seconds=auth_settings.refresh_token_expire_seconds
     )
 
-    await db.execute(
+    records = await db.execute(
         create_query,
         {
             'principal_id': principal_id,
@@ -159,7 +145,23 @@ async def issue_token_pair(
             'access_exp': access_expires_at.isoformat(),
             'refresh_exp': refresh_expires_at.isoformat(),
         },
+        columns=['principal_count'],
     )
+    matched = 0
+    if records:
+        raw = graph.parse_agtype(records[0].get('principal_count'))
+        matched = int(raw or 0)
+    if matched == 0:
+        # Never log or raise with the raw principal id: for users it is
+        # a full email address (PII) and for service accounts it may
+        # appear in logs that are aggregated with less privileged
+        # audiences. The generic message below is enough for callers to
+        # convert into a 401; detailed principal context is already
+        # available in the caller's own logs.
+        LOGGER.warning(
+            'issue_token_pair: no %s principal matched', principal_type
+        )
+        raise PrincipalNotFoundError(f'No {principal_type} found')
 
     return (
         access_token,

--- a/src/imbi_api/auth/tokens.py
+++ b/src/imbi_api/auth/tokens.py
@@ -41,6 +41,12 @@ async def issue_token_pair(
 ) -> tuple[str, str, dict[str, typing.Any]]:
     """Mint an access+refresh pair and persist TokenMetadata nodes.
 
+    Callers (login, refresh, oauth_callback, client_credentials) must
+    verify the principal exists before invoking this helper. The
+    Cypher ``MATCH`` below is a silent no-op if the principal is
+    missing, so a raise-here guard would duplicate existing checks at
+    every call site.
+
     Args:
         db: Graph database connection.
         principal_type: ``'user'`` or ``'service_account'``.

--- a/src/imbi_api/auth/tokens.py
+++ b/src/imbi_api/auth/tokens.py
@@ -1,0 +1,119 @@
+"""Token issuance helpers.
+
+Centralizes the access+refresh token minting flow used by the
+login, refresh, OAuth callback, and client_credentials endpoints.
+The JWT claims are recovered via a non-verifying decode because the
+tokens were just generated locally and the signature is trusted.
+"""
+
+import datetime
+import typing
+
+import jwt
+from imbi_common import graph
+from imbi_common.auth import core
+
+from imbi_api import settings
+
+PrincipalType = typing.Literal['user', 'service_account']
+
+_PRINCIPAL_CYPHER: dict[PrincipalType, tuple[str, str]] = {
+    'user': ('User', 'email'),
+    'service_account': ('ServiceAccount', 'slug'),
+}
+
+
+def _decode_claims(token: str) -> dict[str, typing.Any]:
+    """Decode JWT claims without signature verification.
+
+    Safe because the token was just produced by this process; the
+    signature is already trusted. Avoids a second HMAC round trip.
+    """
+    return jwt.decode(token, options={'verify_signature': False})
+
+
+async def issue_token_pair(
+    db: graph.Graph,
+    principal_type: PrincipalType,
+    principal_id: str,
+    auth_settings: settings.Auth,
+    extra_claims: dict[str, typing.Any] | None = None,
+) -> tuple[str, str, dict[str, typing.Any]]:
+    """Mint an access+refresh pair and persist TokenMetadata nodes.
+
+    Args:
+        db: Graph database connection.
+        principal_type: ``'user'`` or ``'service_account'``.
+        principal_id: Email for users, slug for service accounts.
+        auth_settings: Auth settings for JWT configuration.
+        extra_claims: Optional additional JWT claims.
+
+    Returns:
+        ``(access_token, refresh_token, meta)`` where ``meta``
+        contains ``access_jti``, ``refresh_jti``, ``issued_at``,
+        ``access_expires_at``, and ``refresh_expires_at``.
+
+    """
+    access_token = core.create_access_token(
+        principal_id,
+        extra_claims=extra_claims,
+        auth_settings=auth_settings,
+    )
+    refresh_token = core.create_refresh_token(
+        principal_id,
+        extra_claims=extra_claims,
+        auth_settings=auth_settings,
+    )
+
+    access_claims = _decode_claims(access_token)
+    refresh_claims = _decode_claims(refresh_token)
+
+    now = datetime.datetime.now(datetime.UTC)
+    access_expires_at = now + datetime.timedelta(
+        seconds=auth_settings.access_token_expire_seconds
+    )
+    refresh_expires_at = now + datetime.timedelta(
+        seconds=auth_settings.refresh_token_expire_seconds
+    )
+
+    label, match_prop = _PRINCIPAL_CYPHER[principal_type]
+    query = (
+        f'MATCH (p:{label} {{{{{match_prop}: {{principal_id}}}}}}) '
+        'CREATE (at:TokenMetadata {{'
+        'jti: {access_jti}, '
+        "token_type: 'access', "
+        'issued_at: {issued_at}, '
+        'expires_at: {access_exp}, '
+        'revoked: false'
+        '}})-[:ISSUED_TO]->(p) '
+        'CREATE (rt:TokenMetadata {{'
+        'jti: {refresh_jti}, '
+        "token_type: 'refresh', "
+        'issued_at: {issued_at}, '
+        'expires_at: {refresh_exp}, '
+        'revoked: false'
+        '}})-[:ISSUED_TO]->(p)'
+    )
+    await db.execute(
+        query,
+        {
+            'principal_id': principal_id,
+            'access_jti': access_claims['jti'],
+            'refresh_jti': refresh_claims['jti'],
+            'issued_at': now.isoformat(),
+            'access_exp': access_expires_at.isoformat(),
+            'refresh_exp': refresh_expires_at.isoformat(),
+        },
+    )
+
+    return (
+        access_token,
+        refresh_token,
+        {
+            'access_jti': access_claims['jti'],
+            'refresh_jti': refresh_claims['jti'],
+            'issued_at': now,
+            'access_expires_at': access_expires_at,
+            'refresh_expires_at': refresh_expires_at,
+        },
+    )

--- a/src/imbi_api/auth/tokens.py
+++ b/src/imbi_api/auth/tokens.py
@@ -7,6 +7,7 @@ tokens were just generated locally and the signature is trusted.
 """
 
 import datetime
+import logging
 import typing
 
 import jwt
@@ -15,11 +16,61 @@ from imbi_common.auth import core
 
 from imbi_api import settings
 
+LOGGER = logging.getLogger(__name__)
+
 PrincipalType = typing.Literal['user', 'service_account']
 
-_PRINCIPAL_CYPHER: dict[PrincipalType, tuple[str, str]] = {
-    'user': ('User', 'email'),
-    'service_account': ('ServiceAccount', 'slug'),
+
+class PrincipalNotFoundError(Exception):
+    """Raised when no principal node matches the given id."""
+
+
+_USER_CHECK: typing.LiteralString = (
+    'MATCH (p:User {{email: {principal_id}}}) RETURN p LIMIT 1'
+)
+_SERVICE_ACCOUNT_CHECK: typing.LiteralString = (
+    'MATCH (p:ServiceAccount {{slug: {principal_id}}}) RETURN p LIMIT 1'
+)
+_USER_CREATE: typing.LiteralString = (
+    'MATCH (p:User {{email: {principal_id}}}) '
+    'CREATE (at:TokenMetadata {{'
+    'jti: {access_jti}, '
+    "token_type: 'access', "
+    'issued_at: {issued_at}, '
+    'expires_at: {access_exp}, '
+    'revoked: false'
+    '}})-[:ISSUED_TO]->(p) '
+    'CREATE (rt:TokenMetadata {{'
+    'jti: {refresh_jti}, '
+    "token_type: 'refresh', "
+    'issued_at: {issued_at}, '
+    'expires_at: {refresh_exp}, '
+    'revoked: false'
+    '}})-[:ISSUED_TO]->(p)'
+)
+_SERVICE_ACCOUNT_CREATE: typing.LiteralString = (
+    'MATCH (p:ServiceAccount {{slug: {principal_id}}}) '
+    'CREATE (at:TokenMetadata {{'
+    'jti: {access_jti}, '
+    "token_type: 'access', "
+    'issued_at: {issued_at}, '
+    'expires_at: {access_exp}, '
+    'revoked: false'
+    '}})-[:ISSUED_TO]->(p) '
+    'CREATE (rt:TokenMetadata {{'
+    'jti: {refresh_jti}, '
+    "token_type: 'refresh', "
+    'issued_at: {issued_at}, '
+    'expires_at: {refresh_exp}, '
+    'revoked: false'
+    '}})-[:ISSUED_TO]->(p)'
+)
+
+_PRINCIPAL_QUERIES: dict[
+    PrincipalType, tuple[typing.LiteralString, typing.LiteralString]
+] = {
+    'user': (_USER_CHECK, _USER_CREATE),
+    'service_account': (_SERVICE_ACCOUNT_CHECK, _SERVICE_ACCOUNT_CREATE),
 }
 
 
@@ -41,12 +92,6 @@ async def issue_token_pair(
 ) -> tuple[str, str, dict[str, typing.Any]]:
     """Mint an access+refresh pair and persist TokenMetadata nodes.
 
-    Callers (login, refresh, oauth_callback, client_credentials) must
-    verify the principal exists before invoking this helper. The
-    Cypher ``MATCH`` below is a silent no-op if the principal is
-    missing, so a raise-here guard would duplicate existing checks at
-    every call site.
-
     Args:
         db: Graph database connection.
         principal_type: ``'user'`` or ``'service_account'``.
@@ -59,7 +104,29 @@ async def issue_token_pair(
         contains ``access_jti``, ``refresh_jti``, ``issued_at``,
         ``access_expires_at``, and ``refresh_expires_at``.
 
+    Raises:
+        PrincipalNotFoundError: No principal matched ``principal_id``.
+            Raised before any JWT is signed so tokens are never issued
+            without a corresponding ``TokenMetadata``/``ISSUED_TO`` row.
+
     """
+    check_query, create_query = _PRINCIPAL_QUERIES[principal_type]
+
+    existing = await db.execute(
+        check_query,
+        {'principal_id': principal_id},
+        columns=['p'],
+    )
+    if not existing:
+        LOGGER.warning(
+            'issue_token_pair: no %s matching %r',
+            principal_type,
+            principal_id,
+        )
+        raise PrincipalNotFoundError(
+            f'No {principal_type} found for {principal_id!r}'
+        )
+
     access_token = core.create_access_token(
         principal_id,
         extra_claims=extra_claims,
@@ -82,26 +149,8 @@ async def issue_token_pair(
         seconds=auth_settings.refresh_token_expire_seconds
     )
 
-    label, match_prop = _PRINCIPAL_CYPHER[principal_type]
-    query = (
-        f'MATCH (p:{label} {{{{{match_prop}: {{principal_id}}}}}}) '
-        'CREATE (at:TokenMetadata {{'
-        'jti: {access_jti}, '
-        "token_type: 'access', "
-        'issued_at: {issued_at}, '
-        'expires_at: {access_exp}, '
-        'revoked: false'
-        '}})-[:ISSUED_TO]->(p) '
-        'CREATE (rt:TokenMetadata {{'
-        'jti: {refresh_jti}, '
-        "token_type: 'refresh', "
-        'issued_at: {issued_at}, '
-        'expires_at: {refresh_exp}, '
-        'revoked: false'
-        '}})-[:ISSUED_TO]->(p)'
-    )
     await db.execute(
-        query,
+        create_query,
         {
             'principal_id': principal_id,
             'access_jti': access_claims['jti'],

--- a/src/imbi_api/endpoints/auth.py
+++ b/src/imbi_api/endpoints/auth.py
@@ -16,7 +16,7 @@ from imbi_common.auth import core, encryption
 
 from imbi_api import models, settings
 from imbi_api.auth import models as auth_models
-from imbi_api.auth import oauth, permissions
+from imbi_api.auth import oauth, permissions, tokens
 from imbi_api.auth import password as password_auth
 from imbi_api.middleware import rate_limit
 
@@ -205,76 +205,16 @@ async def token(
     }
     if granted_scopes:
         extra_claims['scope'] = ' '.join(sorted(granted_scopes))
-    access_token = core.create_access_token(
-        sa.slug,
-        extra_claims=extra_claims,
+    access_token, refresh_token, _ = await tokens.issue_token_pair(
+        db,
+        principal_type='service_account',
+        principal_id=sa.slug,
         auth_settings=auth_settings,
-    )
-    access_claims = core.verify_token(access_token, auth_settings)
-
-    refresh_token = core.create_refresh_token(
-        sa.slug,
         extra_claims=extra_claims,
-        auth_settings=auth_settings,
-    )
-    refresh_claims = core.verify_token(refresh_token, auth_settings)
-
-    # Store token metadata (link to ServiceAccount)
-    now = datetime.datetime.now(datetime.UTC)
-
-    access_exp = (
-        now
-        + datetime.timedelta(seconds=auth_settings.access_token_expire_seconds)
-    ).isoformat()
-
-    access_meta_query: typing.LiteralString = """
-    MATCH (s:ServiceAccount {{slug: {slug}}})
-    CREATE (t:TokenMetadata {{
-        jti: {jti},
-        token_type: 'access',
-        issued_at: {issued_at},
-        expires_at: {expires_at},
-        revoked: false
-    }})-[:ISSUED_TO]->(s)
-    """
-    await db.execute(
-        access_meta_query,
-        {
-            'jti': access_claims['jti'],
-            'expires_at': access_exp,
-            'issued_at': now.isoformat(),
-            'slug': sa.slug,
-        },
-    )
-
-    refresh_exp = (
-        now
-        + datetime.timedelta(
-            seconds=auth_settings.refresh_token_expire_seconds
-        )
-    ).isoformat()
-
-    refresh_meta_query: typing.LiteralString = """
-    MATCH (s:ServiceAccount {{slug: {slug}}})
-    CREATE (t:TokenMetadata {{
-        jti: {jti},
-        token_type: 'refresh',
-        issued_at: {issued_at},
-        expires_at: {expires_at},
-        revoked: false
-    }})-[:ISSUED_TO]->(s)
-    """
-    await db.execute(
-        refresh_meta_query,
-        {
-            'jti': refresh_claims['jti'],
-            'expires_at': refresh_exp,
-            'issued_at': now.isoformat(),
-            'slug': sa.slug,
-        },
     )
 
     # Update last_used on credential, last_authenticated on SA
+    now_iso = datetime.datetime.now(datetime.UTC).isoformat()
     update_query: typing.LiteralString = """
     MATCH (c:ClientCredential {{client_id: {client_id}}})
     SET c.last_used = {now}
@@ -286,7 +226,7 @@ async def token(
         update_query,
         {
             'client_id': client_id,
-            'now': now.isoformat(),
+            'now': now_iso,
         },
     )
 
@@ -487,47 +427,15 @@ async def login(
 
     # Create tokens
     auth_settings = settings.get_auth_settings()
-    access_token = core.create_access_token(
-        user.email, auth_settings=auth_settings
+    access_token, refresh_token, meta = await tokens.issue_token_pair(
+        db,
+        principal_type='user',
+        principal_id=user.email,
+        auth_settings=auth_settings,
     )
-    access_claims = core.verify_token(access_token, auth_settings)
-    access_jti = access_claims['jti']
-
-    refresh_token = core.create_refresh_token(
-        user.email, auth_settings=auth_settings
-    )
-    refresh_claims = core.verify_token(refresh_token, auth_settings)
-    refresh_jti = refresh_claims['jti']
-
-    # Store token metadata for access token
-    now = datetime.datetime.now(datetime.UTC)
-    access_token_meta = models.TokenMetadata(
-        jti=access_jti,
-        token_type='access',
-        issued_at=now,
-        expires_at=now
-        + datetime.timedelta(
-            seconds=auth_settings.access_token_expire_seconds
-        ),
-        user=user,
-    )
-    await db.merge(access_token_meta)
-
-    # Store token metadata for refresh token
-    refresh_token_meta = models.TokenMetadata(
-        jti=refresh_jti,
-        token_type='refresh',
-        issued_at=now,
-        expires_at=now
-        + datetime.timedelta(
-            seconds=auth_settings.refresh_token_expire_seconds
-        ),
-        user=user,
-    )
-    await db.merge(refresh_token_meta)
 
     # Update last login timestamp
-    user.last_login = now
+    user.last_login = meta['issued_at']
     await db.merge(user, match_on=['email'])
 
     LOGGER.info('User %s logged in successfully', user.email)
@@ -611,7 +519,8 @@ async def refresh_token(
     # Resolve principal (user or service account)
     subject = payload['sub']
     auth_method = payload.get('auth_method')
-    extra_claims: dict[str, typing.Any] = {}
+    principal_type: tokens.PrincipalType
+    extra_claims: dict[str, typing.Any] | None = None
 
     if auth_method == 'client_credentials':
         sa_results = await db.match(models.ServiceAccount, {'slug': subject})
@@ -626,6 +535,7 @@ async def refresh_token(
                 status_code=401,
                 detail='Service account not found or inactive',
             )
+        principal_type = 'service_account'
         principal_id = sa.slug
         extra_claims = {'auth_method': 'client_credentials'}
     else:
@@ -640,90 +550,16 @@ async def refresh_token(
                 status_code=401,
                 detail='User not found or inactive',
             )
+        principal_type = 'user'
         principal_id = user.email
 
-    # Create new access token
-    access_token = core.create_access_token(
-        principal_id,
-        extra_claims=extra_claims or None,
+    # Mint rotated access+refresh pair
+    access_token, new_refresh_token, _ = await tokens.issue_token_pair(
+        db,
+        principal_type=principal_type,
+        principal_id=principal_id,
         auth_settings=auth_settings,
-    )
-    access_claims = core.verify_token(access_token, auth_settings)
-    access_jti = access_claims['jti']
-
-    # Create NEW refresh token (token rotation)
-    new_refresh_token = core.create_refresh_token(
-        principal_id,
-        extra_claims=extra_claims or None,
-        auth_settings=auth_settings,
-    )
-    new_refresh_claims = core.verify_token(new_refresh_token, auth_settings)
-    new_refresh_jti = new_refresh_claims['jti']
-
-    # Store new token metadata via Cypher (handles both
-    # User and ServiceAccount via ISSUED_TO)
-    now = datetime.datetime.now(datetime.UTC)
-
-    if auth_method == 'client_credentials':
-        # Link to ServiceAccount
-        meta_query: typing.LiteralString = """
-        MATCH (s:ServiceAccount {{slug: {subject}}})
-        CREATE (at:TokenMetadata {{
-            jti: {access_jti},
-            token_type: 'access',
-            issued_at: {issued_at},
-            expires_at: {access_exp},
-            revoked: false
-        }})-[:ISSUED_TO]->(s)
-        CREATE (rt:TokenMetadata {{
-            jti: {refresh_jti},
-            token_type: 'refresh',
-            issued_at: {issued_at},
-            expires_at: {refresh_exp},
-            revoked: false
-        }})-[:ISSUED_TO]->(s)
-        """
-    else:
-        # Link to User
-        meta_query = """
-        MATCH (u:User {{email: {subject}}})
-        CREATE (at:TokenMetadata {{
-            jti: {access_jti},
-            token_type: 'access',
-            issued_at: {issued_at},
-            expires_at: {access_exp},
-            revoked: false
-        }})-[:ISSUED_TO]->(u)
-        CREATE (rt:TokenMetadata {{
-            jti: {refresh_jti},
-            token_type: 'refresh',
-            issued_at: {issued_at},
-            expires_at: {refresh_exp},
-            revoked: false
-        }})-[:ISSUED_TO]->(u)
-        """
-
-    access_exp = (
-        now
-        + datetime.timedelta(seconds=auth_settings.access_token_expire_seconds)
-    ).isoformat()
-    refresh_exp = (
-        now
-        + datetime.timedelta(
-            seconds=auth_settings.refresh_token_expire_seconds
-        )
-    ).isoformat()
-
-    await db.execute(
-        meta_query,
-        {
-            'subject': subject,
-            'access_jti': access_jti,
-            'access_exp': access_exp,
-            'issued_at': now.isoformat(),
-            'refresh_jti': new_refresh_jti,
-            'refresh_exp': refresh_exp,
-        },
+        extra_claims=extra_claims,
     )
 
     LOGGER.info(
@@ -1044,39 +880,13 @@ async def oauth_callback(
             )
 
         # Create JWT tokens
-        at = core.create_access_token(user.email, auth_settings=auth_settings)
-        at_claims = core.verify_token(at, auth_settings)
-        access_jti = at_claims['jti']
-
-        rt = core.create_refresh_token(user.email, auth_settings=auth_settings)
-        rt_claims = core.verify_token(rt, auth_settings)
-        refresh_jti = rt_claims['jti']
-
-        # Store token metadata
-        now = datetime.datetime.now(datetime.UTC)
-        access_token_meta = models.TokenMetadata(
-            jti=access_jti,
-            token_type='access',
-            issued_at=now,
-            expires_at=now
-            + datetime.timedelta(
-                seconds=(auth_settings.access_token_expire_seconds)
-            ),
-            user=user,
+        at, rt, meta = await tokens.issue_token_pair(
+            db,
+            principal_type='user',
+            principal_id=user.email,
+            auth_settings=auth_settings,
         )
-        await db.merge(access_token_meta)
-
-        refresh_token_meta = models.TokenMetadata(
-            jti=refresh_jti,
-            token_type='refresh',
-            issued_at=now,
-            expires_at=now
-            + datetime.timedelta(
-                seconds=(auth_settings.refresh_token_expire_seconds)
-            ),
-            user=user,
-        )
-        await db.merge(refresh_token_meta)
+        now = meta['issued_at']
 
         # Update user last_login
         user.last_login = now

--- a/src/imbi_api/endpoints/environments.py
+++ b/src/imbi_api/endpoints/environments.py
@@ -11,56 +11,12 @@ from imbi_common import blueprints, graph, models
 
 from imbi_api import patch as json_patch
 from imbi_api.auth import permissions
-from imbi_api.relationships import relationship_link
+from imbi_api.graph_sql import props_template, set_clause
+from imbi_api.relationships import build_relationships
 
 LOGGER = logging.getLogger(__name__)
 
 environments_router = fastapi.APIRouter(tags=['Environments'])
-
-
-def _props_template(props: dict[str, typing.Any]) -> str:
-    """Build a Cypher property-map template with double-escaped braces.
-
-    Each key becomes ``key: {key}`` inside doubled braces so that
-    ``psycopg.sql.SQL.format()`` resolves them correctly::
-
-        >>> _props_template({'name': 'x', 'slug': 'y'})
-        '{{name: {name}, slug: {slug}}}'
-
-    """
-    if not props:
-        return ''
-    pairs = [f'{k}: {{{k}}}' for k in props]
-    return '{{' + ', '.join(pairs) + '}}'
-
-
-def _set_clause(
-    alias: str,
-    props: dict[str, typing.Any],
-) -> str:
-    """Build a Cypher SET clause from a property dict.
-
-    Returns a string like ``SET e.name = {name}, e.slug = {slug}``.
-
-    """
-    if not props:
-        return ''
-    assignments = ', '.join(f'{alias}.{k} = {{{k}}}' for k in props)
-    return f'SET {assignments}'
-
-
-def _add_relationships(
-    env: dict[str, typing.Any],
-    project_count: int = 0,
-) -> dict[str, typing.Any]:
-    """Attach relationships sub-object to an environment dict."""
-    env['relationships'] = {
-        'projects': relationship_link(
-            f'/api/projects?environment={env["slug"]}',
-            project_count,
-        ),
-    }
-    return env
 
 
 @environments_router.post('/', status_code=201)
@@ -125,7 +81,7 @@ async def create_environment(
         exclude={'organization'},
     )
 
-    create_tpl = _props_template(props)
+    create_tpl = props_template(props)
     query = (
         f'MATCH (o:Organization {{{{slug: {{org_slug}}}}}})'
         f' CREATE (e:Environment {create_tpl})'
@@ -151,10 +107,19 @@ async def create_environment(
             detail=(f'Organization with slug {org_slug!r} not found'),
         )
 
-    env_props = graph.parse_agtype(records[0]['e'])
+    env_props: dict[str, typing.Any] = graph.parse_agtype(records[0]['e'])
     org_props = graph.parse_agtype(records[0]['o'])
     env_props['organization'] = org_props
-    return _add_relationships(env_props)
+    env_props['relationships'] = build_relationships(
+        '',
+        {
+            'projects': (
+                f'/api/projects?environment={env_props["slug"]}',
+                0,
+            ),
+        },
+    )
+    return env_props
 
 
 @environments_router.get('/')
@@ -198,7 +163,15 @@ async def list_environments(
         env['organization'] = org
         env.setdefault('sort_order', 0)
         pc = graph.parse_agtype(record['project_count'])
-        _add_relationships(env, pc or 0)
+        env['relationships'] = build_relationships(
+            '',
+            {
+                'projects': (
+                    f'/api/projects?environment={env["slug"]}',
+                    pc or 0,
+                ),
+            },
+        )
         environments.append(env)
     return environments
 
@@ -247,12 +220,21 @@ async def get_environment(
             detail=(f'Environment with slug {slug!r} not found'),
         )
 
-    env = graph.parse_agtype(records[0]['e'])
+    env: dict[str, typing.Any] = graph.parse_agtype(records[0]['e'])
     org = graph.parse_agtype(records[0]['o'])
     env['organization'] = org
     env.setdefault('sort_order', 0)
     pc = graph.parse_agtype(records[0]['project_count'])
-    return _add_relationships(env, pc or 0)
+    env['relationships'] = build_relationships(
+        '',
+        {
+            'projects': (
+                f'/api/projects?environment={env["slug"]}',
+                pc or 0,
+            ),
+        },
+    )
+    return env
 
 
 async def _persist_environment(
@@ -311,7 +293,7 @@ async def _persist_environment(
         exclude={'organization'},
     )
 
-    set_stmt = _set_clause('e', props)
+    set_stmt = set_clause('e', props)
     update_query = (
         f'MATCH (e:Environment {{{{slug: {{slug}}}}}})'
         f' -[:BELONGS_TO]->(o:Organization'
@@ -345,12 +327,21 @@ async def _persist_environment(
             detail=(f'Environment with slug {original_slug!r} not found'),
         )
 
-    env = graph.parse_agtype(updated[0]['e'])
+    env: dict[str, typing.Any] = graph.parse_agtype(updated[0]['e'])
     org = graph.parse_agtype(updated[0]['o'])
     env['organization'] = org
     env.setdefault('sort_order', 0)
     pc = graph.parse_agtype(updated[0]['project_count'])
-    return _add_relationships(env, pc or 0)
+    env['relationships'] = build_relationships(
+        '',
+        {
+            'projects': (
+                f'/api/projects?environment={env["slug"]}',
+                pc or 0,
+            ),
+        },
+    )
+    return env
 
 
 @environments_router.put('/{slug}')

--- a/src/imbi_api/endpoints/link_definitions.py
+++ b/src/imbi_api/endpoints/link_definitions.py
@@ -152,6 +152,9 @@ async def create_link_definition(
     )
     org = graph.parse_agtype(records[0]['o'])
     result['organization'] = org
+    # The projects href is intentionally empty because list_projects does
+    # not yet support a link_definition query filter; only the count is
+    # meaningful here.
     result['relationships'] = build_relationships(
         '',
         {'projects': ('', 0)},
@@ -203,6 +206,8 @@ async def list_link_definitions(
         org = graph.parse_agtype(record['o'])
         ld['organization'] = org
         pc = graph.parse_agtype(record['project_count'])
+        # See note in create_link_definition: projects href is empty
+        # until list_projects supports a link_definition filter.
         ld['relationships'] = build_relationships(
             '',
             {'projects': ('', pc or 0)},
@@ -265,6 +270,8 @@ async def get_link_definition(
     org = graph.parse_agtype(records[0]['o'])
     result['organization'] = org
     pc = graph.parse_agtype(records[0]['project_count'])
+    # See note in create_link_definition: projects href is empty
+    # until list_projects supports a link_definition filter.
     result['relationships'] = build_relationships(
         '',
         {'projects': ('', pc or 0)},
@@ -369,6 +376,8 @@ async def _persist_link_definition(
     org = graph.parse_agtype(updated[0]['o'])
     result['organization'] = org
     pc = graph.parse_agtype(updated[0]['project_count'])
+    # See note in create_link_definition: projects href is empty
+    # until list_projects supports a link_definition filter.
     result['relationships'] = build_relationships(
         '',
         {'projects': ('', pc or 0)},

--- a/src/imbi_api/endpoints/link_definitions.py
+++ b/src/imbi_api/endpoints/link_definitions.py
@@ -11,63 +11,14 @@ from imbi_common import blueprints, graph, models
 
 from imbi_api import patch as json_patch
 from imbi_api.auth import permissions
-from imbi_api.relationships import relationship_link
+from imbi_api.graph_sql import props_template, set_clause
+from imbi_api.relationships import build_relationships
 
 LOGGER = logging.getLogger(__name__)
 
 link_definitions_router = fastapi.APIRouter(
     tags=['Link Definitions'],
 )
-
-
-def _props_template(props: dict[str, typing.Any]) -> str:
-    """Build a Cypher property-map template with double-escaped braces.
-
-    Each key becomes ``key: {key}`` inside doubled braces so that
-    ``psycopg.sql.SQL.format()`` resolves them correctly::
-
-        >>> _props_template({'name': 'x', 'slug': 'y'})
-        '{{name: {name}, slug: {slug}}}'
-
-    """
-    if not props:
-        return ''
-    pairs = [f'{k}: {{{k}}}' for k in props]
-    return '{{' + ', '.join(pairs) + '}}'
-
-
-def _set_clause(
-    alias: str,
-    props: dict[str, typing.Any],
-) -> str:
-    """Build a Cypher SET clause from a property dict.
-
-    Returns ``SET ld.name = {name}, ld.slug = {slug}``.
-
-    """
-    if not props:
-        return ''
-    assignments = ', '.join(f'{alias}.{k} = {{{k}}}' for k in props)
-    return f'SET {assignments}'
-
-
-def _add_relationships(
-    ld: dict[str, typing.Any],
-    project_count: int = 0,
-) -> dict[str, typing.Any]:
-    """Attach relationships sub-object to a link definition dict.
-
-    The projects href is omitted because ``list_projects`` does not
-    yet support a ``link`` query-parameter filter.  Only the count
-    is accurate for now.
-    """
-    ld['relationships'] = {
-        'projects': relationship_link(
-            '',
-            project_count,
-        ),
-    }
-    return ld
 
 
 class LinkDefinitionCreate(pydantic.BaseModel):
@@ -168,7 +119,7 @@ async def create_link_definition(
         exclude={'organization'},
     )
 
-    create_tpl = _props_template(props)
+    create_tpl = props_template(props)
     query = (
         f'MATCH (o:Organization {{{{slug: {{org_slug}}}}}})'
         f' CREATE (ld:LinkDefinition {create_tpl})'
@@ -201,7 +152,10 @@ async def create_link_definition(
     )
     org = graph.parse_agtype(records[0]['o'])
     result['organization'] = org
-    _add_relationships(result, 0)
+    result['relationships'] = build_relationships(
+        '',
+        {'projects': ('', 0)},
+    )
     return result
 
 
@@ -249,7 +203,10 @@ async def list_link_definitions(
         org = graph.parse_agtype(record['o'])
         ld['organization'] = org
         pc = graph.parse_agtype(record['project_count'])
-        _add_relationships(ld, pc or 0)
+        ld['relationships'] = build_relationships(
+            '',
+            {'projects': ('', pc or 0)},
+        )
         results.append(ld)
     return results
 
@@ -308,7 +265,10 @@ async def get_link_definition(
     org = graph.parse_agtype(records[0]['o'])
     result['organization'] = org
     pc = graph.parse_agtype(records[0]['project_count'])
-    _add_relationships(result, pc or 0)
+    result['relationships'] = build_relationships(
+        '',
+        {'projects': ('', pc or 0)},
+    )
     return result
 
 
@@ -368,7 +328,7 @@ async def _persist_link_definition(
         exclude={'organization'},
     )
 
-    set_stmt = _set_clause('ld', props)
+    set_stmt = set_clause('ld', props)
     update_query = (
         f'MATCH (ld:LinkDefinition {{{{slug: {{slug}}}}}})'
         f' -[:BELONGS_TO]->(o:Organization'
@@ -409,7 +369,10 @@ async def _persist_link_definition(
     org = graph.parse_agtype(updated[0]['o'])
     result['organization'] = org
     pc = graph.parse_agtype(updated[0]['project_count'])
-    _add_relationships(result, pc or 0)
+    result['relationships'] = build_relationships(
+        '',
+        {'projects': ('', pc or 0)},
+    )
     return result
 
 

--- a/src/imbi_api/endpoints/link_definitions.py
+++ b/src/imbi_api/endpoints/link_definitions.py
@@ -21,6 +21,21 @@ link_definitions_router = fastapi.APIRouter(
 )
 
 
+def _projects_relationship(
+    project_count: int,
+) -> dict[str, models.RelationshipLink]:
+    """Build the ``projects`` relationship for a link definition.
+
+    The href is intentionally empty because ``list_projects`` does not
+    yet support a ``link_definition`` query filter; only the count is
+    meaningful today.
+    """
+    return build_relationships(
+        '',
+        {'projects': ('', project_count)},
+    )
+
+
 class LinkDefinitionCreate(pydantic.BaseModel):
     """Request model for creating a link definition."""
 
@@ -152,13 +167,7 @@ async def create_link_definition(
     )
     org = graph.parse_agtype(records[0]['o'])
     result['organization'] = org
-    # The projects href is intentionally empty because list_projects does
-    # not yet support a link_definition query filter; only the count is
-    # meaningful here.
-    result['relationships'] = build_relationships(
-        '',
-        {'projects': ('', 0)},
-    )
+    result['relationships'] = _projects_relationship(0)
     return result
 
 
@@ -206,12 +215,7 @@ async def list_link_definitions(
         org = graph.parse_agtype(record['o'])
         ld['organization'] = org
         pc = graph.parse_agtype(record['project_count'])
-        # See note in create_link_definition: projects href is empty
-        # until list_projects supports a link_definition filter.
-        ld['relationships'] = build_relationships(
-            '',
-            {'projects': ('', pc or 0)},
-        )
+        ld['relationships'] = _projects_relationship(pc or 0)
         results.append(ld)
     return results
 
@@ -270,12 +274,7 @@ async def get_link_definition(
     org = graph.parse_agtype(records[0]['o'])
     result['organization'] = org
     pc = graph.parse_agtype(records[0]['project_count'])
-    # See note in create_link_definition: projects href is empty
-    # until list_projects supports a link_definition filter.
-    result['relationships'] = build_relationships(
-        '',
-        {'projects': ('', pc or 0)},
-    )
+    result['relationships'] = _projects_relationship(pc or 0)
     return result
 
 
@@ -376,12 +375,7 @@ async def _persist_link_definition(
     org = graph.parse_agtype(updated[0]['o'])
     result['organization'] = org
     pc = graph.parse_agtype(updated[0]['project_count'])
-    # See note in create_link_definition: projects href is empty
-    # until list_projects supports a link_definition filter.
-    result['relationships'] = build_relationships(
-        '',
-        {'projects': ('', pc or 0)},
-    )
+    result['relationships'] = _projects_relationship(pc or 0)
     return result
 
 

--- a/src/imbi_api/endpoints/organizations.py
+++ b/src/imbi_api/endpoints/organizations.py
@@ -11,7 +11,7 @@ from imbi_common import graph, models
 
 from imbi_api import patch as json_patch
 from imbi_api.auth import permissions
-from imbi_api.relationships import relationship_link
+from imbi_api.relationships import build_relationships
 
 from .environments import environments_router
 from .link_definitions import link_definitions_router
@@ -71,31 +71,6 @@ organizations_router.include_router(
 )
 
 
-def _add_relationships(
-    org: dict[str, typing.Any],
-    team_count: int = 0,
-    member_count: int = 0,
-    project_count: int = 0,
-) -> dict[str, typing.Any]:
-    """Attach relationships sub-object to an organization dict."""
-    slug = org['slug']
-    org['relationships'] = {
-        'teams': relationship_link(
-            f'/api/organizations/{slug}/teams',
-            team_count,
-        ),
-        'members': relationship_link(
-            f'/api/organizations/{slug}/members',
-            member_count,
-        ),
-        'projects': relationship_link(
-            f'/api/organizations/{slug}/projects',
-            project_count,
-        ),
-    }
-    return org
-
-
 @organizations_router.post('/', status_code=201)
 async def create_organization(
     org: models.Organization,
@@ -130,7 +105,16 @@ async def create_organization(
             detail=(f'Organization with slug {org.slug!r} already exists'),
         ) from e
     result = created.model_dump()
-    return _add_relationships(result)
+    slug = result['slug']
+    result['relationships'] = build_relationships(
+        f'/api/organizations/{slug}',
+        {
+            'teams': ('/teams', 0),
+            'members': ('/members', 0),
+            'projects': ('/projects', 0),
+        },
+    )
+    return result
 
 
 @organizations_router.get('/')
@@ -172,11 +156,14 @@ async def list_organizations(
         team_count = graph.parse_agtype(record['team_count'])
         member_count = graph.parse_agtype(record['member_count'])
         project_count = graph.parse_agtype(record['project_count'])
-        _add_relationships(
-            org_data,
-            team_count,
-            member_count,
-            project_count,
+        slug = org_data['slug']
+        org_data['relationships'] = build_relationships(
+            f'/api/organizations/{slug}',
+            {
+                'teams': ('/teams', team_count),
+                'members': ('/members', member_count),
+                'projects': ('/projects', project_count),
+            },
         )
         organizations.append(org_data)
     return organizations
@@ -228,13 +215,26 @@ async def get_organization(
             status_code=404,
             detail=f'Organization with slug {slug!r} not found',
         )
-    org_data = graph.parse_agtype(records[0]['o'])
-    return _add_relationships(
-        org_data,
-        graph.parse_agtype(records[0]['team_count']),
-        graph.parse_agtype(records[0]['member_count']),
-        graph.parse_agtype(records[0]['project_count']),
+    org_data: dict[str, typing.Any] = graph.parse_agtype(records[0]['o'])
+    slug = org_data['slug']
+    org_data['relationships'] = build_relationships(
+        f'/api/organizations/{slug}',
+        {
+            'teams': (
+                '/teams',
+                graph.parse_agtype(records[0]['team_count']),
+            ),
+            'members': (
+                '/members',
+                graph.parse_agtype(records[0]['member_count']),
+            ),
+            'projects': (
+                '/projects',
+                graph.parse_agtype(records[0]['project_count']),
+            ),
+        },
     )
+    return org_data
 
 
 async def _persist_organization(
@@ -306,12 +306,24 @@ async def _persist_organization(
     )
     counts = count_records[0] if count_records else {}
     org_dict = org.model_dump()
-    return _add_relationships(
-        org_dict,
-        graph.parse_agtype(counts.get('team_count', 0)),
-        graph.parse_agtype(counts.get('member_count', 0)),
-        graph.parse_agtype(counts.get('project_count', 0)),
+    org_dict['relationships'] = build_relationships(
+        f'/api/organizations/{org.slug}',
+        {
+            'teams': (
+                '/teams',
+                graph.parse_agtype(counts.get('team_count', 0)),
+            ),
+            'members': (
+                '/members',
+                graph.parse_agtype(counts.get('member_count', 0)),
+            ),
+            'projects': (
+                '/projects',
+                graph.parse_agtype(counts.get('project_count', 0)),
+            ),
+        },
     )
+    return org_dict
 
 
 @organizations_router.put('/{slug}')

--- a/src/imbi_api/endpoints/project_types.py
+++ b/src/imbi_api/endpoints/project_types.py
@@ -11,63 +11,12 @@ from imbi_common import blueprints, graph, models
 
 from imbi_api import patch as json_patch
 from imbi_api.auth import permissions
-from imbi_api.relationships import relationship_link
+from imbi_api.graph_sql import props_template, set_clause
+from imbi_api.relationships import build_relationships
 
 LOGGER = logging.getLogger(__name__)
 
 project_types_router = fastapi.APIRouter(tags=['Project Types'])
-
-
-def _escape_prop(name: str) -> str:
-    """Escape a Cypher property name with backticks."""
-    return '`' + name.replace('`', '``') + '`'
-
-
-def _props_template(props: dict[str, typing.Any]) -> str:
-    """Build a Cypher property-map template with double-escaped braces.
-
-    Each key becomes ```key`: {key}`` inside doubled braces so that
-    ``psycopg.sql.SQL.format()`` resolves them correctly::
-
-        >>> _props_template({'name': 'x', 'slug': 'y'})
-        '{{`name`: {name}, `slug`: {slug}}}'
-
-    """
-    if not props:
-        return ''
-    pairs = [f'{_escape_prop(k)}: {{{k}}}' for k in props]
-    return '{{' + ', '.join(pairs) + '}}'
-
-
-def _set_clause(
-    alias: str,
-    props: dict[str, typing.Any],
-) -> str:
-    """Build a Cypher SET clause from a property dict.
-
-    Returns ``SET pt.`name` = {name}, pt.`slug` = {slug}``.
-
-    """
-    if not props:
-        return ''
-    assignments = ', '.join(
-        f'{alias}.{_escape_prop(k)} = {{{k}}}' for k in props
-    )
-    return f'SET {assignments}'
-
-
-def _add_relationships(
-    pt: dict[str, typing.Any],
-    project_count: int = 0,
-) -> dict[str, typing.Any]:
-    """Attach relationships sub-object to a project type dict."""
-    pt['relationships'] = {
-        'projects': relationship_link(
-            f'/api/projects?project-type={pt["slug"]}',
-            project_count,
-        ),
-    }
-    return pt
 
 
 @project_types_router.post('/', status_code=201)
@@ -132,7 +81,7 @@ async def create_project_type(
         exclude={'organization'},
     )
 
-    create_tpl = _props_template(props)
+    create_tpl = props_template(props)
     query = (
         f'MATCH (o:Organization {{{{slug: {{org_slug}}}}}})'
         f' CREATE (pt:ProjectType {create_tpl})'
@@ -160,10 +109,19 @@ async def create_project_type(
             detail=(f'Organization with slug {org_slug!r} not found'),
         )
 
-    pt_props = graph.parse_agtype(records[0]['pt'])
+    pt_props: dict[str, typing.Any] = graph.parse_agtype(records[0]['pt'])
     org_props = graph.parse_agtype(records[0]['o'])
     pt_props['organization'] = org_props
-    return _add_relationships(pt_props)
+    pt_props['relationships'] = build_relationships(
+        '',
+        {
+            'projects': (
+                f'/api/projects?project-type={pt_props["slug"]}',
+                0,
+            ),
+        },
+    )
+    return pt_props
 
 
 @project_types_router.get('/')
@@ -206,7 +164,15 @@ async def list_project_types(
         org = graph.parse_agtype(record['o'])
         pt['organization'] = org
         pc = graph.parse_agtype(record['project_count'])
-        _add_relationships(pt, pc or 0)
+        pt['relationships'] = build_relationships(
+            '',
+            {
+                'projects': (
+                    f'/api/projects?project-type={pt["slug"]}',
+                    pc or 0,
+                ),
+            },
+        )
         project_types.append(pt)
     return project_types
 
@@ -255,11 +221,20 @@ async def get_project_type(
             detail=(f'Project type with slug {slug!r} not found'),
         )
 
-    pt = graph.parse_agtype(records[0]['pt'])
+    pt: dict[str, typing.Any] = graph.parse_agtype(records[0]['pt'])
     org = graph.parse_agtype(records[0]['o'])
     pt['organization'] = org
     pc = graph.parse_agtype(records[0]['project_count'])
-    return _add_relationships(pt, pc or 0)
+    pt['relationships'] = build_relationships(
+        '',
+        {
+            'projects': (
+                f'/api/projects?project-type={pt["slug"]}',
+                pc or 0,
+            ),
+        },
+    )
+    return pt
 
 
 async def _persist_project_type(
@@ -318,7 +293,7 @@ async def _persist_project_type(
         exclude={'organization'},
     )
 
-    set_stmt = _set_clause('pt', props)
+    set_stmt = set_clause('pt', props)
     update_query = (
         f'MATCH (pt:ProjectType {{{{slug: {{slug}}}}}})'
         f' -[:BELONGS_TO]->(o:Organization'
@@ -352,11 +327,20 @@ async def _persist_project_type(
             detail=(f'Project type with slug {original_slug!r} not found'),
         )
 
-    pt = graph.parse_agtype(updated[0]['pt'])
+    pt: dict[str, typing.Any] = graph.parse_agtype(updated[0]['pt'])
     org = graph.parse_agtype(updated[0]['o'])
     pt['organization'] = org
     pc = graph.parse_agtype(updated[0]['project_count'])
-    return _add_relationships(pt, pc or 0)
+    pt['relationships'] = build_relationships(
+        '',
+        {
+            'projects': (
+                f'/api/projects?project-type={pt["slug"]}',
+                pc or 0,
+            ),
+        },
+    )
+    return pt
 
 
 @project_types_router.put('/{slug}')

--- a/src/imbi_api/endpoints/projects.py
+++ b/src/imbi_api/endpoints/projects.py
@@ -17,7 +17,8 @@ from imbi_common import blueprints, graph, models
 
 from imbi_api import patch as json_patch
 from imbi_api.auth import permissions
-from imbi_api.relationships import relationship_link
+from imbi_api.graph_sql import escape_prop, props_template, set_clause
+from imbi_api.relationships import build_relationships
 
 LOGGER = logging.getLogger(__name__)
 
@@ -155,44 +156,6 @@ class ProjectResponse(pydantic.BaseModel):
 # -- Helpers ------------------------------------------------------------
 
 
-def _escape_prop(name: str) -> str:
-    """Escape a Cypher property name with backticks."""
-    return '`' + name.replace('`', '``') + '`'
-
-
-def _props_template(props: dict[str, typing.Any]) -> str:
-    """Build a Cypher property-map template with double-escaped braces.
-
-    Each key becomes ```key`: {key}`` inside doubled braces so that
-    ``psycopg.sql.SQL.format()`` resolves them correctly::
-
-        >>> _props_template({'name': 'x', 'slug': 'y'})
-        '{{`name`: {name}, `slug`: {slug}}}'
-
-    """
-    if not props:
-        return ''
-    pairs = [f'{_escape_prop(k)}: {{{k}}}' for k in props]
-    return '{{' + ', '.join(pairs) + '}}'
-
-
-def _set_clause(
-    alias: str,
-    props: dict[str, typing.Any],
-) -> str:
-    """Build a Cypher SET clause from a property dict.
-
-    Returns ``SET p.`name` = {name}, p.`slug` = {slug}``.
-
-    """
-    if not props:
-        return ''
-    assignments = ', '.join(
-        f'{alias}.{_escape_prop(k)} = {{{k}}}' for k in props
-    )
-    return f'SET {assignments}'
-
-
 def _env_entries_template(
     entries: list[dict[str, typing.Any]],
 ) -> tuple[str, dict[str, typing.Any]]:
@@ -212,7 +175,7 @@ def _env_entries_template(
         pairs: list[str] = []
         for key, value in entry.items():
             param = f'env_{i}_{key}'
-            pairs.append(f'{_escape_prop(key)}: {{{param}}}')
+            pairs.append(f'{escape_prop(key)}: {{{param}}}')
             params[param] = value
         maps.append('{{' + ', '.join(pairs) + '}}')
     return '[' + ', '.join(maps) + ']', params
@@ -238,7 +201,7 @@ def _edge_create_props(
     prop_keys = list(all_keys)
     if not prop_keys:
         return ''
-    pairs = [f'{_escape_prop(k)}: entry.{_escape_prop(k)}' for k in prop_keys]
+    pairs = [f'{escape_prop(k)}: entry.{escape_prop(k)}' for k in prop_keys]
     return ' {{' + ', '.join(pairs) + '}}'
 
 
@@ -338,33 +301,6 @@ def _flatten_edge_props(
             env.update(
                 {k: v for k, v in edge.items() if k not in _PROTECTED_ENV_KEYS}
             )
-    return project
-
-
-def _add_relationships(
-    project: dict[str, typing.Any],
-    org_slug: str,
-    outbound_count: int = 0,
-    inbound_count: int = 0,
-) -> dict[str, typing.Any]:
-    """Attach relationships sub-object to a project dict."""
-    project_id = project.get('id') or ''
-    team = project.get('team', {})
-    team_slug = team.get('slug', '') if team else ''
-    base = f'/api/organizations/{org_slug}/projects/{project_id}'
-    project['relationships'] = {
-        'team': relationship_link(
-            f'/api/organizations/{org_slug}/teams/{team_slug}',
-            1 if team_slug else 0,
-        ),
-        'environments': relationship_link(
-            f'{base}/environments',
-            len(project.get('environments') or []),
-        ),
-        'href': f'{base}/relationships',
-        'outbound_count': outbound_count,
-        'inbound_count': inbound_count,
-    }
     return project
 
 
@@ -518,7 +454,7 @@ async def create_project(
             list(data.environments.keys()),
         )
 
-    create_tpl = _props_template(props)
+    create_tpl = props_template(props)
     env_entries = [{'slug': s, **ep} for s, ep in data.environments.items()]
     env_tpl, env_params = _env_entries_template(env_entries)
     edge_props_tpl = _edge_create_props(env_entries)
@@ -591,13 +527,45 @@ async def create_project(
 
     project_data = graph.parse_agtype(records[0]['project'])
     _flatten_edge_props(project_data)
-    result = _add_relationships(
+    _attach_project_relationships(
         project_data,
         org_slug,
         graph.parse_agtype(records[0]['outbound_count']),
         graph.parse_agtype(records[0]['inbound_count']),
     )
-    return ProjectResponse.model_validate(result)
+    return ProjectResponse.model_validate(project_data)
+
+
+def _attach_project_relationships(
+    project: dict[str, typing.Any],
+    org_slug: str,
+    outbound_count: int = 0,
+    inbound_count: int = 0,
+) -> None:
+    """Attach relationships sub-object to a project dict."""
+    project_id = project.get('id') or ''
+    team = project.get('team', {})
+    team_slug = team.get('slug', '') if team else ''
+    base = f'/api/organizations/{org_slug}/projects/{project_id}'
+    rels: dict[str, typing.Any] = dict(
+        build_relationships(
+            '',
+            {
+                'team': (
+                    f'/api/organizations/{org_slug}/teams/{team_slug}',
+                    1 if team_slug else 0,
+                ),
+                'environments': (
+                    f'{base}/environments',
+                    len(project.get('environments') or []),
+                ),
+            },
+        )
+    )
+    rels['href'] = f'{base}/relationships'
+    rels['outbound_count'] = outbound_count
+    rels['inbound_count'] = inbound_count
+    project['relationships'] = rels
 
 
 @projects_router.get('/')
@@ -642,14 +610,14 @@ async def list_projects(
     for record in records:
         project_data = graph.parse_agtype(record['project'])
         _flatten_edge_props(project_data)
-        proj = _add_relationships(
+        _attach_project_relationships(
             project_data,
             org_slug,
             graph.parse_agtype(record['outbound_count']),
             graph.parse_agtype(record['inbound_count']),
         )
         results.append(
-            ProjectResponse.model_validate(proj),
+            ProjectResponse.model_validate(project_data),
         )
     return results
 
@@ -839,13 +807,13 @@ async def get_project(
         )
     project_data = graph.parse_agtype(records[0]['project'])
     _flatten_edge_props(project_data)
-    result = _add_relationships(
+    _attach_project_relationships(
         project_data,
         org_slug,
         graph.parse_agtype(records[0]['outbound_count']),
         graph.parse_agtype(records[0]['inbound_count']),
     )
-    return ProjectResponse.model_validate(result)
+    return ProjectResponse.model_validate(project_data)
 
 
 class ProjectRelationshipSummary(pydantic.BaseModel):
@@ -1330,7 +1298,7 @@ async def _execute_project_update(
     await _validate_update_refs(db, org_slug, data)
 
     rel_clauses, new_env_params = _build_update_clauses(data)
-    set_clause = _set_clause('p', props)
+    set_stmt = set_clause('p', props)
 
     update_query: str = (
         """
@@ -1339,7 +1307,7 @@ async def _execute_project_update(
           -[:BELONGS_TO]->(o:Organization {{slug: {org_slug}}})
     WITH DISTINCT p, o
     """
-        + set_clause
+        + set_stmt
         + rel_clauses
         + """
     WITH DISTINCT p, o
@@ -1374,13 +1342,13 @@ async def _execute_project_update(
 
     updated_data = graph.parse_agtype(updated[0]['project'])
     _flatten_edge_props(updated_data)
-    result = _add_relationships(
+    _attach_project_relationships(
         updated_data,
         org_slug,
         graph.parse_agtype(updated[0]['outbound_count']),
         graph.parse_agtype(updated[0]['inbound_count']),
     )
-    return ProjectResponse.model_validate(result)
+    return ProjectResponse.model_validate(updated_data)
 
 
 @projects_router.put('/{project_id}')

--- a/src/imbi_api/endpoints/teams.py
+++ b/src/imbi_api/endpoints/teams.py
@@ -11,63 +11,12 @@ from imbi_common import blueprints, graph, models
 
 from imbi_api import patch as json_patch
 from imbi_api.auth import permissions
-from imbi_api.relationships import relationship_link
+from imbi_api.graph_sql import props_template, set_clause
+from imbi_api.relationships import build_relationships
 
 LOGGER = logging.getLogger(__name__)
 
 teams_router = fastapi.APIRouter(tags=['Teams'])
-
-
-def _props_template(props: dict[str, typing.Any]) -> str:
-    """Build a Cypher property-map template with double-escaped braces.
-
-    Each key becomes ``key: {key}`` inside doubled braces so that
-    ``psycopg.sql.SQL.format()`` resolves them correctly::
-
-        >>> _props_template({'name': 'x', 'slug': 'y'})
-        '{{name: {name}, slug: {slug}}}'
-
-    """
-    if not props:
-        return ''
-    pairs = [f'{k}: {{{k}}}' for k in props]
-    return '{{' + ', '.join(pairs) + '}}'
-
-
-def _set_clause(
-    alias: str,
-    props: dict[str, typing.Any],
-) -> str:
-    """Build a Cypher SET clause from a property dict.
-
-    Returns a string like ``SET t.name = {name}, t.slug = {slug}``.
-
-    """
-    if not props:
-        return ''
-    assignments = ', '.join(f'{alias}.{k} = {{{k}}}' for k in props)
-    return f'SET {assignments}'
-
-
-def _add_relationships(
-    team: dict[str, typing.Any],
-    org_slug: str,
-    project_count: int = 0,
-    member_count: int = 0,
-) -> dict[str, typing.Any]:
-    """Attach relationships sub-object to a team dict."""
-    slug = team['slug']
-    team['relationships'] = {
-        'projects': relationship_link(
-            f'/api/projects?team={slug}',
-            project_count,
-        ),
-        'members': relationship_link(
-            f'/api/organizations/{org_slug}/teams/{slug}/members',
-            member_count,
-        ),
-    }
-    return team
 
 
 @teams_router.post('/', status_code=201)
@@ -129,7 +78,7 @@ async def create_team(
         exclude={'organization'},
     )
 
-    create_tpl = _props_template(props)
+    create_tpl = props_template(props)
     query = (
         f'MATCH (o:Organization {{{{slug: {{org_slug}}}}}})'
         f' CREATE (t:Team {create_tpl})'
@@ -155,10 +104,21 @@ async def create_team(
             detail=(f'Organization with slug {org_slug!r} not found'),
         )
 
-    team_props = graph.parse_agtype(records[0]['t'])
+    team_props: dict[str, typing.Any] = graph.parse_agtype(records[0]['t'])
     org_props = graph.parse_agtype(records[0]['o'])
     team_props['organization'] = org_props
-    return _add_relationships(team_props, org_slug)
+    slug = team_props['slug']
+    team_props['relationships'] = build_relationships(
+        '',
+        {
+            'projects': (f'/api/projects?team={slug}', 0),
+            'members': (
+                f'/api/organizations/{org_slug}/teams/{slug}/members',
+                0,
+            ),
+        },
+    )
+    return team_props
 
 
 @teams_router.get('/')
@@ -201,11 +161,16 @@ async def list_teams(
         team['organization'] = org
         pc = graph.parse_agtype(record['project_count'])
         mc = graph.parse_agtype(record['member_count'])
-        _add_relationships(
-            team,
-            org_slug,
-            pc or 0,
-            mc or 0,
+        slug = team['slug']
+        team['relationships'] = build_relationships(
+            '',
+            {
+                'projects': (f'/api/projects?team={slug}', pc or 0),
+                'members': (
+                    f'/api/organizations/{org_slug}/teams/{slug}/members',
+                    mc or 0,
+                ),
+            },
         )
         teams.append(team)
     return teams
@@ -255,12 +220,22 @@ async def get_team(
             detail=f'Team with slug {slug!r} not found',
         )
 
-    team = graph.parse_agtype(records[0]['t'])
+    team: dict[str, typing.Any] = graph.parse_agtype(records[0]['t'])
     org = graph.parse_agtype(records[0]['o'])
     team['organization'] = org
     pc = graph.parse_agtype(records[0]['project_count'])
     mc = graph.parse_agtype(records[0]['member_count'])
-    return _add_relationships(team, org_slug, pc or 0, mc or 0)
+    team['relationships'] = build_relationships(
+        '',
+        {
+            'projects': (f'/api/projects?team={slug}', pc or 0),
+            'members': (
+                f'/api/organizations/{org_slug}/teams/{slug}/members',
+                mc or 0,
+            ),
+        },
+    )
+    return team
 
 
 async def _persist_team(
@@ -313,7 +288,7 @@ async def _persist_team(
     team.updated_at = datetime.datetime.now(datetime.UTC)
     props = team.model_dump(mode='json', exclude={'organization'})
 
-    set_stmt = _set_clause('t', props)
+    set_stmt = set_clause('t', props)
     update_query = (
         f'MATCH (t:Team {{{{slug: {{slug}}}}}})'
         f' -[:BELONGS_TO]->(o:Organization {{{{slug: {{org_slug}}}}}})'
@@ -348,12 +323,23 @@ async def _persist_team(
             detail=f'Team with slug {original_slug!r} not found',
         )
 
-    team_data = graph.parse_agtype(updated[0]['t'])
+    team_data: dict[str, typing.Any] = graph.parse_agtype(updated[0]['t'])
     org_data = graph.parse_agtype(updated[0]['o'])
     team_data['organization'] = org_data
     pc = graph.parse_agtype(updated[0]['project_count'])
     mc = graph.parse_agtype(updated[0]['member_count'])
-    return _add_relationships(team_data, org_slug, pc or 0, mc or 0)
+    slug = team_data['slug']
+    team_data['relationships'] = build_relationships(
+        '',
+        {
+            'projects': (f'/api/projects?team={slug}', pc or 0),
+            'members': (
+                f'/api/organizations/{org_slug}/teams/{slug}/members',
+                mc or 0,
+            ),
+        },
+    )
+    return team_data
 
 
 @teams_router.put('/{slug}')

--- a/src/imbi_api/endpoints/third_party_services.py
+++ b/src/imbi_api/endpoints/third_party_services.py
@@ -13,6 +13,7 @@ from imbi_common.auth import encryption
 from imbi_api import patch as json_patch
 from imbi_api.auth import permissions
 from imbi_api.domain import models
+from imbi_api.graph_sql import props_template, set_clause
 
 LOGGER = logging.getLogger(__name__)
 
@@ -25,37 +26,6 @@ _APP_JSON_FIELDS: dict[str, list[str] | dict[str, typing.Any]] = {
     'scopes': [],
     'settings': {},
 }
-
-
-def _props_template(props: dict[str, typing.Any]) -> str:
-    """Build a Cypher property-map template with double-escaped braces.
-
-    Each key becomes ``key: {key}`` inside doubled braces so that
-    ``psycopg.sql.SQL.format()`` resolves them correctly::
-
-        >>> _props_template({'name': 'x', 'slug': 'y'})
-        '{{name: {name}, slug: {slug}}}'
-
-    """
-    if not props:
-        return ''
-    pairs = [f'{k}: {{{k}}}' for k in props]
-    return '{{' + ', '.join(pairs) + '}}'
-
-
-def _set_clause(
-    alias: str,
-    props: dict[str, typing.Any],
-) -> str:
-    """Build a Cypher SET clause from a property dict.
-
-    Returns a string like ``SET s.name = {name}, s.slug = {slug}``.
-
-    """
-    if not props:
-        return ''
-    assignments = ', '.join(f'{alias}.{k} = {{{k}}}' for k in props)
-    return f'SET {assignments}'
 
 
 def _build_service_response(
@@ -178,7 +148,7 @@ async def create_third_party_service(
     }
 
     graph_props = _serialize_json_fields(props, _SERVICE_JSON_FIELDS)
-    create_tpl = _props_template(graph_props)
+    create_tpl = props_template(graph_props)
 
     if data.team_slug:
         query: str = (
@@ -652,7 +622,7 @@ async def create_service_application(
         )
 
     graph_props = _serialize_json_fields(props, _APP_JSON_FIELDS)
-    app_tpl = _props_template(graph_props)
+    app_tpl = props_template(graph_props)
 
     create_query: str = (
         'MATCH (s:ThirdPartyService {{slug: {svc_slug}}})'
@@ -721,7 +691,7 @@ async def _execute_service_update(
     }
 
     graph_props = _serialize_json_fields(props, _SERVICE_JSON_FIELDS)
-    set_clause = _set_clause('s', graph_props)
+    set_stmt = set_clause('s', graph_props)
 
     if update_data.team_slug:
         update_query: str = (
@@ -733,7 +703,7 @@ async def _execute_service_update(
             ' OPTIONAL MATCH (s)-[old_mgr:MANAGED_BY]->()'
             ' DELETE old_mgr'
             ' WITH s, o, t'
-            f' {set_clause}'
+            f' {set_stmt}'
             ' CREATE (s)-[:MANAGED_BY]->(t)'
             ' RETURN s{{.*, organization: o{{.*}},'
             ' team: t{{.*}}}} AS service'
@@ -752,7 +722,7 @@ async def _execute_service_update(
             ' OPTIONAL MATCH (s)-[old_mgr:MANAGED_BY]->()'
             ' DELETE old_mgr'
             ' WITH s, o'
-            f' {set_clause}'
+            f' {set_stmt}'
             ' RETURN s{{.*, organization: o{{.*}},'
             ' team: null}} AS service'
         )
@@ -879,7 +849,7 @@ async def update_service_application(
         props[field] = existing.get(field)
 
     graph_props = _serialize_json_fields(props, _APP_JSON_FIELDS)
-    app_set = _set_clause('a', graph_props)
+    app_set = set_clause('a', graph_props)
 
     update_query: str = (
         'MATCH (a:ServiceApplication {{slug: {cur_app_slug}}})'

--- a/src/imbi_api/endpoints/third_party_services.py
+++ b/src/imbi_api/endpoints/third_party_services.py
@@ -322,26 +322,6 @@ async def update_third_party_service(
         409: Slug conflict
 
     """
-    # Fetch existing to validate it exists
-    fetch_query: typing.LiteralString = """
-    MATCH (s:ThirdPartyService {{slug: {slug}}})
-          -[:BELONGS_TO]->(o:Organization {{slug: {org_slug}}})
-    OPTIONAL MATCH (s)-[:MANAGED_BY]->(t:Team)
-    RETURN s{{.*, organization: o{{.*}}, team: t{{.*}}}}
-        AS service
-    """
-    records = await db.execute(
-        fetch_query,
-        {'slug': slug, 'org_slug': org_slug},
-        ['service'],
-    )
-
-    if not records:
-        raise fastapi.HTTPException(
-            status_code=404,
-            detail=(f'Third-party service with slug {slug!r} not found'),
-        )
-
     return await _execute_service_update(slug, org_slug, data, db)
 
 

--- a/src/imbi_api/endpoints/webhooks.py
+++ b/src/imbi_api/endpoints/webhooks.py
@@ -13,39 +13,9 @@ from imbi_common.auth import encryption
 from imbi_api import patch as json_patch
 from imbi_api.auth import permissions
 from imbi_api.domain import models
+from imbi_api.graph_sql import props_template, set_clause
 
 LOGGER = logging.getLogger(__name__)
-
-
-def _props_template(props: dict[str, typing.Any]) -> str:
-    """Build a Cypher property-map template with double-escaped braces.
-
-    Each key becomes ``key: {key}`` inside doubled braces so that
-    ``psycopg.sql.SQL.format()`` resolves them correctly::
-
-        >>> _props_template({'name': 'x', 'slug': 'y'})
-        '{{name: {name}, slug: {slug}}}'
-
-    """
-    if not props:
-        return ''
-    pairs = [f'{k}: {{{k}}}' for k in props]
-    return '{{' + ', '.join(pairs) + '}}'
-
-
-def _set_clause(
-    alias: str,
-    props: dict[str, typing.Any],
-) -> str:
-    """Build a Cypher SET clause from a property dict.
-
-    Returns a string like ``SET w.name = {name}, w.slug = {slug}``.
-
-    """
-    if not props:
-        return ''
-    assignments = ', '.join(f'{alias}.{k} = {{{k}}}' for k in props)
-    return f'SET {assignments}'
 
 
 def _rules_create_clauses(
@@ -130,7 +100,7 @@ async def create_webhook(
             encryptor.encrypt(data.secret) if data.secret is not None else None
         ),
     }
-    create_tpl = _props_template(props)
+    create_tpl = props_template(props)
 
     # Build rule creation params as scalars
     rule_dicts: list[dict[str, str | int]] = []
@@ -357,7 +327,7 @@ async def update_webhook(
         'notification_path': data.notification_path,
         'secret': encrypted_secret,
     }
-    set_clause = _set_clause('w', props)
+    set_stmt = set_clause('w', props)
 
     rule_dicts: list[dict[str, str | int]] = []
     for idx, rule in enumerate(data.rules):
@@ -389,7 +359,7 @@ async def update_webhook(
             ' (w)-[old_impl:IMPLEMENTED_BY]->()'
             ' DELETE old_impl'
             ' WITH DISTINCT w, o, tps'
-            f' {set_clause}'
+            f' {set_stmt}'
             ' CREATE (w)-[impl:IMPLEMENTED_BY]->(tps)'
             ' SET impl.identifier_selector'
             ' = {identifier_selector}'
@@ -417,7 +387,7 @@ async def update_webhook(
             ' (w)-[old_impl:IMPLEMENTED_BY]->()'
             ' DELETE old_impl'
             ' WITH DISTINCT w'
-            f' {set_clause}' + rule_clauses + ' RETURN w.slug AS slug'
+            f' {set_stmt}' + rule_clauses + ' RETURN w.slug AS slug'
         )
         params = {
             'old_slug': slug,
@@ -551,7 +521,7 @@ async def patch_webhook(
         'notification_path': data.notification_path,
         'secret': encrypted_secret,
     }
-    set_clause = _set_clause('w', props)
+    set_stmt = set_clause('w', props)
 
     rule_dicts: list[dict[str, str | int]] = []
     for idx, rule in enumerate(data.rules):
@@ -582,7 +552,7 @@ async def patch_webhook(
             ' (w)-[old_impl:IMPLEMENTED_BY]->()'
             ' DELETE old_impl'
             ' WITH DISTINCT w, o, tps'
-            f' {set_clause}'
+            f' {set_stmt}'
             ' CREATE (w)-[impl:IMPLEMENTED_BY]->(tps)'
             ' SET impl.identifier_selector'
             ' = {identifier_selector}'
@@ -610,7 +580,7 @@ async def patch_webhook(
             ' (w)-[old_impl:IMPLEMENTED_BY]->()'
             ' DELETE old_impl'
             ' WITH DISTINCT w'
-            f' {set_clause}' + rule_clauses + ' RETURN w.slug AS slug'
+            f' {set_stmt}' + rule_clauses + ' RETURN w.slug AS slug'
         )
         params = {
             'old_slug': slug,

--- a/src/imbi_api/endpoints/webhooks.py
+++ b/src/imbi_api/endpoints/webhooks.py
@@ -72,6 +72,38 @@ RETURN w{{.*}} AS webhook,
 """
 
 
+_UPDATE_RETURN_TAIL_WITH_TPS: typing.LiteralString = (
+    ' WITH w, tps, impl'
+    ' OPTIONAL MATCH (r:WebhookRule)-[:ACTIONS]->(w)'
+    ' WITH w, tps, impl, r ORDER BY r.ordinal'
+    ' WITH w, tps, impl,'
+    ' collect(CASE WHEN r IS NOT NULL'
+    ' THEN r{{.filter_expression, .handler,'
+    ' .handler_config, .ordinal}} END) AS all_rules'
+    ' RETURN w{{.*}} AS webhook, tps{{.*}} AS tps,'
+    ' impl.identifier_selector AS identifier_selector,'
+    ' [x IN all_rules'
+    ' | x {{.filter_expression, .handler,'
+    ' .handler_config}}] AS rules'
+)
+
+
+_UPDATE_RETURN_TAIL_NO_TPS: typing.LiteralString = (
+    ' WITH w'
+    ' OPTIONAL MATCH (r:WebhookRule)-[:ACTIONS]->(w)'
+    ' WITH w, r ORDER BY r.ordinal'
+    ' WITH w,'
+    ' collect(CASE WHEN r IS NOT NULL'
+    ' THEN r{{.filter_expression, .handler,'
+    ' .handler_config, .ordinal}} END) AS all_rules'
+    ' RETURN w{{.*}} AS webhook, null AS tps,'
+    ' null AS identifier_selector,'
+    ' [x IN all_rules'
+    ' | x {{.filter_expression, .handler,'
+    ' .handler_config}}] AS rules'
+)
+
+
 webhooks_router = fastapi.APIRouter(tags=['Webhooks'])
 
 
@@ -287,37 +319,7 @@ async def update_webhook(
     ],
 ) -> models.WebhookResponse:
     """Update a webhook (full replacement including rules)."""
-    # Verify exists
-    check_query: typing.LiteralString = """
-    MATCH (w:Webhook {{slug: {slug}}})
-          -[:BELONGS_TO]->(o:Organization {{slug: {org_slug}}})
-    RETURN w{{.*}} AS webhook
-    """
-    existing = await db.execute(
-        check_query,
-        {'slug': slug, 'org_slug': org_slug},
-        ['webhook'],
-    )
-
-    if not existing:
-        raise fastapi.HTTPException(
-            status_code=404,
-            detail=f'Webhook with slug {slug!r} not found',
-        )
-
     encryptor = encryption.TokenEncryption.get_instance()
-
-    # Distinguish omitted secret (preserve existing) from explicit
-    # null (clear) or a new value (encrypt and store).
-    existing_webhook = graph.parse_agtype(
-        existing[0]['webhook'],
-    )
-    if 'secret' not in data.model_fields_set:
-        encrypted_secret = existing_webhook.get('secret')
-    elif data.secret is None:
-        encrypted_secret = None
-    else:
-        encrypted_secret = encryptor.encrypt(data.secret)
 
     props: dict[str, typing.Any] = {
         'name': data.name,
@@ -325,8 +327,11 @@ async def update_webhook(
         'description': data.description,
         'icon': data.icon,
         'notification_path': data.notification_path,
-        'secret': encrypted_secret,
     }
+    if 'secret' in data.model_fields_set:
+        props['secret'] = (
+            None if data.secret is None else encryptor.encrypt(data.secret)
+        )
     set_stmt = set_clause('w', props)
 
     rule_dicts: list[dict[str, str | int]] = []
@@ -364,7 +369,7 @@ async def update_webhook(
             ' SET impl.identifier_selector'
             ' = {identifier_selector}'
             + rule_clauses
-            + ' RETURN w.slug AS slug'
+            + _UPDATE_RETURN_TAIL_WITH_TPS
         )
         params: dict[str, typing.Any] = {
             'old_slug': slug,
@@ -387,7 +392,7 @@ async def update_webhook(
             ' (w)-[old_impl:IMPLEMENTED_BY]->()'
             ' DELETE old_impl'
             ' WITH DISTINCT w'
-            f' {set_stmt}' + rule_clauses + ' RETURN w.slug AS slug'
+            f' {set_stmt}' + rule_clauses + _UPDATE_RETURN_TAIL_NO_TPS
         )
         params = {
             'old_slug': slug,
@@ -397,10 +402,10 @@ async def update_webhook(
         }
 
     try:
-        write_records = await db.execute(
+        records = await db.execute(
             write_query,
             params,
-            ['slug'],
+            ['webhook', 'tps', 'identifier_selector', 'rules'],
         )
     except psycopg.errors.UniqueViolation as e:
         raise fastapi.HTTPException(
@@ -412,17 +417,12 @@ async def update_webhook(
             ),
         ) from e
 
-    if not write_records:
+    if not records:
         raise fastapi.HTTPException(
             status_code=404,
             detail=f'Webhook with slug {slug!r} not found',
         )
 
-    records = await db.execute(
-        _FETCH_WEBHOOK_QUERY,
-        {'slug': data.slug, 'org_slug': org_slug},
-        ['webhook', 'tps', 'identifier_selector', 'rules'],
-    )
     return models.WebhookResponse.from_graph_record(records[0])
 
 

--- a/src/imbi_api/graph_sql.py
+++ b/src/imbi_api/graph_sql.py
@@ -1,0 +1,26 @@
+"""Shared Cypher property-template helpers for AGE queries."""
+
+import typing
+
+
+def escape_prop(name: str) -> str:
+    """Escape a Cypher property name with backticks."""
+    return '`' + name.replace('`', '``') + '`'
+
+
+def props_template(props: dict[str, typing.Any]) -> str:
+    """Build a Cypher property-map template with double-escaped braces."""
+    if not props:
+        return ''
+    pairs = [f'{escape_prop(k)}: {{{k}}}' for k in props]
+    return '{{' + ', '.join(pairs) + '}}'
+
+
+def set_clause(alias: str, props: dict[str, typing.Any]) -> str:
+    """Build a Cypher SET clause from a property dict."""
+    if not props:
+        return ''
+    assignments = ', '.join(
+        f'{alias}.{escape_prop(k)} = {{{k}}}' for k in props
+    )
+    return f'SET {assignments}'

--- a/src/imbi_api/middleware/rate_limit.py
+++ b/src/imbi_api/middleware/rate_limit.py
@@ -1,8 +1,7 @@
 """Rate limiting middleware using slowapi (Phase 5).
 
 This module provides rate limiting functionality for FastAPI endpoints
-using the slowapi library. Rate limits are applied per-user, per-API-key,
-or per-IP address depending on the authentication method.
+using the slowapi library. Rate limits are keyed by client IP address.
 """
 
 import logging
@@ -16,31 +15,7 @@ LOGGER = logging.getLogger(__name__)
 
 
 def get_rate_limit_key(request: typing.Any) -> str:
-    """Extract rate limit key from request.
-
-    The key is determined by priority:
-    1. API key ID (if authenticated via API key)
-    2. User ID (if authenticated via JWT)
-    3. IP address (fallback for unauthenticated requests)
-
-    Args:
-        request: FastAPI request object
-
-    Returns:
-        Rate limit key string (e.g., 'api_key:ik_abc123',
-            'user:johndoe', 'ip:192.168.1.1')
-
-    """
-    # Check for auth context (set by get_current_user dependency)
-    if hasattr(request.state, 'auth_context'):
-        auth = request.state.auth_context
-        if hasattr(auth, 'auth_method'):
-            if auth.auth_method == 'api_key':
-                return f'api_key:{auth.user.email}'
-            elif auth.auth_method == 'jwt':
-                return f'user:{auth.user.email}'
-
-    # Fallback to IP address
+    """Extract rate limit key from request."""
     return f'ip:{slowapi_util.get_remote_address(request)}'
 
 

--- a/src/imbi_api/middleware/rate_limit.py
+++ b/src/imbi_api/middleware/rate_limit.py
@@ -15,7 +15,15 @@ LOGGER = logging.getLogger(__name__)
 
 
 def get_rate_limit_key(request: typing.Any) -> str:
-    """Extract rate limit key from request."""
+    """Extract rate limit key from request.
+
+    Uses ``slowapi.util.get_remote_address`` which returns
+    ``request.client.host``. When deploying behind a reverse proxy,
+    ``ProxyHeadersMiddleware`` (configured in ``app.create_app``)
+    rewrites ``client.host`` from the trusted ``X-Forwarded-For``
+    chain before this function runs, so the key reflects the real
+    client rather than the proxy address.
+    """
     return f'ip:{slowapi_util.get_remote_address(request)}'
 
 

--- a/src/imbi_api/relationships.py
+++ b/src/imbi_api/relationships.py
@@ -6,3 +6,14 @@ from imbi_common.models import RelationshipLink
 def relationship_link(href: str, count: int) -> RelationshipLink:
     """Build a hypermedia-style relationship link with count."""
     return RelationshipLink(href=href, count=count)
+
+
+def build_relationships(
+    base_url: str,
+    links: dict[str, tuple[str, int]],
+) -> dict[str, RelationshipLink]:
+    """Build a relationships dict from name -> (path_suffix, count)."""
+    return {
+        name: RelationshipLink(href=f'{base_url}{suffix}', count=count)
+        for name, (suffix, count) in links.items()
+    }

--- a/src/imbi_api/settings.py
+++ b/src/imbi_api/settings.py
@@ -46,6 +46,11 @@ class ServerConfig(pydantic_settings.BaseSettings):
         8000
     )
     cors_allowed_origins: list[str] = []
+    # Comma-separated list (or '*') of trusted proxy IPs whose
+    # X-Forwarded-* headers are honored. Must be set when deploying
+    # behind a reverse proxy so rate limiting keys on the real client
+    # IP rather than the proxy address. Empty disables the middleware.
+    forwarded_allow_ips: str = ''
 
 
 class Auth(settings.Auth):  # type: ignore[misc]

--- a/src/imbi_api/storage/client.py
+++ b/src/imbi_api/storage/client.py
@@ -1,6 +1,7 @@
 """S3 client for object storage operations."""
 
 import asyncio
+import contextlib
 import logging
 import typing
 
@@ -33,6 +34,8 @@ class StorageClient:
         )
         self._initialized = False
         self._lock = asyncio.Lock()
+        self._exit_stack: contextlib.AsyncExitStack | None = None
+        self._s3: typing.Any = None
 
     async def initialize(self) -> None:
         """Initialize the storage client and ensure the bucket exists.
@@ -48,6 +51,20 @@ class StorageClient:
             if self._initialized:
                 return
 
+            kwargs: dict[str, typing.Any] = {}
+            if self._settings.endpoint_url:
+                kwargs['endpoint_url'] = self._settings.endpoint_url
+            stack = contextlib.AsyncExitStack()
+            await stack.__aenter__()
+            try:
+                self._s3 = await stack.enter_async_context(
+                    self._session.client('s3', **kwargs)  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType,reportArgumentType]
+                )
+            except BaseException:
+                await stack.aclose()
+                raise
+            self._exit_stack = stack
+
             if self._settings.create_bucket_on_init:
                 await self._ensure_bucket()
 
@@ -56,6 +73,10 @@ class StorageClient:
     async def aclose(self) -> None:
         """Clean up storage client resources."""
         async with self._lock:
+            if self._exit_stack is not None:
+                await self._exit_stack.aclose()
+            self._s3 = None
+            self._exit_stack = None
             self._initialized = False
             LOGGER.debug('Storage client closed')
 
@@ -73,13 +94,14 @@ class StorageClient:
             content_type: MIME type of the file
 
         """
-        async with self._s3_client() as s3:
-            await s3.put_object(
-                Bucket=self._settings.bucket,
-                Key=key,
-                Body=data,
-                ContentType=content_type,
-            )
+        if self._s3 is None:
+            raise RuntimeError('StorageClient not initialized')
+        await self._s3.put_object(
+            Bucket=self._settings.bucket,
+            Key=key,
+            Body=data,
+            ContentType=content_type,
+        )
         LOGGER.debug('Uploaded %s (%d bytes)', key, len(data))
 
     async def download(self, key: str) -> bytes:
@@ -92,13 +114,14 @@ class StorageClient:
             File content as bytes
 
         """
-        async with self._s3_client() as s3:
-            response = await s3.get_object(
-                Bucket=self._settings.bucket,
-                Key=key,
-            )
-            async with response['Body'] as body:
-                data: bytes = await body.read()
+        if self._s3 is None:
+            raise RuntimeError('StorageClient not initialized')
+        response = await self._s3.get_object(
+            Bucket=self._settings.bucket,
+            Key=key,
+        )
+        async with response['Body'] as body:
+            data: bytes = await body.read()
         LOGGER.debug('Downloaded %s (%d bytes)', key, len(data))
         return data
 
@@ -109,11 +132,12 @@ class StorageClient:
             key: S3 object key
 
         """
-        async with self._s3_client() as s3:
-            await s3.delete_object(
-                Bucket=self._settings.bucket,
-                Key=key,
-            )
+        if self._s3 is None:
+            raise RuntimeError('StorageClient not initialized')
+        await self._s3.delete_object(
+            Bucket=self._settings.bucket,
+            Key=key,
+        )
         LOGGER.debug('Deleted %s', key)
 
     async def presigned_url(
@@ -131,50 +155,33 @@ class StorageClient:
             Presigned URL string
 
         """
-        async with self._s3_client() as s3:
-            url: str = await s3.generate_presigned_url(
-                'get_object',
-                Params={
-                    'Bucket': self._settings.bucket,
-                    'Key': key,
-                },
-                ExpiresIn=expires_in,
-            )
-        return url
-
-    def _s3_client(self) -> typing.Any:  # pyright: ignore[reportUnknownMemberType]
-        """Create an S3 client context manager.
-
-        Returns:
-            Async context manager yielding an S3 client.
-
-        """
-        kwargs: dict[str, typing.Any] = {}
-        if self._settings.endpoint_url:
-            kwargs['endpoint_url'] = self._settings.endpoint_url
-        return self._session.client(  # pyright: ignore[reportUnknownMemberType,reportUnknownVariableType]
-            's3', **kwargs
+        if self._s3 is None:
+            raise RuntimeError('StorageClient not initialized')
+        url: str = await self._s3.generate_presigned_url(
+            'get_object',
+            Params={
+                'Bucket': self._settings.bucket,
+                'Key': key,
+            },
+            ExpiresIn=expires_in,
         )
+        return url
 
     async def _ensure_bucket(self) -> None:
         """Create the S3 bucket if it does not exist."""
-        async with self._s3_client() as s3:
-            try:
-                await s3.head_bucket(Bucket=self._settings.bucket)
-                LOGGER.debug(
-                    'Bucket %s already exists',
-                    self._settings.bucket,
-                )
-            except botocore_exceptions.ClientError:
-                params: dict[str, typing.Any] = {
-                    'Bucket': self._settings.bucket,
+        try:
+            await self._s3.head_bucket(Bucket=self._settings.bucket)
+            LOGGER.debug(
+                'Bucket %s already exists',
+                self._settings.bucket,
+            )
+        except botocore_exceptions.ClientError:
+            params: dict[str, typing.Any] = {
+                'Bucket': self._settings.bucket,
+            }
+            if self._settings.region and self._settings.region != 'us-east-1':
+                params['CreateBucketConfiguration'] = {
+                    'LocationConstraint': self._settings.region,
                 }
-                if (
-                    self._settings.region
-                    and self._settings.region != 'us-east-1'
-                ):
-                    params['CreateBucketConfiguration'] = {
-                        'LocationConstraint': self._settings.region,
-                    }
-                await s3.create_bucket(**params)
-                LOGGER.info('Created bucket %s', self._settings.bucket)
+            await self._s3.create_bucket(**params)
+            LOGGER.info('Created bucket %s', self._settings.bucket)

--- a/tests/auth/test_authentication.py
+++ b/tests/auth/test_authentication.py
@@ -176,12 +176,11 @@ class LoginEndpointTestCase(unittest.TestCase):
         # merge() for token metadata and last_login update
         self.mock_db.merge.return_value = None
         # execute() is called twice during login: MFA check (no MFA ->
-        # []) and the principal existence check inside issue_token_pair
-        # (returns a row so tokens are issued).
+        # []) and the atomic MATCH/CREATE inside issue_token_pair that
+        # both persists token metadata and returns principal_count.
         self.mock_db.execute.side_effect = [
             [],
-            [{'p': {'email': self.test_user.email}}],
-            None,
+            [{'principal_count': 1}],
         ]
 
         response = self.client.post(
@@ -344,12 +343,11 @@ class TokenRefreshEndpointTestCase(unittest.TestCase):
         ]
         # merge() for revoking old token
         self.mock_db.merge.return_value = None
-        # execute() is called for the principal existence check inside
-        # issue_token_pair (returns a row) and for storing new token
-        # metadata.
-        self.mock_db.execute.side_effect = [
-            [{'p': {'email': self.test_user.email}}],
-            None,
+        # execute() runs the atomic MATCH/CREATE inside
+        # issue_token_pair that persists token metadata and returns
+        # principal_count.
+        self.mock_db.execute.return_value = [
+            {'principal_count': 1},
         ]
 
         with mock.patch(

--- a/tests/auth/test_authentication.py
+++ b/tests/auth/test_authentication.py
@@ -175,8 +175,14 @@ class LoginEndpointTestCase(unittest.TestCase):
         self.mock_db.match.return_value = [self.test_user]
         # merge() for token metadata and last_login update
         self.mock_db.merge.return_value = None
-        # execute() for MFA check (returns empty = no MFA)
-        self.mock_db.execute.return_value = []
+        # execute() is called twice during login: MFA check (no MFA ->
+        # []) and the principal existence check inside issue_token_pair
+        # (returns a row so tokens are issued).
+        self.mock_db.execute.side_effect = [
+            [],
+            [{'p': {'email': self.test_user.email}}],
+            None,
+        ]
 
         response = self.client.post(
             '/auth/login',
@@ -338,8 +344,13 @@ class TokenRefreshEndpointTestCase(unittest.TestCase):
         ]
         # merge() for revoking old token
         self.mock_db.merge.return_value = None
-        # execute() for storing new token metadata
-        self.mock_db.execute.return_value = []
+        # execute() is called for the principal existence check inside
+        # issue_token_pair (returns a row) and for storing new token
+        # metadata.
+        self.mock_db.execute.side_effect = [
+            [{'p': {'email': self.test_user.email}}],
+            None,
+        ]
 
         with mock.patch(
             'imbi_api.settings.get_auth_settings'

--- a/tests/auth/test_seed.py
+++ b/tests/auth/test_seed.py
@@ -12,8 +12,9 @@ class SeedPermissionsTestCase(unittest.IsolatedAsyncioTestCase):
     async def test_seed_permissions_creates_all(self) -> None:
         """Verify all standard permissions are created."""
         mock_db = mock.AsyncMock()
-        # check query returns is_new=True, merge returns []
-        mock_db.execute.return_value = [{'is_new': True}]
+        mock_db.execute.return_value = [
+            {'created': len(seed.STANDARD_PERMISSIONS)}
+        ]
 
         with mock.patch(
             'imbi_common.graph.parse_agtype',
@@ -22,12 +23,12 @@ class SeedPermissionsTestCase(unittest.IsolatedAsyncioTestCase):
             count = await seed.seed_permissions(mock_db)
 
         self.assertEqual(count, len(seed.STANDARD_PERMISSIONS))
+        mock_db.execute.assert_awaited_once()
 
     async def test_seed_permissions_idempotent(self) -> None:
         """Second run creates no duplicates."""
         mock_db = mock.AsyncMock()
-        # All permissions already exist
-        mock_db.execute.return_value = [{'is_new': False}]
+        mock_db.execute.return_value = [{'created': 0}]
 
         with mock.patch(
             'imbi_common.graph.parse_agtype',
@@ -35,8 +36,8 @@ class SeedPermissionsTestCase(unittest.IsolatedAsyncioTestCase):
         ):
             count = await seed.seed_permissions(mock_db)
 
-        # Should create 0 new permissions
         self.assertEqual(count, 0)
+        mock_db.execute.assert_awaited_once()
 
     async def test_permission_format_validation(self) -> None:
         """Ensure all permission names match resource_type:action."""
@@ -60,13 +61,7 @@ class SeedDefaultRolesTestCase(unittest.IsolatedAsyncioTestCase):
     async def test_seed_default_roles_creates_all(self) -> None:
         """Verify all 3 default roles are created."""
         mock_db = mock.AsyncMock()
-
-        def execute_side_effect(query, params=None, columns=None):
-            if 'GRANTS' in query:
-                return []
-            return [{'is_new': True}]
-
-        mock_db.execute = mock.AsyncMock(side_effect=execute_side_effect)
+        mock_db.execute.return_value = [{'created': len(seed.DEFAULT_ROLES)}]
 
         with mock.patch(
             'imbi_common.graph.parse_agtype',
@@ -74,19 +69,13 @@ class SeedDefaultRolesTestCase(unittest.IsolatedAsyncioTestCase):
         ):
             count = await seed.seed_default_roles(mock_db)
 
-        # Should create 3 roles (admin, developer, readonly)
-        self.assertEqual(count, 3)
+        self.assertEqual(count, len(seed.DEFAULT_ROLES))
+        mock_db.execute.assert_awaited_once()
 
     async def test_seed_default_roles_idempotent(self) -> None:
         """Second run creates no duplicate roles."""
         mock_db = mock.AsyncMock()
-
-        def execute_side_effect(query, params=None, columns=None):
-            if 'GRANTS' in query:
-                return []
-            return [{'is_new': False}]
-
-        mock_db.execute = mock.AsyncMock(side_effect=execute_side_effect)
+        mock_db.execute.return_value = [{'created': 0}]
 
         with mock.patch(
             'imbi_common.graph.parse_agtype',
@@ -94,8 +83,8 @@ class SeedDefaultRolesTestCase(unittest.IsolatedAsyncioTestCase):
         ):
             count = await seed.seed_default_roles(mock_db)
 
-        # Should create 0 new roles
         self.assertEqual(count, 0)
+        mock_db.execute.assert_awaited_once()
 
     def test_default_roles_structure(self) -> None:
         """Verify default role definitions are well-formed."""

--- a/tests/auth/test_sessions.py
+++ b/tests/auth/test_sessions.py
@@ -1,6 +1,5 @@
 """Tests for session management."""
 
-import datetime
 import unittest
 from unittest import mock
 
@@ -24,86 +23,31 @@ class EnforceSessionLimitTestCase(unittest.IsolatedAsyncioTestCase):
         await sessions.enforce_session_limit(
             mock_db, 'testuser', self.auth_settings
         )
+        mock_db.execute.assert_awaited_once()
 
     async def test_enforce_limit_within_limit(self) -> None:
         """Test enforce_session_limit with sessions within limit."""
         mock_db = mock.AsyncMock()
-        mock_db.execute.return_value = [
-            {
-                'session_id': 'sess1',
-                'last_activity': datetime.datetime.now(
-                    datetime.UTC
-                ).isoformat(),
-            },
-            {
-                'session_id': 'sess2',
-                'last_activity': datetime.datetime.now(
-                    datetime.UTC
-                ).isoformat(),
-            },
-        ]
+        mock_db.execute.return_value = [{'removed': 0}]
 
         with mock.patch(
             'imbi_common.graph.parse_agtype',
             side_effect=lambda x: x,
         ):
-            # Should not delete any sessions
+            # Should issue a single query and not log any removal
             await sessions.enforce_session_limit(
                 mock_db, 'testuser', self.auth_settings
             )
+        mock_db.execute.assert_awaited_once()
+        call_args = mock_db.execute.await_args
+        params = call_args[0][1] if len(call_args[0]) > 1 else {}
+        self.assertEqual('testuser', params.get('email'))
+        self.assertEqual(3, params.get('limit'))
 
     async def test_enforce_limit_exceeds_limit(self) -> None:
         """Test enforce_session_limit removes oldest sessions."""
-        now = datetime.datetime.now(datetime.UTC)
-
-        # Create 5 sessions (limit is 3), returned sorted by
-        # last_activity DESC
-        session_data = [
-            {
-                'session_id': 'sess1',
-                'last_activity': (
-                    now - datetime.timedelta(minutes=1)
-                ).isoformat(),
-            },
-            {
-                'session_id': 'sess2',
-                'last_activity': (
-                    now - datetime.timedelta(minutes=2)
-                ).isoformat(),
-            },
-            {
-                'session_id': 'sess3',
-                'last_activity': (
-                    now - datetime.timedelta(minutes=3)
-                ).isoformat(),
-            },
-            {
-                'session_id': 'sess4',
-                'last_activity': (
-                    now - datetime.timedelta(minutes=4)
-                ).isoformat(),
-            },
-            {
-                'session_id': 'sess5',
-                'last_activity': (
-                    now - datetime.timedelta(minutes=5)
-                ).isoformat(),
-            },
-        ]
-
         mock_db = mock.AsyncMock()
-        deleted_session_ids: list[str] = []
-
-        def execute_side_effect(query, params=None, columns=None):
-            if 'RETURN s.session_id' in query:
-                return session_data
-            elif 'DETACH DELETE' in query:
-                if params and 'session_id' in params:
-                    deleted_session_ids.append(params['session_id'])
-                return []
-            return []
-
-        mock_db.execute = mock.AsyncMock(side_effect=execute_side_effect)
+        mock_db.execute.return_value = [{'removed': 2}]
 
         with mock.patch(
             'imbi_common.graph.parse_agtype',
@@ -113,10 +57,12 @@ class EnforceSessionLimitTestCase(unittest.IsolatedAsyncioTestCase):
                 mock_db, 'testuser', self.auth_settings
             )
 
-        # Sessions 4 and 5 (oldest) should be deleted
-        self.assertIn('sess4', deleted_session_ids)
-        self.assertIn('sess5', deleted_session_ids)
-        self.assertEqual(len(deleted_session_ids), 2)
+        # Single query with email and limit params
+        mock_db.execute.assert_awaited_once()
+        call_args = mock_db.execute.await_args
+        params = call_args[0][1] if len(call_args[0]) > 1 else {}
+        self.assertEqual('testuser', params.get('email'))
+        self.assertEqual(3, params.get('limit'))
 
 
 class UpdateSessionActivityTestCase(

--- a/tests/endpoints/test_auth.py
+++ b/tests/endpoints/test_auth.py
@@ -388,8 +388,15 @@ class LoginPasswordRehashTestCase(unittest.TestCase):
 
         # db.match returns user
         self.mock_db.match.return_value = [test_user]
-        # db.execute returns empty for TOTP and token
-        self.mock_db.execute.return_value = []
+        # db.execute is called for the MFA/TOTP check (no TOTP -> []),
+        # the principal existence check inside issue_token_pair (must
+        # return a row so tokens are issued), and the token metadata
+        # CREATE.
+        self.mock_db.execute.side_effect = [
+            [],
+            [{'p': {'email': test_user.email}}],
+            None,
+        ]
         # db.merge returns None (void)
         self.mock_db.merge.return_value = None
 
@@ -1276,7 +1283,13 @@ class TokenRefreshTestCase(unittest.TestCase):
             [test_user],
         ]
         self.mock_db.merge.return_value = None
-        self.mock_db.execute.return_value = []
+        # execute() runs the principal existence check inside
+        # issue_token_pair (returns a row) and then the token metadata
+        # CREATE.
+        self.mock_db.execute.side_effect = [
+            [{'p': {'email': test_user.email}}],
+            None,
+        ]
 
         with mock.patch(
             'imbi_api.settings.get_auth_settings',

--- a/tests/endpoints/test_auth.py
+++ b/tests/endpoints/test_auth.py
@@ -388,14 +388,12 @@ class LoginPasswordRehashTestCase(unittest.TestCase):
 
         # db.match returns user
         self.mock_db.match.return_value = [test_user]
-        # db.execute is called for the MFA/TOTP check (no TOTP -> []),
-        # the principal existence check inside issue_token_pair (must
-        # return a row so tokens are issued), and the token metadata
-        # CREATE.
+        # db.execute is called for the MFA/TOTP check (no TOTP -> [])
+        # and for the atomic MATCH/CREATE inside issue_token_pair that
+        # both persists token metadata and returns principal_count.
         self.mock_db.execute.side_effect = [
             [],
-            [{'p': {'email': test_user.email}}],
-            None,
+            [{'principal_count': 1}],
         ]
         # db.merge returns None (void)
         self.mock_db.merge.return_value = None
@@ -547,8 +545,13 @@ class LoginMFATestCase(unittest.TestCase):
         }
 
         self.mock_db.match.return_value = [test_user]
-        self.mock_db.execute.return_value = [
-            {'n': totp_data},
+        # execute(): TOTP fetch, TOTP last_used update, then the
+        # atomic MATCH/CREATE inside issue_token_pair that returns
+        # principal_count.
+        self.mock_db.execute.side_effect = [
+            [{'n': totp_data}],
+            [],
+            [{'principal_count': 1}],
         ]
         self.mock_db.merge.return_value = None
 
@@ -593,8 +596,13 @@ class LoginMFATestCase(unittest.TestCase):
         }
 
         self.mock_db.match.return_value = [test_user]
-        self.mock_db.execute.return_value = [
-            {'n': totp_data},
+        # execute(): TOTP fetch, backup_codes update, then the atomic
+        # MATCH/CREATE inside issue_token_pair that returns
+        # principal_count.
+        self.mock_db.execute.side_effect = [
+            [{'n': totp_data}],
+            [],
+            [{'principal_count': 1}],
         ]
         self.mock_db.merge.return_value = None
 
@@ -842,8 +850,11 @@ class OAuthCallbackSuccessTestCase(unittest.TestCase):
                 datetime.UTC,
             ).isoformat(),
         }
-        self.mock_db.execute.return_value = [
-            {'u': user_data},
+        # execute(): user fetch, then the atomic MATCH/CREATE inside
+        # issue_token_pair that returns principal_count.
+        self.mock_db.execute.side_effect = [
+            [{'u': user_data}],
+            [{'principal_count': 1}],
         ]
 
         with (
@@ -933,8 +944,13 @@ class OAuthCallbackSuccessTestCase(unittest.TestCase):
                 datetime.UTC,
             ).isoformat(),
         }
-        self.mock_db.execute.return_value = [
-            {'u': user_data},
+        # execute(): OAUTH_IDENTITY MERGE, user fetch, then the atomic
+        # MATCH/CREATE inside issue_token_pair that returns
+        # principal_count.
+        self.mock_db.execute.side_effect = [
+            [],
+            [{'u': user_data}],
+            [{'principal_count': 1}],
         ]
 
         with (
@@ -1111,8 +1127,13 @@ class OAuthCallbackSuccessTestCase(unittest.TestCase):
                 datetime.UTC,
             ).isoformat(),
         }
-        self.mock_db.execute.return_value = [
-            {'u': user_data},
+        # execute(): OAUTH_IDENTITY MERGE, user fetch, then the atomic
+        # MATCH/CREATE inside issue_token_pair that returns
+        # principal_count.
+        self.mock_db.execute.side_effect = [
+            [],
+            [{'u': user_data}],
+            [{'principal_count': 1}],
         ]
 
         with (
@@ -1283,12 +1304,11 @@ class TokenRefreshTestCase(unittest.TestCase):
             [test_user],
         ]
         self.mock_db.merge.return_value = None
-        # execute() runs the principal existence check inside
-        # issue_token_pair (returns a row) and then the token metadata
-        # CREATE.
-        self.mock_db.execute.side_effect = [
-            [{'p': {'email': test_user.email}}],
-            None,
+        # execute() runs the atomic MATCH/CREATE inside
+        # issue_token_pair that persists token metadata and returns
+        # principal_count.
+        self.mock_db.execute.return_value = [
+            {'principal_count': 1},
         ]
 
         with mock.patch(
@@ -1774,8 +1794,13 @@ class ServiceAccountAuthTestCase(unittest.TestCase):
             ).isoformat(),
         }
 
-        self.mock_db.execute.return_value = [
-            {'c': cred_data, 's': sa_data},
+        # execute(): credential+SA fetch, atomic MATCH/CREATE inside
+        # issue_token_pair returning principal_count, then the
+        # last_used/last_authenticated update.
+        self.mock_db.execute.side_effect = [
+            [{'c': cred_data, 's': sa_data}],
+            [{'principal_count': 1}],
+            [],
         ]
 
         with (
@@ -2009,8 +2034,13 @@ class ServiceAccountAuthTestCase(unittest.TestCase):
             ).isoformat(),
         }
 
-        self.mock_db.execute.return_value = [
-            {'c': cred_data, 's': sa_data},
+        # execute(): credential+SA fetch, atomic MATCH/CREATE inside
+        # issue_token_pair returning principal_count, then the
+        # last_used/last_authenticated update.
+        self.mock_db.execute.side_effect = [
+            [{'c': cred_data, 's': sa_data}],
+            [{'principal_count': 1}],
+            [],
         ]
 
         with (

--- a/tests/endpoints/test_third_party_services.py
+++ b/tests/endpoints/test_third_party_services.py
@@ -328,10 +328,7 @@ class ThirdPartyServiceEndpointsTestCase(unittest.TestCase):
         updated = dict(self.service_data)
         updated['description'] = 'Updated description'
 
-        self.mock_db.execute.side_effect = [
-            [{'service': self.service_data}],
-            [{'service': updated}],
-        ]
+        self.mock_db.execute.return_value = [{'service': updated}]
 
         payload = dict(self.service_update_json)
         payload['description'] = 'Updated description'
@@ -358,10 +355,7 @@ class ThirdPartyServiceEndpointsTestCase(unittest.TestCase):
             'slug': 'backend',
         }
 
-        self.mock_db.execute.side_effect = [
-            [{'service': self.service_data}],
-            [{'service': updated}],
-        ]
+        self.mock_db.execute.return_value = [{'service': updated}]
 
         payload = dict(self.service_update_json)
         payload['team_slug'] = 'backend'
@@ -419,10 +413,7 @@ class ThirdPartyServiceEndpointsTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 422)
 
     def test_update_slug_conflict(self) -> None:
-        self.mock_db.execute.side_effect = [
-            [{'service': self.service_data}],
-            psycopg.errors.UniqueViolation(),
-        ]
+        self.mock_db.execute.side_effect = psycopg.errors.UniqueViolation()
 
         payload = dict(self.service_update_json)
         payload['slug'] = 'existing-slug'
@@ -441,24 +432,6 @@ class ThirdPartyServiceEndpointsTestCase(unittest.TestCase):
             'already exists',
             response.json()['detail'],
         )
-
-    def test_update_concurrent_delete(self) -> None:
-        """Service deleted between fetch and update."""
-        self.mock_db.execute.side_effect = [
-            [{'service': self.service_data}],
-            [],
-        ]
-
-        with mock.patch(
-            'imbi_common.graph.parse_agtype',
-            side_effect=lambda x: x,
-        ):
-            response = self.client.put(
-                '/organizations/engineering/third-party-services/stripe',
-                json=self.service_update_json,
-            )
-
-        self.assertEqual(response.status_code, 404)
 
     # -- Patch --
 

--- a/tests/endpoints/test_webhooks.py
+++ b/tests/endpoints/test_webhooks.py
@@ -355,16 +355,7 @@ class WebhookEndpointsTestCase(unittest.TestCase):
         updated = copy.deepcopy(self.webhook_record)
         updated['webhook']['description'] = 'Updated'
 
-        fetch_result = [
-            {'webhook': self.webhook_record['webhook']},
-        ]
-        update_result = [updated]
-
-        self.mock_db.execute.side_effect = [
-            fetch_result,
-            update_result,
-            [updated],
-        ]
+        self.mock_db.execute.return_value = [updated]
 
         payload = dict(self.webhook_update_json)
         payload['description'] = 'Updated'
@@ -389,9 +380,12 @@ class WebhookEndpointsTestCase(unittest.TestCase):
 
     def test_update_webhook_not_found(self) -> None:
         self.mock_db.execute.return_value = []
-        with mock.patch(
-            'imbi_common.graph.parse_agtype',
-            side_effect=lambda x: x,
+        with (
+            self._patch_encryption(),
+            mock.patch(
+                'imbi_common.graph.parse_agtype',
+                side_effect=lambda x: x,
+            ),
         ):
             response = self.client.put(
                 '/organizations/engineering/webhooks/nonexistent',
@@ -402,14 +396,7 @@ class WebhookEndpointsTestCase(unittest.TestCase):
         self.assertIn('not found', response.json()['detail'])
 
     def test_update_slug_conflict(self) -> None:
-        fetch_result = [
-            {'webhook': self.webhook_record['webhook']},
-        ]
-
-        self.mock_db.execute.side_effect = [
-            fetch_result,
-            psycopg.errors.UniqueViolation(),
-        ]
+        self.mock_db.execute.side_effect = psycopg.errors.UniqueViolation()
 
         payload = dict(self.webhook_update_json)
         payload['slug'] = 'existing-slug'
@@ -431,31 +418,6 @@ class WebhookEndpointsTestCase(unittest.TestCase):
             'already exists',
             response.json()['detail'],
         )
-
-    def test_update_concurrent_delete(self) -> None:
-        fetch_result = [
-            {'webhook': self.webhook_record['webhook']},
-        ]
-        empty_result: list[dict] = []
-
-        self.mock_db.execute.side_effect = [
-            fetch_result,
-            empty_result,
-        ]
-
-        with (
-            self._patch_encryption(),
-            mock.patch(
-                'imbi_common.graph.parse_agtype',
-                side_effect=lambda x: x,
-            ),
-        ):
-            response = self.client.put(
-                '/organizations/engineering/webhooks/github-events',
-                json=self.webhook_update_json,
-            )
-
-        self.assertEqual(response.status_code, 404)
 
     def test_update_missing_required_field(self) -> None:
         response = self.client.put(

--- a/tests/middleware/test_rate_limit.py
+++ b/tests/middleware/test_rate_limit.py
@@ -11,38 +11,9 @@ from imbi_api.middleware import rate_limit
 class GetRateLimitKeyTestCase(unittest.TestCase):
     """Test cases for get_rate_limit_key function."""
 
-    def test_api_key_authentication(self) -> None:
-        """Test rate limit key for API key authentication."""
-        # Create mock request with API key auth context
+    def test_returns_ip_key(self) -> None:
+        """Test rate limit key uses the remote IP address."""
         mock_request = mock.MagicMock()
-        mock_auth = mock.MagicMock()
-        mock_auth.auth_method = 'api_key'
-        mock_auth.user.email = 'service@example.com'
-        mock_request.state.auth_context = mock_auth
-
-        key = rate_limit.get_rate_limit_key(mock_request)
-
-        self.assertEqual(key, 'api_key:service@example.com')
-
-    def test_jwt_authentication(self) -> None:
-        """Test rate limit key for JWT authentication."""
-        # Create mock request with JWT auth context
-        mock_request = mock.MagicMock()
-        mock_auth = mock.MagicMock()
-        mock_auth.auth_method = 'jwt'
-        mock_auth.user.email = 'user@example.com'
-        mock_request.state.auth_context = mock_auth
-
-        key = rate_limit.get_rate_limit_key(mock_request)
-
-        self.assertEqual(key, 'user:user@example.com')
-
-    def test_unauthenticated_fallback_to_ip(self) -> None:
-        """Test rate limit key fallback to IP for unauthenticated requests."""
-        # Create mock request without auth context
-        mock_request = mock.MagicMock()
-        # Use spec=[] to create a state without auth_context attribute
-        mock_request.state = mock.Mock(spec=[])
 
         with mock.patch(
             'imbi_api.middleware.rate_limit.slowapi_util.get_remote_address',
@@ -52,43 +23,9 @@ class GetRateLimitKeyTestCase(unittest.TestCase):
 
         self.assertEqual(key, 'ip:192.168.1.100')
 
-    def test_auth_context_without_auth_method(self) -> None:
-        """Test fallback to IP when auth context lacks auth_method."""
-        # Create mock request with auth context but no auth_method
-        mock_request = mock.MagicMock()
-        mock_auth = mock.MagicMock(spec=[])  # No auth_method attribute
-        mock_request.state.auth_context = mock_auth
-
-        with mock.patch(
-            'imbi_api.middleware.rate_limit.slowapi_util.get_remote_address',
-            return_value='10.0.0.1',
-        ):
-            key = rate_limit.get_rate_limit_key(mock_request)
-
-        self.assertEqual(key, 'ip:10.0.0.1')
-
-    def test_unknown_auth_method_fallback_to_ip(self) -> None:
-        """Test fallback to IP for unknown authentication method."""
-        # Create mock request with unknown auth method
-        mock_request = mock.MagicMock()
-        mock_auth = mock.MagicMock()
-        mock_auth.auth_method = 'unknown_method'
-        mock_auth.user.email = 'user@example.com'
-        mock_request.state.auth_context = mock_auth
-
-        with mock.patch(
-            'imbi_api.middleware.rate_limit.slowapi_util.get_remote_address',
-            return_value='172.16.0.1',
-        ):
-            key = rate_limit.get_rate_limit_key(mock_request)
-
-        self.assertEqual(key, 'ip:172.16.0.1')
-
     def test_ipv6_address(self) -> None:
         """Test rate limit key with IPv6 address."""
         mock_request = mock.MagicMock()
-        # Use spec=[] to create a state without auth_context attribute
-        mock_request.state = mock.Mock(spec=[])
 
         with mock.patch(
             'imbi_api.middleware.rate_limit.slowapi_util.get_remote_address',

--- a/tests/storage/test_client.py
+++ b/tests/storage/test_client.py
@@ -25,41 +25,39 @@ class StorageClientOperationsTestCase(
         )
 
         with mock.patch.object(
-            self.client,
-            '_s3_client',
+            self.client._session,
+            'client',
             return_value=_async_ctx(mock_s3),
         ):
             await self.client.initialize()
 
         mock_s3.create_bucket.assert_called_once()
+        await self.client.aclose()
 
     async def test_initialize_skips_existing_bucket(self) -> None:
         """Test that initialize skips if bucket exists."""
         mock_s3 = mock.AsyncMock()
 
         with mock.patch.object(
-            self.client,
-            '_s3_client',
+            self.client._session,
+            'client',
             return_value=_async_ctx(mock_s3),
         ):
             await self.client.initialize()
 
         mock_s3.create_bucket.assert_not_called()
+        await self.client.aclose()
 
     async def test_upload(self) -> None:
         """Test uploading bytes to S3."""
         mock_s3 = mock.AsyncMock()
+        self.client._s3 = mock_s3
 
-        with mock.patch.object(
-            self.client,
-            '_s3_client',
-            return_value=_async_ctx(mock_s3),
-        ):
-            await self.client.upload(
-                'test/key',
-                b'data',
-                'text/plain',
-            )
+        await self.client.upload(
+            'test/key',
+            b'data',
+            'text/plain',
+        )
 
         mock_s3.put_object.assert_called_once_with(
             Bucket=self.client._settings.bucket,
@@ -76,26 +74,18 @@ class StorageClientOperationsTestCase(
         mock_body.__aexit__.return_value = None
         mock_s3 = mock.AsyncMock()
         mock_s3.get_object.return_value = {'Body': mock_body}
+        self.client._s3 = mock_s3
 
-        with mock.patch.object(
-            self.client,
-            '_s3_client',
-            return_value=_async_ctx(mock_s3),
-        ):
-            result = await self.client.download('test/key')
+        result = await self.client.download('test/key')
 
         self.assertEqual(result, b'file-data')
 
     async def test_delete(self) -> None:
         """Test deleting an object from S3."""
         mock_s3 = mock.AsyncMock()
+        self.client._s3 = mock_s3
 
-        with mock.patch.object(
-            self.client,
-            '_s3_client',
-            return_value=_async_ctx(mock_s3),
-        ):
-            await self.client.delete('test/key')
+        await self.client.delete('test/key')
 
         mock_s3.delete_object.assert_called_once_with(
             Bucket=self.client._settings.bucket,
@@ -108,16 +98,12 @@ class StorageClientOperationsTestCase(
         mock_s3.generate_presigned_url.return_value = (
             'https://s3.example.com/signed'
         )
+        self.client._s3 = mock_s3
 
-        with mock.patch.object(
-            self.client,
-            '_s3_client',
-            return_value=_async_ctx(mock_s3),
-        ):
-            url = await self.client.presigned_url(
-                'test/key',
-                3600,
-            )
+        url = await self.client.presigned_url(
+            'test/key',
+            3600,
+        )
 
         self.assertEqual(url, 'https://s3.example.com/signed')
         mock_s3.generate_presigned_url.assert_called_once_with(
@@ -134,6 +120,19 @@ class StorageClientOperationsTestCase(
         self.client._initialized = True
         await self.client.aclose()
         self.assertFalse(self.client._initialized)
+        self.assertIsNone(self.client._s3)
+        self.assertIsNone(self.client._exit_stack)
+
+    async def test_operations_require_initialization(self) -> None:
+        """Operations must raise when client is not initialized."""
+        with self.assertRaises(RuntimeError):
+            await self.client.upload('k', b'data', 'text/plain')
+        with self.assertRaises(RuntimeError):
+            await self.client.download('k')
+        with self.assertRaises(RuntimeError):
+            await self.client.delete('k')
+        with self.assertRaises(RuntimeError):
+            await self.client.presigned_url('k', 3600)
 
 
 class _AsyncContextManager:


### PR DESCRIPTION
## Summary

Implements all six tracks from `docs/refactor-plan.md` in a single bundled PR. Work was performed by parallel subagents in isolated worktrees, then cherry-picked onto this branch. Net diff: **+702 / −1184 lines** (including test updates).

### Tracks

- **Track A — Shared Cypher helpers** (`9cdc458`)
  - New `src/imbi_api/graph_sql.py` exporting `escape_prop` / `props_template` / `set_clause` (backtick-escaped canonical form).
  - New `build_relationships(base_url, links)` in `relationships.py`.
  - Migrated 7 endpoint files and deleted per-file `_props_template` / `_set_clause` / `_escape_prop` / `_add_relationships` copies.
  - `grep -rn "_props_template\|_set_clause\|_escape_prop" src/imbi_api/endpoints/` → 0 hits. `grep -rn "def _add_relationships" src/imbi_api/endpoints/` → 0 hits.

- **Track B — `issue_token_pair` helper** (`51889fe`)
  - New `src/imbi_api/auth/tokens.py`: mints access + refresh tokens and creates both `TokenMetadata` nodes + `ISSUED_TO` edges in one Cypher call.
  - Extracts claims via `jwt.decode(..., options={'verify_signature': False})` on the just-minted token (the shim route from the plan's risk note — no `imbi-common` coordination required).
  - Collapses the four branched call sites in `endpoints/auth.py` (`token`, `login`, `refresh_token`, `oauth_callback`).
  - `auth.py`: 1285 → 1095 lines (−190).

- **Track C — `StorageClient` lifecycle** (`c0fc786`)
  - Hold a single long-lived `aioboto3` S3 client via `AsyncExitStack`; enter once in `initialize()`, close in `aclose()`.
  - `upload` / `download` / `delete` / `presigned_url` now hit `self._s3` directly with a `RuntimeError('StorageClient not initialized')` guard.
  - Removed `_s3_client()` method.
  - Tests rewritten to mock `self._session.client` for init paths and set `self._s3` directly for ops (`f3921f9`).

- **Track D — Batch seeding** (`0eb663f`)
  - `seed_permissions` and `seed_default_roles` each collapsed to a single Cypher statement using UNWIND over parameter lists.
  - ~60 line reduction in `seed.py`; round-trips drop from ~100 to ~3 at startup/setup.
  - Return semantics (count of newly-created rows) preserved.

- **Track E — Rate-limit cleanup** (`52e69fa`)
  - Stripped `get_rate_limit_key` to IP-only keying.
  - Deleted the dead `request.state.auth_context` branches (never populated anywhere in `src/`) and their test cases.
  - Eliminates the latent `AttributeError` for service-account API keys.

- **Track F1 — `enforce_session_limit`** (`120d11c`)
  - Single Cypher query: `MATCH ... ORDER BY last_activity DESC SKIP {limit} DETACH DELETE s RETURN count(s) AS removed`.
  - Log only when non-zero removals.

- **Track F2 — Drop redundant PUT fetches** (`dd3b06b`)
  - `update_third_party_service`: removed the pre-fetch; `_execute_service_update` already raises 404 when the row is missing.
  - `update_webhook`: removed the pre-fetch and folded the post-write re-fetch into the write query's RETURN via new `_UPDATE_RETURN_TAIL_WITH_TPS` / `_UPDATE_RETURN_TAIL_NO_TPS` constants.

### Out of scope (deferred per plan)

Items explicitly listed as "Out of scope" in `docs/refactor-plan.md` (permission-loader merge, team-slug branch unification, project-schema server filtering, projects PUT/PATCH consolidation, etc.).

## Verification

- `uv run pre-commit run --all-files` — clean.
- `uv run basedpyright` — 0 errors, 0 warnings.
- `uv run mypy -p imbi_api` — Success (56 source files).
- `uv run pytest` — **932 passed, 1 skipped**, coverage **90.38%** (above the 90% floor).

## Test plan

- [x] Full pytest suite passes locally against live Docker services.
- [ ] CI (`testing.yaml`) lint + test on Python 3.14.
- [ ] CodeRabbit review on PR.
- [ ] Manual smoke for tracks A, B, C: `just serve`, then `curl` representative CRUD paths end-to-end.