### PR TITLE
Restore user and service-account org-role update as PATCH

### DIFF
--- a/src/imbi_api/endpoints/_helpers.py
+++ b/src/imbi_api/endpoints/_helpers.py
@@ -1,0 +1,140 @@
+"""Shared helpers for endpoint handlers."""
+
+import logging
+import typing
+
+import fastapi
+from imbi_common import graph
+
+from imbi_api import patch as json_patch
+
+LOGGER = logging.getLogger(__name__)
+
+
+_USER_UPDATE_ROLE_QUERY: typing.LiteralString = """
+MATCH (p:User {{email: {principal_value}}})
+      -[m:MEMBER_OF]->(o:Organization {{slug: {org_slug}}})
+SET m.role = {role_slug}
+RETURN m.role AS role
+"""
+
+_SA_UPDATE_ROLE_QUERY: typing.LiteralString = """
+MATCH (p:ServiceAccount {{slug: {principal_value}}})
+      -[m:MEMBER_OF]->(o:Organization {{slug: {org_slug}}})
+SET m.role = {role_slug}
+RETURN m.role AS role
+"""
+
+_ROLE_EXISTS_QUERY: typing.LiteralString = (
+    'MATCH (r:Role {{slug: {role_slug}}}) RETURN r.slug AS slug'
+)
+
+
+async def update_membership_role(
+    db: graph.Graph,
+    principal_label: typing.Literal['User', 'ServiceAccount'],
+    principal_match_prop: typing.Literal['email', 'slug'],
+    principal_value: str,
+    org_slug: str,
+    role_slug: str,
+) -> None:
+    """Update a principal's role in an organization.
+
+    Parameters:
+        db: Graph pool.
+        principal_label: Node label of the principal ('User' or
+            'ServiceAccount').
+        principal_match_prop: Property used to match the principal
+            ('email' or 'slug'). Must align with ``principal_label``:
+            ``email`` for ``User`` and ``slug`` for ``ServiceAccount``.
+        principal_value: Value for ``principal_match_prop``.
+        org_slug: Slug of the organization.
+        role_slug: Slug of the new role.
+
+    Raises:
+        fastapi.HTTPException: HTTP 404 if the target role does not
+            exist or the principal is not a member of the organization.
+
+    """
+    role_records = await db.execute(
+        _ROLE_EXISTS_QUERY,
+        {'role_slug': role_slug},
+        ['slug'],
+    )
+    if not role_records:
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail=f'Role {role_slug!r} not found',
+        )
+
+    if principal_label == 'User' and principal_match_prop == 'email':
+        query = _USER_UPDATE_ROLE_QUERY
+    elif (
+        principal_label == 'ServiceAccount' and principal_match_prop == 'slug'
+    ):
+        query = _SA_UPDATE_ROLE_QUERY
+    else:
+        raise ValueError(
+            f'Unsupported principal_label/match_prop combination:'
+            f' {principal_label}/{principal_match_prop}'
+        )
+
+    records = await db.execute(
+        query,
+        {
+            'principal_value': principal_value,
+            'org_slug': org_slug,
+            'role_slug': role_slug,
+        },
+        ['role'],
+    )
+    if not records:
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail=(
+                f'{principal_label} {principal_value!r} is not a member'
+                f' of organization {org_slug!r}'
+            ),
+        )
+
+
+def extract_role_slug(
+    operations: list[json_patch.PatchOperation],
+) -> str:
+    """Extract ``role_slug`` from a JSON Patch membership update.
+
+    The body must be a single ``replace`` (or ``add``) operation
+    targeting ``/role_slug`` with a non-empty string value.
+
+    Parameters:
+        operations: The parsed JSON Patch operations.
+
+    Returns:
+        The new role slug.
+
+    Raises:
+        fastapi.HTTPException: HTTP 400 if the patch is malformed.
+
+    """
+    if len(operations) != 1:
+        raise fastapi.HTTPException(
+            status_code=400,
+            detail=('Membership patch must contain exactly one operation'),
+        )
+    op = operations[0]
+    if op.op not in ('replace', 'add'):
+        raise fastapi.HTTPException(
+            status_code=400,
+            detail="Membership patch op must be 'replace' or 'add'",
+        )
+    if op.path != '/role_slug':
+        raise fastapi.HTTPException(
+            status_code=400,
+            detail="Membership patch path must be '/role_slug'",
+        )
+    if not isinstance(op.value, str) or not op.value:
+        raise fastapi.HTTPException(
+            status_code=400,
+            detail='role_slug value must be a non-empty string',
+        )
+    return op.value

--- a/src/imbi_api/endpoints/service_accounts.py
+++ b/src/imbi_api/endpoints/service_accounts.py
@@ -12,6 +12,7 @@ from imbi_common import graph
 from imbi_api import models
 from imbi_api import patch as json_patch
 from imbi_api.auth import permissions
