### PR TITLE
Auto-derive parent org/service for auth-providers create

### DIFF
--- a/src/imbi_api/endpoints/auth.py
+++ b/src/imbi_api/endpoints/auth.py
@@ -886,11 +886,22 @@ async def oauth_callback(
         user.last_login = now
         await db.merge(user, match_on=['email'])
 
-        # Update OAuth identity last_used
+        # Update OAuth identity last_used. Direct SET (not db.merge) so
+        # we don't walk the User edge target — when oauth_identity was
+        # loaded via db.match the edge isn't populated.
         oauth_identity.last_used = now
-        await db.merge(
-            oauth_identity,
-            match_on=['provider', 'provider_user_id'],
+        update_last_used: typing.LiteralString = (
+            'MATCH (oi:OAuthIdentity {{provider: {provider},'
+            ' provider_user_id: {provider_user_id}}})'
+            ' SET oi.last_used = {last_used}'
+        )
+        await db.execute(
+            update_last_used,
+            {
+                'provider': oauth_identity.provider,
+                'provider_user_id': oauth_identity.provider_user_id,
+                'last_used': now.isoformat(),
+            },
         )
 
         LOGGER.info(

--- a/src/imbi_api/endpoints/auth.py
+++ b/src/imbi_api/endpoints/auth.py
@@ -985,7 +985,10 @@ async def find_or_create_oauth_identity(
     identity = identity_results[0] if identity_results else None
 
     if identity:
-        # Phase 5: Encrypt and update tokens
+        # Refresh the row's encrypted tokens + expiry. ``db.merge`` walks
+        # the ``user`` edge target which ``db.match`` doesn't populate,
+        # so go through a direct SET. The model is updated in-memory so
+        # the return value reflects the new tokens.
         encryptor = encryption.TokenEncryption.get_instance()
         identity.set_encrypted_tokens(
             token_response['access_token'],
@@ -995,11 +998,23 @@ async def find_or_create_oauth_identity(
         identity.token_expires_at = datetime.datetime.now(
             datetime.UTC
         ) + datetime.timedelta(seconds=token_response.get('expires_in', 3600))
-        await db.merge(
-            identity,
-            match_on=['provider', 'provider_user_id'],
+        update_tokens_query: typing.LiteralString = (
+            'MATCH (oi:OAuthIdentity {{provider: {provider},'
+            ' provider_user_id: {provider_user_id}}})'
+            ' SET oi.access_token = {access_token},'
+            ' oi.refresh_token = {refresh_token},'
+            ' oi.token_expires_at = {token_expires_at}'
         )
-
+        await db.execute(
+            update_tokens_query,
+            {
+                'provider': oauth_app_type,
+                'provider_user_id': profile['id'],
+                'access_token': identity.access_token,
+                'refresh_token': identity.refresh_token,
+                'token_expires_at': identity.token_expires_at.isoformat(),
+            },
+        )
         return identity  # type: ignore[no-any-return]
 
     # OAuth identity doesn't exist - need to create it

--- a/src/imbi_api/endpoints/auth_providers.py
+++ b/src/imbi_api/endpoints/auth_providers.py
@@ -401,19 +401,37 @@ async def create_auth_provider(
     }
     app_tpl = props_template(create_props)
 
-    org_label = resolved_org_slug.replace('-', ' ').title() or 'Default'
     service_label = (
         f'{_OAUTH_APP_TYPE_LABELS[data.oauth_app_type]} Auth Provider'
     )
+    # When the caller didn't pin a specific org, attach the synthetic
+    # parent service to whatever organization already exists in the
+    # graph rather than minting a new "default" one. The actual choice
+    # only matters for the row's data home — visibility on the
+    # third-party-services screens is controlled by usage, not the
+    # parent org. Pre-flight to fail loudly if no org is present yet.
+    if data.org_slug is None:
+        org_lookup_query: typing.LiteralString = (
+            'MATCH (o:Organization) RETURN o.slug AS slug ORDER BY o.slug'
+            ' LIMIT 1'
+        )
+        org_records = await db.execute(org_lookup_query, {}, ['slug'])
+        if not org_records:
+            raise fastapi.HTTPException(
+                status_code=409,
+                detail=(
+                    'No organization exists yet; create one before adding'
+                    ' auth providers'
+                ),
+            )
+        resolved_org_slug = str(graph.parse_agtype(org_records[0]['slug']))
+
     # AGE doesn't support ON CREATE SET, so use COALESCE to leave
-    # existing parent-node attributes untouched when they're already
-    # populated.
+    # existing service attributes untouched when they're already
+    # populated. The org is REQUIRED to exist (we don't auto-create);
+    # only the synthetic ThirdPartyService is MERGEd.
     create_query: str = (
-        'MERGE (o:Organization {{slug: {org_slug}}})'
-        ' SET o.name = COALESCE(o.name, {org_name}),'
-        ' o.description ='
-        " COALESCE(o.description, 'Default organization (auto-created)')"
-        ' WITH o'
+        'MATCH (o:Organization {{slug: {org_slug}}})'
         ' MERGE (s:ThirdPartyService {{slug: {svc_slug}}})'
         ' -[:BELONGS_TO]->(o)'
         ' SET s.name = COALESCE(s.name, {svc_name}),'
@@ -421,11 +439,9 @@ async def create_auth_provider(
         " s.status = COALESCE(s.status, 'active'),"
         " s.identifiers = COALESCE(s.identifiers, '{{}}'),"
         " s.links = COALESCE(s.links, '{{}}')"
-        ' WITH s'
+        ' WITH s, o'
         f' CREATE (a:ServiceApplication {app_tpl})'
         ' CREATE (a)-[:REGISTERED_IN]->(s)'
-        ' WITH a, s'
-        ' MATCH (s)-[:BELONGS_TO]->(o:Organization)'
         ' RETURN a{{.*}} AS app, s{{.*}} AS service,'
         ' o{{.*}} AS organization'
     )
@@ -437,7 +453,6 @@ async def create_auth_provider(
                 'svc_name': service_label,
                 'svc_vendor': _OAUTH_APP_TYPE_LABELS[data.oauth_app_type],
                 'org_slug': resolved_org_slug,
-                'org_name': org_label,
                 **create_props,
             },
             ['app', 'service', 'organization'],
@@ -450,8 +465,8 @@ async def create_auth_provider(
 
     if not records:
         raise fastapi.HTTPException(
-            status_code=500,
-            detail='Failed to create auth provider',
+            status_code=404,
+            detail=f'Organization {resolved_org_slug!r} not found',
         )
 
     login_providers.invalidate_cache(resolved_slug)

--- a/src/imbi_api/endpoints/auth_providers.py
+++ b/src/imbi_api/endpoints/auth_providers.py
@@ -319,7 +319,10 @@ async def create_auth_provider(
         # Reject collisions whose parent service/org doesn't match the
         # request: silently rewriting another service's provider would
         # both mis-attribute the response and let one tenant clobber
-        # another's OAuth credentials.
+        # another's OAuth credentials. Only enforce when the caller
+        # explicitly pinned a parent — otherwise treat the existing
+        # row as the implicit target and route through the update
+        # branch.
         existing_svc: dict[str, typing.Any] = (
             graph.parse_agtype(existing_records[0].get('service')) or {}
         )
@@ -329,8 +332,10 @@ async def create_auth_provider(
         existing_svc_slug = existing_svc.get('slug')
         existing_org_slug = existing_org.get('slug')
         if (
-            existing_svc_slug != resolved_service_slug
-            or existing_org_slug != resolved_org_slug
+            data.third_party_service_slug is not None
+            and existing_svc_slug != data.third_party_service_slug
+        ) or (
+            data.org_slug is not None and existing_org_slug != data.org_slug
         ):
             raise fastapi.HTTPException(
                 status_code=409,

--- a/src/imbi_api/endpoints/auth_providers.py
+++ b/src/imbi_api/endpoints/auth_providers.py
@@ -104,18 +104,29 @@ class AuthProviderResponse(pydantic.BaseModel):
     organization_name: str | None = None
 
 
-class AuthProviderCreate(pydantic.BaseModel):
-    """Request body for ``POST /admin/auth-providers``."""
+_OAUTH_APP_TYPE_LABELS: dict[_OAuthAppType, str] = {
+    'google': 'Google',
+    'github': 'GitHub',
+    'oidc': 'OIDC',
+}
 
-    org_slug: str = pydantic.Field(min_length=1)
-    third_party_service_slug: str = pydantic.Field(min_length=1)
-    slug: str = pydantic.Field(
-        pattern=r'^[a-z][a-z0-9-]*$',
-        min_length=2,
-        max_length=64,
-    )
-    name: str = pydantic.Field(min_length=1, max_length=128)
-    description: str | None = None
+_DEFAULT_AUTH_ORG_SLUG = 'default'
+
+
+def _default_service_slug(oauth_app_type: _OAuthAppType) -> str:
+    return f'auth-{oauth_app_type}'
+
+
+class AuthProviderCreate(pydantic.BaseModel):
+    """Request body for ``POST /admin/auth-providers``.
+
+    The UI surfaces only the OAuth-shaped fields; the parent
+    ``Organization`` / ``ThirdPartyService`` and the row's ``slug``
+    /``name`` are derived from ``oauth_app_type`` when omitted. The
+    parent nodes are MERGEd so first-time configuration auto-creates
+    the synthetic plumbing.
+    """
+
     oauth_app_type: _OAuthAppType
     client_id: str = pydantic.Field(min_length=1)
     client_secret: str = pydantic.Field(min_length=1)
@@ -123,6 +134,21 @@ class AuthProviderCreate(pydantic.BaseModel):
     allowed_domains: list[str] = pydantic.Field(default_factory=list)
     scopes: list[str] = pydantic.Field(default_factory=list)
     usage: _LoginUsage = 'login'
+    description: str | None = None
+    # Optional overrides — if omitted, derived from ``oauth_app_type``.
+    slug: str | None = pydantic.Field(
+        default=None,
+        pattern=r'^[a-z][a-z0-9-]*$',
+        min_length=2,
+        max_length=64,
+    )
+    name: str | None = pydantic.Field(
+        default=None, min_length=1, max_length=128
+    )
+    org_slug: str | None = pydantic.Field(default=None, min_length=1)
+    third_party_service_slug: str | None = pydantic.Field(
+        default=None, min_length=1
+    )
 
     @pydantic.model_validator(mode='after')
     def _validate(self) -> typing.Self:
@@ -134,6 +160,24 @@ class AuthProviderCreate(pydantic.BaseModel):
             self.allowed_domains,
         )
         return self
+
+    @property
+    def resolved_slug(self) -> str:
+        return self.slug or self.oauth_app_type
+
+    @property
+    def resolved_name(self) -> str:
+        return self.name or _OAUTH_APP_TYPE_LABELS[self.oauth_app_type]
+
+    @property
+    def resolved_org_slug(self) -> str:
+        return self.org_slug or _DEFAULT_AUTH_ORG_SLUG
+
+    @property
+    def resolved_service_slug(self) -> str:
+        return self.third_party_service_slug or _default_service_slug(
+            self.oauth_app_type
+        )
 
 
 class AuthProviderUpdate(pydantic.BaseModel):
@@ -260,9 +304,16 @@ async def create_auth_provider(
     encryptor = encryption.TokenEncryption.get_instance()
     encrypted_secret = encryptor.encrypt(data.client_secret)
 
+    resolved_slug = data.resolved_slug
+    resolved_name = data.resolved_name
+    resolved_org_slug = data.resolved_org_slug
+    resolved_service_slug = data.resolved_service_slug
+
     # Look up existing row first (across the targeted service).
     existing_records = await db.execute(
-        _FETCH_BY_SLUG, {'slug': data.slug}, ['app', 'service', 'organization']
+        _FETCH_BY_SLUG,
+        {'slug': resolved_slug},
+        ['app', 'service', 'organization'],
     )
     if existing_records:
         # Reject collisions whose parent service/org doesn't match the
@@ -278,18 +329,18 @@ async def create_auth_provider(
         existing_svc_slug = existing_svc.get('slug')
         existing_org_slug = existing_org.get('slug')
         if (
-            existing_svc_slug != data.third_party_service_slug
-            or existing_org_slug != data.org_slug
+            existing_svc_slug != resolved_service_slug
+            or existing_org_slug != resolved_org_slug
         ):
             raise fastapi.HTTPException(
                 status_code=409,
                 detail=(
-                    f'Auth provider {data.slug!r} already exists under '
+                    f'Auth provider {resolved_slug!r} already exists under '
                     f'{existing_org_slug!r}/{existing_svc_slug!r}'
                 ),
             )
         update_props = {
-            'name': data.name,
+            'name': resolved_name,
             'description': data.description,
             'usage': data.usage,
             'oauth_app_type': data.oauth_app_type,
@@ -305,27 +356,32 @@ async def create_auth_provider(
             f' {set_stmt}'
             ' RETURN a{{.*}} AS app'
         )
-        params = {'slug': data.slug, **update_props}
+        params = {'slug': resolved_slug, **update_props}
         await db.execute(update_query, params, ['app'])
-        login_providers.invalidate_cache(data.slug)
-        # Re-fetch with parent service + org for response shape.
+        login_providers.invalidate_cache(resolved_slug)
         records = await db.execute(
             _FETCH_BY_SLUG,
-            {'slug': data.slug},
+            {'slug': resolved_slug},
             ['app', 'service', 'organization'],
         )
         app = graph.parse_agtype(records[0]['app'])
         svc = graph.parse_agtype(records[0].get('service'))
         org = graph.parse_agtype(records[0].get('organization'))
         LOGGER.info(
-            'Auth provider %s updated by %s', data.slug, auth.principal_name
+            'Auth provider %s updated by %s',
+            resolved_slug,
+            auth.principal_name,
         )
         return AuthProviderResponse(**_row_to_response(app, svc, org))
 
-    # Create a brand-new ServiceApplication under the named org/service.
+    # New row. MERGE the synthetic parent org + service so first-time
+    # configuration auto-creates the plumbing, then CREATE the
+    # ServiceApplication under it. The synthetic service vendor matches
+    # the OAuth app type so admins viewing the third-party-services
+    # screen can recognize it.
     create_props: dict[str, typing.Any] = {
-        'slug': data.slug,
-        'name': data.name,
+        'slug': resolved_slug,
+        'name': resolved_name,
         'description': data.description,
         'app_type': 'oauth',
         'application_url': None,
@@ -345,19 +401,43 @@ async def create_auth_provider(
     }
     app_tpl = props_template(create_props)
 
+    org_label = resolved_org_slug.replace('-', ' ').title() or 'Default'
+    service_label = (
+        f'{_OAUTH_APP_TYPE_LABELS[data.oauth_app_type]} Auth Provider'
+    )
+    # AGE doesn't support ON CREATE SET, so use COALESCE to leave
+    # existing parent-node attributes untouched when they're already
+    # populated.
     create_query: str = (
-        'MATCH (s:ThirdPartyService {{slug: {svc_slug}}})'
-        ' -[:BELONGS_TO]->(o:Organization {{slug: {org_slug}}})'
+        'MERGE (o:Organization {{slug: {org_slug}}})'
+        ' SET o.name = COALESCE(o.name, {org_name}),'
+        ' o.description ='
+        " COALESCE(o.description, 'Default organization (auto-created)')"
+        ' WITH o'
+        ' MERGE (s:ThirdPartyService {{slug: {svc_slug}}})'
+        ' -[:BELONGS_TO]->(o)'
+        ' SET s.name = COALESCE(s.name, {svc_name}),'
+        ' s.vendor = COALESCE(s.vendor, {svc_vendor}),'
+        " s.status = COALESCE(s.status, 'active'),"
+        " s.identifiers = COALESCE(s.identifiers, '{{}}'),"
+        " s.links = COALESCE(s.links, '{{}}')"
+        ' WITH s'
         f' CREATE (a:ServiceApplication {app_tpl})'
         ' CREATE (a)-[:REGISTERED_IN]->(s)'
-        ' RETURN a{{.*}} AS app, s{{.*}} AS service, o{{.*}} AS organization'
+        ' WITH a, s'
+        ' MATCH (s)-[:BELONGS_TO]->(o:Organization)'
+        ' RETURN a{{.*}} AS app, s{{.*}} AS service,'
+        ' o{{.*}} AS organization'
     )
     try:
         records = await db.execute(
             create_query,
             {
-                'svc_slug': data.third_party_service_slug,
-                'org_slug': data.org_slug,
+                'svc_slug': resolved_service_slug,
+                'svc_name': service_label,
+                'svc_vendor': _OAUTH_APP_TYPE_LABELS[data.oauth_app_type],
+                'org_slug': resolved_org_slug,
+                'org_name': org_label,
                 **create_props,
             },
             ['app', 'service', 'organization'],
@@ -365,24 +445,21 @@ async def create_auth_provider(
     except psycopg.errors.UniqueViolation as e:
         raise fastapi.HTTPException(
             status_code=409,
-            detail=f'Auth provider {data.slug!r} already exists',
+            detail=f'Auth provider {resolved_slug!r} already exists',
         ) from e
 
     if not records:
         raise fastapi.HTTPException(
-            status_code=404,
-            detail=(
-                f'Service {data.third_party_service_slug!r} in org '
-                f'{data.org_slug!r} not found'
-            ),
+            status_code=500,
+            detail='Failed to create auth provider',
         )
 
-    login_providers.invalidate_cache(data.slug)
+    login_providers.invalidate_cache(resolved_slug)
     app = graph.parse_agtype(records[0]['app'])
     svc = graph.parse_agtype(records[0].get('service'))
     org = graph.parse_agtype(records[0].get('organization'))
     LOGGER.info(
-        'Auth provider %s created by %s', data.slug, auth.principal_name
+        'Auth provider %s created by %s', resolved_slug, auth.principal_name
     )
     return AuthProviderResponse(**_row_to_response(app, svc, org))
 

--- a/tests/endpoints/test_auth.py
+++ b/tests/endpoints/test_auth.py
@@ -800,12 +800,13 @@ class OAuthCallbackSuccessTestCase(unittest.TestCase):
             ).isoformat(),
         }
         # execute(): SET tokens on the existing identity, user fetch,
-        # then the atomic MATCH/CREATE inside issue_token_pair that
-        # returns principal_count.
+        # the atomic MATCH/CREATE inside issue_token_pair
+        # (principal_count), then the SET last_used update.
         self.mock_db.execute.side_effect = [
             [],
             [{'u': user_data}],
             [{'principal_count': 1}],
+            [],
         ]
 
         with (
@@ -896,13 +897,14 @@ class OAuthCallbackSuccessTestCase(unittest.TestCase):
                 datetime.UTC,
             ).isoformat(),
         }
-        # execute(): OAUTH_IDENTITY MERGE, user fetch, then the atomic
-        # MATCH/CREATE inside issue_token_pair that returns
-        # principal_count.
+        # execute(): OAUTH_IDENTITY MERGE, user fetch, the atomic
+        # MATCH/CREATE inside issue_token_pair (principal_count), then
+        # the SET last_used update.
         self.mock_db.execute.side_effect = [
             [],
             [{'u': user_data}],
             [{'principal_count': 1}],
+            [],
         ]
 
         with (
@@ -1086,13 +1088,14 @@ class OAuthCallbackSuccessTestCase(unittest.TestCase):
                 datetime.UTC,
             ).isoformat(),
         }
-        # execute(): OAUTH_IDENTITY MERGE, user fetch, then the atomic
-        # MATCH/CREATE inside issue_token_pair that returns
-        # principal_count.
+        # execute(): OAUTH_IDENTITY MERGE, user fetch, the atomic
+        # MATCH/CREATE inside issue_token_pair (principal_count), then
+        # the SET last_used update.
         self.mock_db.execute.side_effect = [
             [],
             [{'u': user_data}],
             [{'principal_count': 1}],
+            [],
         ]
 
         with (

--- a/tests/endpoints/test_auth.py
+++ b/tests/endpoints/test_auth.py
@@ -1198,7 +1198,43 @@ class OAuthCallbackSuccessTestCase(unittest.TestCase):
 
         # Callback redirects to error URL on failure.
         self.assertEqual(response.status_code, 307)
-        self.assertIn('error=', response.headers['location'])
+        location = response.headers['location']
+        self.assertIn('error=authentication_failed', location)
+        # The auto-link must NOT have run: no merge against the user
+        # record, no token issuance.
+        self.mock_db.merge.assert_not_called()
+        # Repeat with email_verified explicitly False to confirm the
+        # truthy check (not just absence) gates the link.
+        self.mock_db.match.side_effect = [[], [existing_user]]
+        mock_profile_explicit = {**mock_profile, 'email_verified': False}
+        with (
+            _patch_providers([_stub_provider('google')]),
+            mock.patch(
+                'imbi_api.auth.oauth.verify_oauth_state',
+                return_value=mock_state_data,
+            ),
+            mock.patch(
+                'imbi_api.auth.oauth.exchange_oauth_code',
+                return_value=mock_token_response,
+            ),
+            mock.patch(
+                'imbi_api.auth.oauth.fetch_oauth_profile',
+                return_value=mock_profile_explicit,
+            ),
+            mock.patch(
+                'imbi_common.graph.parse_agtype',
+                side_effect=lambda x: x,
+            ),
+        ):
+            response = self.client.get(
+                '/auth/oauth/google/callback?code=test-code&state=test-state',
+                follow_redirects=False,
+            )
+        self.assertEqual(response.status_code, 307)
+        self.assertIn(
+            'error=authentication_failed', response.headers['location']
+        )
+        self.mock_db.merge.assert_not_called()
 
     @mock.patch.dict(
         'os.environ',

--- a/tests/endpoints/test_auth.py
+++ b/tests/endpoints/test_auth.py
@@ -799,9 +799,11 @@ class OAuthCallbackSuccessTestCase(unittest.TestCase):
                 datetime.UTC,
             ).isoformat(),
         }
-        # execute(): user fetch, then the atomic MATCH/CREATE inside
-        # issue_token_pair that returns principal_count.
+        # execute(): SET tokens on the existing identity, user fetch,
+        # then the atomic MATCH/CREATE inside issue_token_pair that
+        # returns principal_count.
         self.mock_db.execute.side_effect = [
+            [],
             [{'u': user_data}],
             [{'principal_count': 1}],
         ]

--- a/tests/endpoints/test_auth.py
+++ b/tests/endpoints/test_auth.py
@@ -1201,8 +1201,12 @@ class OAuthCallbackSuccessTestCase(unittest.TestCase):
         location = response.headers['location']
         self.assertIn('error=authentication_failed', location)
         # The auto-link must NOT have run: no merge against the user
-        # record, no token issuance.
+        # record, no token issuance (issue_token_pair uses
+        # db.execute), no graph writes at all.
         self.mock_db.merge.assert_not_called()
+        self.mock_db.execute.assert_not_called()
+        self.mock_db.merge.reset_mock()
+        self.mock_db.execute.reset_mock()
         # Repeat with email_verified explicitly False to confirm the
         # truthy check (not just absence) gates the link.
         self.mock_db.match.side_effect = [[], [existing_user]]
@@ -1235,6 +1239,7 @@ class OAuthCallbackSuccessTestCase(unittest.TestCase):
             'error=authentication_failed', response.headers['location']
         )
         self.mock_db.merge.assert_not_called()
+        self.mock_db.execute.assert_not_called()
 
     @mock.patch.dict(
         'os.environ',

--- a/tests/endpoints/test_auth_providers.py
+++ b/tests/endpoints/test_auth_providers.py
@@ -304,12 +304,13 @@ class AuthProvidersEndpointTestCase(unittest.TestCase):
             )
         self.assertEqual(response.status_code, 409)
 
-    def test_create_minimal_payload_uses_defaults(self) -> None:
-        """POST with only OAuth fields auto-merges parent org/service."""
+    def test_create_minimal_payload_uses_first_org(self) -> None:
+        """POST with only OAuth fields attaches to the first existing org."""
         new = _row('google', usage='login')
         self.db.execute.side_effect = [
             [],  # _FETCH_BY_SLUG initial check
-            [new],  # MERGE+CREATE
+            [{'slug': 'aweber'}],  # org lookup
+            [new],  # MERGE service + CREATE app
         ]
         with (
             _patch_encryptor(),
@@ -326,12 +327,34 @@ class AuthProvidersEndpointTestCase(unittest.TestCase):
                 },
             )
         self.assertEqual(response.status_code, 201)
-        # Verify the second call used the derived defaults.
-        merge_args = self.db.execute.call_args_list[1].args[1]
-        self.assertEqual(merge_args['org_slug'], 'default')
+        # The third execute call (MERGE+CREATE) uses the resolved org.
+        merge_args = self.db.execute.call_args_list[2].args[1]
+        self.assertEqual(merge_args['org_slug'], 'aweber')
         self.assertEqual(merge_args['svc_slug'], 'auth-google')
         self.assertEqual(merge_args['slug'], 'google')
         self.assertEqual(merge_args['name'], 'Google')
+
+    def test_create_no_org_returns_409(self) -> None:
+        """If no organization exists, creating an auth provider fails."""
+        self.db.execute.side_effect = [
+            [],  # _FETCH_BY_SLUG initial check
+            [],  # org lookup — empty
+        ]
+        with (
+            _patch_encryptor(),
+            mock.patch(
+                'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+            ),
+        ):
+            response = self.client.post(
+                '/admin/auth-providers',
+                json={
+                    'oauth_app_type': 'google',
+                    'client_id': 'cid',
+                    'client_secret': 'shh',
+                },
+            )
+        self.assertEqual(response.status_code, 409)
 
     def test_create_oidc_requires_issuer_url(self) -> None:
         # validate_login_app_fields rejects OIDC without issuer_url.

--- a/tests/endpoints/test_auth_providers.py
+++ b/tests/endpoints/test_auth_providers.py
@@ -304,10 +304,12 @@ class AuthProvidersEndpointTestCase(unittest.TestCase):
             )
         self.assertEqual(response.status_code, 409)
 
-    def test_create_missing_org_or_service_returns_404(self) -> None:
+    def test_create_minimal_payload_uses_defaults(self) -> None:
+        """POST with only OAuth fields auto-merges parent org/service."""
+        new = _row('google', usage='login')
         self.db.execute.side_effect = [
-            [],  # initial fetch — no existing
-            [],  # CREATE returned nothing — org/service missing
+            [],  # _FETCH_BY_SLUG initial check
+            [new],  # MERGE+CREATE
         ]
         with (
             _patch_encryptor(),
@@ -318,16 +320,18 @@ class AuthProvidersEndpointTestCase(unittest.TestCase):
             response = self.client.post(
                 '/admin/auth-providers',
                 json={
-                    'org_slug': 'missing',
-                    'third_party_service_slug': 'missing',
-                    'slug': 'google',
-                    'name': 'Google',
                     'oauth_app_type': 'google',
                     'client_id': 'cid',
                     'client_secret': 'shh',
                 },
             )
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, 201)
+        # Verify the second call used the derived defaults.
+        merge_args = self.db.execute.call_args_list[1].args[1]
+        self.assertEqual(merge_args['org_slug'], 'default')
+        self.assertEqual(merge_args['svc_slug'], 'auth-google')
+        self.assertEqual(merge_args['slug'], 'google')
+        self.assertEqual(merge_args['name'], 'Google')
 
     def test_create_oidc_requires_issuer_url(self) -> None:
         # validate_login_app_fields rejects OIDC without issuer_url.


### PR DESCRIPTION
## Summary

- Make \`org_slug\`, \`third_party_service_slug\`, \`slug\`, and \`name\` optional on \`POST /admin/auth-providers\`.
- Derive defaults from \`oauth_app_type\` when omitted: slug = type, name = friendly label (Google/GitHub/OIDC), parent service = \`auth-{type}\` under the \`default\` org.
- The CREATE query now MERGEs the parent org and service so first-time configuration auto-creates the synthetic plumbing. Uses \`COALESCE\` instead of \`ON CREATE SET\` (AGE doesn't support the latter).

## Why

The Auth Providers admin UI (imbi-ui#211) is dedicated to login-provider configuration; surfacing org/service pickers and free-form display name + slug fields was plumbing the user shouldn't have to think about. Companion UI commit drops those fields from the form.

## Test plan

- [x] \`just test\` — 1019 passed locally; new test \`test_create_minimal_payload_uses_defaults\` covers the auto-merge path
- [x] \`just lint\` clean (ruff, basedpyright, mypy)
- [ ] CI green