### PR TITLE
Restore project-dependency management via edge endpoints

### DIFF
--- a/src/imbi_api/endpoints/projects.py
+++ b/src/imbi_api/endpoints/projects.py
@@ -941,6 +941,115 @@ async def list_project_relationships(
     )
 
 
+@projects_router.post(
+    '/{project_id}/relationships/{target_id}',
+    status_code=204,
+)
+async def create_project_relationship(
+    org_slug: str,
+    project_id: str,
+    target_id: str,
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('project:write'),
+        ),
+    ],
+) -> None:
+    """Create a single ``DEPENDS_ON`` edge from source to target project.
+
+    Idempotent: if the edge already exists, returns 204 without error.
+
+    Raises:
+        400: ``project_id`` equals ``target_id`` (self-reference).
+        404: Source or target project does not exist within ``org_slug``.
+    """
+    if project_id == target_id:
+        raise fastapi.HTTPException(
+            status_code=400,
+            detail='A project cannot depend on itself',
+        )
+
+    query: typing.LiteralString = """
+    MATCH (src:Project {{id: {project_id}}})
+          -[:OWNED_BY]->(:Team)
+          -[:BELONGS_TO]->(:Organization {{slug: {org_slug}}})
+    MATCH (tgt:Project {{id: {target_id}}})
+          -[:OWNED_BY]->(:Team)
+          -[:BELONGS_TO]->(:Organization {{slug: {org_slug}}})
+    MERGE (src)-[:DEPENDS_ON]->(tgt)
+    RETURN src.id AS source_id
+    """
+    records = await db.execute(
+        query,
+        {
+            'project_id': project_id,
+            'org_slug': org_slug,
+            'target_id': target_id,
+        },
+        ['source_id'],
+    )
+    if not records:
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail=(
+                f'Project {project_id!r} or target {target_id!r} not found'
+            ),
+        )
+
+
+@projects_router.delete(
+    '/{project_id}/relationships/{target_id}',
+    status_code=204,
+)
+async def delete_project_relationship(
+    org_slug: str,
+    project_id: str,
+    target_id: str,
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('project:write'),
+        ),
+    ],
+) -> None:
+    """Remove a ``DEPENDS_ON`` edge from source to target project.
+
+    Raises:
+        404: The edge does not exist (source, target, or the edge
+            itself may be missing).
+    """
+    query: typing.LiteralString = """
+    MATCH (src:Project {{id: {project_id}}})
+          -[:OWNED_BY]->(:Team)
+          -[:BELONGS_TO]->(:Organization {{slug: {org_slug}}})
+    MATCH (tgt:Project {{id: {target_id}}})
+          -[:OWNED_BY]->(:Team)
+          -[:BELONGS_TO]->(:Organization {{slug: {org_slug}}})
+    MATCH (src)-[r:DEPENDS_ON]->(tgt)
+    DELETE r
+    RETURN src.id AS source_id
+    """
+    records = await db.execute(
+        query,
+        {
+            'project_id': project_id,
+            'org_slug': org_slug,
+            'target_id': target_id,
+        },
+        ['source_id'],
+    )
+    if not records:
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail=(
+                f'Relationship from {project_id!r} to {target_id!r} not found'
+            ),
+        )
+
+
 async def _validate_update_refs(
     db: graph.Pool,
     org_slug: str,

--- a/tests/endpoints/test_projects.py
+++ b/tests/endpoints/test_projects.py
@@ -908,3 +908,125 @@ class ProjectRelationshipsEndpointTestCase(_RelationshipsTestBase):
             'so ordering is stable when multiple related projects share a '
             'name across namespaces',
         )
