### PR TITLE
Add title and is_pinned to notes; simplify PATCH value sentinel

### DIFF
--- a/src/imbi_api/endpoints/notes.py
+++ b/src/imbi_api/endpoints/notes.py
@@ -49,16 +49,19 @@ class TagRef(pydantic.BaseModel):
 
 class NoteResponse(pydantic.BaseModel):
     id: str
+    title: str = ''
     content: str
     created_by: str
     created_at: datetime.datetime
     updated_by: str | None = None
     updated_at: datetime.datetime | None = None
     project_id: str
+    is_pinned: bool = False
     tags: list[TagRef] = []
 
 
 class NoteCreate(pydantic.BaseModel):
+    title: str = pydantic.Field(min_length=1, max_length=200)
     content: str = pydantic.Field(min_length=1)
     tags: list[str] = pydantic.Field(
         default_factory=list,
@@ -138,6 +141,9 @@ def _parse_note_row(record: dict[str, typing.Any]) -> dict[str, typing.Any]:
         )
     note['project_id'] = project.get('id', '')
     note['tags'] = tags
+    # Defaults for rows written before these columns landed.
+    note['is_pinned'] = bool(note.get('is_pinned', False))
+    note['title'] = str(note.get('title') or '')
     return note
 
 
@@ -151,6 +157,47 @@ _TAGS_TAIL: typing.LiteralString = """
     WITH n, p, [t IN raw_tags WHERE t IS NOT NULL] AS tags
     RETURN n, p, tags
 """
