### PR TITLE
Add email_notifications preference to User model

### DIFF
--- a/src/imbi_api/domain/models.py
+++ b/src/imbi_api/domain/models.py
@@ -68,6 +68,7 @@ class User(models.GraphModel):
     is_service_account: bool = False
     last_login: datetime.datetime | None = None
     avatar_url: pydantic.HttpUrl | None = None
+    email_notifications: bool = True
 
     organizations: typing.Annotated[
         list[OrganizationEdge],
@@ -373,6 +374,7 @@ class UserCreate(pydantic.BaseModel):
     is_active: bool = True
     is_admin: bool = False
     is_service_account: bool = False
+    email_notifications: bool = True
     organization_slug: str
     role_slug: str
 
@@ -390,6 +392,7 @@ class UserResponse(pydantic.BaseModel):
     created_at: datetime.datetime
     last_login: datetime.datetime | None = None
     avatar_url: pydantic.HttpUrl | None = None
+    email_notifications: bool = True
 
     organizations: list[OrgMembership] = []
 

--- a/src/imbi_api/endpoints/users.py
+++ b/src/imbi_api/endpoints/users.py
@@ -75,6 +75,7 @@ async def create_user(
         is_active=user_create.is_active,
         is_admin=user_create.is_admin,
         is_service_account=user_create.is_service_account,
+        email_notifications=user_create.email_notifications,
     )
 
     # Check if user already exists before creating to avoid
@@ -150,6 +151,7 @@ async def create_user(
         created_at=user.created_at,
         last_login=user.last_login,
         avatar_url=user.avatar_url,
+        email_notifications=user.email_notifications,
         organizations=organizations,
     )
 
@@ -199,6 +201,7 @@ async def list_users(
                 created_at=user.created_at,
                 last_login=user.last_login,
                 avatar_url=user.avatar_url,
+                email_notifications=user.email_notifications,
             )
         )
     return users
@@ -272,6 +275,7 @@ async def get_user(
         created_at=user.created_at,
         last_login=user.last_login,
         avatar_url=user.avatar_url,
+        email_notifications=user.email_notifications,
         organizations=organizations,
     )
 
@@ -326,6 +330,7 @@ async def patch_user(
         'is_active': existing_user.is_active,
         'is_admin': existing_user.is_admin,
         'is_service_account': existing_user.is_service_account,
+        'email_notifications': existing_user.email_notifications,
     }
 
     patched = json_patch.apply_patch(
@@ -369,6 +374,9 @@ async def patch_user(
         is_service_account=patched.get(
             'is_service_account', existing_user.is_service_account
         ),
+        email_notifications=patched.get(
+            'email_notifications', existing_user.email_notifications
+        ),
         created_at=existing_user.created_at,
         last_login=existing_user.last_login,
         avatar_url=existing_user.avatar_url,
@@ -385,6 +393,7 @@ async def patch_user(
         created_at=updated_user.created_at,
         last_login=updated_user.last_login,
         avatar_url=updated_user.avatar_url,
+        email_notifications=updated_user.email_notifications,
     )
 
 


### PR DESCRIPTION
## Summary
- Adds `email_notifications: bool = True` to `User`, `UserCreate`, and `UserResponse` in `domain/models.py`.
- Threads the field through `create_user`, `list_users`, `get_user`, and `patch_user` (including the JSON-Patch `current` document and the response builder).

## Why
The settings UI exposes an Email notifications preference toggle. This adds the underlying field so the value can be persisted and read back via the existing user APIs.

## Migration / compatibility
Existing `User` nodes in AGE without the property read back as `True` via the Pydantic default; the next `db.merge` writes the property. If you'd prefer an explicit backfill, run:

```cypher
MATCH (u:User) WHERE u.email_notifications IS NULL SET u.email_notifications = true
```

## Not in this PR
The `PATCH /users/{email}` endpoint still requires `user:update`, so a non-admin can't toggle their own preference yet. A follow-up PR will add a self-update path (either a `/users/me` endpoint or a self-edit allowance on the existing endpoint).

## Test plan
- [x] `pytest tests/endpoints/test_users.py` — 37 passed
- [x] `ruff check` clean
- [x] `mypy` clean
- [ ] Manual: confirm a fresh user shows `email_notifications: true` from `GET /users/{email}`
- [ ] Manual: PATCH with `[{"op":"replace","path":"/email_notifications","value":false}]` and re-GET

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>