### PR TITLE
Add endpoint for current release per environment

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -18,6 +18,8 @@ jobs:
         uses: actions/checkout@v5
       - name: Install just
         uses: extractions/setup-just@v2
+        with:
+          just-version: '1.50.0'
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
@@ -39,6 +41,8 @@ jobs:
         uses: actions/checkout@v5
       - name: Install just
         uses: extractions/setup-just@v2
+        with:
+          just-version: '1.50.0'
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -17,9 +17,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
       - name: Install just
-        uses: extractions/setup-just@v2
+        uses: taiki-e/install-action@v2
         with:
-          just-version: '1.50.0'
+          tool: just@1.50.0
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
@@ -40,9 +40,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
       - name: Install just
-        uses: extractions/setup-just@v2
+        uses: taiki-e/install-action@v2
         with:
-          just-version: '1.50.0'
+          tool: just@1.50.0
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:

--- a/src/imbi_api/endpoints/releases.py
+++ b/src/imbi_api/endpoints/releases.py
@@ -110,6 +110,20 @@ class ReleaseEnvironmentEdgeResponse(pydantic.BaseModel):
     current_status: _DEPLOYMENT_STATUS | None = None
 
 
+class CurrentReleaseEnvironment(pydantic.BaseModel):
+    """Latest deployment state for one environment of a project.
+
+    ``release`` and ``current_status`` are ``None`` when the project is
+    configured to deploy in the environment but has no recorded
+    deployment events there yet.
+    """
+
+    environment: ReleaseEnvironmentRef
+    release: ReleaseResponse | None = None
+    current_status: _DEPLOYMENT_STATUS | None = None
+    last_event_at: datetime.datetime | None = None
+
+
 # -- Helpers ------------------------------------------------------------
 
 
@@ -354,6 +368,108 @@ async def list_releases(
         _release_to_response(graph.parse_agtype(r['release']), project_id)
         for r in rows
     ]
+
+
+@releases_router.get(
+    '/current',
+    response_model=list[CurrentReleaseEnvironment],
+)
+async def list_current_releases(
+    org_slug: str,
+    project_id: str,
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('project:read'),
+        ),
+    ],
+) -> list[CurrentReleaseEnvironment]:
+    """List the most-current release per environment for a project.
+
+    For each environment the project is configured to deploy in
+    (``DEPLOYED_IN``), returns the release whose ``DEPLOYED_TO`` edge
+    contains the deployment event with the latest timestamp.
+    Environments with no deployment events are returned with
+    ``release=None``. Results are sorted by ``Environment.sort_order``
+    ascending, then by name.
+    """
+    del auth
+    if not await _project_exists(db, org_slug, project_id):
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail=f'Project {project_id!r} not found',
+        )
+
+    query: typing.LiteralString = """
+    MATCH (p:Project {{id: {project_id}}})
+          -[:OWNED_BY]->(:Team)
+          -[:BELONGS_TO]->(:Organization {{slug: {org_slug}}})
+    MATCH (p)-[:DEPLOYED_IN]->(e:Environment)
+    OPTIONAL MATCH (p)-[:HAS_RELEASE]->(r:Release)
+                   -[d:DEPLOYED_TO]->(e)
+    RETURN e{{.slug, .name, .sort_order}} AS env,
+           CASE WHEN r IS NULL THEN null ELSE r{{.*}} END AS release,
+           CASE WHEN d IS NULL THEN null ELSE d.deployments END
+               AS deployments
+    """
+    rows = await db.execute(
+        query,
+        {'project_id': project_id, 'org_slug': org_slug},
+        ['env', 'release', 'deployments'],
+    )
+
+    # Group by env.slug; keep the (release, event) pair with the latest
+    # event timestamp. Envs with no deployments are seeded with None.
+    by_env: dict[
+        str,
+        tuple[
+            dict[str, typing.Any],
+            dict[str, typing.Any] | None,
+            models.DeploymentEvent | None,
+        ],
+    ] = {}
+
+    for row in rows:
+        env = graph.parse_agtype(row['env'])
+        if not env:
+            continue
+        slug = env['slug']
+        release_raw = graph.parse_agtype(row['release'])
+        events = _parse_deployments(graph.parse_agtype(row['deployments']))
+
+        if release_raw is None or not events:
+            by_env.setdefault(slug, (env, None, None))
+            continue
+
+        latest = max(events, key=lambda ev: ev.timestamp)
+        existing = by_env.get(slug)
+        if (
+            existing is None
+            or existing[2] is None
+            or latest.timestamp > existing[2].timestamp
+        ):
+            by_env[slug] = (env, release_raw, latest)
+
+    sortable: list[tuple[int, str, CurrentReleaseEnvironment]] = []
+    for env, release_raw, event in by_env.values():
+        release_resp = (
+            _release_to_response(release_raw, project_id)
+            if release_raw is not None
+            else None
+        )
+        item = CurrentReleaseEnvironment(
+            environment=ReleaseEnvironmentRef(
+                slug=env['slug'], name=env['name']
+            ),
+            release=release_resp,
+            current_status=event.status if event else None,
+            last_event_at=event.timestamp if event else None,
+        )
+        sortable.append((env.get('sort_order') or 0, env['name'], item))
+
+    sortable.sort(key=lambda t: (t[0], t[1]))
+    return [item for _, _, item in sortable]
 
 
 @releases_router.get('/{version}', response_model=ReleaseResponse)

