### PR TITLE
Add notes and tags endpoints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -217,4 +217,4 @@ url = "https://pypi.org/simple"
 default = true
 
 [tool.uv.sources]
-imbi-common = { git = "https://github.com/AWeber-Imbi/imbi-common.git", rev = "main" }
+imbi-common = { git = "https://github.com/AWeber-Imbi/imbi-common.git", rev = "feature/notes-and-tags" }

--- a/src/imbi_api/auth/seed.py
+++ b/src/imbi_api/auth/seed.py
@@ -227,6 +227,16 @@ STANDARD_PERMISSIONS: list[tuple[str, str, str, str]] = [
         'delete',
         'Delete operations log entries',
     ),
+    # Tag management
+    ('tag:create', 'tag', 'create', 'Create tags'),
+    ('tag:read', 'tag', 'read', 'View tags'),
+    ('tag:write', 'tag', 'write', 'Update tags'),
+    ('tag:delete', 'tag', 'delete', 'Delete tags'),
+    # Note management
+    ('note:create', 'note', 'create', 'Create project notes'),
+    ('note:read', 'note', 'read', 'View project notes'),
+    ('note:write', 'note', 'write', 'Update project notes'),
+    ('note:delete', 'note', 'delete', 'Delete project notes'),
 ]
 
 # Default role definitions
@@ -264,6 +274,13 @@ DEFAULT_ROLES: list[tuple[str, str, str, int, list[str]]] = [
             'upload:read',
             'webhook:read',
             'webhook:update',
+            'tag:create',
+            'tag:read',
+            'tag:write',
+            'note:create',
+            'note:read',
+            'note:write',
+            'note:delete',
         ],
     ),
     (
@@ -285,6 +302,8 @@ DEFAULT_ROLES: list[tuple[str, str, str, int, list[str]]] = [
             'role:read',
             'upload:read',
             'webhook:read',
+            'tag:read',
+            'note:read',
         ],
     ),
 ]

