### PR TITLE
Restore service-application PATCH endpoints (fields + secrets)

### DIFF
--- a/src/imbi_api/endpoints/third_party_services.py
+++ b/src/imbi_api/endpoints/third_party_services.py
@@ -766,6 +766,140 @@ async def get_service_application(
     return models.ServiceApplicationResponse(**app)
 
 
+_APP_SECRET_PATHS: frozenset[str] = frozenset(
+    f'/{field}' for field in models.SECRET_FIELDS
+)
+
+
+class _ServiceApplicationPatchFields(pydantic.BaseModel):
+    """Internal validator for non-secret application fields."""
+
+    slug: str = pydantic.Field(
+        pattern=r'^[a-z][a-z0-9-]*$',
+        min_length=2,
+        max_length=64,
+    )
+    name: str = pydantic.Field(min_length=1, max_length=128)
+    description: str | None = None
+    app_type: str = pydantic.Field(min_length=1, max_length=64)
+    application_url: str | None = None
+    client_id: str = pydantic.Field(min_length=1)
+    scopes: list[str] = pydantic.Field(default_factory=list)
+    settings: dict[str, str | int | bool] = pydantic.Field(
+        default_factory=dict,
+    )
+    status: typing.Literal['active', 'inactive', 'revoked'] = 'active'
+
+    model_config = pydantic.ConfigDict(extra='ignore')
+
+
+@third_party_services_router.patch(
+    '/{slug}/applications/{app_slug}',
+)
+async def patch_service_application(
+    org_slug: str,
+    slug: str,
+    app_slug: str,
+    operations: list[json_patch.PatchOperation],
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission(
+                'third_party_service:update',
+            ),
+        ),
+    ],
+) -> models.ServiceApplicationResponse:
+    """Partially update non-secret application fields via JSON Patch.
+
+    Secret fields (``client_secret``, ``webhook_secret``, ``private_key``,
+    ``signing_secret``) cannot be modified here — use the ``/secrets``
+    sub-resource instead. Attempts to patch them return 400.
+
+    Parameters:
+        org_slug: Organization slug from URL.
+        slug: Third-party service slug from URL.
+        app_slug: Application slug from URL.
+        operations: JSON Patch operations.
+
+    Returns:
+        The updated application (secrets stripped).
+
+    Raises:
+        400: Invalid patch or secret path targeted.
+        404: Application not found.
+        409: Slug conflict.
+        422: Patch test failed or validation error.
+
+    """
+    existing = await _fetch_application(db, org_slug, slug, app_slug)
+    preserved_secrets = {
+        field: existing.get(field) for field in models.SECRET_FIELDS
+    }
+
+    patchable = {
+        k: v for k, v in existing.items() if k not in models.SECRET_FIELDS
+    }
+
+    readonly = json_patch.READONLY_PATHS | _APP_SECRET_PATHS
+    patched = json_patch.apply_patch(patchable, operations, readonly)
+
+    try:
+        validated = _ServiceApplicationPatchFields(**patched)
+    except pydantic.ValidationError as e:
+        raise fastapi.HTTPException(
+            status_code=400,
+            detail=f'Validation error: {e.errors()}',
+        ) from e
+
+    props = validated.model_dump(mode='json')
+    for field in models.SECRET_FIELDS:
+        props[field] = preserved_secrets.get(field)
+
+    graph_props = _serialize_json_fields(props, _APP_JSON_FIELDS)
+    app_set = set_clause('a', graph_props)
+
+    update_query: str = (
+        'MATCH (a:ServiceApplication {{slug: {cur_app_slug}}})'
+        ' -[:REGISTERED_IN]->(s:ThirdPartyService'
+        ' {{slug: {svc_slug}}})'
+        ' -[:BELONGS_TO]->(o:Organization {{slug: {org_slug}}})'
+        f' {app_set}'
+        ' RETURN a{{.*}} AS app'
+    )
+    try:
+        updated = await db.execute(
+            update_query,
+            {
+                'cur_app_slug': app_slug,
+                'svc_slug': slug,
+                'org_slug': org_slug,
+                **graph_props,
+            },
+            ['app'],
+        )
+    except psycopg.errors.UniqueViolation as e:
+        raise fastapi.HTTPException(
+            status_code=409,
+            detail=(
+                f'Application {props["slug"]!r} already exists'
+                f' in service {slug!r}'
+            ),
+        ) from e
+
+    if not updated:
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail=(f'Application {app_slug!r} not found in service {slug!r}'),
+        )
+
+    app = graph.parse_agtype(updated[0]['app'])
+    app = _deserialize_json_fields(app, _APP_JSON_FIELDS)
+    _strip_secrets(app)
+    return models.ServiceApplicationResponse(**app)
+
+
 @third_party_services_router.delete(
     '/{slug}/applications/{app_slug}',
     status_code=204,
@@ -844,3 +978,192 @@ async def get_application_secrets(
     app = await _fetch_application(db, org_slug, slug, app_slug)
     encryptor = encryption.TokenEncryption.get_instance()
     return _build_secrets_response(app, encryptor)
+
+
+def _require_secret_field(path: str) -> str:
+    """Validate that a JSON Pointer path targets a known secret field.
+
+    Returns the field name. Raises 400 otherwise.
+    """
+    if not path.startswith('/') or '/' in path[1:]:
+        raise fastapi.HTTPException(
+            status_code=400,
+            detail=f'Invalid secret path {path!r}',
+        )
+    field = path[1:]
+    if field not in models.SECRET_FIELDS:
+        raise fastapi.HTTPException(
+            status_code=400,
+            detail=(
+                f'Path {path!r} is not a recognized secret field;'
+                f' allowed: {sorted(models.SECRET_FIELDS)}'
+            ),
+        )
+    return field
+
+
+@third_party_services_router.patch(
+    '/{slug}/applications/{app_slug}/secrets',
+)
+async def patch_application_secrets(
+    org_slug: str,
+    slug: str,
+    app_slug: str,
+    operations: list[json_patch.PatchOperation],
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission(
+                'third_party_service:update',
+            ),
+        ),
+    ],
+) -> models.ServiceApplicationSecrets:
+    """Update application secrets via JSON Patch.
+
+    Each operation's ``value`` is plaintext; the handler encrypts it
+    before persisting. Only fields in ``models.SECRET_FIELDS`` are
+    addressable. Requires admin privileges.
+    """
+    if not auth.is_admin:
+        raise fastapi.HTTPException(
+            status_code=403,
+            detail='Admin privileges required to update secrets',
+        )
+
+    existing = await _fetch_application(db, org_slug, slug, app_slug)
+    encryptor = encryption.TokenEncryption.get_instance()
+
+    secret_updates: dict[str, str | None] = {}
+    for op in operations:
+        field = _require_secret_field(op.path)
+        if op.op in ('add', 'replace'):
+            if not isinstance(op.value, str) or not op.value:
+                raise fastapi.HTTPException(
+                    status_code=400,
+                    detail=(
+                        f'Secret {field!r} requires a non-empty string value'
+                    ),
+                )
+            secret_updates[field] = encryptor.encrypt(op.value)
+        elif op.op == 'remove':
+            if field == 'client_secret':
+                raise fastapi.HTTPException(
+                    status_code=400,
+                    detail='client_secret is required and cannot be removed',
+                )
+            secret_updates[field] = None
+        else:
+            raise fastapi.HTTPException(
+                status_code=400,
+                detail=(
+                    f'Operation {op.op!r} is not supported on secrets;'
+                    ' use add, replace, or remove'
+                ),
+            )
+
+    if not secret_updates:
+        return _build_secrets_response(existing, encryptor)
+
+    app_set = set_clause('a', secret_updates)
+    update_query: str = (
+        'MATCH (a:ServiceApplication {{slug: {app_slug}}})'
+        ' -[:REGISTERED_IN]->(s:ThirdPartyService'
+        ' {{slug: {svc_slug}}})'
+        ' -[:BELONGS_TO]->(o:Organization {{slug: {org_slug}}})'
+        f' {app_set}'
+        ' RETURN a{{.*}} AS app'
+    )
+    records = await db.execute(
+        update_query,
+        {
+            'app_slug': app_slug,
+            'svc_slug': slug,
+            'org_slug': org_slug,
+            **secret_updates,
+        },
+        ['app'],
+    )
+
+    if not records:
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail=(f'Application {app_slug!r} not found in service {slug!r}'),
+        )
+
+    updated_app = graph.parse_agtype(records[0]['app'])
+    return _build_secrets_response(updated_app, encryptor)
+
+
+@third_party_services_router.delete(
+    '/{slug}/applications/{app_slug}/secrets/{field}',
+    status_code=204,
+)
+async def delete_application_secret(
+    org_slug: str,
+    slug: str,
+    app_slug: str,
+    field: str,
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission(
+                'third_party_service:update',
+            ),
+        ),
+    ],
+) -> None:
+    """Clear a single optional application secret. Admin-only.
+
+    ``client_secret`` is required and cannot be cleared via this
+    endpoint.
+    """
+    if not auth.is_admin:
+        raise fastapi.HTTPException(
+            status_code=403,
+            detail='Admin privileges required to update secrets',
+        )
+
+    if field not in models.SECRET_FIELDS:
+        raise fastapi.HTTPException(
+            status_code=400,
+            detail=(
+                f'Field {field!r} is not a recognized secret;'
+                f' allowed: {sorted(models.SECRET_FIELDS)}'
+            ),
+        )
+    if field == 'client_secret':
+        raise fastapi.HTTPException(
+            status_code=400,
+            detail='client_secret is required and cannot be cleared',
+        )
+
+    await _fetch_application(db, org_slug, slug, app_slug)
+
+    app_set = set_clause('a', {field: None})
+    update_query: str = (
+        'MATCH (a:ServiceApplication {{slug: {app_slug}}})'
+        ' -[:REGISTERED_IN]->(s:ThirdPartyService'
+        ' {{slug: {svc_slug}}})'
+        ' -[:BELONGS_TO]->(o:Organization {{slug: {org_slug}}})'
+        f' {app_set}'
+        ' RETURN a{{.*}} AS app'
+    )
+    records = await db.execute(
+        update_query,
+        {
+            'app_slug': app_slug,
+            'svc_slug': slug,
+            'org_slug': org_slug,
+            field: None,
+        },
+        ['app'],
+    )
+
+    if not records:
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail=(f'Application {app_slug!r} not found in service {slug!r}'),
+        )

