### PR TITLE
Add note template CRUD endpoints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -217,4 +217,4 @@ url = "https://pypi.org/simple"
 default = true
 
 [tool.uv.sources]
-imbi-common = { git = "https://github.com/AWeber-Imbi/imbi-common.git", rev = "main" }
+imbi-common = { git = "https://github.com/AWeber-Imbi/imbi-common.git", rev = "feature/note-templates" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -217,4 +217,4 @@ url = "https://pypi.org/simple"
 default = true
 
 [tool.uv.sources]
-imbi-common = { git = "https://github.com/AWeber-Imbi/imbi-common.git", rev = "feature/note-templates" }
+imbi-common = { git = "https://github.com/AWeber-Imbi/imbi-common.git", rev = "main" }

--- a/src/imbi_api/auth/seed.py
+++ b/src/imbi_api/auth/seed.py
@@ -237,6 +237,31 @@ STANDARD_PERMISSIONS: list[tuple[str, str, str, str]] = [
     ('note:read', 'note', 'read', 'View project notes'),
     ('note:write', 'note', 'write', 'Update project notes'),
     ('note:delete', 'note', 'delete', 'Delete project notes'),
+    # Note template management
+    (
+        'note_template:create',
+        'note_template',
+        'create',
+        'Create note templates',
+    ),
+    (
+        'note_template:read',
+        'note_template',
+        'read',
+        'View note templates',
+    ),
+    (
+        'note_template:write',
+        'note_template',
+        'write',
+        'Update note templates',
+    ),
+    (
+        'note_template:delete',
+        'note_template',
+        'delete',
+        'Delete note templates',
+    ),
 ]
 
 # Default role definitions
@@ -281,6 +306,7 @@ DEFAULT_ROLES: list[tuple[str, str, str, int, list[str]]] = [
             'note:read',
             'note:write',
             'note:delete',
+            'note_template:read',
         ],
     ),
     (
@@ -304,6 +330,7 @@ DEFAULT_ROLES: list[tuple[str, str, str, int, list[str]]] = [
             'webhook:read',
             'tag:read',
             'note:read',
+            'note_template:read',
         ],
     ),
 ]

--- a/src/imbi_api/endpoints/note_templates.py
+++ b/src/imbi_api/endpoints/note_templates.py
@@ -162,12 +162,15 @@ async def _attach_tags(
 ) -> None:
     if not tag_slugs:
         return
