### PR TITLE
Refactor: unify team-slug branches in TPS and webhook creates

### DIFF
--- a/src/imbi_api/endpoints/third_party_services.py
+++ b/src/imbi_api/endpoints/third_party_services.py
@@ -150,34 +150,24 @@ async def create_third_party_service(
     graph_props = _serialize_json_fields(props, _SERVICE_JSON_FIELDS)
     create_tpl = props_template(graph_props)
 
-    if data.team_slug:
-        query: str = (
-            'MATCH (o:Organization {{slug: {org_slug}}})'
-            ' MATCH (t:Team {{slug: {team_slug}}})'
-            '-[:BELONGS_TO]->(o)'
-            f' CREATE (s:ThirdPartyService {create_tpl})'
-            ' CREATE (s)-[:BELONGS_TO]->(o)'
-            ' CREATE (s)-[:MANAGED_BY]->(t)'
-            ' RETURN s{{.*, organization: o{{.*}},'
-            ' team: t{{.*}}}} AS service'
-        )
-        params: dict[str, typing.Any] = {
-            'org_slug': org_slug,
-            'team_slug': data.team_slug,
-            **graph_props,
-        }
-    else:
-        query = (
-            'MATCH (o:Organization {{slug: {org_slug}}})'
-            f' CREATE (s:ThirdPartyService {create_tpl})'
-            ' CREATE (s)-[:BELONGS_TO]->(o)'
-            ' RETURN s{{.*, organization: o{{.*}},'
-            ' team: null}} AS service'
-        )
-        params = {
-            'org_slug': org_slug,
-            **graph_props,
-        }
+    query: str = (
+        'MATCH (o:Organization {{slug: {org_slug}}})'
+        ' OPTIONAL MATCH (t:Team {{slug: {team_slug}}})'
+        '-[:BELONGS_TO]->(o)'
+        ' WITH o, t'
+        ' WHERE {team_slug} IS NULL OR t IS NOT NULL'
+        f' CREATE (s:ThirdPartyService {create_tpl})'
+        ' CREATE (s)-[:BELONGS_TO]->(o)'
+        ' FOREACH (_ IN CASE WHEN t IS NULL THEN [] ELSE [1] END |'
+        ' CREATE (s)-[:MANAGED_BY]->(t))'
+        ' RETURN s{{.*, organization: o{{.*}},'
+        ' team: t{{.*}}}} AS service'
+    )
+    params: dict[str, typing.Any] = {
+        'org_slug': org_slug,
+        'team_slug': data.team_slug,
+        **graph_props,
+    }
 
     try:
         records = await db.execute(

--- a/src/imbi_api/endpoints/webhooks.py
+++ b/src/imbi_api/endpoints/webhooks.py
@@ -149,39 +149,27 @@ async def create_webhook(
         )
     rule_clauses, rules_params = _rules_create_clauses(rule_dicts)
 
-    if data.third_party_service_slug:
-        write_query: str = (
-            'MATCH (o:Organization {{slug: {org_slug}}})'
-            ' MATCH (tps:ThirdPartyService'
-            ' {{slug: {tps_slug}}})-[:BELONGS_TO]->(o)'
-            f' CREATE (w:Webhook {create_tpl})'
-            ' CREATE (w)-[:BELONGS_TO]->(o)'
-            ' CREATE (w)-[impl:IMPLEMENTED_BY]->(tps)'
-            ' SET impl.identifier_selector'
-            ' = {identifier_selector}'
-            + rule_clauses
-            + ' RETURN w.slug AS slug'
-        )
-        write_params: dict[str, typing.Any] = {
-            'org_slug': org_slug,
-            'tps_slug': data.third_party_service_slug,
-            **props,
-            'identifier_selector': data.identifier_selector,
-            **rules_params,
-        }
-    else:
-        write_query = (
-            'MATCH (o:Organization {{slug: {org_slug}}})'
-            f' CREATE (w:Webhook {create_tpl})'
-            ' CREATE (w)-[:BELONGS_TO]->(o)'
-            + rule_clauses
-            + ' RETURN w.slug AS slug'
-        )
-        write_params = {
-            'org_slug': org_slug,
-            **props,
-            **rules_params,
-        }
+    write_query: str = (
+        'MATCH (o:Organization {{slug: {org_slug}}})'
+        ' OPTIONAL MATCH (tps:ThirdPartyService'
+        ' {{slug: {tps_slug}}})-[:BELONGS_TO]->(o)'
+        ' WITH o, tps'
+        ' WHERE {tps_slug} IS NULL OR tps IS NOT NULL'
+        f' CREATE (w:Webhook {create_tpl})'
+        ' CREATE (w)-[:BELONGS_TO]->(o)'
+        ' FOREACH (_ IN CASE WHEN tps IS NULL THEN [] ELSE [1] END |'
+        ' CREATE (w)-[:IMPLEMENTED_BY'
+        ' {{identifier_selector: {identifier_selector}}}]->(tps))'
+        + rule_clauses
+        + ' RETURN w.slug AS slug'
+    )
+    write_params: dict[str, typing.Any] = {
+        'org_slug': org_slug,
+        'tps_slug': data.third_party_service_slug,
+        **props,
+        'identifier_selector': data.identifier_selector,
+        **rules_params,
+    }
 
     try:
         write_records = await db.execute(
@@ -200,6 +188,14 @@ async def create_webhook(
         ) from e
 
     if not write_records:
+        if data.third_party_service_slug:
+            raise fastapi.HTTPException(
+                status_code=404,
+                detail=(
+                    f'Organization {org_slug!r} or third-party service '
+                    f'{data.third_party_service_slug!r} not found'
+                ),
+            )
         raise fastapi.HTTPException(
             status_code=404,
             detail=f'Organization {org_slug!r} not found',

--- a/tests/endpoints/test_webhooks.py
+++ b/tests/endpoints/test_webhooks.py
@@ -237,6 +237,28 @@ class WebhookEndpointsTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 404)
         self.assertIn('not found', response.json()['detail'])
 
+    def test_create_third_party_service_not_found(self) -> None:
+        self.mock_db.execute.return_value = []
+        with (
+            self._patch_encryption(),
+            mock.patch(
+                'imbi_common.graph.parse_agtype',
+                side_effect=lambda x: x,
+            ),
+        ):
+            payload = dict(self.webhook_create_json)
+            payload['third_party_service_slug'] = 'nonexistent'
+            payload['identifier_selector'] = '$.repository.full_name'
+            response = self.client.post(
+                '/organizations/engineering/webhooks/',
+                json=payload,
+            )
+
+        self.assertEqual(response.status_code, 404)
+        detail = response.json()['detail']
+        self.assertIn('not found', detail)
+        self.assertIn('nonexistent', detail)
+
     def test_create_missing_name(self) -> None:
         response = self.client.post(
             '/organizations/engineering/webhooks/',


### PR DESCRIPTION
## Summary

The create handlers in `third_party_services.py` and `webhooks.py` each
held two near-identical copies of their Cypher query — one for the
"team / tps supplied" path and one without — selected by a Python `if`.
This PR collapses them to a single query using
`OPTIONAL MATCH (related {slug: {slug}})` plus the
`FOREACH (_ IN CASE WHEN related IS NULL THEN [] ELSE [1] END | CREATE ...)`
pattern recommended in the refactor follow-up doc (§2.2).

- `create_third_party_service`: one query creates the `:BELONGS_TO`
  edge unconditionally and the `:MANAGED_BY` edge only when the
  optional `Team` match hit. A `WITH ... WHERE {team_slug} IS NULL OR
  t IS NOT NULL` guard keeps the existing 404 when `team_slug` is
  provided but no team matches.
- `create_webhook`: same shape for `ThirdPartyService`. Because AGE
  rejects `SET rel.prop = ...` on a relationship variable declared
  inside `FOREACH`, the `identifier_selector` is now attached inline
  via the edge property map
  (`CREATE (w)-[:IMPLEMENTED_BY {identifier_selector: {identifier_selector}}]->(tps)`).
- Adds `test_create_third_party_service_not_found` to cover the
  "tps_slug supplied but no matching service" path.

## AGE compatibility notes

- `OPTIONAL MATCH` with a `null` parameter (`{slug: null}`) matches no
  rows and leaves the variable `NULL` — confirmed via the existing
  `list_third_party_services` / `list_webhooks` queries which already
  project `t{.*}` / `tps{.*}` yielding `null` on misses.
- `FOREACH (_ IN CASE WHEN x IS NULL THEN [] ELSE [1] END | ...)` is
  the documented AGE-safe idiom for a conditional write — the inner
  body runs zero or one time.
- Parameters are serialized via `imbi_common.graph.client._cypher_param`
  which maps Python `None` to the Cypher literal `null`, so `{team_slug}
  IS NULL` evaluates correctly at query time.
- I was not able to run the query against the live AGE container from
  this agent sandbox (shared-container writes require user approval),
  so verification is test-based. If FOREACH turns out to have a quirk
  on the deployed AGE version, the fallback is to keep the unified
  Python code but split the query string on `team_slug is None` before
  `db.execute`; the handler shape would not change.

## Test plan

- [x] `uv run pytest tests/endpoints/test_third_party_services.py tests/endpoints/test_webhooks.py` — 78 passed
- [x] `uv run ruff check` / `ruff format` — clean
- [x] `uv run basedpyright src/ tests/` — 0 errors
- [x] `uv run mypy --config-file mypy.ini src/imbi_api` — no issues
- [ ] Integration run against live Postgres+AGE (not executed in the
      agent sandbox; please verify in CI or locally via `just test`).