### PR TITLE
Atomically revoke refresh tokens to close concurrent-refresh race

### DIFF
--- a/src/imbi_api/auth/tokens.py
+++ b/src/imbi_api/auth/tokens.py
@@ -11,6 +11,7 @@ import logging
 import typing
 
 import jwt
+import nanoid
 from imbi_common import graph
 from imbi_common.auth import core
 
@@ -28,17 +29,21 @@ class PrincipalNotFoundError(Exception):
 _USER_CREATE: typing.LiteralString = (
     'MATCH (p:User {{email: {principal_id}}}) '
     'CREATE (at:TokenMetadata {{'
+    'id: {access_id}, '
     'jti: {access_jti}, '
     "token_type: 'access', "
     'issued_at: {issued_at}, '
     'expires_at: {access_exp}, '
+    'created_at: {issued_at}, '
     'revoked: false'
     '}})-[:ISSUED_TO]->(p) '
     'CREATE (rt:TokenMetadata {{'
+    'id: {refresh_id}, '
     'jti: {refresh_jti}, '
     "token_type: 'refresh', "
     'issued_at: {issued_at}, '
     'expires_at: {refresh_exp}, '
+    'created_at: {issued_at}, '
     'revoked: false'
     '}})-[:ISSUED_TO]->(p) '
     'RETURN count(p) AS principal_count'
@@ -46,17 +51,21 @@ _USER_CREATE: typing.LiteralString = (
 _SERVICE_ACCOUNT_CREATE: typing.LiteralString = (
     'MATCH (p:ServiceAccount {{slug: {principal_id}}}) '
     'CREATE (at:TokenMetadata {{'
+    'id: {access_id}, '
     'jti: {access_jti}, '
     "token_type: 'access', "
     'issued_at: {issued_at}, '
     'expires_at: {access_exp}, '
+    'created_at: {issued_at}, '
     'revoked: false'
     '}})-[:ISSUED_TO]->(p) '
     'CREATE (rt:TokenMetadata {{'
+    'id: {refresh_id}, '
     'jti: {refresh_jti}, '
     "token_type: 'refresh', "
     'issued_at: {issued_at}, '
     'expires_at: {refresh_exp}, '
+    'created_at: {issued_at}, '
     'revoked: false'
     '}})-[:ISSUED_TO]->(p) '
     'RETURN count(p) AS principal_count'
@@ -139,7 +148,9 @@ async def issue_token_pair(
         create_query,
         {
             'principal_id': principal_id,
+            'access_id': nanoid.generate(),
             'access_jti': access_claims['jti'],
+            'refresh_id': nanoid.generate(),
             'refresh_jti': refresh_claims['jti'],
             'issued_at': now.isoformat(),
             'access_exp': access_expires_at.isoformat(),

--- a/src/imbi_api/endpoints/auth.py
+++ b/src/imbi_api/endpoints/auth.py
@@ -503,7 +503,7 @@ async def refresh_token(
     # the second gets ``revoked_count = 0`` and a clean 401 instead
     # of AGE raising ``Entity failed to be updated: 3`` on the
     # concurrently-updated vertex.
-    revoke_query = (
+    revoke_query: typing.LiteralString = (
         'MATCH (n:TokenMetadata {{jti: {jti}}}) '
         "WHERE n.revoked = false AND n.token_type = 'refresh' "
         'SET n.revoked = true, n.revoked_at = {revoked_at} '

--- a/src/imbi_api/endpoints/auth.py
+++ b/src/imbi_api/endpoints/auth.py
@@ -496,12 +496,32 @@ async def refresh_token(
             status_code=401, detail='Invalid token type'
         )
 
-    # Check if refresh token is revoked
-    token_results = await db.match(
-        models.TokenMetadata, {'jti': payload['jti']}
+    # Atomically revoke the refresh token. Matching on
+    # ``revoked = false`` in the same statement as the SET closes
+    # the TOCTOU gap between the check and the write: when two
+    # refreshes race on the same token, only the first matches, so
+    # the second gets ``revoked_count = 0`` and a clean 401 instead
+    # of AGE raising ``Entity failed to be updated: 3`` on the
+    # concurrently-updated vertex.
+    revoke_query = (
+        'MATCH (n:TokenMetadata {{jti: {jti}}}) '
+        "WHERE n.revoked = false AND n.token_type = 'refresh' "
+        'SET n.revoked = true, n.revoked_at = {revoked_at} '
+        'RETURN count(n) AS revoked_count'
     )
-    token_meta = token_results[0] if token_results else None
-    if not token_meta or token_meta.revoked:
+    revoke_records = await db.execute(
+        revoke_query,
+        {
+            'jti': payload['jti'],
+            'revoked_at': datetime.datetime.now(datetime.UTC).isoformat(),
+        },
+        columns=['revoked_count'],
+    )
+    revoked = 0
+    if revoke_records:
+        raw = graph.parse_agtype(revoke_records[0].get('revoked_count'))
+        revoked = int(raw or 0)
+    if revoked == 0:
         LOGGER.warning(
             'Token refresh failed: token revoked or not found (jti=%s)',
             payload['jti'],
@@ -510,11 +530,6 @@ async def refresh_token(
             status_code=401,
             detail='Refresh token has been revoked',
         )
-
-    # Phase 5: Revoke old refresh token (token rotation)
-    token_meta.revoked = True
-    token_meta.revoked_at = datetime.datetime.now(datetime.UTC)
-    await db.merge(token_meta, match_on=['jti'])
 
     # Resolve principal (user or service account)
     subject = payload['sub']

--- a/tests/auth/test_authentication.py
+++ b/tests/auth/test_authentication.py
@@ -318,36 +318,17 @@ class TokenRefreshEndpointTestCase(unittest.TestCase):
         refresh_token = core.create_refresh_token(
             self.test_user.email, auth_settings=self.auth_settings
         )
-        payload = jwt.decode(
-            refresh_token,
-            self.auth_settings.jwt_secret,
-            algorithms=[self.auth_settings.jwt_algorithm],
-        )
-        refresh_jti = payload['jti']
 
-        # Create non-revoked token metadata
-        token_metadata = models.TokenMetadata(
-            jti=refresh_jti,
-            token_type='refresh',
-            issued_at=datetime.datetime.now(datetime.UTC),
-            expires_at=datetime.datetime.now(datetime.UTC)
-            + datetime.timedelta(days=30),
-            revoked=False,
-            user=self.test_user,
-        )
-
-        # match() returns token metadata first, then user
-        self.mock_db.match.side_effect = [
-            [token_metadata],
-            [self.test_user],
-        ]
-        # merge() for revoking old token
-        self.mock_db.merge.return_value = None
-        # execute() runs the atomic MATCH/CREATE inside
-        # issue_token_pair that persists token metadata and returns
-        # principal_count.
-        self.mock_db.execute.return_value = [
-            {'principal_count': 1},
+        # Token metadata lookup is folded into the atomic revoke, so
+        # only the user match remains.
+        self.mock_db.match.return_value = [self.test_user]
+        # execute() is called twice: first for the atomic revoke
+        # (revoked_count=1 means the row was unrevoked and is now
+        # revoked), then for the MATCH/CREATE inside issue_token_pair
+        # that persists token metadata and returns principal_count.
+        self.mock_db.execute.side_effect = [
+            [{'revoked_count': 1}],
+            [{'principal_count': 1}],
         ]
 
         with mock.patch(
@@ -425,25 +406,10 @@ class TokenRefreshEndpointTestCase(unittest.TestCase):
         refresh_token = core.create_refresh_token(
             self.test_user.email, auth_settings=self.auth_settings
         )
-        payload = jwt.decode(
-            refresh_token,
-            self.auth_settings.jwt_secret,
-            algorithms=[self.auth_settings.jwt_algorithm],
-        )
-        refresh_jti = payload['jti']
 
-        # Create revoked token metadata
-        revoked_token = models.TokenMetadata(
-            jti=refresh_jti,
-            token_type='refresh',
-            issued_at=datetime.datetime.now(datetime.UTC),
-            expires_at=datetime.datetime.now(datetime.UTC)
-            + datetime.timedelta(days=30),
-            revoked=True,
-            user=self.test_user,
-        )
-
-        self.mock_db.match.return_value = [revoked_token]
+        # Atomic revoke returns 0 when the token is already revoked
+        # (or the jti doesn't match any TokenMetadata vertex).
+        self.mock_db.execute.return_value = [{'revoked_count': 0}]
 
         with mock.patch(
             'imbi_api.settings.get_auth_settings'

--- a/tests/endpoints/test_auth.py
+++ b/tests/endpoints/test_auth.py
@@ -1276,39 +1276,17 @@ class TokenRefreshTestCase(unittest.TestCase):
             test_user.email,
             auth_settings=auth_settings,
         )
-        payload = jwt.decode(
-            refresh_token,
-            auth_settings.jwt_secret,
-            algorithms=[auth_settings.jwt_algorithm],
-        )
-        refresh_jti = payload['jti']
 
-        token_meta = models.TokenMetadata(
-            jti=refresh_jti,
-            token_type='refresh',
-            issued_at=datetime.datetime.now(datetime.UTC),
-            expires_at=(
-                datetime.datetime.now(datetime.UTC)
-                + datetime.timedelta(
-                    seconds=auth_settings.refresh_token_expire_seconds
-                )
-            ),
-            user=test_user,
-            revoked=False,
-        )
-
-        # First match: token metadata found
-        # Second match: user found
-        self.mock_db.match.side_effect = [
-            [token_meta],
-            [test_user],
-        ]
-        self.mock_db.merge.return_value = None
-        # execute() runs the atomic MATCH/CREATE inside
-        # issue_token_pair that persists token metadata and returns
-        # principal_count.
-        self.mock_db.execute.return_value = [
-            {'principal_count': 1},
+        # Token metadata lookup is folded into the atomic revoke, so
+        # only the user match remains.
+        self.mock_db.match.return_value = [test_user]
+        # execute() is called twice: first for the atomic revoke
+        # (revoked_count=1 means the row was unrevoked and is now
+        # revoked), then for the MATCH/CREATE inside issue_token_pair
+        # that persists token metadata and returns principal_count.
+        self.mock_db.execute.side_effect = [
+            [{'revoked_count': 1}],
+            [{'principal_count': 1}],
         ]
 
         with mock.patch(
@@ -1429,46 +1407,18 @@ class TokenRefreshTestCase(unittest.TestCase):
         """Test token refresh with revoked token."""
         from imbi_common.auth import core
 
-        from imbi_api import models
-
         auth_settings = settings.Auth(
             jwt_secret='test-secret-key-min-32-chars-long',
         )
 
-        test_user = models.User(
-            email='test@example.com',
-            display_name='Test User',
-            is_active=True,
-            password_hash=None,
-            created_at=datetime.datetime.now(datetime.UTC),
-        )
-
         refresh_token = core.create_refresh_token(
-            test_user.email,
+            'test@example.com',
             auth_settings=auth_settings,
         )
-        payload = jwt.decode(
-            refresh_token,
-            auth_settings.jwt_secret,
-            algorithms=[auth_settings.jwt_algorithm],
-        )
-        refresh_jti = payload['jti']
 
-        token_meta = models.TokenMetadata(
-            jti=refresh_jti,
-            token_type='refresh',
-            issued_at=datetime.datetime.now(datetime.UTC),
-            expires_at=(
-                datetime.datetime.now(datetime.UTC)
-                + datetime.timedelta(
-                    seconds=auth_settings.refresh_token_expire_seconds
-                )
-            ),
-            user=test_user,
-            revoked=True,
-        )
-
-        self.mock_db.match.return_value = [token_meta]
+        # Atomic revoke returns 0 when the token is already revoked
+        # (or the jti doesn't match any TokenMetadata vertex).
+        self.mock_db.execute.return_value = [{'revoked_count': 0}]
 
         with mock.patch(
             'imbi_api.settings.get_auth_settings',
@@ -1507,33 +1457,11 @@ class TokenRefreshTestCase(unittest.TestCase):
             test_user.email,
             auth_settings=auth_settings,
         )
-        payload = jwt.decode(
-            refresh_token,
-            auth_settings.jwt_secret,
-            algorithms=[auth_settings.jwt_algorithm],
-        )
-        refresh_jti = payload['jti']
 
-        token_meta = models.TokenMetadata(
-            jti=refresh_jti,
-            token_type='refresh',
-            issued_at=datetime.datetime.now(datetime.UTC),
-            expires_at=(
-                datetime.datetime.now(datetime.UTC)
-                + datetime.timedelta(
-                    seconds=auth_settings.refresh_token_expire_seconds
-                )
-            ),
-            user=test_user,
-            revoked=False,
-        )
-
-        # First match: token metadata, second: user
-        self.mock_db.match.side_effect = [
-            [token_meta],
-            [test_user],
-        ]
-        self.mock_db.merge.return_value = None
+        # Atomic revoke succeeds (token is valid), then the user
+        # match returns the inactive user.
+        self.mock_db.match.return_value = [test_user]
+        self.mock_db.execute.return_value = [{'revoked_count': 1}]
 
         with mock.patch(
             'imbi_api.settings.get_auth_settings',


### PR DESCRIPTION
## Summary

Two concurrent `POST /auth/token/refresh` calls with the same refresh token both passed the "is this token revoked?" check before either committed the revocation. The first `merge()` won; the second surfaced as:

```
psycopg.errors.InternalError_: Entity failed to be updated: 3
```

That's PostgreSQL's `TM_Updated` (enum value 3), raised in Apache AGE's `update_entity_tuple()` when `heap_lock_tuple` / `table_tuple_update` find the row was modified by a concurrently-committed transaction. It surfaces whenever a client (e.g. a React app fanning out parallel 401 retries) races refresh calls on the same token.

## Changes

- **Atomic revoke in `refresh_token`.** Replace `match → mutate → merge` with a single Cypher statement that matches on `revoked = false AND token_type = 'refresh'` and SETs `revoked = true` in one go. Use `count(n)` to detect the race: only the first caller gets `revoked_count = 1`; the rest get `0` and a clean 401 instead of a 500. Also covers the "jti not found" and "wrong token_type" cases with the same 401 path.
- **Fill in `id` and `created_at` at CREATE time** in `_USER_CREATE` / `_SERVICE_ACCOUNT_CREATE` so the stored `TokenMetadata` vertex matches the Pydantic model (previously Pydantic invented defaults on every `match()`).
- Update the two `TokenRefresh*TestCase` classes to match the new execute-based flow.

## Test plan

- [x] `tests/endpoints/test_auth.py::TokenRefreshTestCase` — 6 passed
- [x] `tests/auth/test_authentication.py::TokenRefreshEndpointTestCase` — 5 passed
- [x] Full auth suite — 189 passed
- [x] ruff + mypy clean on touched files
- [ ] Manual: hit `/auth/token/refresh` with the same refresh token from two clients in parallel; expect one `200` and one `401`, no `500`

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>