### PR TITLE
Fix missing parse_agtype on webhook identifier_selector

### DIFF
--- a/src/imbi_api/domain/models.py
+++ b/src/imbi_api/domain/models.py
@@ -880,7 +880,9 @@ class WebhookResponse(pydantic.BaseModel):
             icon=webhook.get('icon'),
             notification_path=webhook['notification_path'],
             third_party_service=tps,
-            identifier_selector=record.get('identifier_selector'),
+            identifier_selector=graph.parse_agtype(
+                record.get('identifier_selector')
+            ),
             rules=rules,
         )
 

--- a/src/imbi_api/endpoints/webhooks.py
+++ b/src/imbi_api/endpoints/webhooks.py
@@ -361,7 +361,9 @@ async def patch_webhook(
         'third_party_service_slug': (
             existing_tps.get('slug') if existing_tps else None
         ),
-        'identifier_selector': existing[0].get('identifier_selector'),
+        'identifier_selector': graph.parse_agtype(
+            existing[0].get('identifier_selector')
+        ),
         'rules': [
             {
                 'filter_expression': r['filter_expression'],


### PR DESCRIPTION
## Summary

Wrap two `identifier_selector` reads in `graph.parse_agtype()` so the field is decoded before use.

## Problem

Apache AGE returns edge relationship properties as JSON-encoded strings. The `identifier_selector` field on the `IMPLEMENTED_BY` edge was being read directly from the query record without decoding, causing it to be returned with an extra layer of JSON quoting — e.g. `"/project/id"` instead of `/project/id`.

The sibling fields (`webhook`, `tps`) in the same code paths were already correctly calling `graph.parse_agtype()`, making this an oversight specific to `identifier_selector`.

## Solution

- In `WebhookResponse.from_graph_record()` (`domain/models.py`): wrap `record.get('identifier_selector')` in `graph.parse_agtype()`, matching the pattern used for `tps`.
- In `patch_webhook` (`endpoints/webhooks.py`): wrap `existing[0].get('identifier_selector')` in `graph.parse_agtype()` when building the patchable document, so PATCH requests read the decoded value rather than the raw JSON string.

## Impact

Webhook GET/POST/PATCH responses will now return `identifier_selector` as a plain string instead of a double-quoted string. Any client that worked around the extra quotes will need to stop doing so.