--- a/src/imbi_api/endpoints/notes.py
+++ b/src/imbi_api/endpoints/notes.py
@@ -1,0 +1,566 @@
+"""Project notes with tag support.
+
+Notes are project-scoped via a required ``ATTACHED_TO`` edge and may
+optionally be tagged with org-scoped ``Tag`` nodes via ``TAGGED_WITH``.
+The top-level ``notes_router`` supports cross-project search filtered
+by tag; ``notes_project_router`` handles CRUD scoped to a single
+project.
+"""
+
+import base64
+import datetime
+import logging
+import typing
+import urllib.parse
+
+import fastapi
+import fastapi.responses
+import nanoid
+import pydantic
+from imbi_common import graph
+
+from imbi_api import patch as json_patch
+from imbi_api.auth import permissions
+
+LOGGER = logging.getLogger(__name__)
+
+notes_router = fastapi.APIRouter(tags=['Notes'])
+notes_project_router = fastapi.APIRouter(tags=['Notes'])
+
+DEFAULT_LIMIT: int = 50
+MAX_LIMIT: int = 500
+
+_NOTE_READONLY_PATHS: frozenset[str] = frozenset(
+    [
+        '/id',
+        '/project_id',
+        '/project_slug',
+        '/created_by',
+        '/created_at',
+        '/updated_by',
+        '/updated_at',
+    ]
+)
+
+
+class TagRef(pydantic.BaseModel):
+    name: str
+    slug: str
+
+
+class NoteResponse(pydantic.BaseModel):
+    id: str
+    content: str
+    created_by: str
+    created_at: datetime.datetime
+    updated_by: str | None = None
+    updated_at: datetime.datetime | None = None
+    project_id: str
+    project_slug: str
+    tags: list[TagRef] = []
+
+
+class NoteCreate(pydantic.BaseModel):
+    content: str = pydantic.Field(min_length=1)
+    tags: list[str] = pydantic.Field(
+        default_factory=list,
+        description='Tag slugs to attach. Must already exist in the org.',
+    )
+
+
+class NoteListResponse(pydantic.BaseModel):
+    data: list[NoteResponse]
+
+
+def _encode_cursor(created_at: datetime.datetime, note_id: str) -> str:
+    payload = f'{created_at.isoformat()}|{note_id}'.encode()
+    return base64.urlsafe_b64encode(payload).rstrip(b'=').decode('ascii')
+
+
+def _decode_cursor(
+    cursor: str,
+) -> tuple[datetime.datetime, str] | None:
+    if not cursor:
+        return None
+    padding = '=' * (-len(cursor) % 4)
+    try:
+        raw = base64.urlsafe_b64decode(cursor + padding).decode('utf-8')
+    except (ValueError, UnicodeDecodeError):
+        return None
+    if '|' not in raw:
+        return None
+    ts_str, _, note_id = raw.partition('|')
+    if not note_id:
+        return None
+    try:
+        ts = datetime.datetime.fromisoformat(ts_str)
+    except ValueError:
+        return None
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=datetime.UTC)
+    return ts.astimezone(datetime.UTC), note_id
+
+
+def _build_link_header(
+    request: fastapi.Request, next_cursor: str | None
+) -> str:
+    url = request.url
+    base_params = {
+        k: v for k, v in request.query_params.multi_items() if k != 'cursor'
+    }
+
+    def _url_with(params: dict[str, str]) -> str:
+        base = f'{url.scheme}://{url.netloc}{url.path}'
+        if not params:
+            return base
+        return f'{base}?{urllib.parse.urlencode(params)}'
+
+    links = [f'<{_url_with(base_params)}>; rel="first"']
+    if next_cursor is not None:
+        next_params = dict(base_params)
+        next_params['cursor'] = next_cursor
+        links.append(f'<{_url_with(next_params)}>; rel="next"')
+    return ', '.join(links)
+
+
+def _parse_note_row(record: dict[str, typing.Any]) -> dict[str, typing.Any]:
+    note: dict[str, typing.Any] = graph.parse_agtype(record['n'])
+    project: dict[str, typing.Any] = graph.parse_agtype(record['p'])
+    raw_tags: list[typing.Any] = graph.parse_agtype(record['tags']) or []
+    tags: list[dict[str, str]] = []
+    for t in raw_tags:
+        if not isinstance(t, dict):
+            continue
+        entry = typing.cast(dict[str, typing.Any], t)
+        slug = entry.get('slug')
+        if not slug:
+            continue
+        tags.append(
+            {'name': str(entry.get('name', '')), 'slug': str(slug)},
+        )
+    note['project_id'] = project.get('id', '')
+    note['project_slug'] = project.get('slug', '')
+    note['tags'] = tags
+    return note
+
+
+# Tail fragment used by every query that returns a note. Always runs
+# on ``n, p`` already in scope and emits ``n, p, tags`` columns.
+_TAGS_TAIL: typing.LiteralString = """
+    OPTIONAL MATCH (n)-[:TAGGED_WITH]->(tag:Tag)
+    WITH n, p, collect(CASE WHEN tag IS NOT NULL
+                            THEN tag{{.name, .slug}}
+                            END) AS raw_tags
+    WITH n, p, [t IN raw_tags WHERE t IS NOT NULL] AS tags
+    RETURN n, p, tags
+"""
+
+
+async def _validate_tag_slugs(
+    db: graph.Pool, org_slug: str, tag_slugs: list[str]
+) -> None:
+    if not tag_slugs:
+        return
+    query: typing.LiteralString = """
+    MATCH (o:Organization {{slug: {org_slug}}})
+    UNWIND {slugs} AS tag_slug
+    OPTIONAL MATCH (t:Tag {{slug: tag_slug}})-[:BELONGS_TO]->(o)
+    RETURN tag_slug, t IS NOT NULL AS found
+    """
+    records = await db.execute(
+        query,
+        {'org_slug': org_slug, 'slugs': tag_slugs},
+        columns=['tag_slug', 'found'],
+    )
+    missing = [
+        graph.parse_agtype(r['tag_slug'])
+        for r in records
+        if not graph.parse_agtype(r['found'])
+    ]
+    if missing:
+        raise fastapi.HTTPException(
+            status_code=422,
+            detail=f'Tag slug(s) not found: {sorted(missing)!r}',
+        )
+
+
+@notes_project_router.post('/', status_code=201, response_model=NoteResponse)
+async def create_note(
+    org_slug: str,
+    project_id: str,
+    data: NoteCreate,
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(permissions.require_permission('note:create')),
+    ],
+) -> dict[str, typing.Any]:
+    """Create a note attached to a project, optionally with tags."""
+    tag_slugs = list(dict.fromkeys(data.tags))
+    await _validate_tag_slugs(db, org_slug, tag_slugs)
+
+    now = datetime.datetime.now(datetime.UTC)
+    note_id = nanoid.generate()
+    params: dict[str, typing.Any] = {
+        'org_slug': org_slug,
+        'project_id': project_id,
+        'id': note_id,
+        'content': data.content,
+        'created_by': auth.principal_name,
+        'created_at': now.isoformat(),
+        'tag_slugs': tag_slugs,
+    }
+    query: str = (
+        """
+    MATCH (p:Project {{id: {project_id}}})
+          -[:OWNED_BY]->(:Team)
+          -[:BELONGS_TO]->(o:Organization {{slug: {org_slug}}})
+    CREATE (n:Note {{
+        id: {id},
+        content: {content},
+        created_by: {created_by},
+        created_at: {created_at}
+    }})
+    CREATE (n)-[:ATTACHED_TO]->(p)
+    WITH n, p, o
+    UNWIND (CASE WHEN size({tag_slugs}) = 0 THEN [null]
+                 ELSE {tag_slugs} END) AS tag_slug
+    OPTIONAL MATCH (tag:Tag {{slug: tag_slug}})-[:BELONGS_TO]->(o)
+    FOREACH (_ IN CASE WHEN tag IS NOT NULL THEN [1] ELSE [] END |
+        CREATE (n)-[:TAGGED_WITH]->(tag)
+    )
+    WITH DISTINCT n, p
+    """
+        + _TAGS_TAIL
+    )
+    records = await db.execute(query, params, columns=['n', 'p', 'tags'])
+    if not records:
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail=f'Project {project_id!r} not found',
+        )
+    return _parse_note_row(records[0])
+
+
+async def _list_notes_impl(
+    *,
+    request: fastapi.Request,
+    db: graph.Pool,
+    org_slug: str,
+    project_id: str | None,
+    tag_slug: str | None,
+    limit: int,
+    cursor: str | None,
+) -> fastapi.Response:
+    if limit < 1 or limit > MAX_LIMIT:
+        raise fastapi.HTTPException(
+            status_code=400,
+            detail=f'limit must be 1..{MAX_LIMIT}',
+        )
+
+    params: dict[str, typing.Any] = {
+        'org_slug': org_slug,
+        'row_limit': limit + 1,
+    }
+    project_predicate = ''
+    if project_id is not None:
+        project_predicate = ' AND p.id = {project_id}'
+        params['project_id'] = project_id
+
+    tag_match = ''
+    if tag_slug is not None:
+        tag_match = (
+            ' MATCH (n)-[:TAGGED_WITH]->'
+            '(:Tag {{slug: {tag_slug}}})-[:BELONGS_TO]->(o)'
+        )
+        params['tag_slug'] = tag_slug
+
+    cursor_clause = ''
+    if cursor is not None:
+        decoded = _decode_cursor(cursor)
+        if decoded is None:
+            raise fastapi.HTTPException(
+                status_code=400, detail='Invalid cursor'
+            )
+        cursor_ts, cursor_id = decoded
+        cursor_clause = (
+            ' WHERE n.created_at < {cursor_ts}'
+            ' OR (n.created_at = {cursor_ts} AND n.id < {cursor_id})'
+        )
+        params['cursor_ts'] = cursor_ts.isoformat()
+        params['cursor_id'] = cursor_id
+
+    query: str = (
+        """
+    MATCH (o:Organization {{slug: {org_slug}}})
+    MATCH (n:Note)-[:ATTACHED_TO]->(p:Project)
+          -[:OWNED_BY]->(:Team)-[:BELONGS_TO]->(o)
+    WHERE 1 = 1"""
+        + project_predicate
+        + tag_match
+        + cursor_clause
+        + """
+    WITH DISTINCT n, p
+    ORDER BY n.created_at DESC, n.id DESC
+    LIMIT {row_limit}
+    """
+        + _TAGS_TAIL
+    )
+
+    records = await db.execute(query, params, columns=['n', 'p', 'tags'])
+    next_cursor: str | None = None
+    parsed = [_parse_note_row(r) for r in records]
+    if len(parsed) > limit:
+        parsed = parsed[:limit]
+        last = parsed[-1]
+        last_ts = last['created_at']
+        if isinstance(last_ts, str):
+            last_ts = datetime.datetime.fromisoformat(last_ts)
+        next_cursor = _encode_cursor(last_ts, last['id'])
+
+    adapter = pydantic.TypeAdapter(list[NoteResponse])
+    response = fastapi.responses.JSONResponse(
+        {
+            'data': adapter.dump_python(
+                [NoteResponse.model_validate(n) for n in parsed],
+                mode='json',
+            )
+        }
+    )
+    response.headers['Link'] = _build_link_header(request, next_cursor)
+    return response
+
+
+@notes_router.get('/', response_model=NoteListResponse)
+async def list_notes(
+    request: fastapi.Request,
+    org_slug: str,
+    db: graph.Pool,
+    _auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(permissions.require_permission('note:read')),
+    ],
+    limit: int = DEFAULT_LIMIT,
+    cursor: str | None = None,
+    tag: str | None = None,
+    project_id: str | None = None,
+) -> fastapi.Response:
+    """Cross-project note search. Filter by tag slug and/or project id."""
+    return await _list_notes_impl(
+        request=request,
+        db=db,
+        org_slug=org_slug,
+        project_id=project_id,
+        tag_slug=tag,
+        limit=limit,
+        cursor=cursor,
+    )
+
+
+@notes_project_router.get('/', response_model=NoteListResponse)
+async def list_project_notes(
+    request: fastapi.Request,
+    org_slug: str,
+    project_id: str,
+    db: graph.Pool,
+    _auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(permissions.require_permission('note:read')),
+    ],
+    limit: int = DEFAULT_LIMIT,
+    cursor: str | None = None,
+    tag: str | None = None,
+) -> fastapi.Response:
+    """List notes attached to a specific project."""
+    return await _list_notes_impl(
+        request=request,
+        db=db,
+        org_slug=org_slug,
+        project_id=project_id,
+        tag_slug=tag,
+        limit=limit,
+        cursor=cursor,
+    )
+
+
+async def _fetch_note(
+    db: graph.Pool,
+    org_slug: str,
+    project_id: str,
+    note_id: str,
+) -> dict[str, typing.Any] | None:
+    query: str = (
+        """
+    MATCH (n:Note {{id: {note_id}}})
+          -[:ATTACHED_TO]->(p:Project {{id: {project_id}}})
+          -[:OWNED_BY]->(:Team)
+          -[:BELONGS_TO]->(:Organization {{slug: {org_slug}}})
+    WITH DISTINCT n, p
+    """
+        + _TAGS_TAIL
+    )
+    records = await db.execute(
+        query,
+        {
+            'note_id': note_id,
+            'project_id': project_id,
+            'org_slug': org_slug,
+        },
+        columns=['n', 'p', 'tags'],
+    )
+    if not records:
+        return None
+    return _parse_note_row(records[0])
+
+
+@notes_project_router.get('/{note_id}', response_model=NoteResponse)
+async def get_note(
+    org_slug: str,
+    project_id: str,
+    note_id: str,
+    db: graph.Pool,
+    _auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(permissions.require_permission('note:read')),
+    ],
+) -> dict[str, typing.Any]:
+    """Retrieve a single note."""
+    note = await _fetch_note(db, org_slug, project_id, note_id)
+    if note is None:
+        raise fastapi.HTTPException(
+            status_code=404, detail=f'Note {note_id!r} not found'
+        )
+    return note
+
+
+class NoteUpdate(pydantic.BaseModel):
+    content: str | None = pydantic.Field(default=None, min_length=1)
+    tags: list[str] | None = None
+
+
+@notes_project_router.patch('/{note_id}', response_model=NoteResponse)
+async def patch_note(
+    org_slug: str,
+    project_id: str,
+    note_id: str,
+    operations: list[json_patch.PatchOperation],
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(permissions.require_permission('note:write')),
+    ],
+) -> dict[str, typing.Any]:
+    """Update note content and/or tag attachments via JSON Patch."""
+    existing = await _fetch_note(db, org_slug, project_id, note_id)
+    if existing is None:
+        raise fastapi.HTTPException(
+            status_code=404, detail=f'Note {note_id!r} not found'
+        )
+
+    current = {
+        'content': existing['content'],
+        'tags': [t['slug'] for t in existing.get('tags', [])],
+    }
+    patched = json_patch.apply_patch(current, operations, _NOTE_READONLY_PATHS)
+    try:
+        update = NoteUpdate(**patched)
+    except pydantic.ValidationError as e:
+        raise fastapi.HTTPException(
+            status_code=400,
+            detail=f'Validation error: {e.errors()}',
+        ) from e
+
+    new_content = (
+        update.content if update.content is not None else existing['content']
+    )
+    replace_tags = update.tags is not None
+    new_tags: list[str] = (
+        list(dict.fromkeys(update.tags))
+        if update.tags is not None
+        else [t['slug'] for t in existing.get('tags', [])]
+    )
+    if replace_tags:
+        await _validate_tag_slugs(db, org_slug, new_tags)
+
+    now = datetime.datetime.now(datetime.UTC)
+    params: dict[str, typing.Any] = {
+        'org_slug': org_slug,
+        'project_id': project_id,
+        'note_id': note_id,
+        'content': new_content,
+        'updated_by': auth.principal_name,
+        'updated_at': now.isoformat(),
+        'tag_slugs': new_tags,
+    }
+
+    tag_replacement = ''
+    if replace_tags:
+        tag_replacement = """
+        WITH DISTINCT n, p, o
+        OPTIONAL MATCH (n)-[tw:TAGGED_WITH]->(:Tag)
+        DELETE tw
+        WITH DISTINCT n, p, o
+        UNWIND (CASE WHEN size({tag_slugs}) = 0 THEN [null]
+                     ELSE {tag_slugs} END) AS tag_slug
+        OPTIONAL MATCH (tag:Tag {{slug: tag_slug}})-[:BELONGS_TO]->(o)
+        FOREACH (_ IN CASE WHEN tag IS NOT NULL THEN [1] ELSE [] END |
+            CREATE (n)-[:TAGGED_WITH]->(tag)
+        )
+        """
+
+    query: str = (
+        """
+    MATCH (n:Note {{id: {note_id}}})
+          -[:ATTACHED_TO]->(p:Project {{id: {project_id}}})
+          -[:OWNED_BY]->(:Team)
+          -[:BELONGS_TO]->(o:Organization {{slug: {org_slug}}})
+    SET n.content = {content},
+        n.updated_by = {updated_by},
+        n.updated_at = {updated_at}
+    """
+        + tag_replacement
+        + """
+    WITH DISTINCT n, p
+    """
+        + _TAGS_TAIL
+    )
+    records = await db.execute(query, params, columns=['n', 'p', 'tags'])
+    if not records:
+        raise fastapi.HTTPException(
+            status_code=404, detail=f'Note {note_id!r} not found'
+        )
+    return _parse_note_row(records[0])
+
+
+@notes_project_router.delete('/{note_id}', status_code=204)
+async def delete_note(
+    org_slug: str,
+    project_id: str,
+    note_id: str,
+    db: graph.Pool,
+    _auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(permissions.require_permission('note:delete')),
+    ],
+) -> None:
+    """Delete a note."""
+    query: typing.LiteralString = """
+    MATCH (n:Note {{id: {note_id}}})
+          -[:ATTACHED_TO]->(p:Project {{id: {project_id}}})
+          -[:OWNED_BY]->(:Team)
+          -[:BELONGS_TO]->(:Organization {{slug: {org_slug}}})
+    DETACH DELETE n
+    RETURN n
+    """
+    records = await db.execute(
+        query,
+        {
+            'note_id': note_id,
+            'project_id': project_id,
+            'org_slug': org_slug,
+        },
+    )
+    if not records:
+        raise fastapi.HTTPException(
+            status_code=404, detail=f'Note {note_id!r} not found'
+        )