--- a/tests/endpoints/test_releases.py
+++ b/tests/endpoints/test_releases.py
@@ -582,3 +582,188 @@ class DeploymentEdgeTestCase(_ReleasesTestBase):
         self.assertEqual(response.status_code, 200)
         body = response.json()
         self.assertEqual(body['current_status'], 'success')
+
+
+class CurrentReleasesTestCase(_ReleasesTestBase):
+    """GET /releases/current — latest deployment event per env."""
+
+    @staticmethod
+    def _env(
+        slug: str,
+        sort_order: int = 0,
+    ) -> dict[str, typing.Any]:
+        return {
+            'slug': slug,
+            'name': slug.title(),
+            'sort_order': sort_order,
+        }
+
+    @staticmethod
+    def _events(*specs: tuple[str, str]) -> str:
+        return json.dumps(
+            [
+                {'timestamp': ts, 'status': status, 'note': None}
+                for ts, status in specs
+            ]
+        )
+
+    def test_404_when_project_missing(self) -> None:
+        self.mock_db.execute.side_effect = [[]]
+        response = self.client.get(self._url('/current'))
+        self.assertEqual(response.status_code, 404)
+
+    def test_env_with_no_deployments(self) -> None:
+        self.mock_db.execute.side_effect = [
+            [{'id': PROJECT_ID}],  # _project_exists
+            [
+                {
+                    'env': self._env('testing', sort_order=10),
+                    'release': None,
+                    'deployments': None,
+                }
+            ],
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            response = self.client.get(self._url('/current'))
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]['environment']['slug'], 'testing')
+        self.assertIsNone(data[0]['release'])
+        self.assertIsNone(data[0]['current_status'])
+        self.assertIsNone(data[0]['last_event_at'])
+
+    def test_latest_event_wins_across_releases(self) -> None:
+        # production has been deployed v1.0.0 then v1.1.0; v1.1.0
+        # event timestamp is later, so it must win.
+        self.mock_db.execute.side_effect = [
+            [{'id': PROJECT_ID}],
+            [
+                {
+                    'env': self._env('production', sort_order=30),
+                    'release': _release_row(version='1.0.0', id='r1'),
+                    'deployments': self._events(
+                        ('2026-04-20T10:00:00+00:00', 'success'),
+                    ),
+                },
+                {
+                    'env': self._env('production', sort_order=30),
+                    'release': _release_row(version='1.1.0', id='r2'),
+                    'deployments': self._events(
+                        ('2026-04-22T10:00:00+00:00', 'success'),
+                    ),
+                },
+            ],
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            response = self.client.get(self._url('/current'))
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]['release']['version'], '1.1.0')
+        self.assertEqual(data[0]['current_status'], 'success')
+        self.assertEqual(data[0]['last_event_at'], '2026-04-22T10:00:00Z')
+
+    def test_rollback_surfaces_older_release(self) -> None:
+        # v1.1.0 was deployed, then rolled back by re-deploying v1.0.0;
+        # the latest event lives on the v1.0.0 edge so v1.0.0 wins.
+        self.mock_db.execute.side_effect = [
+            [{'id': PROJECT_ID}],
+            [
+                {
+                    'env': self._env('production'),
+                    'release': _release_row(version='1.0.0', id='r1'),
+                    'deployments': self._events(
+                        ('2026-04-20T10:00:00+00:00', 'success'),
+                        ('2026-04-23T10:00:00+00:00', 'success'),
+                    ),
+                },
+                {
+                    'env': self._env('production'),
+                    'release': _release_row(version='1.1.0', id='r2'),
+                    'deployments': self._events(
+                        ('2026-04-22T10:00:00+00:00', 'success'),
+                        (
+                            '2026-04-22T18:00:00+00:00',
+                            'rolled_back',
+                        ),
+                    ),
+                },
+            ],
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            response = self.client.get(self._url('/current'))
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data[0]['release']['version'], '1.0.0')
+        self.assertEqual(data[0]['current_status'], 'success')
+
+    def test_sorts_by_environment_sort_order(self) -> None:
+        events = self._events(('2026-04-20T10:00:00+00:00', 'success'))
+        self.mock_db.execute.side_effect = [
+            [{'id': PROJECT_ID}],
+            [
+                {
+                    'env': self._env('production', sort_order=30),
+                    'release': _release_row(version='1.0.0', id='r1'),
+                    'deployments': events,
+                },
+                {
+                    'env': self._env('testing', sort_order=10),
+                    'release': _release_row(version='1.0.0', id='r1'),
+                    'deployments': events,
+                },
+                {
+                    'env': self._env('staging', sort_order=20),
+                    'release': _release_row(version='1.0.0', id='r1'),
+                    'deployments': events,
+                },
+            ],
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            response = self.client.get(self._url('/current'))
+        self.assertEqual(response.status_code, 200)
+        slugs = [row['environment']['slug'] for row in response.json()]
+        self.assertEqual(slugs, ['testing', 'staging', 'production'])
+
+    def test_undeployed_env_appears_alongside_deployed(self) -> None:
+        self.mock_db.execute.side_effect = [
+            [{'id': PROJECT_ID}],
+            [
+                {
+                    'env': self._env('production', sort_order=30),
+                    'release': _release_row(version='1.0.0', id='r1'),
+                    'deployments': self._events(
+                        ('2026-04-20T10:00:00+00:00', 'success'),
+                    ),
+                },
+                {
+                    'env': self._env('testing', sort_order=10),
+                    'release': None,
+                    'deployments': None,
+                },
+            ],
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            response = self.client.get(self._url('/current'))
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(len(data), 2)
+        by_slug = {row['environment']['slug']: row for row in data}
+        self.assertIsNone(by_slug['testing']['release'])
+        self.assertEqual(by_slug['production']['release']['version'], '1.0.0')


### PR DESCRIPTION
## Summary

Adds `GET /organizations/{org_slug}/projects/{project_id}/releases/current`, returning, for each environment a project is configured to deploy in, the release whose `DEPLOYED_TO` edge contains the deployment event with the latest timestamp. Environments configured but never deployed to are returned with `release=null`.

## Why

Powers the per-environment "current version" display on the project detail page in imbi-ui. Defining "current" as the latest deployment event (rather than the latest release that touched the env) reflects actual state — including rollbacks and re-deploys of older versions.

## Approach

- Cypher starts from the project's `DEPLOYED_IN` environments and outer-joins to `(Project)-[:HAS_RELEASE]->(Release)-[:DEPLOYED_TO]->(Environment)`. Outer join keeps configured-but-undeployed environments in the response.
- Aggregation across releases is done in Python because deployment events live in a JSON-encoded edge property; AGE cannot order by them. At expected cardinality (envs × releases per project) this is fine.
- Results sorted by `Environment.sort_order` then name.
- Route registered before `GET /{version}` so the literal `/current` segment is matched ahead of the version path parameter.

## Test plan

- [x] `pytest tests/endpoints/test_releases.py` — 30 passed (6 new in `CurrentReleasesTestCase` covering: project not found, env with no deployments, latest event wins across releases, rollback re-promotes older release, sort order, undeployed env appears alongside deployed)
- [x] `pre-commit run` clean (ruff, mypy)
- [ ] Smoke test against real populated data

## Follow-ups

- The companion UI PR (imbi-ui#TBD) wires this endpoint into ProjectDetail's environments card and the deployment-pipeline header chips.