+
+
+async def _attach_tags(
+    db: graph.Pool,
+    org_slug: str,
+    note_id: str,
+    tag_slugs: list[str],
+) -> None:
+    """Create ``TAGGED_WITH`` edges from note -> tags.
+
+    Split from the CREATE/SET query because AGE's Cypher translator does
+    not support ``FOREACH``; a plain ``UNWIND`` + ``MATCH`` + ``CREATE``
+    is portable.
+    """
+    if not tag_slugs:
+        return
+    query: typing.LiteralString = """
+    MATCH (n:Note {{id: {note_id}}}),
+          (:Organization {{slug: {org_slug}}})<-[:BELONGS_TO]-(t:Tag)
+    WHERE t.slug IN {tag_slugs}
+    CREATE (n)-[:TAGGED_WITH]->(t)
+    RETURN count(t) AS attached
+    """
+    await db.execute(
+        query,
+        {'note_id': note_id, 'org_slug': org_slug, 'tag_slugs': tag_slugs},
+        columns=['attached'],
+    )
+
+
+async def _detach_all_tags(
+    db: graph.Pool,
+    note_id: str,
+) -> None:
+    """Remove every ``TAGGED_WITH`` edge from ``note``."""
+    query: typing.LiteralString = """
+    MATCH (n:Note {{id: {note_id}}})-[tw:TAGGED_WITH]->(:Tag)
+    DELETE tw
+    RETURN count(tw) AS removed
+    """
+    await db.execute(query, {'note_id': note_id}, columns=['removed'])
 
 
 async def _validate_tag_slugs(
@@ -198,45 +245,50 @@ async def create_note(
 
     now = datetime.datetime.now(datetime.UTC)
     note_id = nanoid.generate()
-    params: dict[str, typing.Any] = {
-        'org_slug': org_slug,
-        'project_id': project_id,
-        'id': note_id,
-        'content': data.content,
-        'created_by': auth.principal_name,
-        'created_at': now.isoformat(),
-        'tag_slugs': tag_slugs,
-    }
-    query: str = (
-        """
+    create_query: typing.LiteralString = """
     MATCH (p:Project {{id: {project_id}}})
           -[:OWNED_BY]->(:Team)
-          -[:BELONGS_TO]->(o:Organization {{slug: {org_slug}}})
+          -[:BELONGS_TO]->(:Organization {{slug: {org_slug}}})
     CREATE (n:Note {{
         id: {id},
+        title: {title},
         content: {content},
         created_by: {created_by},
-        created_at: {created_at}
+        created_at: {created_at},
+        is_pinned: {is_pinned}
     }})
     CREATE (n)-[:ATTACHED_TO]->(p)
-    WITH n, p, o
-    UNWIND (CASE WHEN size({tag_slugs}) = 0 THEN [null]
-                 ELSE {tag_slugs} END) AS tag_slug
-    OPTIONAL MATCH (tag:Tag {{slug: tag_slug}})-[:BELONGS_TO]->(o)
-    FOREACH (_ IN CASE WHEN tag IS NOT NULL THEN [1] ELSE [] END |
-        CREATE (n)-[:TAGGED_WITH]->(tag)
-    )
-    WITH DISTINCT n, p
+    RETURN n.id AS id
     """
-        + _TAGS_TAIL
+    records = await db.execute(
+        create_query,
+        {
+            'org_slug': org_slug,
+            'project_id': project_id,
+            'id': note_id,
+            'title': data.title,
+            'content': data.content,
+            'created_by': auth.principal_name,
+            'created_at': now.isoformat(),
+            'is_pinned': False,
+        },
+        columns=['id'],
     )
-    records = await db.execute(query, params, columns=['n', 'p', 'tags'])
     if not records:
         raise fastapi.HTTPException(
             status_code=404,
             detail=f'Project {project_id!r} not found',
         )
-    return _parse_note_row(records[0])
+
+    if tag_slugs:
+        await _attach_tags(db, org_slug, note_id, tag_slugs)
+
+    note = await _fetch_note(db, org_slug, project_id, note_id)
+    if note is None:
+        raise fastapi.HTTPException(
+            status_code=500, detail='Note created but could not be read back'
+        )
+    return note
 
 
 async def _list_notes_impl(
@@ -297,7 +349,7 @@ async def _list_notes_impl(
         + tag_match
         + cursor_clause
         + """
-    WITH DISTINCT n, p
+    WITH n, p
     ORDER BY n.created_at DESC, n.id DESC
     LIMIT {row_limit}
     """
@@ -431,8 +483,12 @@ async def get_note(
 
 
 class NoteUpdate(pydantic.BaseModel):
+    title: str | None = pydantic.Field(
+        default=None, min_length=1, max_length=200
+    )
     content: str | None = pydantic.Field(default=None, min_length=1)
     tags: list[str] | None = None
+    is_pinned: bool | None = None
 
 
 @notes_project_router.patch('/{note_id}', response_model=NoteResponse)
@@ -455,78 +511,100 @@ async def patch_note(
         )
 
     current = {
+        'title': str(existing.get('title') or ''),
         'content': existing['content'],
         'tags': [t['slug'] for t in existing.get('tags', [])],
+        'is_pinned': bool(existing.get('is_pinned', False)),
     }
     patched = json_patch.apply_patch(current, operations, _NOTE_READONLY_PATHS)
+    # Only validate fields the patch actually touched. The merged ``patched``
+    # dict carries every field from ``current`` (incl. legacy values that
+    # may not satisfy ``NoteUpdate`` constraints), so validating it whole
+    # would reject a ``/is_pinned`` patch on a note with an empty title.
+    touched: set[str] = set()
+    for op in operations:
+        if op.path.startswith('/'):
+            head = op.path.split('/', 2)[1]
+            if head:
+                touched.add(head)
     try:
-        update = NoteUpdate(**patched)
+        update = NoteUpdate(**{k: patched[k] for k in touched if k in patched})
     except pydantic.ValidationError as e:
         raise fastapi.HTTPException(
             status_code=400,
             detail=f'Validation error: {e.errors()}',
         ) from e
 
+    new_title = (
+        update.title
+        if update.title is not None
+        else str(existing.get('title') or '')
+    )
     new_content = (
         update.content if update.content is not None else existing['content']
     )
-    replace_tags = update.tags is not None
+    # Replace tag edges only when an op actually targeted ``/tags``. The
+    # patched dict always carries a ``tags`` key from ``current``, so
+    # ``update.tags is not None`` alone can't distinguish "left alone" from
+    # "set to []".
+    replace_tags = any(
+        op.path == '/tags' or op.path.startswith('/tags/') for op in operations
+    )
     new_tags: list[str] = (
-        list(dict.fromkeys(update.tags))
-        if update.tags is not None
+        list(dict.fromkeys(update.tags or []))
+        if replace_tags
         else [t['slug'] for t in existing.get('tags', [])]
     )
     if replace_tags:
         await _validate_tag_slugs(db, org_slug, new_tags)
+    new_is_pinned = (
+        update.is_pinned
+        if update.is_pinned is not None
+        else bool(existing.get('is_pinned', False))
+    )
 
     now = datetime.datetime.now(datetime.UTC)
-    params: dict[str, typing.Any] = {
-        'org_slug': org_slug,
-        'project_id': project_id,
-        'note_id': note_id,
-        'content': new_content,
-        'updated_by': auth.principal_name,
-        'updated_at': now.isoformat(),
-        'tag_slugs': new_tags,
-    }
-
-    tag_replacement = ''
-    if replace_tags:
-        tag_replacement = """
-        WITH DISTINCT n, p, o
-        OPTIONAL MATCH (n)-[tw:TAGGED_WITH]->(:Tag)
-        DELETE tw
-        WITH DISTINCT n, p, o
-        UNWIND (CASE WHEN size({tag_slugs}) = 0 THEN [null]
-                     ELSE {tag_slugs} END) AS tag_slug
-        OPTIONAL MATCH (tag:Tag {{slug: tag_slug}})-[:BELONGS_TO]->(o)
-        FOREACH (_ IN CASE WHEN tag IS NOT NULL THEN [1] ELSE [] END |
-            CREATE (n)-[:TAGGED_WITH]->(tag)
-        )
-        """
-
-    query: str = (
-        """
+    set_query: typing.LiteralString = """
     MATCH (n:Note {{id: {note_id}}})
-          -[:ATTACHED_TO]->(p:Project {{id: {project_id}}})
+          -[:ATTACHED_TO]->(:Project {{id: {project_id}}})
           -[:OWNED_BY]->(:Team)
-          -[:BELONGS_TO]->(o:Organization {{slug: {org_slug}}})
-    SET n.content = {content},
+          -[:BELONGS_TO]->(:Organization {{slug: {org_slug}}})
+    SET n.title = {title},
+        n.content = {content},
         n.updated_by = {updated_by},
-        n.updated_at = {updated_at}
+        n.updated_at = {updated_at},
+        n.is_pinned = {is_pinned}
+    RETURN n.id AS id
     """
-        + tag_replacement
-        + """
-    WITH DISTINCT n, p
-    """
-        + _TAGS_TAIL
+    records = await db.execute(
+        set_query,
+        {
+            'org_slug': org_slug,
+            'project_id': project_id,
+            'note_id': note_id,
+            'title': new_title,
+            'content': new_content,
+            'updated_by': auth.principal_name,
+            'updated_at': now.isoformat(),
+            'is_pinned': new_is_pinned,
+        },
+        columns=['id'],
     )
-    records = await db.execute(query, params, columns=['n', 'p', 'tags'])
     if not records:
         raise fastapi.HTTPException(
             status_code=404, detail=f'Note {note_id!r} not found'
         )
-    return _parse_note_row(records[0])
+
+    if replace_tags:
+        await _detach_all_tags(db, note_id)
+        await _attach_tags(db, org_slug, note_id, new_tags)
+
+    note = await _fetch_note(db, org_slug, project_id, note_id)
+    if note is None:
+        raise fastapi.HTTPException(
+            status_code=404, detail=f'Note {note_id!r} not found'
+        )
+    return note
 
 
 @notes_project_router.delete('/{note_id}', status_code=204)

--- a/src/imbi_api/endpoints/notes.py
+++ b/src/imbi_api/endpoints/notes.py
@@ -491,6 +491,28 @@ class NoteUpdate(pydantic.BaseModel):
     is_pinned: bool | None = None
 
 
+def _resolve_patched_field(
+    field: str,
+    touched: set[str],
+    new_value: typing.Any,
+    fallback: typing.Any,
+) -> typing.Any:
+    """Return the resolved value for a non-nullable field after a JSON Patch.
+
+    If the patch touched ``field`` and ``new_value`` is ``None`` (an explicit
+    ``null``), raise 400 — silent no-ops would make the response disagree with
+    the patch document. Otherwise return ``new_value`` when touched, else
+    ``fallback``.
+    """
+    if field in touched:
+        if new_value is None:
+            raise fastapi.HTTPException(
+                status_code=400, detail=f'{field} cannot be null'
+            )
+        return new_value
+    return fallback
+
+
 @notes_project_router.patch('/{note_id}', response_model=NoteResponse)
 async def patch_note(
     org_slug: str,
@@ -535,21 +557,18 @@ async def patch_note(
             detail=f'Validation error: {e.errors()}',
         ) from e
 
-    new_title = (
-        update.title
-        if update.title is not None
-        else str(existing.get('title') or '')
+    # Use ``touched`` (not ``is not None``) so that explicit ``null`` values
+    # in the patch document are rejected rather than silently treated as
+    # "field omitted". ``apply_patch()`` preserves explicit nulls, so the
+    # PATCH result must agree with the patch document.
+    new_title = _resolve_patched_field(
+        'title', touched, update.title, str(existing.get('title') or '')
     )
-    new_content = (
-        update.content if update.content is not None else existing['content']
+    new_content = _resolve_patched_field(
+        'content', touched, update.content, existing['content']
     )
-    # Replace tag edges only when an op actually targeted ``/tags``. The
-    # patched dict always carries a ``tags`` key from ``current``, so
-    # ``update.tags is not None`` alone can't distinguish "left alone" from
-    # "set to []".
-    replace_tags = any(
-        op.path == '/tags' or op.path.startswith('/tags/') for op in operations
-    )
+    # Replace tag edges only when an op actually targeted ``/tags``.
+    replace_tags = 'tags' in touched
     new_tags: list[str] = (
         list(dict.fromkeys(update.tags or []))
         if replace_tags
@@ -557,10 +576,11 @@ async def patch_note(
     )
     if replace_tags:
         await _validate_tag_slugs(db, org_slug, new_tags)
-    new_is_pinned = (
-        update.is_pinned
-        if update.is_pinned is not None
-        else bool(existing.get('is_pinned', False))
+    new_is_pinned = _resolve_patched_field(
+        'is_pinned',
+        touched,
+        update.is_pinned,
+        bool(existing.get('is_pinned', False)),
     )
 
     now = datetime.datetime.now(datetime.UTC)

--- a/src/imbi_api/patch.py
+++ b/src/imbi_api/patch.py
@@ -17,8 +17,6 @@ READONLY_PATHS: frozenset[str] = frozenset(
     ]
 )
 
-_UNSET: object = object()
-
 
 class PatchOperation(pydantic.BaseModel):
     """A single JSON Patch operation (RFC 6902).
@@ -35,7 +33,7 @@ class PatchOperation(pydantic.BaseModel):
 
     op: typing.Literal['add', 'remove', 'replace', 'move', 'copy', 'test']
     path: str
-    value: typing.Any = _UNSET
+    value: typing.Any = None
     from_: str | None = pydantic.Field(None, alias='from')
 
 
@@ -84,7 +82,7 @@ def apply_patch(
     ops_list: list[dict[str, typing.Any]] = []
     for op in operations:
         d: dict[str, typing.Any] = {'op': op.op, 'path': op.path}
-        if op.value is not _UNSET:
+        if 'value' in op.model_fields_set:
             d['value'] = op.value
         if op.from_ is not None:
             d['from'] = op.from_

--- a/tests/endpoints/test_notes.py
+++ b/tests/endpoints/test_notes.py
@@ -442,6 +442,60 @@ class NoteEndpointsTestCase(unittest.TestCase):
         write_call = self.mock_db.execute.await_args_list[1]
         self.assertTrue(write_call.args[1]['is_pinned'])
 
+    def test_patch_title_null_rejected(self) -> None:
+        """Explicit ``replace /title -> null`` must 400, not silently no-op."""
+        self.mock_db.execute.return_value = [
+            {
+                'n': self._note_data(),
+                'p': self._project(),
+                'tags': [],
+            }
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.patch(
+                '/organizations/engineering/projects/proj-abc/notes/note-1',
+                json=[{'op': 'replace', 'path': '/title', 'value': None}],
+            )
+        self.assertEqual(response.status_code, 400)
+
+    def test_patch_is_pinned_null_rejected(self) -> None:
+        """Explicit ``replace /is_pinned -> null`` must 400."""
+        self.mock_db.execute.return_value = [
+            {
+                'n': self._note_data(),
+                'p': self._project(),
+                'tags': [],
+            }
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.patch(
+                '/organizations/engineering/projects/proj-abc/notes/note-1',
+                json=[{'op': 'replace', 'path': '/is_pinned', 'value': None}],
+            )
+        self.assertEqual(response.status_code, 400)
+
+    def test_patch_content_null_rejected(self) -> None:
+        """Explicit ``replace /content -> null`` must 400."""
+        self.mock_db.execute.return_value = [
+            {
+                'n': self._note_data(),
+                'p': self._project(),
+                'tags': [],
+            }
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.patch(
+                '/organizations/engineering/projects/proj-abc/notes/note-1',
+                json=[{'op': 'replace', 'path': '/content', 'value': None}],
+            )
+        self.assertEqual(response.status_code, 400)
+
     def test_patch_readonly_path_rejected(self) -> None:
         self.mock_db.execute.return_value = [
             {

--- a/tests/endpoints/test_notes.py
+++ b/tests/endpoints/test_notes.py
@@ -57,6 +57,7 @@ class NoteEndpointsTestCase(unittest.TestCase):
     def _note_data(self, **overrides: typing.Any) -> dict:
         data: dict[str, typing.Any] = {
             'id': 'note-1',
+            'title': 'DB lock runbook',
             'content': 'Watch out for DB locks',
             'created_by': 'admin@example.com',
             'created_at': '2026-03-17T12:00:00Z',
@@ -85,19 +86,25 @@ class NoteEndpointsTestCase(unittest.TestCase):
         ):
             response = self.client.post(
                 '/organizations/engineering/projects/proj-abc/notes/',
-                json={'content': 'Watch out for DB locks'},
+                json={
+                    'title': 'DB lock runbook',
+                    'content': 'Watch out for DB locks',
+                },
             )
         self.assertEqual(response.status_code, 201)
         self.assertEqual(response.json()['project_id'], 'proj-abc')
+        self.assertEqual(response.json()['title'], 'DB lock runbook')
         self.assertEqual(response.json()['tags'], [])
 
     def test_create_with_tags(self) -> None:
-        # first call = _validate_tag_slugs (both found), second = insert
+        # Calls: validate_tags, create_note, attach_tags, fetch_note
         self.mock_db.execute.side_effect = [
             [
                 {'tag_slug': 'runbook', 'found': True},
                 {'tag_slug': 'alert', 'found': True},
             ],
+            [{'id': 'note-1'}],
+            [{'attached': 2}],
             [
                 {
                     'n': self._note_data(),
@@ -114,11 +121,19 @@ class NoteEndpointsTestCase(unittest.TestCase):
         ):
             response = self.client.post(
                 '/organizations/engineering/projects/proj-abc/notes/',
-                json={'content': 'x', 'tags': ['runbook', 'alert']},
+                json={
+                    'title': 't',
+                    'content': 'x',
+                    'tags': ['runbook', 'alert'],
+                },
             )
         self.assertEqual(response.status_code, 201)
         tags = {t['slug'] for t in response.json()['tags']}
         self.assertEqual(tags, {'runbook', 'alert'})
+        attach_call = self.mock_db.execute.await_args_list[2]
+        self.assertEqual(
+            attach_call.args[1]['tag_slugs'], ['runbook', 'alert']
+        )
 
     def test_create_unknown_tag_returns_422(self) -> None:
         self.mock_db.execute.return_value = [
@@ -130,7 +145,11 @@ class NoteEndpointsTestCase(unittest.TestCase):
         ):
             response = self.client.post(
                 '/organizations/engineering/projects/proj-abc/notes/',
-                json={'content': 'x', 'tags': ['runbook', 'ghost']},
+                json={
+                    'title': 't',
+                    'content': 'x',
+                    'tags': ['runbook', 'ghost'],
+                },
             )
         self.assertEqual(response.status_code, 422)
         self.assertIn('ghost', response.json()['detail'])
@@ -142,14 +161,28 @@ class NoteEndpointsTestCase(unittest.TestCase):
         ):
             response = self.client.post(
                 '/organizations/engineering/projects/missing/notes/',
-                json={'content': 'x'},
+                json={'title': 't', 'content': 'x'},
             )
         self.assertEqual(response.status_code, 404)
 
     def test_create_empty_content_rejected(self) -> None:
         response = self.client.post(
             '/organizations/engineering/projects/proj-abc/notes/',
-            json={'content': ''},
+            json={'title': 't', 'content': ''},
+        )
+        self.assertEqual(response.status_code, 422)
+
+    def test_create_missing_title_rejected(self) -> None:
+        response = self.client.post(
+            '/organizations/engineering/projects/proj-abc/notes/',
+            json={'content': 'x'},
+        )
+        self.assertEqual(response.status_code, 422)
+
+    def test_create_empty_title_rejected(self) -> None:
+        response = self.client.post(
+            '/organizations/engineering/projects/proj-abc/notes/',
+            json={'title': '', 'content': 'x'},
         )
         self.assertEqual(response.status_code, 422)
 
@@ -242,6 +275,7 @@ class NoteEndpointsTestCase(unittest.TestCase):
     # -- Patch ---------------------------------------------------------
 
     def test_patch_content(self) -> None:
+        # 1: _fetch_note (existing), 2: SET query, 3: _fetch_note (final)
         self.mock_db.execute.side_effect = [
             [
                 {
@@ -250,6 +284,7 @@ class NoteEndpointsTestCase(unittest.TestCase):
                     'tags': [],
                 }
             ],
+            [{'id': 'note-1'}],
             [
                 {
                     'n': self._note_data(content='Updated text'),
@@ -275,6 +310,7 @@ class NoteEndpointsTestCase(unittest.TestCase):
         self.assertEqual(response.json()['content'], 'Updated text')
 
     def test_patch_replace_tags(self) -> None:
+        # fetch-existing, validate, SET, detach, attach, fetch-final
         self.mock_db.execute.side_effect = [
             [
                 {
@@ -283,9 +319,10 @@ class NoteEndpointsTestCase(unittest.TestCase):
                     'tags': [],
                 }
             ],
-            [  # _validate_tag_slugs
-                {'tag_slug': 'runbook', 'found': True},
-            ],
+            [{'tag_slug': 'runbook', 'found': True}],
+            [{'id': 'note-1'}],
+            [{'removed': 0}],
+            [{'attached': 1}],
             [
                 {
                     'n': self._note_data(updated_by='admin@example.com'),
@@ -311,6 +348,99 @@ class NoteEndpointsTestCase(unittest.TestCase):
         self.assertEqual(
             [t['slug'] for t in response.json()['tags']], ['runbook']
         )
+
+    def test_create_defaults_is_pinned_false(self) -> None:
+        self.mock_db.execute.return_value = [
+            {'n': self._note_data(), 'p': self._project(), 'tags': []}
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.post(
+                '/organizations/engineering/projects/proj-abc/notes/',
+                json={
+                    'title': 'DB lock runbook',
+                    'content': 'Watch out for DB locks',
+                },
+            )
+        self.assertEqual(response.status_code, 201)
+        self.assertFalse(response.json()['is_pinned'])
+        create_call = self.mock_db.execute.await_args_list[0]
+        self.assertFalse(create_call.args[1]['is_pinned'])
+
+    def test_patch_title(self) -> None:
+        self.mock_db.execute.side_effect = [
+            [
+                {
+                    'n': self._note_data(),
+                    'p': self._project(),
+                    'tags': [],
+                }
+            ],
+            [{'id': 'note-1'}],
+            [
+                {
+                    'n': self._note_data(title='New title'),
+                    'p': self._project(),
+                    'tags': [],
+                }
+            ],
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.patch(
+                '/organizations/engineering/projects/proj-abc/notes/note-1',
+                json=[
+                    {
+                        'op': 'replace',
+                        'path': '/title',
+                        'value': 'New title',
+                    }
+                ],
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()['title'], 'New title')
+        # SET query is the second call (after the initial _fetch_note).
+        write_call = self.mock_db.execute.await_args_list[1]
+        self.assertEqual(write_call.args[1]['title'], 'New title')
+
+    def test_patch_is_pinned(self) -> None:
+        self.mock_db.execute.side_effect = [
+            [
+                {
+                    'n': self._note_data(),
+                    'p': self._project(),
+                    'tags': [],
+                }
+            ],
+            [{'id': 'note-1'}],
+            [
+                {
+                    'n': self._note_data(is_pinned=True),
+                    'p': self._project(),
+                    'tags': [],
+                }
+            ],
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.patch(
+                '/organizations/engineering/projects/proj-abc/notes/note-1',
+                json=[
+                    {
+                        'op': 'replace',
+                        'path': '/is_pinned',
+                        'value': True,
+                    }
+                ],
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.json()['is_pinned'])
+        # SET query is the second call (after the initial _fetch_note).
+        write_call = self.mock_db.execute.await_args_list[1]
+        self.assertTrue(write_call.args[1]['is_pinned'])
 
     def test_patch_readonly_path_rejected(self) -> None:
         self.mock_db.execute.return_value = [

--- a/uv.lock
+++ b/uv.lock
@@ -944,7 +944,7 @@ docs = [
 [[package]]
 name = "imbi-common"
 version = "0.1.0"
-source = { git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=main#26c1a07ca80023b7aec30d6b9ea878690953407b" }
+source = { git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=main#c18876b3fd6db8beb26c5cccabca3ae3f12e862d" }
 dependencies = [
     { name = "cryptography" },
     { name = "jsonschema-models" },


### PR DESCRIPTION
## Summary

- `NoteResponse` exposes `title` (default empty) and `is_pinned`; the row parser backfills both so pre-existing notes still deserialize cleanly.
- `NoteCreate` requires a `title` (1–200 chars).
- Tag attach/detach extracted into dedicated helpers (`_attach_tags`, `_detach_all_tags`) — AGE's Cypher translator does not support `FOREACH`, so a plain `UNWIND` + `MATCH` + `CREATE` is portable.
- Replace the module-level `_UNSET` sentinel in `patch.py` with pydantic's `model_fields_set`. This makes `PatchOperation` behave correctly when `value=None` is the explicit patch payload (before, `None` was indistinguishable from "not provided").

Depends on AWeber-Imbi/imbi-common#60 (adds the fields to the shared `Note` graph model).

## Test plan

- [ ] `tests/endpoints/test_notes.py` covers create-with-title, tag attach/detach, and the `_parse_note_row` backfill path.
- [ ] Confirm patching `is_pinned=true` flips the flag and persists via the graph edge.
- [ ] Confirm patching a field to `null` via JSON Patch now round-trips (regression for the `_UNSET` change).