### PR TITLE
Point uv.sources back to imbi-common main

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -217,4 +217,4 @@ url = "https://pypi.org/simple"
 default = true
 
 [tool.uv.sources]
-imbi-common = { git = "https://github.com/AWeber-Imbi/imbi-common.git", rev = "feature/notes-and-tags" }
+imbi-common = { git = "https://github.com/AWeber-Imbi/imbi-common.git", rev = "main" }

--- a/uv.lock
+++ b/uv.lock
@@ -897,7 +897,7 @@ requires-dist = [
     { name = "fastapi" },
     { name = "filetype" },
     { name = "httpx", specifier = ">=0.28.1" },
-    { name = "imbi-common", extras = ["databases", "server"], git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=feature%2Fnotes-and-tags" },
+    { name = "imbi-common", extras = ["databases", "server"], git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=main" },
     { name = "jinja2" },
     { name = "jsonpatch", specifier = ">=1.33" },
     { name = "nanoid", specifier = ">=2.0.0" },
@@ -944,7 +944,7 @@ docs = [
 [[package]]
 name = "imbi-common"
 version = "0.1.0"
-source = { git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=feature%2Fnotes-and-tags#e3b993b522e43a0f66d0aed608cc8d2163437943" }
+source = { git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=main#26c1a07ca80023b7aec30d6b9ea878690953407b" }
 dependencies = [
     { name = "cryptography" },
     { name = "jsonschema-models" },


### PR DESCRIPTION
## Summary
Flip `tool.uv.sources.imbi-common.rev` from `feature/notes-and-tags` back to `main` and regenerate `uv.lock` against the merged [imbi-common#59](https://github.com/AWeber-Imbi/imbi-common/pull/59) commit (`26c1a07`).

## Why this is a follow-up
#240 was merged before the uv.sources flip commit landed on that PR, so `main` still references the (since-merged) feature branch. Mechanical cleanup.

## Test plan
- [x] `uv lock` resolves cleanly (only `imbi-common` SHA changes)
- [x] `uv sync --frozen` installs the new imbi-common commit