+
+
+class CreateProjectRelationshipTestCase(_RelationshipsTestBase):
+    """Tests for POST /projects/{id}/relationships/{target_id}."""
+
+    _permissions: typing.ClassVar[set[str]] = {'project:write'}
+
+    def _target_url(self, target_id: str, pid: str = PROJECT_ID) -> str:
+        return (
+            f'/organizations/engineering/projects/{pid}'
+            f'/relationships/{target_id}'
+        )
+
+    def test_create_edge(self) -> None:
+        """Creates a DEPENDS_ON edge and returns 204."""
+        self.mock_db.execute.return_value = [{'source_id': PROJECT_ID}]
+
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            response = self.client.post(self._target_url('target1'))
+
+        self.assertEqual(response.status_code, 204)
+        self.assertEqual(self.mock_db.execute.call_count, 1)
+        query = self.mock_db.execute.call_args.args[0]
+        self.assertIn('MERGE', query)
+        self.assertIn('DEPENDS_ON', query)
+
+    def test_create_is_idempotent(self) -> None:
+        """MERGE makes repeated calls safe; still returns 204."""
+        self.mock_db.execute.return_value = [{'source_id': PROJECT_ID}]
+
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            first = self.client.post(self._target_url('target1'))
+            second = self.client.post(self._target_url('target1'))
+
+        self.assertEqual(first.status_code, 204)
+        self.assertEqual(second.status_code, 204)
+
+    def test_source_not_found(self) -> None:
+        """Returns 404 when source project is missing."""
+        self.mock_db.execute.return_value = []
+
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            response = self.client.post(
+                self._target_url('target1', pid='missing'),
+            )
+
+        self.assertEqual(response.status_code, 404)
+        self.assertIn('not found', response.json()['detail'])
+
+    def test_target_not_found(self) -> None:
+        """Returns 404 when target project is missing."""
+        self.mock_db.execute.return_value = []
+
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            response = self.client.post(self._target_url('missing-target'))
+
+        self.assertEqual(response.status_code, 404)
+        self.assertIn('not found', response.json()['detail'])
+
+    def test_self_reference_rejected(self) -> None:
+        """Returns 400 when source and target are the same project."""
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            response = self.client.post(self._target_url(PROJECT_ID))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('itself', response.json()['detail'])
+        self.mock_db.execute.assert_not_called()
+
+
+class DeleteProjectRelationshipTestCase(_RelationshipsTestBase):
+    """Tests for DELETE /projects/{id}/relationships/{target_id}."""
+
+    _permissions: typing.ClassVar[set[str]] = {'project:write'}
+
+    def _target_url(self, target_id: str, pid: str = PROJECT_ID) -> str:
+        return (
+            f'/organizations/engineering/projects/{pid}'
+            f'/relationships/{target_id}'
+        )
+
+    def test_delete_edge(self) -> None:
+        """Removes a DEPENDS_ON edge and returns 204."""
+        self.mock_db.execute.return_value = [{'source_id': PROJECT_ID}]
+
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            response = self.client.delete(self._target_url('target1'))
+
+        self.assertEqual(response.status_code, 204)
+        query = self.mock_db.execute.call_args.args[0]
+        self.assertIn('DELETE r', query)
+        self.assertIn('DEPENDS_ON', query)
+
+    def test_edge_missing(self) -> None:
+        """Returns 404 when the edge does not exist."""
+        self.mock_db.execute.return_value = []
+
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            response = self.client.delete(self._target_url('target1'))
+
+        self.assertEqual(response.status_code, 404)
+        self.assertIn('not found', response.json()['detail'])

--- a/tests/endpoints/test_projects.py
+++ b/tests/endpoints/test_projects.py
@@ -950,6 +950,11 @@ class CreateProjectRelationshipTestCase(_RelationshipsTestBase):
 
         self.assertEqual(first.status_code, 204)
         self.assertEqual(second.status_code, 204)
+        self.assertEqual(self.mock_db.execute.call_count, 2)
+        for call in self.mock_db.execute.call_args_list:
+            query = call.args[0]
+            self.assertIn('MERGE', query)
+            self.assertIn('DEPENDS_ON', query)
 
     def test_source_not_found(self) -> None:
         """Returns 404 when source project is missing."""


### PR DESCRIPTION
## Summary

PR #233 removed the bulk `PUT /organizations/{org_slug}/projects/{project_id}/relationships` setter along with its `ProjectRelationshipsUpdate` / `ProjectRelationshipsResponse` update models. This restores the ability to manage `DEPENDS_ON` edges between projects using per-edge endpoints, the approach preferred in section 1.3 of `docs/refactor-followups.md`.

- `POST /organizations/{org_slug}/projects/{project_id}/relationships/{target_id}` creates a single edge using `MERGE`, making it idempotent. Returns 204 on success, 404 when the source or target project is missing, and 400 when source and target are the same project.
- `DELETE /organizations/{org_slug}/projects/{project_id}/relationships/{target_id}` removes the edge. Returns 204 on success and 404 when the edge does not exist.

Both endpoints require `project:write`, matching the permission used by `patch_project`. No bulk replace path was added, per §1.3.

## Test plan

- [x] `pytest tests/endpoints/test_projects.py` passes locally (all 30 tests, including 7 new ones covering success, 404 source/target, self-ref 400, idempotent MERGE, DELETE success, and DELETE 404 edge-missing)
- [x] `ruff check` / `ruff format` clean
- [x] `basedpyright` clean
- [x] `mypy` clean
- [ ] CI green on push