+from imbi_api.endpoints import _helpers
 
 LOGGER = logging.getLogger(__name__)
 
@@ -362,6 +363,45 @@ async def add_to_organization(
             f'organization {org_slug!r}, '
             f'or role {role_slug!r} not found',
         )
+
+
+@service_accounts_router.patch(
+    '/{slug}/organizations/{org_slug}', status_code=204
+)
+async def update_organization_role(
+    slug: str,
+    org_slug: str,
+    operations: list[json_patch.PatchOperation],
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('service_account:update')
+        ),
+    ],
+) -> None:
+    """Change a service account's role in an organization via JSON Patch.
+
+    Parameters:
+        slug (str): Service account slug.
+        org_slug (str): Organization slug.
+        operations (list): JSON Patch operations. Exactly one
+            ``replace`` or ``add`` op targeting ``/role_slug``.
+
+    Raises:
+        fastapi.HTTPException: HTTP 400 on malformed patch, HTTP 404
+            if membership or role not found.
+
+    """
+    role_slug = _helpers.extract_role_slug(operations)
+    await _helpers.update_membership_role(
+        db,
+        principal_label='ServiceAccount',
+        principal_match_prop='slug',
+        principal_value=slug,
+        org_slug=org_slug,
+        role_slug=role_slug,
+    )
 
 
 @service_accounts_router.delete(

--- a/src/imbi_api/endpoints/users.py
+++ b/src/imbi_api/endpoints/users.py
@@ -11,6 +11,7 @@ from imbi_common import graph
 from imbi_api import models
 from imbi_api import patch as json_patch
 from imbi_api.auth import password, permissions
+from imbi_api.endpoints import _helpers
 
 LOGGER = logging.getLogger(__name__)
 
@@ -558,6 +559,45 @@ async def add_to_organization(
             detail=f'User {email!r}, organization {org_slug!r},'
             f' or role {role_slug!r} not found',
         )
+
+
+@users_router.patch(
+    '/{email}/organizations/{org_slug}',
+    status_code=204,
+)
+async def update_organization_role(
+    email: str,
+    org_slug: str,
+    operations: list[json_patch.PatchOperation],
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(permissions.require_permission('user:update')),
+    ],
+) -> None:
+    """Change a user's role in an organization via JSON Patch.
+
+    Parameters:
+        email (str): Email of user.
+        org_slug (str): Organization slug.
+        operations (list): JSON Patch operations. Exactly one
+            ``replace`` or ``add`` op targeting ``/role_slug``.
+
+    Raises:
+        fastapi.HTTPException: HTTP 400 on malformed patch, HTTP 404
+            if membership or role not found.
+
+    """
+    email = urlparse.unquote(email)
+    role_slug = _helpers.extract_role_slug(operations)
+    await _helpers.update_membership_role(
+        db,
+        principal_label='User',
+        principal_match_prop='email',
+        principal_value=email,
+        org_slug=org_slug,
+        role_slug=role_slug,
+    )
 
 
 @users_router.delete(

--- a/tests/endpoints/test_service_accounts.py
+++ b/tests/endpoints/test_service_accounts.py
@@ -398,3 +398,81 @@ class ServiceAccountsEndpointsTestCase(unittest.TestCase):
         )
 
         self.assertEqual(response.status_code, 400)
+
+    def test_update_organization_role_success(self) -> None:
+        """PATCH updates the SA's membership role."""
+        self.mock_db.execute.side_effect = [
+            [{'slug': 'deployer'}],
+            [{'role': 'deployer'}],
+        ]
+
+        response = self.client.patch(
+            '/service-accounts/test-bot/organizations/acme-corp',
+            json=[
+                {
+                    'op': 'replace',
+                    'path': '/role_slug',
+                    'value': 'deployer',
+                },
+            ],
+        )
+
+        self.assertEqual(response.status_code, 204)
+        self.assertEqual(self.mock_db.execute.call_count, 2)
+
+    def test_update_organization_role_missing_role(self) -> None:
+        """PATCH returns 404 when the target role does not exist."""
+        self.mock_db.execute.side_effect = [[]]
+
+        response = self.client.patch(
+            '/service-accounts/test-bot/organizations/acme-corp',
+            json=[
+                {
+                    'op': 'replace',
+                    'path': '/role_slug',
+                    'value': 'ghost',
+                },
+            ],
+        )
+
+        self.assertEqual(response.status_code, 404)
+        self.assertIn('Role', response.json()['detail'])
+
+    def test_update_organization_role_missing_membership(
+        self,
+    ) -> None:
+        """PATCH returns 404 when SA is not a member of the org."""
+        self.mock_db.execute.side_effect = [
+            [{'slug': 'deployer'}],
+            [],
+        ]
+
+        response = self.client.patch(
+            '/service-accounts/test-bot/organizations/other-org',
+            json=[
+                {
+                    'op': 'replace',
+                    'path': '/role_slug',
+                    'value': 'deployer',
+                },
+            ],
+        )
+
+        self.assertEqual(response.status_code, 404)
+        self.assertIn('not a member', response.json()['detail'])
+
+    def test_update_organization_role_malformed_patch(self) -> None:
+        """PATCH with wrong path returns 400 without touching graph."""
+        response = self.client.patch(
+            '/service-accounts/test-bot/organizations/acme-corp',
+            json=[
+                {
+                    'op': 'replace',
+                    'path': '/display_name',
+                    'value': 'nope',
+                },
+            ],
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.mock_db.execute.assert_not_awaited()

--- a/tests/endpoints/test_users.py
+++ b/tests/endpoints/test_users.py
@@ -790,6 +790,84 @@ class OrgMembershipEndpointsTestCase(unittest.TestCase):
             response.json()['detail'],
         )
 