+    # MERGE keeps this idempotent — defensive against any future caller
+    # that doesn't first run ``_detach_all_tags``. The TAGGED_WITH edge
+    # carries no properties, so no AGE MERGE-with-properties pitfall.
     query: typing.LiteralString = """
     MATCH (nt:NoteTemplate {{slug: {tpl_slug}}})
           -[:BELONGS_TO]->(o:Organization {{slug: {org_slug}}}),
           (t:Tag)-[:BELONGS_TO]->(o)
     WHERE t.slug IN {tag_slugs}
-    CREATE (nt)-[:TAGGED_WITH]->(t)
+    MERGE (nt)-[:TAGGED_WITH]->(t)
     RETURN count(t) AS attached
     """
     await db.execute(

--- a/src/imbi_api/endpoints/note_templates.py
+++ b/src/imbi_api/endpoints/note_templates.py
@@ -321,7 +321,11 @@ async def list_note_templates(
     results: list[dict[str, typing.Any]] = []
     for record in records:
         template = _parse_template_row(record)
-        slugs = template.get('project_type_slugs') or []
+        raw_slugs = typing.cast(
+            list[typing.Any] | None,
+            template.get('project_type_slugs'),
+        )
+        slugs: list[str] = [str(s) for s in (raw_slugs or [])]
         if project_type is not None and slugs and project_type not in slugs:
             continue
         results.append(template)

--- a/src/imbi_api/endpoints/note_templates.py
+++ b/src/imbi_api/endpoints/note_templates.py
@@ -11,7 +11,6 @@ import logging
 import typing
 
 import fastapi
-import psycopg.errors
 import pydantic
 from imbi_common import graph
 
@@ -238,6 +237,23 @@ async def create_note_template(
     tag_slugs = list(dict.fromkeys(data.tags))
     await _validate_tag_slugs(db, org_slug, tag_slugs)
 
+    # Slugs are unique per-org, not globally — enforce in app code.
+    duplicate_query: typing.LiteralString = """
+    MATCH (nt:NoteTemplate {{slug: {slug}}})
+          -[:BELONGS_TO]->(:Organization {{slug: {org_slug}}})
+    RETURN nt.slug AS slug
+    """
+    existing = await db.execute(
+        duplicate_query,
+        {'slug': data.slug, 'org_slug': org_slug},
+        columns=['slug'],
+    )
+    if existing:
+        raise fastapi.HTTPException(
+            status_code=409,
+            detail=f'Note template with slug {data.slug!r} already exists',
+        )
+
     now = datetime.datetime.now(datetime.UTC)
     props: dict[str, typing.Any] = {
         'id': data.slug,
@@ -260,13 +276,7 @@ async def create_note_template(
         f' RETURN nt, o'
     )
     params = {**props, 'org_slug': org_slug}
-    try:
-        records = await db.execute(query, params, columns=['nt', 'o'])
-    except psycopg.errors.UniqueViolation as e:
-        raise fastapi.HTTPException(
-            status_code=409,
-            detail=(f'Note template with slug {data.slug!r} already exists'),
-        ) from e
+    records = await db.execute(query, params, columns=['nt', 'o'])
 
     if not records:
         raise fastapi.HTTPException(
@@ -369,6 +379,26 @@ async def _persist_update(
     if 'icon' in props and props['icon'] is not None:
         props['icon'] = str(props['icon'])
 
+    new_slug = props.get('slug', original_slug)
+    if new_slug != original_slug:
+        duplicate_query: typing.LiteralString = """
+        MATCH (nt:NoteTemplate {{slug: {slug}}})
+              -[:BELONGS_TO]->(:Organization {{slug: {org_slug}}})
+        RETURN nt.slug AS slug
+        """
+        existing = await db.execute(
+            duplicate_query,
+            {'slug': new_slug, 'org_slug': org_slug},
+            columns=['slug'],
+        )
+        if existing:
+            raise fastapi.HTTPException(
+                status_code=409,
+                detail=(
+                    f'Note template with slug {new_slug!r} already exists'
+                ),
+            )
+
     set_stmt = set_clause('nt', props)
     update_query = (
         f'MATCH (nt:NoteTemplate {{{{slug: {{slug}}}}}})'
@@ -378,16 +408,7 @@ async def _persist_update(
         f' RETURN nt.slug AS slug'
     )
     params = {**props, 'slug': original_slug, 'org_slug': org_slug}
-    try:
-        records = await db.execute(update_query, params, columns=['slug'])
-    except psycopg.errors.UniqueViolation as e:
-        raise fastapi.HTTPException(
-            status_code=409,
-            detail=(
-                f'Note template with slug'
-                f' {props.get("slug", original_slug)!r} already exists'
-            ),
-        ) from e
+    records = await db.execute(update_query, params, columns=['slug'])
 
     if not records:
         raise fastapi.HTTPException(

--- a/src/imbi_api/endpoints/note_templates.py
+++ b/src/imbi_api/endpoints/note_templates.py
@@ -1,0 +1,543 @@
+"""Note template management endpoints.
+
+Templates are scoped to an organization and seed a new
+``Note``'s title, content, and tag set when a user creates a note
+from one. ``project_type_slugs`` filters the templates that apply
+to a given project type.
+"""
+
+import datetime
+import logging
+import typing
+
+import fastapi
+import psycopg.errors
+import pydantic
+from imbi_common import graph
+
+from imbi_api import patch as json_patch
+from imbi_api.auth import permissions
+from imbi_api.graph_sql import props_template, set_clause
+
+LOGGER = logging.getLogger(__name__)
+
+note_templates_router = fastapi.APIRouter(tags=['Note Templates'])
+
+_TEMPLATE_READONLY_PATHS: frozenset[str] = frozenset(
+    [
+        '/id',
+        '/organization',
+        '/created_at',
+        '/updated_at',
+    ]
+)
+
+
+class TagRef(pydantic.BaseModel):
+    name: str
+    slug: str
+
+
+class OrganizationRef(pydantic.BaseModel):
+    name: str
+    slug: str
+
+
+class NoteTemplateBase(pydantic.BaseModel):
+    name: str = pydantic.Field(min_length=1)
+    slug: str = pydantic.Field(min_length=1)
+    description: str | None = None
+    icon: pydantic.HttpUrl | str | None = None
+    title: str | None = None
+    content: str = ''
+    tags: list[str] = pydantic.Field(
+        default_factory=list,
+        description='Tag slugs to attach. Must already exist in the org.',
+    )
+    project_type_slugs: list[str] = []
+    sort_order: int = 0
+
+
+class NoteTemplateCreate(NoteTemplateBase):
+    pass
+
+
+class NoteTemplateUpdate(pydantic.BaseModel):
+    name: str | None = pydantic.Field(default=None, min_length=1)
+    slug: str | None = pydantic.Field(default=None, min_length=1)
+    description: str | None = None
+    icon: pydantic.HttpUrl | str | None = None
+    title: str | None = None
+    content: str | None = None
+    tags: list[str] | None = None
+    project_type_slugs: list[str] | None = None
+    sort_order: int | None = None
+
+
+class NoteTemplateResponse(pydantic.BaseModel):
+    id: str
+    name: str
+    slug: str
+    description: str | None = None
+    icon: pydantic.HttpUrl | str | None = None
+    title: str | None = None
+    content: str = ''
+    tags: list[TagRef] = []
+    project_type_slugs: list[str] = []
+    sort_order: int = 0
+    created_at: datetime.datetime
+    updated_at: datetime.datetime | None = None
+    organization: OrganizationRef
+
+
+_TAGS_TAIL: typing.LiteralString = """
+    OPTIONAL MATCH (nt)-[:TAGGED_WITH]->(tag:Tag)
+    WITH nt, o, collect(CASE WHEN tag IS NOT NULL
+                              THEN tag{{.name, .slug}}
+                              END) AS raw_tags
+    WITH nt, o, [t IN raw_tags WHERE t IS NOT NULL] AS tags
+    RETURN nt, o, tags
+"""
+
+
+def _parse_template_row(
+    record: dict[str, typing.Any],
+) -> dict[str, typing.Any]:
+    template: dict[str, typing.Any] = graph.parse_agtype(record['nt'])
+    org: dict[str, typing.Any] = graph.parse_agtype(record['o'])
+    raw_tags: list[typing.Any] = graph.parse_agtype(record['tags']) or []
+    tags: list[dict[str, str]] = []
+    for t in raw_tags:
+        if not isinstance(t, dict):
+            continue
+        entry = typing.cast(dict[str, typing.Any], t)
+        slug = entry.get('slug')
+        if not slug:
+            continue
+        tags.append(
+            {'name': str(entry.get('name', '')), 'slug': str(slug)},
+        )
+    template['organization'] = {
+        'name': str(org.get('name', '')),
+        'slug': str(org.get('slug', '')),
+    }
+    template['tags'] = tags
+    template.setdefault('project_type_slugs', [])
+    template.setdefault('sort_order', 0)
+    return template
+
+
+async def _validate_tag_slugs(
+    db: graph.Pool, org_slug: str, tag_slugs: list[str]
+) -> None:
+    if not tag_slugs:
+        return
+    query: typing.LiteralString = """
+    MATCH (o:Organization {{slug: {org_slug}}})
+    UNWIND {slugs} AS tag_slug
+    OPTIONAL MATCH (t:Tag {{slug: tag_slug}})-[:BELONGS_TO]->(o)
+    RETURN tag_slug, t IS NOT NULL AS found
+    """
+    records = await db.execute(
+        query,
+        {'org_slug': org_slug, 'slugs': tag_slugs},
+        columns=['tag_slug', 'found'],
+    )
+    missing = [
+        graph.parse_agtype(r['tag_slug'])
+        for r in records
+        if not graph.parse_agtype(r['found'])
+    ]
+    if missing:
+        raise fastapi.HTTPException(
+            status_code=422,
+            detail=f'Tag slug(s) not found: {sorted(missing)!r}',
+        )
+
+
+async def _attach_tags(
+    db: graph.Pool,
+    org_slug: str,
+    template_slug: str,
+    tag_slugs: list[str],
+) -> None:
+    if not tag_slugs:
+        return
+    query: typing.LiteralString = """
+    MATCH (nt:NoteTemplate {{slug: {tpl_slug}}})
+          -[:BELONGS_TO]->(o:Organization {{slug: {org_slug}}}),
+          (t:Tag)-[:BELONGS_TO]->(o)
+    WHERE t.slug IN {tag_slugs}
+    CREATE (nt)-[:TAGGED_WITH]->(t)
+    RETURN count(t) AS attached
+    """
+    await db.execute(
+        query,
+        {
+            'tpl_slug': template_slug,
+            'org_slug': org_slug,
+            'tag_slugs': tag_slugs,
+        },
+        columns=['attached'],
+    )
+
+
+async def _detach_all_tags(
+    db: graph.Pool, org_slug: str, template_slug: str
+) -> None:
+    query: typing.LiteralString = """
+    MATCH (nt:NoteTemplate {{slug: {tpl_slug}}})
+          -[:BELONGS_TO]->(:Organization {{slug: {org_slug}}}),
+          (nt)-[tw:TAGGED_WITH]->(:Tag)
+    DELETE tw
+    RETURN count(tw) AS removed
+    """
+    await db.execute(
+        query,
+        {'tpl_slug': template_slug, 'org_slug': org_slug},
+        columns=['removed'],
+    )
+
+
+async def _fetch_template(
+    db: graph.Pool, org_slug: str, slug: str
+) -> dict[str, typing.Any] | None:
+    query: str = (
+        """
+    MATCH (nt:NoteTemplate {{slug: {slug}}})
+          -[:BELONGS_TO]->(o:Organization {{slug: {org_slug}}})
+    WITH DISTINCT nt, o
+    """
+        + _TAGS_TAIL
+    )
+    records = await db.execute(
+        query,
+        {'slug': slug, 'org_slug': org_slug},
+        columns=['nt', 'o', 'tags'],
+    )
+    if not records:
+        return None
+    return _parse_template_row(records[0])
+
+
+@note_templates_router.post(
+    '/', status_code=201, response_model=NoteTemplateResponse
+)
+async def create_note_template(
+    org_slug: str,
+    data: NoteTemplateCreate,
+    db: graph.Pool,
+    _auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('note_template:create'),
+        ),
+    ],
+) -> dict[str, typing.Any]:
+    """Create a note template scoped to ``org_slug``."""
+    tag_slugs = list(dict.fromkeys(data.tags))
+    await _validate_tag_slugs(db, org_slug, tag_slugs)
+
+    now = datetime.datetime.now(datetime.UTC)
+    props: dict[str, typing.Any] = {
+        'id': data.slug,
+        'name': data.name,
+        'slug': data.slug,
+        'description': data.description,
+        'icon': str(data.icon) if data.icon else None,
+        'title': data.title,
+        'content': data.content,
+        'project_type_slugs': data.project_type_slugs,
+        'sort_order': data.sort_order,
+        'created_at': now.isoformat(),
+        'updated_at': now.isoformat(),
+    }
+    create_tpl = props_template(props)
+    query = (
+        f'MATCH (o:Organization {{{{slug: {{org_slug}}}}}})'
+        f' CREATE (nt:NoteTemplate {create_tpl})'
+        f' CREATE (nt)-[:BELONGS_TO]->(o)'
+        f' RETURN nt, o'
+    )
+    params = {**props, 'org_slug': org_slug}
+    try:
+        records = await db.execute(query, params, columns=['nt', 'o'])
+    except psycopg.errors.UniqueViolation as e:
+        raise fastapi.HTTPException(
+            status_code=409,
+            detail=(f'Note template with slug {data.slug!r} already exists'),
+        ) from e
+
+    if not records:
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail=f'Organization with slug {org_slug!r} not found',
+        )
+
+    if tag_slugs:
+        await _attach_tags(db, org_slug, data.slug, tag_slugs)
+
+    template = await _fetch_template(db, org_slug, data.slug)
+    if template is None:
+        raise fastapi.HTTPException(
+            status_code=500,
+            detail='Note template created but could not be read back',
+        )
+    return template
+
+
+@note_templates_router.get('/', response_model=list[NoteTemplateResponse])
+async def list_note_templates(
+    org_slug: str,
+    db: graph.Pool,
+    _auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('note_template:read'),
+        ),
+    ],
+    project_type: str | None = None,
+) -> list[dict[str, typing.Any]]:
+    """List note templates for an organization.
+
+    ``project_type`` (optional): when provided, only templates that
+    apply to the given project-type slug are returned. Templates with
+    an empty ``project_type_slugs`` apply to every project type.
+    """
+    query: str = (
+        """
+    MATCH (nt:NoteTemplate)
+          -[:BELONGS_TO]->(o:Organization {{slug: {org_slug}}})
+    WITH DISTINCT nt, o
+    ORDER BY nt.sort_order, nt.name
+    """
+        + _TAGS_TAIL
+    )
+    records = await db.execute(
+        query,
+        {'org_slug': org_slug},
+        columns=['nt', 'o', 'tags'],
+    )
+    results: list[dict[str, typing.Any]] = []
+    for record in records:
+        template = _parse_template_row(record)
+        slugs = template.get('project_type_slugs') or []
+        if project_type is not None and slugs and project_type not in slugs:
+            continue
+        results.append(template)
+    return results
+
+
+@note_templates_router.get('/{slug}', response_model=NoteTemplateResponse)
+async def get_note_template(
+    org_slug: str,
+    slug: str,
+    db: graph.Pool,
+    _auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('note_template:read'),
+        ),
+    ],
+) -> dict[str, typing.Any]:
+    """Get a note template by slug."""
+    template = await _fetch_template(db, org_slug, slug)
+    if template is None:
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail=f'Note template with slug {slug!r} not found',
+        )
+    return template
+
+
+async def _persist_update(
+    db: graph.Pool,
+    org_slug: str,
+    original_slug: str,
+    payload: dict[str, typing.Any],
+    tag_slugs: list[str] | None,
+    existing_created_at: str | None,
+) -> dict[str, typing.Any]:
+    now = datetime.datetime.now(datetime.UTC)
+    props = {**payload}
+    props['created_at'] = existing_created_at or now.isoformat()
+    props['updated_at'] = now.isoformat()
+    if 'icon' in props and props['icon'] is not None:
+        props['icon'] = str(props['icon'])
+
+    set_stmt = set_clause('nt', props)
+    update_query = (
+        f'MATCH (nt:NoteTemplate {{{{slug: {{slug}}}}}})'
+        f' -[:BELONGS_TO]->'
+        f'(:Organization {{{{slug: {{org_slug}}}}}})'
+        f' {set_stmt}'
+        f' RETURN nt.slug AS slug'
+    )
+    params = {**props, 'slug': original_slug, 'org_slug': org_slug}
+    try:
+        records = await db.execute(update_query, params, columns=['slug'])
+    except psycopg.errors.UniqueViolation as e:
+        raise fastapi.HTTPException(
+            status_code=409,
+            detail=(
+                f'Note template with slug'
+                f' {props.get("slug", original_slug)!r} already exists'
+            ),
+        ) from e
+
+    if not records:
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail=(f'Note template with slug {original_slug!r} not found'),
+        )
+    new_slug = graph.parse_agtype(records[0]['slug']) or props.get(
+        'slug', original_slug
+    )
+
+    if tag_slugs is not None:
+        await _detach_all_tags(db, org_slug, new_slug)
+        await _attach_tags(db, org_slug, new_slug, tag_slugs)
+
+    template = await _fetch_template(db, org_slug, new_slug)
+    if template is None:
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail=f'Note template with slug {new_slug!r} not found',
+        )
+    return template
+
+
+@note_templates_router.put('/{slug}', response_model=NoteTemplateResponse)
+async def update_note_template(
+    org_slug: str,
+    slug: str,
+    data: NoteTemplateUpdate,
+    db: graph.Pool,
+    _auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('note_template:write'),
+        ),
+    ],
+) -> dict[str, typing.Any]:
+    """Update a note template (whole-or-partial replace)."""
+    existing = await _fetch_template(db, org_slug, slug)
+    if existing is None:
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail=f'Note template with slug {slug!r} not found',
+        )
+
+    incoming = data.model_dump(exclude_unset=True)
+    tag_slugs: list[str] | None = None
+    if 'tags' in incoming:
+        tag_slugs = list(dict.fromkeys(incoming.pop('tags') or []))
+        await _validate_tag_slugs(db, org_slug, tag_slugs)
+
+    merged: dict[str, typing.Any] = {
+        'name': existing.get('name'),
+        'slug': existing.get('slug'),
+        'description': existing.get('description'),
+        'icon': existing.get('icon'),
+        'title': existing.get('title'),
+        'content': existing.get('content', ''),
+        'project_type_slugs': existing.get('project_type_slugs', []),
+        'sort_order': existing.get('sort_order', 0),
+    }
+    merged.update(incoming)
+    merged['id'] = existing.get('id', merged['slug'])
+
+    return await _persist_update(
+        db,
+        org_slug,
+        slug,
+        merged,
+        tag_slugs,
+        existing.get('created_at'),
+    )
+
+
+@note_templates_router.patch('/{slug}', response_model=NoteTemplateResponse)
+async def patch_note_template(
+    org_slug: str,
+    slug: str,
+    operations: list[json_patch.PatchOperation],
+    db: graph.Pool,
+    _auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('note_template:write'),
+        ),
+    ],
+) -> dict[str, typing.Any]:
+    """Partially update a note template using JSON Patch (RFC 6902)."""
+    existing = await _fetch_template(db, org_slug, slug)
+    if existing is None:
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail=f'Note template with slug {slug!r} not found',
+        )
+
+    current: dict[str, typing.Any] = {
+        'name': existing.get('name'),
+        'slug': existing.get('slug'),
+        'description': existing.get('description'),
+        'icon': existing.get('icon'),
+        'title': existing.get('title'),
+        'content': existing.get('content', ''),
+        'tags': [t['slug'] for t in existing.get('tags', [])],
+        'project_type_slugs': existing.get('project_type_slugs', []),
+        'sort_order': existing.get('sort_order', 0),
+    }
+    patched = json_patch.apply_patch(
+        current, operations, _TEMPLATE_READONLY_PATHS
+    )
+
+    tag_slugs: list[str] | None = None
+    touched: set[str] = set()
+    for op in operations:
+        if op.path.startswith('/'):
+            head = op.path.split('/', 2)[1]
+            if head:
+                touched.add(head)
+    if 'tags' in touched:
+        tag_slugs = list(dict.fromkeys(patched.get('tags') or []))
+        await _validate_tag_slugs(db, org_slug, tag_slugs)
+    patched.pop('tags', None)
+    patched['id'] = existing.get('id', patched.get('slug', slug))
+
+    return await _persist_update(
+        db,
+        org_slug,
+        slug,
+        patched,
+        tag_slugs,
+        existing.get('created_at'),
+    )
+
+
+@note_templates_router.delete('/{slug}', status_code=204)
+async def delete_note_template(
+    org_slug: str,
+    slug: str,
+    db: graph.Pool,
+    _auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('note_template:delete'),
+        ),
+    ],
+) -> None:
+    """Delete a note template."""
+    query: typing.LiteralString = """
+    MATCH (nt:NoteTemplate {{slug: {slug}}})
+          -[:BELONGS_TO]->(:Organization {{slug: {org_slug}}})
+    DETACH DELETE nt
+    RETURN nt
+    """
+    records = await db.execute(query, {'slug': slug, 'org_slug': org_slug})
+    if not records:
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail=f'Note template with slug {slug!r} not found',
+        )

