### PR TITLE
Apply API prefix to uploads router

### DIFF
--- a/src/imbi_api/endpoints/__init__.py
+++ b/src/imbi_api/endpoints/__init__.py
@@ -28,12 +28,11 @@ prefixed_routers: list[fastapi.APIRouter] = [
     sa_api_keys_router,
     service_accounts_router,
     status_router,
+    uploads_router,
     users_router,
 ]
 
-unprefixed_routers: list[fastapi.APIRouter] = [
-    uploads_router,
-]
+unprefixed_routers: list[fastapi.APIRouter] = []
 
 routers: list[fastapi.APIRouter] = prefixed_routers + unprefixed_routers
 

--- a/src/imbi_api/settings.py
+++ b/src/imbi_api/settings.py
@@ -53,8 +53,8 @@ class ServerConfig(pydantic_settings.BaseSettings):
     forwarded_allow_ips: str = ''
     # Path prefix prepended to every API route (e.g. '/api'). Empty
     # serves routes at the root. Applied to routing and to hypermedia
-    # link emission. The /uploads, /docs, and /openapi.json endpoints
-    # are always served at the root regardless of this value.
+    # link emission. The /docs and /openapi.json endpoints are always
+    # served at the root regardless of this value.
     api_prefix: str = ''
 
     @pydantic.field_validator('api_prefix')

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -42,7 +42,7 @@ class CreateAppTestCase(unittest.TestCase):
 class ApiPrefixTestCase(unittest.TestCase):
     """Test cases for the IMBI_API_API_PREFIX configuration."""
 
-    def test_prefix_applies_to_routes_but_not_uploads_or_docs(self) -> None:
+    def test_prefix_applies_to_routes_but_not_docs(self) -> None:
         with unittest.mock.patch.dict(
             os.environ, {'IMBI_API_API_PREFIX': '/api'}
         ):
@@ -50,8 +50,8 @@ class ApiPrefixTestCase(unittest.TestCase):
             paths = {route.path for route in application.routes}
         self.assertIn('/api/status', paths)
         self.assertNotIn('/status', paths)
-        self.assertIn('/uploads/', paths)
-        self.assertNotIn('/api/uploads/', paths)
+        self.assertIn('/api/uploads/', paths)
+        self.assertNotIn('/uploads/', paths)
         self.assertIn('/openapi.json', paths)
         self.assertIn('/docs', paths)
 


### PR DESCRIPTION
## Summary
- Move `uploads_router` from `unprefixed_routers` to `prefixed_routers` so `IMBI_API_API_PREFIX` (introduced in #249) covers `/uploads/*`.
- The prior exclusion was unnecessary — uploads are an ordinary API surface and should sit under the same prefix as everything else.

## Test plan
- [x] `pytest tests/test_app.py` — updated `test_prefix_applies_to_routes_but_not_docs` asserts `/api/uploads/` exists, `/uploads/` does not.
- [x] `pytest tests/endpoints/test_uploads.py` — unaffected (default prefix is empty).

🤖 Generated with [Claude Code](https://claude.com/claude-code)