### PR TITLE
Fix list_note_templates 500 from DISTINCT + ORDER BY

### DIFF
--- a/src/imbi_api/endpoints/note_templates.py
+++ b/src/imbi_api/endpoints/note_templates.py
@@ -208,7 +208,7 @@ async def _fetch_template(
         """
     MATCH (nt:NoteTemplate {{slug: {slug}}})
           -[:BELONGS_TO]->(o:Organization {{slug: {org_slug}}})
-    WITH DISTINCT nt, o
+    WITH nt, o
     """
         + _TAGS_TAIL
     )

--- a/src/imbi_api/endpoints/note_templates.py
+++ b/src/imbi_api/endpoints/note_templates.py
@@ -321,7 +321,7 @@ async def list_note_templates(
         """
     MATCH (nt:NoteTemplate)
           -[:BELONGS_TO]->(o:Organization {{slug: {org_slug}}})
-    WITH DISTINCT nt, o
+    WITH nt, o
     ORDER BY nt.sort_order, nt.name
     """
         + _TAGS_TAIL


### PR DESCRIPTION
## Summary

`GET /organizations/{org_slug}/note-templates/` was returning HTTP 500 with `psycopg.errors.InvalidColumnReference: for SELECT DISTINCT, ORDER BY expressions must appear in select list`.

Apache AGE translated the Cypher

```cypher
WITH DISTINCT nt, o
ORDER BY nt.sort_order, nt.name
```

into SQL whose `ORDER BY` referenced columns absent from the `SELECT DISTINCT` list. Each `NoteTemplate` has exactly one `BELONGS_TO` edge to an `Organization`, so `DISTINCT` was defensive and not actually needed — removing it lets the existing ordering pipeline run unchanged.

## Test plan

- [ ] `GET /organizations/{org_slug}/note-templates/` returns 200 with the templates ordered by `sort_order`, then `name`.
- [ ] `GET /organizations/{org_slug}/note-templates/?project_type=...` still filters correctly.
- [ ] An organization with zero note templates returns `[]`.