--- a/src/imbi_api/endpoints/note_templates.py
+++ b/src/imbi_api/endpoints/note_templates.py
@@ -520,6 +520,15 @@ async def patch_note_template(
     patched = json_patch.apply_patch(
         current, operations, _TEMPLATE_READONLY_PATHS
     )
+    # Re-validate against the schema — apply_patch is type-blind, so a
+    # patch like ``/sort_order = 'oops'`` would otherwise reach the DB.
+    try:
+        patched = NoteTemplateBase.model_validate(patched).model_dump()
+    except pydantic.ValidationError as e:
+        raise fastapi.HTTPException(
+            status_code=400,
+            detail=f'Validation error: {e.errors()}',
+        ) from e
 
     tag_slugs: list[str] | None = None
     touched: set[str] = set()

--- a/src/imbi_api/endpoints/note_templates.py
+++ b/src/imbi_api/endpoints/note_templates.py
@@ -50,7 +50,7 @@ class NoteTemplateBase(pydantic.BaseModel):
     title: str | None = None
     content: str = ''
     tags: list[str] = pydantic.Field(
-        default_factory=list,
+        default=[],
         description='Tag slugs to attach. Must already exist in the org.',
     )
     project_type_slugs: list[str] = []

--- a/src/imbi_api/endpoints/organizations.py
+++ b/src/imbi_api/endpoints/organizations.py
@@ -15,6 +15,7 @@ from imbi_api.relationships import build_relationships
 
 from .environments import environments_router
 from .link_definitions import link_definitions_router
+from .note_templates import note_templates_router
 from .notes import notes_project_router, notes_router
 from .operations_log import operations_log_project_router
 from .project_types import project_types_router
@@ -82,6 +83,10 @@ organizations_router.include_router(
 organizations_router.include_router(
     notes_project_router,
     prefix='/{org_slug}/projects/{project_id}/notes',
+)
+organizations_router.include_router(
+    note_templates_router,
+    prefix='/{org_slug}/note-templates',
 )
 
 

--- a/tests/endpoints/test_note_templates.py
+++ b/tests/endpoints/test_note_templates.py
@@ -376,6 +376,35 @@ class NoteTemplateEndpointsTestCase(unittest.TestCase):
             )
         self.assertEqual(response.status_code, 200)
 
+    def test_patch_invalid_type_rejected(self) -> None:
+        # apply_patch is type-blind — re-validation must catch this
+        self.mock_db.execute.return_value = [self._template_row()]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.patch(
+                '/organizations/engineering/note-templates/adr',
+                json=[
+                    {
+                        'op': 'replace',
+                        'path': '/sort_order',
+                        'value': 'oops',
+                    }
+                ],
+            )
+        self.assertEqual(response.status_code, 400)
+
+    def test_patch_empty_name_rejected(self) -> None:
+        self.mock_db.execute.return_value = [self._template_row()]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.patch(
+                '/organizations/engineering/note-templates/adr',
+                json=[{'op': 'replace', 'path': '/name', 'value': ''}],
+            )
+        self.assertEqual(response.status_code, 400)
+
     def test_patch_template_not_found(self) -> None:
         self.mock_db.execute.return_value = []
         response = self.client.patch(

--- a/tests/endpoints/test_note_templates.py
+++ b/tests/endpoints/test_note_templates.py
@@ -204,9 +204,7 @@ class NoteTemplateEndpointsTestCase(unittest.TestCase):
         self.mock_db.execute.return_value = [
             self._template_row(),
             {
-                'nt': self._template_row(
-                    name='Runbook', slug='runbook'
-                )['nt'],
+                'nt': self._template_row(name='Runbook', slug='runbook')['nt'],
                 'o': self._template_row()['o'],
                 'tags': [],
             },

--- a/tests/endpoints/test_note_templates.py
+++ b/tests/endpoints/test_note_templates.py
@@ -1,0 +1,400 @@
+"""Tests for note template CRUD endpoints."""
+
+import datetime
+import typing
+import unittest
+from unittest import mock
+
+import psycopg.errors
+from fastapi.testclient import TestClient
+from imbi_common import graph
+
+from imbi_api import app, models
+
+
+class NoteTemplateEndpointsTestCase(unittest.TestCase):
+    """Test cases for note template CRUD."""
+
+    def setUp(self) -> None:
+        from imbi_api.auth import permissions
+
+        self.test_app = app.create_app()
+
+        self.admin_user = models.User(
+            email='admin@example.com',
+            display_name='Admin User',
+            password_hash='$argon2id$hashed',
+            is_active=True,
+            is_admin=True,
+            is_service_account=False,
+            created_at=datetime.datetime.now(datetime.UTC),
+        )
+        self.auth_context = permissions.AuthContext(
+            user=self.admin_user,
+            session_id='test-session',
+            auth_method='jwt',
+            permissions={
+                'note_template:create',
+                'note_template:read',
+                'note_template:write',
+                'note_template:delete',
+            },
+        )
+
+        async def mock_get_current_user():
+            return self.auth_context
+
+        self.test_app.dependency_overrides[permissions.get_current_user] = (
+            mock_get_current_user
+        )
+
+        self.mock_db = mock.AsyncMock(spec=graph.Graph)
+        self.test_app.dependency_overrides[graph._inject_graph] = (
+            lambda: self.mock_db
+        )
+
+        self.client = TestClient(self.test_app)
+
+    def _template_row(self, **overrides: typing.Any) -> dict[str, typing.Any]:
+        nt: dict[str, typing.Any] = {
+            'id': 'adr',
+            'name': 'ADR',
+            'slug': 'adr',
+            'description': 'Context · Decision · Trade-offs',
+            'icon': 'document',
+            'title': 'New ADR',
+            'content': '# Context\n\n# Decision\n\n# Trade-offs',
+            'project_type_slugs': [],
+            'sort_order': 0,
+            'created_at': '2026-04-24T12:00:00Z',
+            'updated_at': '2026-04-24T12:00:00Z',
+        }
+        nt.update(overrides)
+        return {
+            'nt': nt,
+            'o': {'name': 'Engineering', 'slug': 'engineering'},
+            'tags': [],
+        }
+
+    # -- Create --------------------------------------------------------
+
+    def test_create_success_no_tags(self) -> None:
+        # No tags -> validate skipped, then create + fetch
+        self.mock_db.execute.side_effect = [
+            [
+                {
+                    'nt': self._template_row()['nt'],
+                    'o': self._template_row()['o'],
+                }
+            ],
+            [self._template_row()],
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.post(
+                '/organizations/engineering/note-templates/',
+                json={
+                    'name': 'ADR',
+                    'slug': 'adr',
+                    'description': 'Context · Decision · Trade-offs',
+                    'content': '# Context',
+                },
+            )
+        self.assertEqual(response.status_code, 201)
+        body = response.json()
+        self.assertEqual(body['slug'], 'adr')
+        self.assertEqual(body['organization']['slug'], 'engineering')
+        self.assertEqual(body['tags'], [])
+
+    def test_create_with_tags(self) -> None:
+        # Calls: validate_tags, create, attach_tags, fetch
+        fetch_with_tags = {
+            'nt': self._template_row()['nt'],
+            'o': self._template_row()['o'],
+            'tags': [
+                {'name': 'ADR', 'slug': 'adr'},
+                {'name': 'Architecture', 'slug': 'architecture'},
+            ],
+        }
+        self.mock_db.execute.side_effect = [
+            [
+                {'tag_slug': 'adr', 'found': True},
+                {'tag_slug': 'architecture', 'found': True},
+            ],
+            [
+                {
+                    'nt': self._template_row()['nt'],
+                    'o': self._template_row()['o'],
+                }
+            ],
+            [{'attached': 2}],
+            [fetch_with_tags],
+        ]
+
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.post(
+                '/organizations/engineering/note-templates/',
+                json={
+                    'name': 'ADR',
+                    'slug': 'adr',
+                    'content': '# Context',
+                    'tags': ['adr', 'architecture'],
+                },
+            )
+        self.assertEqual(response.status_code, 201)
+        slugs = {t['slug'] for t in response.json()['tags']}
+        self.assertEqual(slugs, {'adr', 'architecture'})
+
+    def test_create_unknown_tag_returns_422(self) -> None:
+        self.mock_db.execute.return_value = [
+            {'tag_slug': 'adr', 'found': True},
+            {'tag_slug': 'ghost', 'found': False},
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.post(
+                '/organizations/engineering/note-templates/',
+                json={
+                    'name': 'ADR',
+                    'slug': 'adr',
+                    'tags': ['adr', 'ghost'],
+                },
+            )
+        self.assertEqual(response.status_code, 422)
+        self.assertIn('ghost', response.json()['detail'])
+
+    def test_create_org_not_found(self) -> None:
+        # No tags -> first execute is the create; returning [] -> 404
+        self.mock_db.execute.return_value = []
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.post(
+                '/organizations/missing/note-templates/',
+                json={'name': 'ADR', 'slug': 'adr'},
+            )
+        self.assertEqual(response.status_code, 404)
+
+    def test_create_slug_conflict(self) -> None:
+        self.mock_db.execute.side_effect = psycopg.errors.UniqueViolation()
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.post(
+                '/organizations/engineering/note-templates/',
+                json={'name': 'ADR', 'slug': 'adr'},
+            )
+        self.assertEqual(response.status_code, 409)
+        self.assertIn('already exists', response.json()['detail'])
+
+    def test_create_missing_name_rejected(self) -> None:
+        response = self.client.post(
+            '/organizations/engineering/note-templates/',
+            json={'slug': 'adr'},
+        )
+        self.assertEqual(response.status_code, 422)
+
+    # -- List ----------------------------------------------------------
+
+    def test_list_success(self) -> None:
+        self.mock_db.execute.return_value = [
+            self._template_row(),
+            {
+                'nt': self._template_row(
+                    name='Runbook', slug='runbook'
+                )['nt'],
+                'o': self._template_row()['o'],
+                'tags': [],
+            },
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.get(
+                '/organizations/engineering/note-templates/'
+            )
+        self.assertEqual(response.status_code, 200)
+        slugs = [t['slug'] for t in response.json()]
+        self.assertEqual(slugs, ['adr', 'runbook'])
+
+    def test_list_filter_by_project_type(self) -> None:
+        self.mock_db.execute.return_value = [
+            {
+                'nt': self._template_row(slug='global', project_type_slugs=[])[
+                    'nt'
+                ],
+                'o': self._template_row()['o'],
+                'tags': [],
+            },
+            {
+                'nt': self._template_row(
+                    slug='only-api', project_type_slugs=['http-api']
+                )['nt'],
+                'o': self._template_row()['o'],
+                'tags': [],
+            },
+            {
+                'nt': self._template_row(
+                    slug='only-mobile', project_type_slugs=['mobile-app']
+                )['nt'],
+                'o': self._template_row()['o'],
+                'tags': [],
+            },
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.get(
+                '/organizations/engineering/note-templates/'
+                '?project_type=http-api'
+            )
+        self.assertEqual(response.status_code, 200)
+        slugs = [t['slug'] for t in response.json()]
+        self.assertEqual(slugs, ['global', 'only-api'])
+
+    # -- Get -----------------------------------------------------------
+
+    def test_get_success(self) -> None:
+        self.mock_db.execute.return_value = [self._template_row()]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.get(
+                '/organizations/engineering/note-templates/adr'
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()['slug'], 'adr')
+
+    def test_get_not_found(self) -> None:
+        self.mock_db.execute.return_value = []
+        response = self.client.get(
+            '/organizations/engineering/note-templates/nope'
+        )
+        self.assertEqual(response.status_code, 404)
+
+    # -- Update --------------------------------------------------------
+
+    def test_update_success(self) -> None:
+        # Calls: fetch_existing, persist (set), fetch fresh
+        self.mock_db.execute.side_effect = [
+            [self._template_row()],
+            [{'slug': 'adr'}],
+            [
+                {
+                    'nt': self._template_row(name='Architecture Decision')[
+                        'nt'
+                    ],
+                    'o': self._template_row()['o'],
+                    'tags': [],
+                }
+            ],
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.put(
+                '/organizations/engineering/note-templates/adr',
+                json={'name': 'Architecture Decision'},
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()['name'], 'Architecture Decision')
+
+    def test_update_with_tags_replaces(self) -> None:
+        # fetch_existing, validate_tags, set, detach, attach, fetch fresh
+        self.mock_db.execute.side_effect = [
+            [self._template_row()],
+            [{'tag_slug': 'incident', 'found': True}],
+            [{'slug': 'adr'}],
+            [{'removed': 0}],
+            [{'attached': 1}],
+            [
+                {
+                    'nt': self._template_row()['nt'],
+                    'o': self._template_row()['o'],
+                    'tags': [{'name': 'Incident', 'slug': 'incident'}],
+                }
+            ],
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.put(
+                '/organizations/engineering/note-templates/adr',
+                json={'tags': ['incident']},
+            )
+        self.assertEqual(response.status_code, 200)
+        slugs = [t['slug'] for t in response.json()['tags']]
+        self.assertEqual(slugs, ['incident'])
+
+    def test_update_not_found(self) -> None:
+        self.mock_db.execute.return_value = []
+        response = self.client.put(
+            '/organizations/engineering/note-templates/nope',
+            json={'name': 'X'},
+        )
+        self.assertEqual(response.status_code, 404)
+
+    def test_update_slug_conflict(self) -> None:
+        self.mock_db.execute.side_effect = [
+            [self._template_row()],
+            psycopg.errors.UniqueViolation(),
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.put(
+                '/organizations/engineering/note-templates/adr',
+                json={'slug': 'taken'},
+            )
+        self.assertEqual(response.status_code, 409)
+
+    # -- Patch ---------------------------------------------------------
+
+    def test_patch_template_name(self) -> None:
+        self.mock_db.execute.side_effect = [
+            [self._template_row()],
+            [{'slug': 'adr'}],
+            [
+                {
+                    'nt': self._template_row(name='ADR v2')['nt'],
+                    'o': self._template_row()['o'],
+                    'tags': [],
+                }
+            ],
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.patch(
+                '/organizations/engineering/note-templates/adr',
+                json=[{'op': 'replace', 'path': '/name', 'value': 'ADR v2'}],
+            )
+        self.assertEqual(response.status_code, 200)
+
+    def test_patch_template_not_found(self) -> None:
+        self.mock_db.execute.return_value = []
+        response = self.client.patch(
+            '/organizations/engineering/note-templates/nope',
+            json=[{'op': 'replace', 'path': '/name', 'value': 'X'}],
+        )
+        self.assertEqual(response.status_code, 404)
+
+    # -- Delete --------------------------------------------------------
+
+    def test_delete_success(self) -> None:
+        self.mock_db.execute.return_value = [{'nt': True}]
+        response = self.client.delete(
+            '/organizations/engineering/note-templates/adr'
+        )
+        self.assertEqual(response.status_code, 204)
+
+    def test_delete_not_found(self) -> None:
+        self.mock_db.execute.return_value = []
+        response = self.client.delete(
+            '/organizations/engineering/note-templates/nope'
+        )
+        self.assertEqual(response.status_code, 404)

--- a/tests/endpoints/test_note_templates.py
+++ b/tests/endpoints/test_note_templates.py
@@ -5,7 +5,6 @@ import typing
 import unittest
 from unittest import mock
 
-import psycopg.errors
 from fastapi.testclient import TestClient
 from imbi_common import graph
 
@@ -79,8 +78,9 @@ class NoteTemplateEndpointsTestCase(unittest.TestCase):
     # -- Create --------------------------------------------------------
 
     def test_create_success_no_tags(self) -> None:
-        # No tags -> validate skipped, then create + fetch
+        # No tags -> dup check (empty), create, fetch
         self.mock_db.execute.side_effect = [
+            [],
             [
                 {
                     'nt': self._template_row()['nt'],
@@ -108,7 +108,7 @@ class NoteTemplateEndpointsTestCase(unittest.TestCase):
         self.assertEqual(body['tags'], [])
 
     def test_create_with_tags(self) -> None:
-        # Calls: validate_tags, create, attach_tags, fetch
+        # Calls: validate_tags, dup check, create, attach_tags, fetch
         fetch_with_tags = {
             'nt': self._template_row()['nt'],
             'o': self._template_row()['o'],
@@ -122,6 +122,7 @@ class NoteTemplateEndpointsTestCase(unittest.TestCase):
                 {'tag_slug': 'adr', 'found': True},
                 {'tag_slug': 'architecture', 'found': True},
             ],
+            [],
             [
                 {
                     'nt': self._template_row()['nt'],
@@ -180,7 +181,8 @@ class NoteTemplateEndpointsTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 404)
 
     def test_create_slug_conflict(self) -> None:
-        self.mock_db.execute.side_effect = psycopg.errors.UniqueViolation()
+        # No tags -> first execute is the per-org duplicate check.
+        self.mock_db.execute.return_value = [{'slug': 'adr'}]
         with mock.patch(
             'imbi_common.graph.parse_agtype', side_effect=lambda x: x
         ):
@@ -337,9 +339,10 @@ class NoteTemplateEndpointsTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 404)
 
     def test_update_slug_conflict(self) -> None:
+        # fetch existing, then per-org dup check returns conflict
         self.mock_db.execute.side_effect = [
             [self._template_row()],
-            psycopg.errors.UniqueViolation(),
+            [{'slug': 'taken'}],
         ]
         with mock.patch(
             'imbi_common.graph.parse_agtype', side_effect=lambda x: x

--- a/uv.lock
+++ b/uv.lock
@@ -897,7 +897,7 @@ requires-dist = [
     { name = "fastapi" },
     { name = "filetype" },
     { name = "httpx", specifier = ">=0.28.1" },
-    { name = "imbi-common", extras = ["databases", "server"], git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=main" },
+    { name = "imbi-common", extras = ["databases", "server"], git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=feature%2Fnote-templates" },
     { name = "jinja2" },
     { name = "jsonpatch", specifier = ">=1.33" },
     { name = "nanoid", specifier = ">=2.0.0" },
@@ -944,7 +944,7 @@ docs = [
 [[package]]
 name = "imbi-common"
 version = "0.1.0"
-source = { git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=main#c18876b3fd6db8beb26c5cccabca3ae3f12e862d" }
+source = { git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=feature%2Fnote-templates#9790faf95d825b9c7729ce8724bc7117f827d61d" }
 dependencies = [
     { name = "cryptography" },
     { name = "jsonschema-models" },

--- a/uv.lock
+++ b/uv.lock
@@ -944,7 +944,7 @@ docs = [
 [[package]]
 name = "imbi-common"
 version = "0.1.0"
-source = { git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=feature%2Fnote-templates#9790faf95d825b9c7729ce8724bc7117f827d61d" }
+source = { git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=feature%2Fnote-templates#22d06913e8e837d50da068ab2e129c25c4ee0db4" }
 dependencies = [
     { name = "cryptography" },
     { name = "jsonschema-models" },

--- a/uv.lock
+++ b/uv.lock
@@ -897,7 +897,7 @@ requires-dist = [
     { name = "fastapi" },
     { name = "filetype" },
     { name = "httpx", specifier = ">=0.28.1" },
-    { name = "imbi-common", extras = ["databases", "server"], git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=feature%2Fnote-templates" },
+    { name = "imbi-common", extras = ["databases", "server"], git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=main" },
     { name = "jinja2" },
     { name = "jsonpatch", specifier = ">=1.33" },
     { name = "nanoid", specifier = ">=2.0.0" },
@@ -944,7 +944,7 @@ docs = [
 [[package]]
 name = "imbi-common"
 version = "0.1.0"
-source = { git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=feature%2Fnote-templates#22d06913e8e837d50da068ab2e129c25c4ee0db4" }
+source = { git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=main#bb440f3d19c7e1d48ff216549717da1e77a45647" }
 dependencies = [
     { name = "cryptography" },
     { name = "jsonschema-models" },


### PR DESCRIPTION
## Summary

- Adds CRUD for org-scoped note templates at `/organizations/{org_slug}/note-templates/`.
- Seeds `note_template:{create,read,write,delete}` permissions; grants `note_template:read` to `readonly` and `developer` roles.
- Templates carry: `title`, `content` (markdown), `tags` (real `TAGGED_WITH` edges to org `Tag` nodes), `project_type_slugs` (filter), `sort_order`.
- List endpoint accepts `?project_type=<slug>` to filter templates applicable to that project type. Templates with empty `project_type_slugs` apply to every project type in the org.

## Dependencies

Depends on **AWeber-Imbi/imbi-common#61** — `tool.uv.sources` is pinned to `feature/note-templates`. Once that merges, this branch needs a follow-up commit flipping `rev` back to `main` and refreshing the lock.

## Test plan

- [x] `pytest tests/endpoints/test_note_templates.py` — 18 tests covering create/list/get/put/patch/delete, tag validation, slug conflicts, project-type filter.
- [x] `pytest tests/endpoints/test_notes.py tests/endpoints/test_tags.py tests/endpoints/test_organizations.py tests/auth/test_seed.py` — adjacent suites still green.