### PR TITLE
Remove project_slug from NoteResponse

### DIFF
--- a/src/imbi_api/endpoints/notes.py
+++ b/src/imbi_api/endpoints/notes.py
@@ -34,7 +34,6 @@ _NOTE_READONLY_PATHS: frozenset[str] = frozenset(
     [
         '/id',
         '/project_id',
-        '/project_slug',
         '/created_by',
         '/created_at',
         '/updated_by',
@@ -56,7 +55,6 @@ class NoteResponse(pydantic.BaseModel):
     updated_by: str | None = None
     updated_at: datetime.datetime | None = None
     project_id: str
-    project_slug: str
     tags: list[TagRef] = []
 
 
@@ -139,7 +137,6 @@ def _parse_note_row(record: dict[str, typing.Any]) -> dict[str, typing.Any]:
             {'name': str(entry.get('name', '')), 'slug': str(slug)},
         )
     note['project_id'] = project.get('id', '')
-    note['project_slug'] = project.get('slug', '')
     note['tags'] = tags
     return note
 


### PR DESCRIPTION
## Summary

- Drops `project_slug` from `NoteResponse`, the readonly-paths allowlist used by the PATCH endpoint, and the row parser that populated it.

## Problem

The project slug was redundant on every note response. Every note endpoint is already scoped by project via the URL path, and `project_id` is sufficient for clients that need to correlate notes back to their project — the extra field only widened the serialization surface and added another write-guard to maintain.

## Solution

- Remove `project_slug: str` from `NoteResponse`.
- Remove `/project_slug` from `_NOTE_READONLY_PATHS`.
- Stop setting `note['project_slug']` in `_parse_note_row`.

The existing test suite (`tests/endpoints/test_notes.py`, 21 tests) did not assert on `project_slug` and still passes.

## Test plan

- [x] `pytest tests/endpoints/test_notes.py` — 21 passed
- [x] pre-commit hooks (ruff, mypy) — passed