+    def test_update_organization_role_success(self) -> None:
+        """PATCH updates the membership role."""
+        self.mock_db.execute.side_effect = [
+            [{'slug': 'admin'}],
+            [{'role': 'admin'}],
+        ]
+
+        response = self.client.patch(
+            '/users/test@example.com/organizations/default',
+            json=[
+                {
+                    'op': 'replace',
+                    'path': '/role_slug',
+                    'value': 'admin',
+                },
+            ],
+        )
+
+        self.assertEqual(response.status_code, 204)
+        self.assertEqual(self.mock_db.execute.call_count, 2)
+
+    def test_update_organization_role_missing_role(self) -> None:
+        """PATCH returns 404 when the target role does not exist."""
+        self.mock_db.execute.side_effect = [[]]
+
+        response = self.client.patch(
+            '/users/test@example.com/organizations/default',
+            json=[
+                {
+                    'op': 'replace',
+                    'path': '/role_slug',
+                    'value': 'ghost',
+                },
+            ],
+        )
+
+        self.assertEqual(response.status_code, 404)
+        self.assertIn('Role', response.json()['detail'])
+
+    def test_update_organization_role_missing_membership(
+        self,
+    ) -> None:
+        """PATCH returns 404 when the user is not a member."""
+        self.mock_db.execute.side_effect = [
+            [{'slug': 'admin'}],
+            [],
+        ]
+
+        response = self.client.patch(
+            '/users/test@example.com/organizations/other-org',
+            json=[
+                {
+                    'op': 'replace',
+                    'path': '/role_slug',
+                    'value': 'admin',
+                },
+            ],
+        )
+
+        self.assertEqual(response.status_code, 404)
+        self.assertIn('not a member', response.json()['detail'])
+
+    def test_update_organization_role_malformed_patch(self) -> None:
+        """PATCH with wrong path returns 400 without touching graph."""
+        response = self.client.patch(
+            '/users/test@example.com/organizations/default',
+            json=[
+                {
+                    'op': 'replace',
+                    'path': '/display_name',
+                    'value': 'nope',
+                },
+            ],
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.mock_db.execute.assert_not_awaited()
+
 
 class ServiceAccountGuardRailsTestCase(unittest.TestCase):
     """Test guardrails for invalid service account operations."""


### PR DESCRIPTION
## Summary

- PR #233 removed `PUT /users/{email}/organizations/{org_slug}` and `PUT /service-accounts/{slug}/organizations/{org_slug}` without a replacement. This PR restores the behaviour as PATCH endpoints that take a JSON Patch body.
- The new endpoints accept exactly one `replace` or `add` op targeting `/role_slug`:

  ```json
  [{"op": "replace", "path": "/role_slug", "value": "<slug>"}]
  ```

  They return `204` on success, `404` when the target role or membership is missing, and `400` on a malformed patch.
- A shared `update_membership_role` helper (plus `extract_role_slug`) lives in `src/imbi_api/endpoints/_helpers.py` and is reused across the user and service-account handlers; it performs the role-existence check and the `MATCH ... SET m.role` mutation against AGE.

Tracks `docs/refactor-followups.md` §1.1 and §1.2.

## Test plan

- [x] `uv run pre-commit run --all-files` clean
- [x] `uv run basedpyright` → 0 errors, 0 warnings
- [x] `uv run mypy -p imbi_api` → 0 issues
- [x] `uv run pytest tests/endpoints/test_users.py tests/endpoints/test_service_accounts.py` → 56 passed (includes 8 new tests covering success, missing-role 404, missing-membership 404, and malformed-patch 400 for both endpoints)
- [ ] Full suite + coverage on CI