--- a/src/imbi_api/endpoints/organizations.py
+++ b/src/imbi_api/endpoints/organizations.py
@@ -15,10 +15,12 @@ from imbi_api.relationships import build_relationships
 
 from .environments import environments_router
 from .link_definitions import link_definitions_router
+from .notes import notes_project_router, notes_router
 from .operations_log import operations_log_project_router
 from .project_types import project_types_router
 from .projects import projects_router
 from .releases import releases_router
+from .tags import tags_router
 from .teams import teams_router
 from .third_party_services import third_party_services_router
 from .webhooks import project_services_router, webhooks_router
@@ -68,6 +70,18 @@ organizations_router.include_router(
 organizations_router.include_router(
     project_services_router,
     prefix='/{org_slug}/projects/{project_id}/services',
+)
+organizations_router.include_router(
+    tags_router,
+    prefix='/{org_slug}/tags',
+)
+organizations_router.include_router(
+    notes_router,
+    prefix='/{org_slug}/notes',
+)
+organizations_router.include_router(
+    notes_project_router,
+    prefix='/{org_slug}/projects/{project_id}/notes',
 )
 
 

--- a/src/imbi_api/endpoints/tags.py
+++ b/src/imbi_api/endpoints/tags.py
@@ -1,0 +1,322 @@
+"""Tag management endpoints.
+
+Tags are org-scoped, slug-identified labels. Today they attach to
+``Note`` nodes via ``TAGGED_WITH``; the edge type is generic so
+future work can attach the same tags to ``Project``/``Service``
+nodes without schema changes.
+"""
+
+import datetime
+import logging
+import typing
+
+import fastapi
+import nanoid
+import psycopg.errors
+import pydantic
+import slugify
+from imbi_common import graph, models
+
+from imbi_api import patch as json_patch
+from imbi_api.auth import permissions
+from imbi_api.relationships import build_relationships
+
+LOGGER = logging.getLogger(__name__)
+
+tags_router = fastapi.APIRouter(tags=['Tags'])
+
+
+class TagCreate(pydantic.BaseModel):
+    name: str
+    slug: str | None = None
+    description: str | None = None
+
+
+class OrganizationRef(pydantic.BaseModel):
+    name: str
+    slug: str
+
+
+class TagResponse(pydantic.BaseModel):
+    id: str
+    name: str
+    slug: str
+    description: str | None = None
+    created_at: datetime.datetime | None = None
+    updated_at: datetime.datetime | None = None
+    organization: OrganizationRef
+    relationships: dict[str, models.RelationshipLink] | None = None
+
+
+def _tag_relationships(
+    org_slug: str,
+    tag_slug: str,
+    note_count: int,
+) -> dict[str, models.RelationshipLink]:
+    return build_relationships(
+        f'/api/organizations/{org_slug}/tags/{tag_slug}',
+        {'notes': ('/notes', note_count)},
+    )
+
+
+@tags_router.post('/', status_code=201, response_model=TagResponse)
+async def create_tag(
+    org_slug: str,
+    data: TagCreate,
+    db: graph.Pool,
+    _auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(permissions.require_permission('tag:create')),
+    ],
+) -> dict[str, typing.Any]:
+    """Create a new tag in an organization."""
+    tag_slug = data.slug or slugify.slugify(data.name)
+    now = datetime.datetime.now(datetime.UTC)
+    params: dict[str, typing.Any] = {
+        'org_slug': org_slug,
+        'id': nanoid.generate(),
+        'name': data.name,
+        'slug': tag_slug,
+        'description': data.description,
+        'created_at': now.isoformat(),
+        'updated_at': now.isoformat(),
+    }
+    query: typing.LiteralString = """
+    MATCH (o:Organization {{slug: {org_slug}}})
+    CREATE (t:Tag {{
+        id: {id},
+        name: {name},
+        slug: {slug},
+        description: {description},
+        created_at: {created_at},
+        updated_at: {updated_at}
+    }})
+    CREATE (t)-[:BELONGS_TO]->(o)
+    RETURN t, o
+    """
+    try:
+        records = await db.execute(query, params, columns=['t', 'o'])
+    except psycopg.errors.UniqueViolation as e:
+        raise fastapi.HTTPException(
+            status_code=409,
+            detail=f'Tag with slug {tag_slug!r} already exists',
+        ) from e
+    if not records:
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail=f'Organization {org_slug!r} not found',
+        )
+    tag: dict[str, typing.Any] = graph.parse_agtype(records[0]['t'])
+    org = graph.parse_agtype(records[0]['o'])
+    tag['organization'] = org
+    tag['relationships'] = _tag_relationships(org_slug, tag['slug'], 0)
+    return tag
+
+
+@tags_router.get('/', response_model=list[TagResponse])
+async def list_tags(
+    org_slug: str,
+    db: graph.Pool,
+    _auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(permissions.require_permission('tag:read')),
+    ],
+) -> list[dict[str, typing.Any]]:
+    """List tags in an organization, each with a note count."""
+    query: typing.LiteralString = """
+    MATCH (t:Tag)-[:BELONGS_TO]->(o:Organization {{slug: {org_slug}}})
+    OPTIONAL MATCH (n:Note)-[:TAGGED_WITH]->(t)
+    WITH t, o, count(DISTINCT n) AS note_count
+    RETURN t, o, note_count
+    ORDER BY t.name
+    """
+    records = await db.execute(
+        query,
+        {'org_slug': org_slug},
+        columns=['t', 'o', 'note_count'],
+    )
+    results: list[dict[str, typing.Any]] = []
+    for record in records:
+        tag = graph.parse_agtype(record['t'])
+        tag['organization'] = graph.parse_agtype(record['o'])
+        tag['relationships'] = _tag_relationships(
+            org_slug,
+            tag['slug'],
+            graph.parse_agtype(record['note_count']) or 0,
+        )
+        results.append(tag)
+    return results
+
+
+@tags_router.get('/{tag_slug}', response_model=TagResponse)
+async def get_tag(
+    org_slug: str,
+    tag_slug: str,
+    db: graph.Pool,
+    _auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(permissions.require_permission('tag:read')),
+    ],
+) -> dict[str, typing.Any]:
+    """Retrieve a single tag by slug."""
+    query: typing.LiteralString = """
+    MATCH (t:Tag {{slug: {tag_slug}}})
+          -[:BELONGS_TO]->(o:Organization {{slug: {org_slug}}})
+    OPTIONAL MATCH (n:Note)-[:TAGGED_WITH]->(t)
+    WITH t, o, count(DISTINCT n) AS note_count
+    RETURN t, o, note_count
+    """
+    records = await db.execute(
+        query,
+        {'tag_slug': tag_slug, 'org_slug': org_slug},
+        columns=['t', 'o', 'note_count'],
+    )
+    if not records:
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail=f'Tag {tag_slug!r} not found',
+        )
+    tag: dict[str, typing.Any] = graph.parse_agtype(records[0]['t'])
+    tag['organization'] = graph.parse_agtype(records[0]['o'])
+    tag['relationships'] = _tag_relationships(
+        org_slug,
+        tag['slug'],
+        graph.parse_agtype(records[0]['note_count']) or 0,
+    )
+    return tag
+
+
+class TagUpdate(pydantic.BaseModel):
+    name: str | None = None
+    slug: str | None = None
+    description: str | None = None
+
+
+_TAG_READONLY_PATHS: frozenset[str] = frozenset(
+    ['/id', '/created_at', '/updated_at', '/organization']
+)
+
+
+@tags_router.patch('/{tag_slug}', response_model=TagResponse)
+async def patch_tag(
+    org_slug: str,
+    tag_slug: str,
+    operations: list[json_patch.PatchOperation],
+    db: graph.Pool,
+    _auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(permissions.require_permission('tag:write')),
+    ],
+) -> dict[str, typing.Any]:
+    """Update a tag via JSON Patch (name/slug/description)."""
+    fetch_query: typing.LiteralString = """
+    MATCH (t:Tag {{slug: {tag_slug}}})
+          -[:BELONGS_TO]->(o:Organization {{slug: {org_slug}}})
+    RETURN t, o
+    """
+    records = await db.execute(
+        fetch_query,
+        {'tag_slug': tag_slug, 'org_slug': org_slug},
+        columns=['t', 'o'],
+    )
+    if not records:
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail=f'Tag {tag_slug!r} not found',
+        )
+    existing = graph.parse_agtype(records[0]['t'])
+    org = graph.parse_agtype(records[0]['o'])
+
+    current = {
+        'name': existing.get('name'),
+        'slug': existing.get('slug'),
+        'description': existing.get('description'),
+    }
+    patched = json_patch.apply_patch(current, operations, _TAG_READONLY_PATHS)
+    try:
+        update = TagUpdate(**patched)
+    except pydantic.ValidationError as e:
+        raise fastapi.HTTPException(
+            status_code=400,
+            detail=f'Validation error: {e.errors()}',
+        ) from e
+
+    now = datetime.datetime.now(datetime.UTC)
+    new_name = update.name if update.name is not None else existing.get('name')
+    new_slug = update.slug if update.slug is not None else existing.get('slug')
+    new_description = (
+        update.description
+        if update.description is not None
+        else existing.get('description')
+    )
+
+    update_query: typing.LiteralString = """
+    MATCH (t:Tag {{slug: {tag_slug}}})
+          -[:BELONGS_TO]->(o:Organization {{slug: {org_slug}}})
+    SET t.name = {name},
+        t.slug = {slug},
+        t.description = {description},
+        t.updated_at = {updated_at}
+    WITH t, o
+    OPTIONAL MATCH (n:Note)-[:TAGGED_WITH]->(t)
+    WITH t, o, count(DISTINCT n) AS note_count
+    RETURN t, o, note_count
+    """
+    try:
+        updated = await db.execute(
+            update_query,
+            {
+                'tag_slug': tag_slug,
+                'org_slug': org_slug,
+                'name': new_name,
+                'slug': new_slug,
+                'description': new_description,
+                'updated_at': now.isoformat(),
+            },
+            columns=['t', 'o', 'note_count'],
+        )
+    except psycopg.errors.UniqueViolation as e:
+        raise fastapi.HTTPException(
+            status_code=409,
+            detail=f'Tag with slug {new_slug!r} already exists',
+        ) from e
+    if not updated:
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail=f'Tag {tag_slug!r} not found',
+        )
+    tag: dict[str, typing.Any] = graph.parse_agtype(updated[0]['t'])
+    tag['organization'] = org
+    tag['relationships'] = _tag_relationships(
+        org_slug,
+        tag['slug'],
+        graph.parse_agtype(updated[0]['note_count']) or 0,
+    )
+    return tag
+
+
+@tags_router.delete('/{tag_slug}', status_code=204)
+async def delete_tag(
+    org_slug: str,
+    tag_slug: str,
+    db: graph.Pool,
+    _auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(permissions.require_permission('tag:delete')),
+    ],
+) -> None:
+    """Delete a tag. Any ``TAGGED_WITH`` edges are removed."""
+    query: typing.LiteralString = """
+    MATCH (t:Tag {{slug: {tag_slug}}})
+          -[:BELONGS_TO]->(:Organization {{slug: {org_slug}}})
+    DETACH DELETE t
+    RETURN t
+    """
+    records = await db.execute(
+        query, {'tag_slug': tag_slug, 'org_slug': org_slug}
+    )
+    if not records:
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail=f'Tag {tag_slug!r} not found',
+        )