--- a/src/imbi_api/endpoints/third_party_services.py
+++ b/src/imbi_api/endpoints/third_party_services.py
@@ -790,7 +790,7 @@ class _ServiceApplicationPatchFields(pydantic.BaseModel):
     )
     status: typing.Literal['active', 'inactive', 'revoked'] = 'active'
 
-    model_config = pydantic.ConfigDict(extra='ignore')
+    model_config = pydantic.ConfigDict(extra='forbid')
 
 
 @third_party_services_router.patch(
@@ -834,9 +834,6 @@ async def patch_service_application(
 
     """
     existing = await _fetch_application(db, org_slug, slug, app_slug)
-    preserved_secrets = {
-        field: existing.get(field) for field in models.SECRET_FIELDS
-    }
 
     patchable = {
         k: v for k, v in existing.items() if k not in models.SECRET_FIELDS
@@ -854,8 +851,6 @@ async def patch_service_application(
         ) from e
 
     props = validated.model_dump(mode='json')
-    for field in models.SECRET_FIELDS:
-        props[field] = preserved_secrets.get(field)
 
     graph_props = _serialize_json_fields(props, _APP_JSON_FIELDS)
     app_set = set_clause('a', graph_props)

--- a/tests/endpoints/test_third_party_services.py
+++ b/tests/endpoints/test_third_party_services.py
@@ -1217,3 +1217,405 @@ class ServiceApplicationEndpointsTestCase(unittest.TestCase):
         data = response.json()[0]
         self.assertEqual(data['scopes'], [])
         self.assertEqual(data['settings'], {})
+
+    # -- PATCH application (non-secret fields) --
+
+    def _set_non_admin(self) -> None:
+        from imbi_api.auth import permissions
+
+        non_admin = models.User(
+            email='user@example.com',
+            display_name='Regular User',
+            password_hash='$argon2id$hashed',
+            is_active=True,
+            is_admin=False,
+            is_service_account=False,
+            created_at=datetime.datetime.now(datetime.UTC),
+        )
+        self.auth_context = permissions.AuthContext(
+            user=non_admin,
+            session_id='test-session',
+            auth_method='jwt',
+            permissions={
+                'third_party_service:read',
+                'third_party_service:update',
+            },
+        )
+
+        async def mock_get_current_user():
+            return self.auth_context
+
+        self.test_app.dependency_overrides[permissions.get_current_user] = (
+            mock_get_current_user
+        )
+
+    def test_patch_application_name(self) -> None:
+        """Patch a non-secret field."""
+        updated = dict(self.app_data)
+        updated['name'] = 'Renamed App'
+        self.mock_db.execute.side_effect = [
+            [{'app': self.app_data}],
+            [{'app': updated}],
+        ]
+
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            response = self.client.patch(
+                '/organizations/engineering'
+                '/third-party-services/stripe'
+                '/applications/my-app',
+                json=[
+                    {
+                        'op': 'replace',
+                        'path': '/name',
+                        'value': 'Renamed App',
+                    },
+                ],
+            )
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data['name'], 'Renamed App')
+        self.assertNotIn('client_secret', data)
+        self.assertNotIn('webhook_secret', data)
+
+    def test_patch_application_rejects_secret_path(self) -> None:
+        """Attempts to PATCH a secret field via this endpoint 400."""
+        self.mock_db.execute.return_value = [{'app': self.app_data}]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            response = self.client.patch(
+                '/organizations/engineering'
+                '/third-party-services/stripe'
+                '/applications/my-app',
+                json=[
+                    {
+                        'op': 'replace',
+                        'path': '/client_secret',
+                        'value': 'new-secret',
+                    },
+                ],
+            )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('read-only', response.json()['detail'])
+
+    def test_patch_application_preserves_secrets(self) -> None:
+        """Non-secret PATCH does not overwrite secret fields."""
+        updated = dict(self.app_data)
+        updated['name'] = 'Renamed'
+        self.mock_db.execute.side_effect = [
+            [{'app': self.app_data}],
+            [{'app': updated}],
+        ]
+
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            response = self.client.patch(
+                '/organizations/engineering'
+                '/third-party-services/stripe'
+                '/applications/my-app',
+                json=[
+                    {'op': 'replace', 'path': '/name', 'value': 'Renamed'},
+                ],
+            )
+
+        self.assertEqual(response.status_code, 200)
+        # Inspect the UPDATE execute call params
+        update_call = self.mock_db.execute.call_args_list[-1]
+        params = update_call.args[1]
+        self.assertEqual(
+            params['client_secret'],
+            self.app_data['client_secret'],
+        )
+        self.assertEqual(
+            params['webhook_secret'],
+            self.app_data['webhook_secret'],
+        )
+
+    def test_patch_application_not_found(self) -> None:
+        self.mock_db.execute.return_value = []
+        response = self.client.patch(
+            '/organizations/engineering'
+            '/third-party-services/stripe'
+            '/applications/missing',
+            json=[{'op': 'replace', 'path': '/name', 'value': 'X'}],
+        )
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_patch_application_slug_conflict(self) -> None:
+        """Slug rename that collides returns 409."""
+        self.mock_db.execute.side_effect = [
+            [{'app': self.app_data}],
+            psycopg.errors.UniqueViolation(),
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            response = self.client.patch(
+                '/organizations/engineering'
+                '/third-party-services/stripe'
+                '/applications/my-app',
+                json=[
+                    {
+                        'op': 'replace',
+                        'path': '/slug',
+                        'value': 'existing',
+                    },
+                ],
+            )
+
+        self.assertEqual(response.status_code, 409)
+        self.assertIn('already exists', response.json()['detail'])
+
+    def test_patch_application_invalid_value(self) -> None:
+        """Pydantic validation failure returns 400."""
+        self.mock_db.execute.return_value = [{'app': self.app_data}]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            response = self.client.patch(
+                '/organizations/engineering'
+                '/third-party-services/stripe'
+                '/applications/my-app',
+                json=[
+                    {
+                        'op': 'replace',
+                        'path': '/status',
+                        'value': 'not-a-status',
+                    },
+                ],
+            )
+
+        self.assertEqual(response.status_code, 400)
+
+    # -- PATCH application secrets --
+
+    def test_patch_secrets_non_admin(self) -> None:
+        self._set_non_admin()
+        response = self.client.patch(
+            '/organizations/engineering'
+            '/third-party-services/stripe'
+            '/applications/my-app/secrets',
+            json=[
+                {
+                    'op': 'replace',
+                    'path': '/client_secret',
+                    'value': 'x',
+                },
+            ],
+        )
+        self.assertEqual(response.status_code, 403)
+        self.assertIn('Admin', response.json()['detail'])
+
+    def test_patch_secrets_encrypts_value(self) -> None:
+        """PATCH secrets encrypts plaintext before persisting."""
+        existing = dict(self.app_data)
+        existing['client_secret'] = 'enc:old-secret'
+        updated = dict(existing)
+        updated['client_secret'] = 'enc:new-secret'
+
+        self.mock_db.execute.side_effect = [
+            [{'app': existing}],
+            [{'app': updated}],
+        ]
+
+        with (
+            self._patch_encryption(),
+            mock.patch(
+                'imbi_common.graph.parse_agtype',
+                side_effect=lambda x: x,
+            ),
+        ):
+            response = self.client.patch(
+                '/organizations/engineering'
+                '/third-party-services/stripe'
+                '/applications/my-app/secrets',
+                json=[
+                    {
+                        'op': 'replace',
+                        'path': '/client_secret',
+                        'value': 'new-secret',
+                    },
+                ],
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json()['client_secret'],
+            'new-secret',
+        )
+        encrypt_calls = [
+            c.args[0] for c in self.mock_encryptor.encrypt.call_args_list
+        ]
+        self.assertIn('new-secret', encrypt_calls)
+
+        # The SET params use the encrypted value
+        update_call = self.mock_db.execute.call_args_list[-1]
+        params = update_call.args[1]
+        self.assertEqual(params['client_secret'], 'enc:new-secret')
+
+    def test_patch_secrets_rejects_non_secret_path(self) -> None:
+        self.mock_db.execute.return_value = [{'app': self.app_data}]
+        with (
+            self._patch_encryption(),
+            mock.patch(
+                'imbi_common.graph.parse_agtype',
+                side_effect=lambda x: x,
+            ),
+        ):
+            response = self.client.patch(
+                '/organizations/engineering'
+                '/third-party-services/stripe'
+                '/applications/my-app/secrets',
+                json=[
+                    {
+                        'op': 'replace',
+                        'path': '/name',
+                        'value': 'whatever',
+                    },
+                ],
+            )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('secret', response.json()['detail'])
+
+    def test_patch_secrets_remove_optional(self) -> None:
+        """Remove op on optional secret nulls the field."""
+        existing = dict(self.app_data)
+        existing['webhook_secret'] = 'enc:old-webhook'
+        updated = dict(existing)
+        updated['webhook_secret'] = None
+
+        self.mock_db.execute.side_effect = [
+            [{'app': existing}],
+            [{'app': updated}],
+        ]
+
+        with (
+            self._patch_encryption(),
+            mock.patch(
+                'imbi_common.graph.parse_agtype',
+                side_effect=lambda x: x,
+            ),
+        ):
+            response = self.client.patch(
+                '/organizations/engineering'
+                '/third-party-services/stripe'
+                '/applications/my-app/secrets',
+                json=[
+                    {'op': 'remove', 'path': '/webhook_secret'},
+                ],
+            )
+
+        self.assertEqual(response.status_code, 200)
+        update_call = self.mock_db.execute.call_args_list[-1]
+        params = update_call.args[1]
+        self.assertIsNone(params['webhook_secret'])
+
+    def test_patch_secrets_remove_client_secret_rejected(self) -> None:
+        """Cannot remove the required client_secret."""
+        self.mock_db.execute.return_value = [{'app': self.app_data}]
+        with (
+            self._patch_encryption(),
+            mock.patch(
+                'imbi_common.graph.parse_agtype',
+                side_effect=lambda x: x,
+            ),
+        ):
+            response = self.client.patch(
+                '/organizations/engineering'
+                '/third-party-services/stripe'
+                '/applications/my-app/secrets',
+                json=[
+                    {'op': 'remove', 'path': '/client_secret'},
+                ],
+            )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('client_secret', response.json()['detail'])
+
+    def test_patch_secrets_application_not_found(self) -> None:
+        self.mock_db.execute.return_value = []
+        with self._patch_encryption():
+            response = self.client.patch(
+                '/organizations/engineering'
+                '/third-party-services/stripe'
+                '/applications/missing/secrets',
+                json=[
+                    {
+                        'op': 'replace',
+                        'path': '/client_secret',
+                        'value': 'x',
+                    },
+                ],
+            )
+
+        self.assertEqual(response.status_code, 404)
+
+    # -- DELETE a single secret --
+
+    def test_delete_single_secret_admin(self) -> None:
+        self.mock_db.execute.side_effect = [
+            [{'app': self.app_data}],
+            [{'app': self.app_data}],
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            response = self.client.delete(
+                '/organizations/engineering'
+                '/third-party-services/stripe'
+                '/applications/my-app/secrets/webhook_secret',
+            )
+
+        self.assertEqual(response.status_code, 204)
+        update_call = self.mock_db.execute.call_args_list[-1]
+        params = update_call.args[1]
+        self.assertIsNone(params['webhook_secret'])
+
+    def test_delete_single_secret_non_admin(self) -> None:
+        self._set_non_admin()
+        response = self.client.delete(
+            '/organizations/engineering'
+            '/third-party-services/stripe'
+            '/applications/my-app/secrets/webhook_secret',
+        )
+        self.assertEqual(response.status_code, 403)
+
+    def test_delete_single_secret_unknown_field(self) -> None:
+        response = self.client.delete(
+            '/organizations/engineering'
+            '/third-party-services/stripe'
+            '/applications/my-app/secrets/bogus_field',
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_delete_single_secret_client_secret_rejected(self) -> None:
+        """Cannot clear the required client_secret."""
+        response = self.client.delete(
+            '/organizations/engineering'
+            '/third-party-services/stripe'
+            '/applications/my-app/secrets/client_secret',
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('client_secret', response.json()['detail'])
+
+    def test_delete_single_secret_not_found(self) -> None:
+        self.mock_db.execute.return_value = []
+        response = self.client.delete(
+            '/organizations/engineering'
+            '/third-party-services/stripe'
+            '/applications/missing/secrets/webhook_secret',
+        )
+        self.assertEqual(response.status_code, 404)

--- a/tests/endpoints/test_third_party_services.py
+++ b/tests/endpoints/test_third_party_services.py
@@ -1327,17 +1327,16 @@ class ServiceApplicationEndpointsTestCase(unittest.TestCase):
             )
 
         self.assertEqual(response.status_code, 200)
-        # Inspect the UPDATE execute call params
+        # Non-secret PATCH must not touch secret columns.
         update_call = self.mock_db.execute.call_args_list[-1]
         params = update_call.args[1]
-        self.assertEqual(
-            params['client_secret'],
-            self.app_data['client_secret'],
-        )
-        self.assertEqual(
-            params['webhook_secret'],
-            self.app_data['webhook_secret'],
-        )
+        for field in (
+            'client_secret',
+            'webhook_secret',
+            'private_key',
+            'signing_secret',
+        ):
+            self.assertNotIn(field, params)
 
     def test_patch_application_not_found(self) -> None:
         self.mock_db.execute.return_value = []
@@ -1394,6 +1393,22 @@ class ServiceApplicationEndpointsTestCase(unittest.TestCase):
                         'value': 'not-a-status',
                     },
                 ],
+            )
+
+        self.assertEqual(response.status_code, 400)
+
+    def test_patch_application_rejects_unknown_path(self) -> None:
+        """Unknown JSON Patch paths are rejected, not silently dropped."""
+        self.mock_db.execute.return_value = [{'app': self.app_data}]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            response = self.client.patch(
+                '/organizations/engineering'
+                '/third-party-services/stripe'
+                '/applications/my-app',
+                json=[{'op': 'add', 'path': '/bogus', 'value': 'x'}],
             )
 
         self.assertEqual(response.status_code, 400)


### PR DESCRIPTION
## Summary

PR #233 removed every `PUT` endpoint, including two that had no
corresponding `PATCH`:

- `PUT /organizations/{org_slug}/third-party-services/{slug}/applications/{app_slug}`
- `PUT /.../applications/{app_slug}/secrets`

This PR restores that functionality as `PATCH` endpoints using JSON
Patch bodies, plus adds a per-field `DELETE` for optional secrets.
Covers sections 1.4 and 1.5 of `docs/refactor-followups.md`.

## Changes

### `PATCH /.../applications/{app_slug}` (§1.4)

- Non-secret fields only. Uses the shared `set_clause('a', ...)`
  helper that adjacent handlers already use.
- Matches on `(a:ServiceApplication)-[:REGISTERED_IN]->(s:ThirdPartyService {slug})-[:BELONGS_TO]->(o:Organization {org_slug})`.
- Preserves `models.SECRET_FIELDS` from the existing row; any op
  whose `path` targets a secret field returns `400` via the shared
  `apply_patch` read-only guard.
- Returns `ServiceApplicationResponse` with secrets stripped.
- Permission: `third_party_service:update`.
- Post-patch validation uses a small internal pydantic model
  (`_ServiceApplicationPatchFields`) — the old `ServiceApplicationUpdate`
  was deleted in #233 and JSON Patch replaces it as the request
  shape.

### `PATCH /.../applications/{app_slug}/secrets` (§1.5)

- Admin-gated (same `auth.is_admin` check as the sibling `GET /secrets`).
- Each op's `value` is plaintext. The handler encrypts via
  `encryption.TokenEncryption` before the `SET`.
- Only fields in `models.SECRET_FIELDS` are addressable — other
  paths return `400`.
- Supports `add`, `replace`, and `remove` ops. `remove` nulls the
  field; `remove` on `client_secret` is rejected (required).

### `DELETE /.../applications/{app_slug}/secrets/{field}`

- Admin-gated shortcut to clear one optional secret.
- Rejects unknown field names and `client_secret`.

## Test plan

- [x] PATCH non-secret field succeeds and returns secrets-stripped body
- [x] PATCH refuses secret-field paths with `400`
- [x] PATCH preserves existing encrypted secret values on update
- [x] PATCH slug conflict returns `409`; not-found returns `404`
- [x] PATCH secrets is admin-only (`403` for non-admin)
- [x] PATCH secrets encrypts plaintext before SET (verified via
      encrypt mock call args)
- [x] PATCH secrets rejects non-secret paths and `remove` on
      `client_secret`
- [x] DELETE single secret field succeeds for admin, rejects for
      non-admin, rejects unknown / `client_secret`, returns `404`
      when app missing
- [x] `just lint` equivalents clean (ruff, basedpyright, mypy)