--- a/tests/endpoints/test_notes.py
+++ b/tests/endpoints/test_notes.py
@@ -1,0 +1,459 @@
+"""Tests for notes CRUD endpoints."""
+
+import datetime
+import typing
+import unittest
+from unittest import mock
+
+from fastapi.testclient import TestClient
+from imbi_common import graph
+
+from imbi_api import app, models
+
+
+class NoteEndpointsTestCase(unittest.TestCase):
+    """Test cases for notes CRUD + cross-project search."""
+
+    def setUp(self) -> None:
+        from imbi_api.auth import permissions
+
+        self.test_app = app.create_app()
+
+        self.admin_user = models.User(
+            email='admin@example.com',
+            display_name='Admin User',
+            password_hash='$argon2id$hashed',
+            is_active=True,
+            is_admin=True,
+            is_service_account=False,
+            created_at=datetime.datetime.now(datetime.UTC),
+        )
+        self.auth_context = permissions.AuthContext(
+            user=self.admin_user,
+            session_id='test-session',
+            auth_method='jwt',
+            permissions={
+                'note:create',
+                'note:read',
+                'note:write',
+                'note:delete',
+            },
+        )
+
+        async def mock_get_current_user():
+            return self.auth_context
+
+        self.test_app.dependency_overrides[permissions.get_current_user] = (
+            mock_get_current_user
+        )
+
+        self.mock_db = mock.AsyncMock(spec=graph.Graph)
+        self.test_app.dependency_overrides[graph._inject_graph] = (
+            lambda: self.mock_db
+        )
+
+        self.client = TestClient(self.test_app)
+
+    def _note_data(self, **overrides: typing.Any) -> dict:
+        data: dict[str, typing.Any] = {
+            'id': 'note-1',
+            'content': 'Watch out for DB locks',
+            'created_by': 'admin@example.com',
+            'created_at': '2026-03-17T12:00:00Z',
+            'updated_by': None,
+            'updated_at': None,
+        }
+        data.update(overrides)
+        return data
+
+    def _project(self, **overrides: typing.Any) -> dict:
+        data: dict[str, typing.Any] = {
+            'id': 'proj-abc',
+            'slug': 'billing-api',
+        }
+        data.update(overrides)
+        return data
+
+    # -- Create --------------------------------------------------------
+
+    def test_create_success_no_tags(self) -> None:
+        self.mock_db.execute.return_value = [
+            {'n': self._note_data(), 'p': self._project(), 'tags': []}
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.post(
+                '/organizations/engineering/projects/proj-abc/notes/',
+                json={'content': 'Watch out for DB locks'},
+            )
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.json()['project_id'], 'proj-abc')
+        self.assertEqual(response.json()['tags'], [])
+
+    def test_create_with_tags(self) -> None:
+        # first call = _validate_tag_slugs (both found), second = insert
+        self.mock_db.execute.side_effect = [
+            [
+                {'tag_slug': 'runbook', 'found': True},
+                {'tag_slug': 'alert', 'found': True},
+            ],
+            [
+                {
+                    'n': self._note_data(),
+                    'p': self._project(),
+                    'tags': [
+                        {'name': 'Runbook', 'slug': 'runbook'},
+                        {'name': 'Alert', 'slug': 'alert'},
+                    ],
+                }
+            ],
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.post(
+                '/organizations/engineering/projects/proj-abc/notes/',
+                json={'content': 'x', 'tags': ['runbook', 'alert']},
+            )
+        self.assertEqual(response.status_code, 201)
+        tags = {t['slug'] for t in response.json()['tags']}
+        self.assertEqual(tags, {'runbook', 'alert'})
+
+    def test_create_unknown_tag_returns_422(self) -> None:
+        self.mock_db.execute.return_value = [
+            {'tag_slug': 'runbook', 'found': True},
+            {'tag_slug': 'ghost', 'found': False},
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.post(
+                '/organizations/engineering/projects/proj-abc/notes/',
+                json={'content': 'x', 'tags': ['runbook', 'ghost']},
+            )
+        self.assertEqual(response.status_code, 422)
+        self.assertIn('ghost', response.json()['detail'])
+
+    def test_create_project_not_found(self) -> None:
+        self.mock_db.execute.return_value = []
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.post(
+                '/organizations/engineering/projects/missing/notes/',
+                json={'content': 'x'},
+            )
+        self.assertEqual(response.status_code, 404)
+
+    def test_create_empty_content_rejected(self) -> None:
+        response = self.client.post(
+            '/organizations/engineering/projects/proj-abc/notes/',
+            json={'content': ''},
+        )
+        self.assertEqual(response.status_code, 422)
+
+    # -- List ----------------------------------------------------------
+
+    def test_list_project_notes(self) -> None:
+        self.mock_db.execute.return_value = [
+            {
+                'n': self._note_data(id='n1'),
+                'p': self._project(),
+                'tags': [],
+            },
+            {
+                'n': self._note_data(id='n2'),
+                'p': self._project(),
+                'tags': [{'name': 'Runbook', 'slug': 'runbook'}],
+            },
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.get(
+                '/organizations/engineering/projects/proj-abc/notes/'
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.json()['data']), 2)
+
+    def test_list_cross_project_by_tag(self) -> None:
+        self.mock_db.execute.return_value = [
+            {
+                'n': self._note_data(id='n1'),
+                'p': self._project(id='proj-a', slug='a'),
+                'tags': [{'name': 'Runbook', 'slug': 'runbook'}],
+            },
+            {
+                'n': self._note_data(id='n2'),
+                'p': self._project(id='proj-b', slug='b'),
+                'tags': [{'name': 'Runbook', 'slug': 'runbook'}],
+            },
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.get(
+                '/organizations/engineering/notes/?tag=runbook'
+            )
+        self.assertEqual(response.status_code, 200)
+        projects = {n['project_id'] for n in response.json()['data']}
+        self.assertEqual(projects, {'proj-a', 'proj-b'})
+
+    def test_list_invalid_limit(self) -> None:
+        response = self.client.get(
+            '/organizations/engineering/notes/?limit=99999'
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_list_invalid_cursor(self) -> None:
+        response = self.client.get(
+            '/organizations/engineering/notes/?cursor=!!not-base64!!'
+        )
+        # malformed base64 decodes to empty/garbage -> 400 via _decode_cursor
+        self.assertIn(response.status_code, {400})
+
+    # -- Get -----------------------------------------------------------
+
+    def test_get_single(self) -> None:
+        self.mock_db.execute.return_value = [
+            {
+                'n': self._note_data(),
+                'p': self._project(),
+                'tags': [],
+            }
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.get(
+                '/organizations/engineering/projects/proj-abc/notes/note-1'
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()['id'], 'note-1')
+
+    def test_get_not_found(self) -> None:
+        self.mock_db.execute.return_value = []
+        response = self.client.get(
+            '/organizations/engineering/projects/proj-abc/notes/ghost'
+        )
+        self.assertEqual(response.status_code, 404)
+
+    # -- Patch ---------------------------------------------------------
+
+    def test_patch_content(self) -> None:
+        self.mock_db.execute.side_effect = [
+            [
+                {
+                    'n': self._note_data(),
+                    'p': self._project(),
+                    'tags': [],
+                }
+            ],
+            [
+                {
+                    'n': self._note_data(content='Updated text'),
+                    'p': self._project(),
+                    'tags': [],
+                }
+            ],
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.patch(
+                '/organizations/engineering/projects/proj-abc/notes/note-1',
+                json=[
+                    {
+                        'op': 'replace',
+                        'path': '/content',
+                        'value': 'Updated text',
+                    }
+                ],
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()['content'], 'Updated text')
+
+    def test_patch_replace_tags(self) -> None:
+        self.mock_db.execute.side_effect = [
+            [
+                {
+                    'n': self._note_data(),
+                    'p': self._project(),
+                    'tags': [],
+                }
+            ],
+            [  # _validate_tag_slugs
+                {'tag_slug': 'runbook', 'found': True},
+            ],
+            [
+                {
+                    'n': self._note_data(updated_by='admin@example.com'),
+                    'p': self._project(),
+                    'tags': [{'name': 'Runbook', 'slug': 'runbook'}],
+                }
+            ],
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.patch(
+                '/organizations/engineering/projects/proj-abc/notes/note-1',
+                json=[
+                    {
+                        'op': 'replace',
+                        'path': '/tags',
+                        'value': ['runbook'],
+                    }
+                ],
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            [t['slug'] for t in response.json()['tags']], ['runbook']
+        )
+
+    def test_patch_readonly_path_rejected(self) -> None:
+        self.mock_db.execute.return_value = [
+            {
+                'n': self._note_data(),
+                'p': self._project(),
+                'tags': [],
+            }
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.patch(
+                '/organizations/engineering/projects/proj-abc/notes/note-1',
+                json=[
+                    {
+                        'op': 'replace',
+                        'path': '/created_by',
+                        'value': 'attacker',
+                    }
+                ],
+            )
+        self.assertEqual(response.status_code, 400)
+
+    def test_patch_not_found(self) -> None:
+        self.mock_db.execute.return_value = []
+        response = self.client.patch(
+            '/organizations/engineering/projects/proj-abc/notes/ghost',
+            json=[{'op': 'replace', 'path': '/content', 'value': 'x'}],
+        )
+        self.assertEqual(response.status_code, 404)
+
+    # -- Delete --------------------------------------------------------
+
+    def test_delete_success(self) -> None:
+        self.mock_db.execute.return_value = [{'n': True}]
+        response = self.client.delete(
+            '/organizations/engineering/projects/proj-abc/notes/note-1'
+        )
+        self.assertEqual(response.status_code, 204)
+
+    def test_delete_not_found(self) -> None:
+        self.mock_db.execute.return_value = []
+        response = self.client.delete(
+            '/organizations/engineering/projects/proj-abc/notes/ghost'
+        )
+        self.assertEqual(response.status_code, 404)
+
+    # -- Pagination + cursor edge cases --------------------------------
+
+    def test_list_pagination_emits_next_cursor(self) -> None:
+        """Returning limit+1 rows emits a Link header with rel=next."""
+        rows = [
+            {
+                'n': self._note_data(
+                    id=f'n{i}',
+                    created_at=f'2026-03-1{i % 10}T12:00:00Z',
+                ),
+                'p': self._project(),
+                'tags': [],
+            }
+            for i in range(3)
+        ]
+        self.mock_db.execute.return_value = rows
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.get(
+                '/organizations/engineering/notes/?limit=2'
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.json()['data']), 2)
+        self.assertIn('rel="next"', response.headers.get('Link', ''))
+
+    def test_list_cursor_roundtrip(self) -> None:
+        """A valid cursor decodes and paginates."""
+        import base64
+
+        cursor = (
+            base64.urlsafe_b64encode(b'2026-03-17T12:00:00+00:00|n-prev')
+            .rstrip(b'=')
+            .decode()
+        )
+        self.mock_db.execute.return_value = [
+            {
+                'n': self._note_data(id='n-next'),
+                'p': self._project(),
+                'tags': [],
+            }
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.get(
+                f'/organizations/engineering/notes/?cursor={cursor}'
+            )
+        self.assertEqual(response.status_code, 200)
+
+    def test_patch_validation_error(self) -> None:
+        """Patching /content to an empty string returns 400."""
+        self.mock_db.execute.return_value = [
+            {
+                'n': self._note_data(),
+                'p': self._project(),
+                'tags': [],
+            }
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.patch(
+                '/organizations/engineering/projects/proj-abc/notes/note-1',
+                json=[{'op': 'replace', 'path': '/content', 'value': ''}],
+            )
+        self.assertEqual(response.status_code, 400)
+
+    def test_patch_concurrent_delete_returns_404(self) -> None:
+        """Update query returning no rows after fetch yields 404."""
+        self.mock_db.execute.side_effect = [
+            [
+                {
+                    'n': self._note_data(),
+                    'p': self._project(),
+                    'tags': [],
+                }
+            ],
+            [],
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.patch(
+                '/organizations/engineering/projects/proj-abc/notes/note-1',
+                json=[
+                    {
+                        'op': 'replace',
+                        'path': '/content',
+                        'value': 'new',
+                    }
+                ],
+            )
+        self.assertEqual(response.status_code, 404)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/endpoints/test_tags.py
+++ b/tests/endpoints/test_tags.py
@@ -1,0 +1,290 @@
+"""Tests for tag CRUD endpoints."""
+
+import datetime
+import typing
+import unittest
+from unittest import mock
+
+import psycopg.errors
+from fastapi.testclient import TestClient
+from imbi_common import graph
+
+from imbi_api import app, models
+
+
+class TagEndpointsTestCase(unittest.TestCase):
+    """Test cases for tag CRUD endpoints."""
+
+    def setUp(self) -> None:
+        from imbi_api.auth import permissions
+
+        self.test_app = app.create_app()
+
+        self.admin_user = models.User(
+            email='admin@example.com',
+            display_name='Admin User',
+            password_hash='$argon2id$hashed',
+            is_active=True,
+            is_admin=True,
+            is_service_account=False,
+            created_at=datetime.datetime.now(datetime.UTC),
+        )
+        self.auth_context = permissions.AuthContext(
+            user=self.admin_user,
+            session_id='test-session',
+            auth_method='jwt',
+            permissions={
+                'tag:create',
+                'tag:read',
+                'tag:write',
+                'tag:delete',
+            },
+        )
+
+        async def mock_get_current_user():
+            return self.auth_context
+
+        self.test_app.dependency_overrides[permissions.get_current_user] = (
+            mock_get_current_user
+        )
+
+        self.mock_db = mock.AsyncMock(spec=graph.Graph)
+        self.test_app.dependency_overrides[graph._inject_graph] = (
+            lambda: self.mock_db
+        )
+
+        self.client = TestClient(self.test_app)
+
+    def _tag_data(self, **overrides: typing.Any) -> dict:
+        data: dict[str, typing.Any] = {
+            'id': 'tag-123',
+            'name': 'Runbook',
+            'slug': 'runbook',
+            'description': None,
+            'created_at': '2026-03-17T12:00:00Z',
+            'updated_at': '2026-03-17T12:00:00Z',
+        }
+        data.update(overrides)
+        return data
+
+    def _org_data(self) -> dict:
+        return {'name': 'Engineering', 'slug': 'engineering'}
+
+    # -- Create --------------------------------------------------------
+
+    def test_create_success(self) -> None:
+        self.mock_db.execute.return_value = [
+            {'t': self._tag_data(), 'o': self._org_data()}
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.post(
+                '/organizations/engineering/tags/',
+                json={'name': 'Runbook'},
+            )
+        self.assertEqual(response.status_code, 201)
+        body = response.json()
+        self.assertEqual(body['slug'], 'runbook')
+        self.assertEqual(body['relationships']['notes']['count'], 0)
+
+    def test_create_auto_slugifies_from_name(self) -> None:
+        self.mock_db.execute.return_value = [
+            {
+                't': self._tag_data(name='Post Mortem', slug='post-mortem'),
+                'o': self._org_data(),
+            }
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.post(
+                '/organizations/engineering/tags/',
+                json={'name': 'Post Mortem'},
+            )
+        self.assertEqual(response.status_code, 201)
+        # second positional arg of .execute call contains the params dict
+        _, args, _ = self.mock_db.execute.mock_calls[0]
+        self.assertEqual(args[1]['slug'], 'post-mortem')
+
+    def test_create_slug_conflict(self) -> None:
+        self.mock_db.execute.side_effect = psycopg.errors.UniqueViolation()
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.post(
+                '/organizations/engineering/tags/',
+                json={'name': 'Runbook', 'slug': 'runbook'},
+            )
+        self.assertEqual(response.status_code, 409)
+
+    def test_create_org_not_found(self) -> None:
+        self.mock_db.execute.return_value = []
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.post(
+                '/organizations/ghost/tags/',
+                json={'name': 'Runbook'},
+            )
+        self.assertEqual(response.status_code, 404)
+
+    # -- List ----------------------------------------------------------
+
+    def test_list_success(self) -> None:
+        self.mock_db.execute.return_value = [
+            {
+                't': self._tag_data(),
+                'o': self._org_data(),
+                'note_count': 4,
+            },
+            {
+                't': self._tag_data(name='Alert', slug='alert'),
+                'o': self._org_data(),
+                'note_count': 0,
+            },
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.get('/organizations/engineering/tags/')
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(len(data), 2)
+        self.assertEqual(data[0]['relationships']['notes']['count'], 4)
+
+    # -- Get -----------------------------------------------------------
+
+    def test_get_success(self) -> None:
+        self.mock_db.execute.return_value = [
+            {
+                't': self._tag_data(),
+                'o': self._org_data(),
+                'note_count': 2,
+            }
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.get(
+                '/organizations/engineering/tags/runbook'
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()['relationships']['notes']['count'], 2)
+
+    def test_get_not_found(self) -> None:
+        self.mock_db.execute.return_value = []
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.get(
+                '/organizations/engineering/tags/missing'
+            )
+        self.assertEqual(response.status_code, 404)
+
+    # -- Patch ---------------------------------------------------------
+
+    def test_patch_rename(self) -> None:
+        self.mock_db.execute.side_effect = [
+            [{'t': self._tag_data(), 'o': self._org_data()}],
+            [
+                {
+                    't': self._tag_data(name='Runbooks'),
+                    'o': self._org_data(),
+                    'note_count': 3,
+                }
+            ],
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.patch(
+                '/organizations/engineering/tags/runbook',
+                json=[{'op': 'replace', 'path': '/name', 'value': 'Runbooks'}],
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()['name'], 'Runbooks')
+
+    def test_patch_slug_conflict(self) -> None:
+        self.mock_db.execute.side_effect = [
+            [{'t': self._tag_data(), 'o': self._org_data()}],
+            psycopg.errors.UniqueViolation(),
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.patch(
+                '/organizations/engineering/tags/runbook',
+                json=[{'op': 'replace', 'path': '/slug', 'value': 'alert'}],
+            )
+        self.assertEqual(response.status_code, 409)
+
+    def test_patch_not_found(self) -> None:
+        self.mock_db.execute.return_value = []
+        response = self.client.patch(
+            '/organizations/engineering/tags/missing',
+            json=[{'op': 'replace', 'path': '/name', 'value': 'X'}],
+        )
+        self.assertEqual(response.status_code, 404)
+
+    def test_patch_readonly_path_rejected(self) -> None:
+        self.mock_db.execute.return_value = [
+            {'t': self._tag_data(), 'o': self._org_data()}
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.patch(
+                '/organizations/engineering/tags/runbook',
+                json=[{'op': 'replace', 'path': '/id', 'value': 'xxx'}],
+            )
+        self.assertEqual(response.status_code, 400)
+
+    # -- Delete --------------------------------------------------------
+
+    def test_delete_success(self) -> None:
+        self.mock_db.execute.return_value = [{'t': True}]
+        response = self.client.delete(
+            '/organizations/engineering/tags/runbook'
+        )
+        self.assertEqual(response.status_code, 204)
+
+    def test_delete_not_found(self) -> None:
+        self.mock_db.execute.return_value = []
+        response = self.client.delete(
+            '/organizations/engineering/tags/missing'
+        )
+        self.assertEqual(response.status_code, 404)
+
+    def test_patch_validation_error(self) -> None:
+        """Patching /name to non-string triggers a 400 validation error."""
+        self.mock_db.execute.return_value = [
+            {'t': self._tag_data(), 'o': self._org_data()}
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.patch(
+                '/organizations/engineering/tags/runbook',
+                json=[{'op': 'replace', 'path': '/name', 'value': 123}],
+            )
+        self.assertEqual(response.status_code, 400)
+
+    def test_patch_concurrent_delete_returns_404(self) -> None:
+        """Update returning no rows after fetch yields 404."""
+        self.mock_db.execute.side_effect = [
+            [{'t': self._tag_data(), 'o': self._org_data()}],
+            [],
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.patch(
+                '/organizations/engineering/tags/runbook',
+                json=[{'op': 'replace', 'path': '/name', 'value': 'Runbooks'}],
+            )
+        self.assertEqual(response.status_code, 404)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/uv.lock
+++ b/uv.lock
@@ -897,7 +897,7 @@ requires-dist = [
     { name = "fastapi" },
     { name = "filetype" },
     { name = "httpx", specifier = ">=0.28.1" },
-    { name = "imbi-common", extras = ["databases", "server"], git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=main" },
+    { name = "imbi-common", extras = ["databases", "server"], git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=feature%2Fnotes-and-tags" },
     { name = "jinja2" },
     { name = "jsonpatch", specifier = ">=1.33" },
     { name = "nanoid", specifier = ">=2.0.0" },
@@ -944,7 +944,7 @@ docs = [
 [[package]]
 name = "imbi-common"
 version = "0.1.0"
-source = { git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=main#b6ae276c61164c96b69580a40059c5e9a8916d7f" }
+source = { git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=feature%2Fnotes-and-tags#e3b993b522e43a0f66d0aed608cc8d2163437943" }
 dependencies = [
     { name = "cryptography" },
     { name = "jsonschema-models" },


### PR DESCRIPTION
## Summary
- Project-scoped **notes** (markdown content, author + timestamps, JSON Patch updates) stored as first-class `:Note` graph nodes
- Org-scoped **tags** (flat `name`/`slug` labels) as `:Tag` graph nodes, attached to notes via `TAGGED_WITH`
- Cross-project note search filtered by tag and/or `project_id`
- New `tag:*` and `note:*` permissions seeded into `admin`, `developer`, and `readonly` roles

## Motivation
Replaces the v1 `v1.project_notes` flat PostgreSQL table (29 rows in prod, no tagging) with a first-class graph model that matches the rest of v2 (Projects, Releases, etc.). The `TAGGED_WITH` edge type is deliberately generic so future work can tag other node types (projects, services) without schema changes.

## Routes (all under `/api`)

| Method | Path | Purpose |
|---|---|---|
| `POST` | `/organizations/{org}/tags/` | Create tag |
| `GET` | `/organizations/{org}/tags/` | List tags (with note counts) |
| `GET` | `/organizations/{org}/tags/{slug}` | Tag detail |
| `PATCH` | `/organizations/{org}/tags/{slug}` | Rename/update tag (JSON Patch) |
| `DELETE` | `/organizations/{org}/tags/{slug}` | Delete tag (drops `TAGGED_WITH` edges) |
| `GET` | `/organizations/{org}/notes/?tag=&project_id=` | Cross-project search |
| `POST` | `/organizations/{org}/projects/{id}/notes/` | Create note (optionally with tag slugs) |
| `GET` | `/organizations/{org}/projects/{id}/notes/` | List for project |
| `GET` | `/organizations/{org}/projects/{id}/notes/{id}` | Note detail |
| `PATCH` | `/organizations/{org}/projects/{id}/notes/{id}` | Update content + tags (JSON Patch) |
| `DELETE` | `/organizations/{org}/projects/{id}/notes/{id}` | Delete note |

## Design
- **Storage**: Apache AGE graph (not ClickHouse) — notes are low-volume, mutation-heavy, and fit the existing node+edge model used by Projects/Releases.
- **Tags as nodes**: enables single-hop "all notes with tag X" queries org-wide. Array-on-note would force full scans.
- **Tags are org-scoped**, like `Team`/`ProjectType`/`Environment`.
- **Cursor pagination** reuses the `(timestamp, id)` base64 pattern from `operations_log`.

## Dependencies
Depends on AWeber-Imbi/imbi-common#59 for the `Note`/`Tag` models. `pyproject.toml` temporarily tracks that feature branch via `uv.sources`; flip back to `main` after imbi-common PR merges.

## Test plan
- [x] `ruff check` passes
- [x] `ruff format` passes
- [x] `mypy` passes
- [x] `basedpyright` passes
- [x] Full test suite passes: 947 pass / 1 skip, 90.45% coverage
- [x] 36 new tests: CRUD, JSON Patch, tag validation, pagination cursors, readonly paths, 404/409/422 paths
- [ ] Manual smoke test once imbi-common#59 merges