### PR TITLE
System-generate webhook slugs, IDs, and notification paths

### DIFF
--- a/src/imbi_api/domain/models.py
+++ b/src/imbi_api/domain/models.py
@@ -813,21 +813,14 @@ class WebhookRuleCreate(pydantic.BaseModel):
 
 
 class WebhookCreate(pydantic.BaseModel):
-    """Request model for creating a webhook."""
+    """Request model for creating a webhook.
+
+    The slug, id, and notification_path are system-generated.
+    """
 
     name: str = pydantic.Field(min_length=1, max_length=128)
-    slug: str = pydantic.Field(
-        pattern=r'^[a-z][a-z0-9-]*$',
-        min_length=2,
-        max_length=64,
-    )
     description: str | None = None
     icon: str | None = None
-    notification_path: str = pydantic.Field(
-        min_length=1,
-        pattern=r'^/',
-        description='URL path for receiving webhooks (must start with /)',
-    )
     secret: str | None = None
     third_party_service_slug: str | None = None
     identifier_selector: str | None = pydantic.Field(
@@ -849,7 +842,12 @@ class WebhookCreate(pydantic.BaseModel):
 
 
 class WebhookUpdate(pydantic.BaseModel):
-    """Request model for updating a webhook (GET-modify-PUT)."""
+    """Patchable fields for a webhook (JSON Patch target document).
+
+    The slug is editable. The id and notification_path are
+    system-managed and rejected at the endpoint level if a patch
+    operation targets them.
+    """
 
     name: str = pydantic.Field(min_length=1, max_length=128)
     slug: str = pydantic.Field(
@@ -859,10 +857,6 @@ class WebhookUpdate(pydantic.BaseModel):
     )
     description: str | None = None
     icon: str | None = None
-    notification_path: str = pydantic.Field(
-        min_length=1,
-        pattern=r'^/',
-    )
     secret: str | None = None
     third_party_service_slug: str | None = None
     identifier_selector: str | None = pydantic.Field(
@@ -898,6 +892,7 @@ class WebhookResponse(pydantic.BaseModel):
 
     model_config = pydantic.ConfigDict(extra='allow')
 
+    id: str
     name: str
     slug: str
     description: str | None = None
@@ -940,6 +935,7 @@ class WebhookResponse(pydantic.BaseModel):
             tps = graph.parse_agtype(tps)
 
         return cls(
+            id=webhook['id'],
             name=webhook['name'],
             slug=webhook['slug'],
             description=webhook.get('description'),

--- a/src/imbi_api/endpoints/webhooks.py
+++ b/src/imbi_api/endpoints/webhooks.py
@@ -2,9 +2,11 @@
 
 import json
 import logging
+import re
 import typing
 
 import fastapi
+import nanoid
 import psycopg
 import pydantic
 from imbi_common import graph
@@ -16,6 +18,37 @@ from imbi_api.domain import models
 from imbi_api.graph_sql import props_template, set_clause
 
 LOGGER = logging.getLogger(__name__)
+
+_READ_ONLY_PATHS = frozenset({'/notification_path', '/id'})
+
+
+def _slugify(value: str) -> str:
+    """Convert a string to a valid webhook slug fragment."""
+    value = value.lower()
+    value = re.sub(r'[^a-z0-9]+', '-', value)
+    value = value.strip('-')
+    if not value:
+        return 'hook'
+    if len(value) < 2:
+        return value + '0'
+    return value
+
+
+def _generate_id() -> str:
+    """Generate a nanoid surrogate key for a webhook."""
+    return str(nanoid.generate())
+
+
+def _compute_webhook_slug(
+    service_slug: str | None,
+    name: str,
+) -> str:
+    """Compute the system-generated slug from service slug and name."""
+    name_part = _slugify(name)
+    if service_slug:
+        combined = f'{service_slug}-{name_part}'
+        return combined[:64]
+    return name_part[:64]
 
 
 def _rules_create_clauses(
@@ -50,8 +83,8 @@ def _rules_create_clauses(
 
 
 _FETCH_WEBHOOK_QUERY: typing.LiteralString = """
-MATCH (w:Webhook {{slug: {slug}}})
-      -[:BELONGS_TO]->(o:Organization {{slug: {org_slug}}})
+MATCH (w:Webhook)-[:BELONGS_TO]->(o:Organization {{slug: {org_slug}}})
+WHERE w.slug = {identifier} OR w.id = {identifier}
 OPTIONAL MATCH (w)-[impl:IMPLEMENTED_BY]->(tps:ThirdPartyService)
 OPTIONAL MATCH (r:WebhookRule)-[:ACTIONS]->(w)
 WITH w, tps, impl, r
@@ -119,22 +152,32 @@ async def create_webhook(
         ),
     ],
 ) -> models.WebhookResponse:
-    """Create a new webhook linked to an organization."""
+    """Create a new webhook linked to an organization.
+
+    The slug, id, and notification_path are system-generated:
+    - slug: ``{service_slug}-{slugified_name}`` or just the slugified name
+    - id: nanoid (21-char URL-safe string, stable surrogate key)
+    - notification_path: ``/{id}``
+    """
     encryptor = encryption.TokenEncryption.get_instance()
 
+    webhook_id = _generate_id()
+    slug = _compute_webhook_slug(data.third_party_service_slug, data.name)
+    notification_path = f'/{webhook_id}'
+
     props: dict[str, typing.Any] = {
+        'id': webhook_id,
         'name': data.name,
-        'slug': data.slug,
+        'slug': slug,
         'description': data.description,
         'icon': data.icon,
-        'notification_path': data.notification_path,
+        'notification_path': notification_path,
         'secret': (
             encryptor.encrypt(data.secret) if data.secret is not None else None
         ),
     }
     create_tpl = props_template(props)
 
-    # Build rule creation params as scalars
     rule_dicts: list[dict[str, str | int]] = []
     for idx, rule in enumerate(data.rules):
         rule_dicts.append(
@@ -164,7 +207,7 @@ async def create_webhook(
             ' CREATE (w)-[:IMPLEMENTED_BY'
             ' {{identifier_selector: {identifier_selector}}}]->(tps)'
             + rule_clauses
-            + ' RETURN w.slug AS slug'
+            + ' RETURN w.id AS id'
         )
         write_params: dict[str, typing.Any] = {
             **base_params,
@@ -177,7 +220,7 @@ async def create_webhook(
             f' CREATE (w:Webhook {create_tpl})'
             ' CREATE (w)-[:BELONGS_TO]->(o)'
             + rule_clauses
-            + ' RETURN w.slug AS slug'
+            + ' RETURN w.id AS id'
         )
         write_params = base_params
 
@@ -185,15 +228,14 @@ async def create_webhook(
         write_records = await db.execute(
             write_query,
             write_params,
-            ['slug'],
+            ['id'],
         )
     except psycopg.errors.UniqueViolation as e:
         raise fastapi.HTTPException(
             status_code=409,
             detail=(
-                f'Webhook with slug {data.slug!r} '
-                f'or notification_path '
-                f'{data.notification_path!r} already exists'
+                f'A webhook with slug {slug!r} already exists. '
+                f'Choose a different name or rename the existing webhook.'
             ),
         ) from e
 
@@ -213,7 +255,7 @@ async def create_webhook(
 
     records = await db.execute(
         _FETCH_WEBHOOK_QUERY,
-        {'slug': data.slug, 'org_slug': org_slug},
+        {'identifier': webhook_id, 'org_slug': org_slug},
         ['webhook', 'tps', 'identifier_selector', 'rules'],
     )
     return models.WebhookResponse.from_graph_record(records[0])
@@ -262,10 +304,10 @@ async def list_webhooks(
     return [models.WebhookResponse.from_graph_record(r) for r in records]
 
 
-@webhooks_router.get('/{slug}')
+@webhooks_router.get('/{webhook}')
 async def get_webhook(
     org_slug: str,
-    slug: str,
+    webhook: str,
     db: graph.Pool,
     auth: typing.Annotated[
         permissions.AuthContext,
@@ -274,47 +316,25 @@ async def get_webhook(
         ),
     ],
 ) -> models.WebhookResponse:
-    """Get a webhook by slug."""
-    query: typing.LiteralString = """
-    MATCH (w:Webhook {{slug: {slug}}})
-          -[:BELONGS_TO]->(o:Organization {{slug: {org_slug}}})
-    OPTIONAL MATCH (w)-[impl:IMPLEMENTED_BY]->
-                   (tps:ThirdPartyService)
-    OPTIONAL MATCH (r:WebhookRule)-[:ACTIONS]->(w)
-    WITH w, tps, impl, r
-    ORDER BY r.ordinal
-    WITH w, tps, impl,
-         collect(CASE WHEN r IS NOT NULL
-                 THEN r{{.filter_expression, .handler,
-                        .handler_config, .ordinal}}
-                 END)
-            AS all_rules
-    RETURN w{{.*}} AS webhook,
-           tps{{.*}} AS tps,
-           impl.identifier_selector AS identifier_selector,
-           [x IN all_rules
-            | x {{.filter_expression, .handler,
-                  .handler_config}}]
-               AS rules
-    """
+    """Get a webhook by slug or id."""
     records = await db.execute(
-        query,
-        {'slug': slug, 'org_slug': org_slug},
+        _FETCH_WEBHOOK_QUERY,
+        {'identifier': webhook, 'org_slug': org_slug},
         ['webhook', 'tps', 'identifier_selector', 'rules'],
     )
 
     if not records:
         raise fastapi.HTTPException(
             status_code=404,
-            detail=f'Webhook with slug {slug!r} not found',
+            detail=f'Webhook {webhook!r} not found',
         )
     return models.WebhookResponse.from_graph_record(records[0])
 
 
-@webhooks_router.patch('/{slug}')
+@webhooks_router.patch('/{webhook}')
 async def patch_webhook(
     org_slug: str,
-    slug: str,
+    webhook: str,
     operations: list[json_patch.PatchOperation],
     db: graph.Pool,
     auth: typing.Annotated[
@@ -324,22 +344,36 @@ async def patch_webhook(
         ),
     ],
 ) -> models.WebhookResponse:
-    """Partially update a webhook using JSON Patch (RFC 6902)."""
+    """Partially update a webhook using JSON Patch (RFC 6902).
+
+    The ``id`` and ``notification_path`` fields are read-only;
+    patch operations targeting them are rejected with 400.
+
+    When ``third_party_service_slug`` is changed and ``slug`` is not
+    explicitly set in the same patch, the slug is auto-regenerated
+    from the new service slug and webhook name.
+    """
+    for op in operations:
+        if op.path in _READ_ONLY_PATHS:
+            raise fastapi.HTTPException(
+                status_code=400,
+                detail=f'{op.path!r} is read-only and cannot be modified',
+            )
+
     existing = await db.execute(
         _FETCH_WEBHOOK_QUERY,
-        {'slug': slug, 'org_slug': org_slug},
+        {'identifier': webhook, 'org_slug': org_slug},
         ['webhook', 'tps', 'identifier_selector', 'rules'],
     )
 
     if not existing:
         raise fastapi.HTTPException(
             status_code=404,
-            detail=f'Webhook with slug {slug!r} not found',
+            detail=f'Webhook {webhook!r} not found',
         )
 
     existing_webhook = graph.parse_agtype(existing[0]['webhook'])
 
-    # Build the patchable document (never expose encrypted secret)
     raw_rules: list[typing.Any] = existing[0].get('rules') or []
     if isinstance(raw_rules, str):
         try:
@@ -356,7 +390,6 @@ async def patch_webhook(
         'slug': existing_webhook.get('slug'),
         'description': existing_webhook.get('description'),
         'icon': existing_webhook.get('icon'),
-        'notification_path': existing_webhook.get('notification_path'),
         'secret': None,
         'third_party_service_slug': (
             existing_tps.get('slug') if existing_tps else None
@@ -379,19 +412,26 @@ async def patch_webhook(
         ],
     }
 
+    op_paths = {op.path for op in operations}
+    service_changed = '/third_party_service_slug' in op_paths
+    slug_explicitly_set = '/slug' in op_paths
+
     patched = json_patch.apply_patch(patchable, operations)
 
-    # Secret handling: preserve encrypted secret if not in patch
+    if service_changed and not slug_explicitly_set:
+        patched['slug'] = _compute_webhook_slug(
+            patched.get('third_party_service_slug'),
+            patched['name'],
+        )
+
     encryptor = encryption.TokenEncryption.get_instance()
-    secret_paths = {op.path for op in operations}
-    if '/secret' not in secret_paths:
+    if '/secret' not in op_paths:
         encrypted_secret: str | None = existing_webhook.get('secret')
     elif patched.get('secret') is None:
         encrypted_secret = None
     else:
         encrypted_secret = encryptor.encrypt(patched['secret'])
 
-    # Validate patched data against WebhookUpdate model
     try:
         data = models.WebhookUpdate.model_validate(patched)
     except pydantic.ValidationError as exc:
@@ -405,7 +445,6 @@ async def patch_webhook(
         'slug': data.slug,
         'description': data.description,
         'icon': data.icon,
-        'notification_path': data.notification_path,
         'secret': encrypted_secret,
     }
     set_stmt = set_clause('w', props)
@@ -424,9 +463,12 @@ async def patch_webhook(
         )
     rule_clauses, rules_params = _rules_create_clauses(rule_dicts)
 
+    # Use id as the stable lookup key for the write query
+    existing_webhook_id: str = existing_webhook.get('id', '')
+
     if data.third_party_service_slug:
         write_query: str = (
-            'MATCH (w:Webhook {{slug: {old_slug}}})'
+            'MATCH (w:Webhook {{id: {webhook_id}}})'
             ' -[:BELONGS_TO]->(o:Organization'
             ' {{slug: {org_slug}}})'
             ' MATCH (tps:ThirdPartyService'
@@ -442,12 +484,10 @@ async def patch_webhook(
             f' {set_stmt}'
             ' CREATE (w)-[impl:IMPLEMENTED_BY]->(tps)'
             ' SET impl.identifier_selector'
-            ' = {identifier_selector}'
-            + rule_clauses
-            + ' RETURN w.slug AS slug'
+            ' = {identifier_selector}' + rule_clauses + ' RETURN w.id AS id'
         )
         params: dict[str, typing.Any] = {
-            'old_slug': slug,
+            'webhook_id': existing_webhook_id,
             'org_slug': org_slug,
             'tps_slug': data.third_party_service_slug,
             **props,
@@ -456,7 +496,7 @@ async def patch_webhook(
         }
     else:
         write_query = (
-            'MATCH (w:Webhook {{slug: {old_slug}}})'
+            'MATCH (w:Webhook {{id: {webhook_id}}})'
             ' -[:BELONGS_TO]->(o:Organization'
             ' {{slug: {org_slug}}})'
             ' OPTIONAL MATCH'
@@ -467,10 +507,10 @@ async def patch_webhook(
             ' (w)-[old_impl:IMPLEMENTED_BY]->()'
             ' DELETE old_impl'
             ' WITH DISTINCT w'
-            f' {set_stmt}' + rule_clauses + ' RETURN w.slug AS slug'
+            f' {set_stmt}' + rule_clauses + ' RETURN w.id AS id'
         )
         params = {
-            'old_slug': slug,
+            'webhook_id': existing_webhook_id,
             'org_slug': org_slug,
             **props,
             **rules_params,
@@ -480,36 +520,32 @@ async def patch_webhook(
         write_records = await db.execute(
             write_query,
             params,
-            ['slug'],
+            ['id'],
         )
     except psycopg.errors.UniqueViolation as e:
         raise fastapi.HTTPException(
             status_code=409,
-            detail=(
-                f'Webhook with slug {data.slug!r} '
-                f'or notification_path '
-                f'{data.notification_path!r} already exists'
-            ),
+            detail=(f'A webhook with slug {data.slug!r} already exists.'),
         ) from e
 
     if not write_records:
         raise fastapi.HTTPException(
             status_code=404,
-            detail=f'Webhook with slug {slug!r} not found',
+            detail=f'Webhook {webhook!r} not found',
         )
 
     records = await db.execute(
         _FETCH_WEBHOOK_QUERY,
-        {'slug': data.slug, 'org_slug': org_slug},
+        {'identifier': existing_webhook_id, 'org_slug': org_slug},
         ['webhook', 'tps', 'identifier_selector', 'rules'],
     )
     return models.WebhookResponse.from_graph_record(records[0])
 
 
-@webhooks_router.delete('/{slug}', status_code=204)
+@webhooks_router.delete('/{webhook}', status_code=204)
 async def delete_webhook(
     org_slug: str,
-    slug: str,
+    webhook: str,
     db: graph.Pool,
     auth: typing.Annotated[
         permissions.AuthContext,
@@ -520,15 +556,15 @@ async def delete_webhook(
 ) -> None:
     """Delete a webhook and its rules."""
     query: typing.LiteralString = """
-    MATCH (w:Webhook {{slug: {slug}}})
-          -[:BELONGS_TO]->(o:Organization {{slug: {org_slug}}})
+    MATCH (w:Webhook)-[:BELONGS_TO]->(o:Organization {{slug: {org_slug}}})
+    WHERE w.slug = {identifier} OR w.id = {identifier}
     OPTIONAL MATCH (r:WebhookRule)-[:ACTIONS]->(w)
     DETACH DELETE r, w
     RETURN count(w) AS deleted
     """
     records = await db.execute(
         query,
-        {'slug': slug, 'org_slug': org_slug},
+        {'identifier': webhook, 'org_slug': org_slug},
         ['deleted'],
     )
 
@@ -536,7 +572,7 @@ async def delete_webhook(
     if not records or deleted == 0:
         raise fastapi.HTTPException(
             status_code=404,
-            detail=f'Webhook with slug {slug!r} not found',
+            detail=f'Webhook {webhook!r} not found',
         )
 
 

--- a/src/imbi_api/endpoints/webhooks.py
+++ b/src/imbi_api/endpoints/webhooks.py
@@ -51,6 +51,52 @@ def _compute_webhook_slug(
     return name_part[:64]
 
 
+async def _check_identifier_collision(
+    db: graph.Graph,
+    org_slug: str,
+    *,
+    slug: str,
+    webhook_id: str | None = None,
+    exclude_id: str | None = None,
+) -> None:
+    """Raise 409 if slug or id would collide with the other identifier type.
+
+    Checks that no webhook in the org has ``id = slug`` (a slug that
+    matches an existing surrogate key) or ``slug = webhook_id`` (an id
+    that matches an existing human-readable slug).  ``exclude_id`` skips
+    the webhook with that id so a PATCH on the current webhook doesn't
+    flag itself.
+    """
+    conditions: list[str] = ['w.id = {chk_slug}']
+    params: dict[str, str] = {'org_slug': org_slug, 'chk_slug': slug}
+    if webhook_id is not None:
+        conditions.append('w.slug = {chk_id}')
+        params['chk_id'] = webhook_id
+    condition_expr = ' OR '.join(conditions)
+
+    exclude_clause = ''
+    if exclude_id is not None:
+        exclude_clause = ' AND w.id <> {exclude_id}'
+        params['exclude_id'] = exclude_id
+
+    query = (
+        'MATCH (w:Webhook)-[:BELONGS_TO]->'
+        '(o:Organization {{slug: {org_slug}}})'
+        f' WHERE ({condition_expr}){exclude_clause}'
+        ' RETURN count(w) AS n'
+    )
+    rows = await db.execute(query, params, ['n'])
+    count = graph.parse_agtype(rows[0].get('n', 0)) if rows else 0
+    if count:
+        raise fastapi.HTTPException(
+            status_code=409,
+            detail=(
+                'The webhook slug and id must not collide with any existing '
+                "webhook's id or slug in this organization."
+            ),
+        )
+
+
 def _rules_create_clauses(
     rules: list[dict[str, str | int]],
 ) -> tuple[str, dict[str, typing.Any]]:
@@ -137,6 +183,16 @@ _UPDATE_RETURN_TAIL_NO_TPS: typing.LiteralString = (
 )
 
 
+def _parse_json_rules(raw: typing.Any) -> list[typing.Any]:
+    """Parse rules from a graph record; handles str (JSON) or list."""
+    if isinstance(raw, str):
+        try:
+            return json.loads(raw)  # type: ignore[no-any-return]
+        except (json.JSONDecodeError, TypeError):
+            return []
+    return list(raw) if raw else []
+
+
 webhooks_router = fastapi.APIRouter(tags=['Webhooks'])
 
 
@@ -163,6 +219,9 @@ async def create_webhook(
 
     webhook_id = _generate_id()
     slug = _compute_webhook_slug(data.third_party_service_slug, data.name)
+    await _check_identifier_collision(
+        db, org_slug, slug=slug, webhook_id=webhook_id
+    )
     notification_path = f'/{webhook_id}'
 
     props: dict[str, typing.Any] = {
@@ -374,12 +433,7 @@ async def patch_webhook(
 
     existing_webhook = graph.parse_agtype(existing[0]['webhook'])
 
-    raw_rules: list[typing.Any] = existing[0].get('rules') or []
-    if isinstance(raw_rules, str):
-        try:
-            raw_rules = json.loads(raw_rules)
-        except (json.JSONDecodeError, TypeError):
-            raw_rules = []
+    raw_rules = _parse_json_rules(existing[0].get('rules'))
 
     existing_tps = existing[0].get('tps')
     if existing_tps:
@@ -422,6 +476,15 @@ async def patch_webhook(
         patched['slug'] = _compute_webhook_slug(
             patched.get('third_party_service_slug'),
             patched['name'],
+        )
+
+    new_slug: str = patched['slug']
+    if new_slug != existing_webhook.get('slug'):
+        await _check_identifier_collision(
+            db,
+            org_slug,
+            slug=new_slug,
+            exclude_id=existing_webhook.get('id', ''),
         )
 
     encryptor = encryption.TokenEncryption.get_instance()

--- a/tests/endpoints/test_third_party_services.py
+++ b/tests/endpoints/test_third_party_services.py
@@ -521,6 +521,7 @@ class ServiceWebhooksEndpointsTestCase(unittest.TestCase):
     def test_list_service_webhooks(self) -> None:
         record = {
             'webhook': {
+                'id': 'wh_test001',
                 'name': 'GitHub PR Events',
                 'slug': 'gh-pr-events',
                 'description': 'PR webhooks',
@@ -579,6 +580,7 @@ class ServiceWebhooksEndpointsTestCase(unittest.TestCase):
         records = [
             {
                 'webhook': {
+                    'id': 'wh_first001',
                     'name': 'First',
                     'slug': 'first',
                     'notification_path': '/webhooks/first',
@@ -592,6 +594,7 @@ class ServiceWebhooksEndpointsTestCase(unittest.TestCase):
             },
             {
                 'webhook': {
+                    'id': 'wh_second01',
                     'name': 'Second',
                     'slug': 'second',
                     'notification_path': '/webhooks/second',
@@ -621,6 +624,7 @@ class ServiceWebhooksEndpointsTestCase(unittest.TestCase):
     def test_list_service_webhooks_with_rules(self) -> None:
         record = {
             'webhook': {
+                'id': 'wh_rules001',
                 'name': 'GitHub Events',
                 'slug': 'gh-events',
                 'notification_path': '/webhooks/gh',
@@ -670,6 +674,7 @@ class ServiceWebhooksEndpointsTestCase(unittest.TestCase):
     ) -> None:
         record = {
             'webhook': {
+                'id': 'wh_null001',
                 'name': 'GitHub Events',
                 'slug': 'gh-events',
                 'notification_path': '/webhooks/gh',
@@ -697,6 +702,7 @@ class ServiceWebhooksEndpointsTestCase(unittest.TestCase):
     ) -> None:
         record = {
             'webhook': {
+                'id': 'wh_malform1',
                 'name': 'GitHub Events',
                 'slug': 'gh-events',
                 'notification_path': '/webhooks/gh',
@@ -731,6 +737,7 @@ class ServiceWebhooksEndpointsTestCase(unittest.TestCase):
     def test_list_service_webhooks_without_tps(self) -> None:
         record = {
             'webhook': {
+                'id': 'wh_notps001',
                 'name': 'GitHub Events',
                 'slug': 'gh-events',
                 'notification_path': '/webhooks/gh',

--- a/tests/endpoints/test_webhooks.py
+++ b/tests/endpoints/test_webhooks.py
@@ -235,7 +235,13 @@ class WebhookEndpointsTestCase(unittest.TestCase):
 
     def test_create_slug_collision_returns_409(self) -> None:
         self.mock_db.execute.side_effect = psycopg.errors.UniqueViolation()
-        with self._patch_encryption():
+        with (
+            self._patch_encryption(),
+            mock.patch(
+                'imbi_api.endpoints.webhooks._check_identifier_collision',
+                new=mock.AsyncMock(),
+            ),
+        ):
             response = self.client.post(
                 '/organizations/engineering/webhooks/',
                 json=self.webhook_create_json,
@@ -495,6 +501,7 @@ class WebhookEndpointsTestCase(unittest.TestCase):
 
         self.mock_db.execute.side_effect = [
             [existing_record],
+            [{'n': 0}],  # collision check
             [updated_record],
             [updated_record],
         ]
@@ -519,7 +526,7 @@ class WebhookEndpointsTestCase(unittest.TestCase):
 
         self.assertEqual(response.status_code, 200)
         # Verify the write query used the regenerated slug
-        write_call_args = self.mock_db.execute.call_args_list[1]
+        write_call_args = self.mock_db.execute.call_args_list[2]
         write_params = write_call_args[0][1]
         self.assertEqual(write_params['slug'], 'gitlab-events')
 
@@ -554,6 +561,7 @@ class WebhookEndpointsTestCase(unittest.TestCase):
 
         self.mock_db.execute.side_effect = [
             [existing_record],
+            [{'n': 0}],  # collision check
             [updated_record],
             [updated_record],
         ]
@@ -582,7 +590,7 @@ class WebhookEndpointsTestCase(unittest.TestCase):
             )
 
         self.assertEqual(response.status_code, 200)
-        write_call_args = self.mock_db.execute.call_args_list[1]
+        write_call_args = self.mock_db.execute.call_args_list[2]
         write_params = write_call_args[0][1]
         self.assertEqual(write_params['slug'], 'my-custom-slug')
 
@@ -667,6 +675,7 @@ class WebhookEndpointsTestCase(unittest.TestCase):
 
         self.mock_db.execute.side_effect = [
             [existing_record],
+            [{'n': 0}],  # collision check (no cross-id collision)
             psycopg.errors.UniqueViolation(),
         ]
 
@@ -930,6 +939,66 @@ class WebhookEndpointsTestCase(unittest.TestCase):
             response.json()['rules'][0]['handler_config'],
             ['step1', 'step2'],
         )
+
+    # -- Identifier collision --
+
+    def test_create_identifier_collision_returns_409(self) -> None:
+        """Slug matching an existing webhook id returns 409."""
+        self.mock_db.execute.return_value = [{'n': 1}]
+        with (
+            self._patch_encryption(),
+            mock.patch(
+                'imbi_common.graph.parse_agtype',
+                side_effect=lambda x: x,
+            ),
+        ):
+            response = self.client.post(
+                '/organizations/engineering/webhooks/',
+                json=self.webhook_create_json,
+            )
+
+        self.assertEqual(response.status_code, 409)
+        self.assertIn('collide', response.json()['detail'])
+
+    def test_patch_identifier_collision_returns_409(self) -> None:
+        """Changing slug to one matching an existing webhook id returns 409."""
+        existing_record = {
+            'webhook': {
+                'id': 'abc123def4',
+                'name': 'Deploy Hook',
+                'slug': 'deploy',
+                'description': None,
+                'notification_path': '/abc123def4',
+                'secret': None,
+            },
+            'tps': None,
+            'identifier_selector': None,
+            'rules': [],
+        }
+        self.mock_db.execute.side_effect = [
+            [existing_record],
+            [{'n': 1}],  # collision check finds a conflicting id
+        ]
+        with (
+            self._patch_encryption(),
+            mock.patch(
+                'imbi_common.graph.parse_agtype',
+                side_effect=lambda x: x,
+            ),
+        ):
+            response = self.client.patch(
+                '/organizations/engineering/webhooks/deploy',
+                json=[
+                    {
+                        'op': 'replace',
+                        'path': '/slug',
+                        'value': 'some-nanoid-value',
+                    }
+                ],
+            )
+
+        self.assertEqual(response.status_code, 409)
+        self.assertIn('collide', response.json()['detail'])
 
     # -- Slug / id generation helpers --
 

--- a/tests/endpoints/test_webhooks.py
+++ b/tests/endpoints/test_webhooks.py
@@ -15,6 +15,7 @@ from imbi_api import app, models
 
 
 class _WebhookDetails(typing.TypedDict):
+    id: str
     name: str
     slug: str
     description: typing.NotRequired[str]
@@ -82,11 +83,12 @@ class WebhookEndpointsTestCase(unittest.TestCase):
 
         self.webhook_record: _WebhookRecord = {
             'webhook': {
+                'id': 'abc123def4',
                 'name': 'GitHub Events',
                 'slug': 'github-events',
                 'description': 'Receives GitHub webhooks',
                 'icon': None,
-                'notification_path': '/webhooks/github',
+                'notification_path': '/abc123def4',
                 'secret': 'enc:my-secret',
             },
             'tps': None,
@@ -94,11 +96,9 @@ class WebhookEndpointsTestCase(unittest.TestCase):
             'rules': [],
         }
 
-        self.webhook_create_json: _WebhookDetails = {
+        # Create payload no longer includes slug or notification_path
+        self.webhook_create_json: dict[str, object] = {
             'name': 'GitHub Events',
-            'slug': 'github-events',
-            'notification_path': '/webhooks/github',
-            'secret': 'my-secret',
         }
 
         self.mock_encryptor = mock.MagicMock()
@@ -133,10 +133,69 @@ class WebhookEndpointsTestCase(unittest.TestCase):
         data = response.json()
         self.assertEqual(data['slug'], 'github-events')
         self.assertEqual(data['name'], 'GitHub Events')
-        self.assertEqual(
-            data['notification_path'],
-            '/webhooks/github',
-        )
+        self.assertEqual(data['id'], 'abc123def4')
+        self.assertEqual(data['notification_path'], '/abc123def4')
+
+    def test_create_slug_auto_generated_from_name(self) -> None:
+        """Slug is derived from the webhook name, not provided by caller."""
+        record = copy.deepcopy(self.webhook_record)
+        record['webhook']['slug'] = 'github-push-events'
+        record['webhook']['name'] = 'GitHub Push Events'
+
+        self.mock_db.execute.return_value = [record]
+        with (
+            self._patch_encryption(),
+            mock.patch(
+                'imbi_common.graph.parse_agtype',
+                side_effect=lambda x: x,
+            ),
+            mock.patch(
+                'imbi_api.endpoints.webhooks._generate_id',
+                return_value='abc123def4',
+            ),
+            mock.patch(
+                'imbi_api.endpoints.webhooks._compute_webhook_slug',
+                return_value='github-push-events',
+            ),
+        ):
+            response = self.client.post(
+                '/organizations/engineering/webhooks/',
+                json={'name': 'GitHub Push Events'},
+            )
+
+        self.assertEqual(response.status_code, 201)
+        data = response.json()
+        self.assertEqual(data['slug'], 'github-push-events')
+
+    def test_create_with_service_slug_is_prefixed(self) -> None:
+        """Slug is prefixed with the service slug when a service is linked."""
+        record = copy.deepcopy(self.webhook_record)
+        record['webhook']['slug'] = 'github-events'
+        record['tps'] = {'name': 'GitHub', 'slug': 'github'}
+        record['identifier_selector'] = '$.repository.full_name'
+
+        self.mock_db.execute.return_value = [record]
+        with (
+            self._patch_encryption(),
+            mock.patch(
+                'imbi_common.graph.parse_agtype',
+                side_effect=lambda x: x,
+            ),
+        ):
+            payload = {
+                'name': 'Events',
+                'third_party_service_slug': 'github',
+                'identifier_selector': '$.repository.full_name',
+            }
+            response = self.client.post(
+                '/organizations/engineering/webhooks/',
+                json=payload,
+            )
+
+        self.assertEqual(response.status_code, 201)
+        data = response.json()
+        self.assertIsNotNone(data['third_party_service'])
+        self.assertEqual(data['third_party_service']['slug'], 'github')
 
     def test_create_with_rules(self) -> None:
         record = copy.deepcopy(self.webhook_record)
@@ -172,44 +231,9 @@ class WebhookEndpointsTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 201)
         data = response.json()
         self.assertEqual(len(data['rules']), 1)
-        self.assertEqual(
-            data['rules'][0]['handler'],
-            'my.handler',
-        )
+        self.assertEqual(data['rules'][0]['handler'], 'my.handler')
 
-    def test_create_with_third_party_service(self) -> None:
-        record = copy.deepcopy(self.webhook_record)
-        record['tps'] = {
-            'name': 'GitHub',
-            'slug': 'github',
-        }
-        record['identifier_selector'] = '$.repository.full_name'
-
-        self.mock_db.execute.return_value = [record]
-        with (
-            self._patch_encryption(),
-            mock.patch(
-                'imbi_common.graph.parse_agtype',
-                side_effect=lambda x: x,
-            ),
-        ):
-            payload = dict(self.webhook_create_json)
-            payload['third_party_service_slug'] = 'github'
-            payload['identifier_selector'] = '$.repository.full_name'
-            response = self.client.post(
-                '/organizations/engineering/webhooks/',
-                json=payload,
-            )
-
-        self.assertEqual(response.status_code, 201)
-        data = response.json()
-        self.assertIsNotNone(data['third_party_service'])
-        self.assertEqual(
-            data['third_party_service']['slug'],
-            'github',
-        )
-
-    def test_create_duplicate_slug(self) -> None:
+    def test_create_slug_collision_returns_409(self) -> None:
         self.mock_db.execute.side_effect = psycopg.errors.UniqueViolation()
         with self._patch_encryption():
             response = self.client.post(
@@ -262,41 +286,16 @@ class WebhookEndpointsTestCase(unittest.TestCase):
     def test_create_missing_name(self) -> None:
         response = self.client.post(
             '/organizations/engineering/webhooks/',
-            json={
-                'slug': 'test',
-                'notification_path': '/test',
-            },
+            json={},
         )
         self.assertEqual(response.status_code, 422)
 
-    def test_create_missing_slug(self) -> None:
+    def test_create_identifier_selector_without_service(self) -> None:
         response = self.client.post(
             '/organizations/engineering/webhooks/',
             json={
                 'name': 'Test',
-                'notification_path': '/test',
-            },
-        )
-        self.assertEqual(response.status_code, 422)
-
-    def test_create_invalid_notification_path(self) -> None:
-        response = self.client.post(
-            '/organizations/engineering/webhooks/',
-            json={
-                'name': 'Test',
-                'slug': 'test',
-                'notification_path': 'no-leading-slash',
-            },
-        )
-        self.assertEqual(response.status_code, 422)
-
-    def test_create_invalid_slug_pattern(self) -> None:
-        response = self.client.post(
-            '/organizations/engineering/webhooks/',
-            json={
-                'name': 'Test',
-                'slug': 'Bad-Slug',
-                'notification_path': '/test',
+                'identifier_selector': '$.foo',
             },
         )
         self.assertEqual(response.status_code, 422)
@@ -318,6 +317,7 @@ class WebhookEndpointsTestCase(unittest.TestCase):
         self.assertIsInstance(data, list)
         self.assertEqual(len(data), 1)
         self.assertEqual(data[0]['slug'], 'github-events')
+        self.assertEqual(data[0]['id'], 'abc123def4')
 
     def test_list_webhooks_empty(self) -> None:
         self.mock_db.execute.return_value = []
@@ -334,7 +334,7 @@ class WebhookEndpointsTestCase(unittest.TestCase):
 
     # -- Get --
 
-    def test_get_webhook(self) -> None:
+    def test_get_webhook_by_slug(self) -> None:
         self.mock_db.execute.return_value = [self.webhook_record]
         with mock.patch(
             'imbi_common.graph.parse_agtype',
@@ -347,10 +347,22 @@ class WebhookEndpointsTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         data = response.json()
         self.assertEqual(data['slug'], 'github-events')
-        self.assertEqual(
-            data['notification_path'],
-            '/webhooks/github',
-        )
+        self.assertEqual(data['id'], 'abc123def4')
+        self.assertEqual(data['notification_path'], '/abc123def4')
+
+    def test_get_webhook_by_id(self) -> None:
+        self.mock_db.execute.return_value = [self.webhook_record]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            response = self.client.get(
+                '/organizations/engineering/webhooks/abc123def4',
+            )
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data['slug'], 'github-events')
 
     def test_get_webhook_not_found(self) -> None:
         self.mock_db.execute.return_value = []
@@ -368,13 +380,13 @@ class WebhookEndpointsTestCase(unittest.TestCase):
     # -- Patch --
 
     def test_patch_webhook_description(self) -> None:
-        """Test patching only the webhook description."""
         existing_record = {
             'webhook': {
+                'id': 'abc123def4',
                 'name': 'Deploy Hook',
                 'slug': 'deploy',
                 'description': 'Old',
-                'notification_path': '/deploy',
+                'notification_path': '/abc123def4',
                 'secret': None,
             },
             'tps': None,
@@ -383,10 +395,11 @@ class WebhookEndpointsTestCase(unittest.TestCase):
         }
         updated_record = {
             'webhook': {
+                'id': 'abc123def4',
                 'name': 'Deploy Hook',
                 'slug': 'deploy',
                 'description': 'New desc',
-                'notification_path': '/deploy',
+                'notification_path': '/abc123def4',
                 'secret': None,
             },
             'tps': None,
@@ -419,8 +432,161 @@ class WebhookEndpointsTestCase(unittest.TestCase):
 
         self.assertEqual(response.status_code, 200)
 
+    def test_patch_notification_path_rejected(self) -> None:
+        """Patching notification_path returns 400."""
+        response = self.client.patch(
+            '/organizations/engineering/webhooks/deploy',
+            json=[
+                {
+                    'op': 'replace',
+                    'path': '/notification_path',
+                    'value': '/new-path',
+                }
+            ],
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('read-only', response.json()['detail'])
+
+    def test_patch_id_rejected(self) -> None:
+        """Patching id returns 400."""
+        response = self.client.patch(
+            '/organizations/engineering/webhooks/deploy',
+            json=[
+                {
+                    'op': 'replace',
+                    'path': '/id',
+                    'value': 'new-id',
+                }
+            ],
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('read-only', response.json()['detail'])
+
+    def test_patch_service_change_regenerates_slug(self) -> None:
+        """Changing third_party_service_slug auto-regenerates the slug."""
+        existing_record = {
+            'webhook': {
+                'id': 'abc123def4',
+                'name': 'Events',
+                'slug': 'github-events',
+                'description': None,
+                'notification_path': '/abc123def4',
+                'secret': None,
+            },
+            'tps': {'slug': 'github', 'name': 'GitHub'},
+            'identifier_selector': None,
+            'rules': [],
+        }
+        updated_record = {
+            'webhook': {
+                'id': 'abc123def4',
+                'name': 'Events',
+                'slug': 'gitlab-events',
+                'description': None,
+                'notification_path': '/abc123def4',
+                'secret': None,
+            },
+            'tps': {'slug': 'gitlab', 'name': 'GitLab'},
+            'identifier_selector': None,
+            'rules': [],
+        }
+
+        self.mock_db.execute.side_effect = [
+            [existing_record],
+            [updated_record],
+            [updated_record],
+        ]
+
+        with (
+            self._patch_encryption(),
+            mock.patch(
+                'imbi_common.graph.parse_agtype',
+                side_effect=lambda x: x,
+            ),
+        ):
+            response = self.client.patch(
+                '/organizations/engineering/webhooks/github-events',
+                json=[
+                    {
+                        'op': 'replace',
+                        'path': '/third_party_service_slug',
+                        'value': 'gitlab',
+                    }
+                ],
+            )
+
+        self.assertEqual(response.status_code, 200)
+        # Verify the write query used the regenerated slug
+        write_call_args = self.mock_db.execute.call_args_list[1]
+        write_params = write_call_args[0][1]
+        self.assertEqual(write_params['slug'], 'gitlab-events')
+
+    def test_patch_explicit_slug_with_service_change(self) -> None:
+        """Explicit /slug in same patch takes precedence over auto-regen."""
+        existing_record = {
+            'webhook': {
+                'id': 'abc123def4',
+                'name': 'Events',
+                'slug': 'github-events',
+                'description': None,
+                'notification_path': '/abc123def4',
+                'secret': None,
+            },
+            'tps': {'slug': 'github', 'name': 'GitHub'},
+            'identifier_selector': None,
+            'rules': [],
+        }
+        updated_record = {
+            'webhook': {
+                'id': 'abc123def4',
+                'name': 'Events',
+                'slug': 'my-custom-slug',
+                'description': None,
+                'notification_path': '/abc123def4',
+                'secret': None,
+            },
+            'tps': {'slug': 'gitlab', 'name': 'GitLab'},
+            'identifier_selector': None,
+            'rules': [],
+        }
+
+        self.mock_db.execute.side_effect = [
+            [existing_record],
+            [updated_record],
+            [updated_record],
+        ]
+
+        with (
+            self._patch_encryption(),
+            mock.patch(
+                'imbi_common.graph.parse_agtype',
+                side_effect=lambda x: x,
+            ),
+        ):
+            response = self.client.patch(
+                '/organizations/engineering/webhooks/github-events',
+                json=[
+                    {
+                        'op': 'replace',
+                        'path': '/third_party_service_slug',
+                        'value': 'gitlab',
+                    },
+                    {
+                        'op': 'replace',
+                        'path': '/slug',
+                        'value': 'my-custom-slug',
+                    },
+                ],
+            )
+
+        self.assertEqual(response.status_code, 200)
+        write_call_args = self.mock_db.execute.call_args_list[1]
+        write_params = write_call_args[0][1]
+        self.assertEqual(write_params['slug'], 'my-custom-slug')
+
     def test_patch_webhook_not_found(self) -> None:
-        """Test patching non-existent webhook returns 404."""
         self.mock_db.execute.return_value = []
 
         response = self.client.patch(
@@ -431,13 +597,13 @@ class WebhookEndpointsTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 404)
 
     def test_patch_webhook_with_tps(self) -> None:
-        """Test patching a webhook that has a third-party service link."""
         existing_record = {
             'webhook': {
+                'id': 'abc123def4',
                 'name': 'GitHub Hook',
                 'slug': 'github-hook',
                 'description': 'Old desc',
-                'notification_path': '/github',
+                'notification_path': '/abc123def4',
                 'secret': None,
             },
             'tps': {'slug': 'github', 'name': 'GitHub'},
@@ -446,10 +612,11 @@ class WebhookEndpointsTestCase(unittest.TestCase):
         }
         updated_record = {
             'webhook': {
+                'id': 'abc123def4',
                 'name': 'GitHub Hook',
                 'slug': 'github-hook',
                 'description': 'New desc',
-                'notification_path': '/github',
+                'notification_path': '/abc123def4',
                 'secret': None,
             },
             'tps': {'slug': 'github', 'name': 'GitHub'},
@@ -483,14 +650,55 @@ class WebhookEndpointsTestCase(unittest.TestCase):
 
         self.assertEqual(response.status_code, 200)
 
-    def test_patch_webhook_encrypt_new_secret(self) -> None:
-        """Test patching a webhook's secret encrypts the new value."""
+    def test_patch_webhook_slug_collision_returns_409(self) -> None:
         existing_record = {
             'webhook': {
+                'id': 'abc123def4',
+                'name': 'Deploy Hook',
+                'slug': 'deploy',
+                'description': None,
+                'notification_path': '/abc123def4',
+                'secret': None,
+            },
+            'tps': None,
+            'identifier_selector': None,
+            'rules': [],
+        }
+
+        self.mock_db.execute.side_effect = [
+            [existing_record],
+            psycopg.errors.UniqueViolation(),
+        ]
+
+        with (
+            self._patch_encryption(),
+            mock.patch(
+                'imbi_common.graph.parse_agtype',
+                side_effect=lambda x: x,
+            ),
+        ):
+            response = self.client.patch(
+                '/organizations/engineering/webhooks/deploy',
+                json=[
+                    {
+                        'op': 'replace',
+                        'path': '/slug',
+                        'value': 'other-existing-slug',
+                    }
+                ],
+            )
+
+        self.assertEqual(response.status_code, 409)
+        self.assertIn('already exists', response.json()['detail'])
+
+    def test_patch_webhook_encrypt_new_secret(self) -> None:
+        existing_record = {
+            'webhook': {
+                'id': 'abc123def4',
                 'name': 'Deploy Hook',
                 'slug': 'deploy',
                 'description': 'A hook',
-                'notification_path': '/deploy',
+                'notification_path': '/abc123def4',
                 'secret': None,
             },
             'tps': None,
@@ -523,13 +731,13 @@ class WebhookEndpointsTestCase(unittest.TestCase):
         self.mock_encryptor.encrypt.assert_called_once_with('my-secret')
 
     def test_patch_webhook_clear_secret(self) -> None:
-        """Test patching secret to null clears the encrypted secret."""
         existing_record = {
             'webhook': {
+                'id': 'abc123def4',
                 'name': 'Deploy Hook',
                 'slug': 'deploy',
                 'description': 'A hook',
-                'notification_path': '/deploy',
+                'notification_path': '/abc123def4',
                 'secret': 'enc:old-secret',
             },
             'tps': None,
@@ -538,10 +746,11 @@ class WebhookEndpointsTestCase(unittest.TestCase):
         }
         updated_record = {
             'webhook': {
+                'id': 'abc123def4',
                 'name': 'Deploy Hook',
                 'slug': 'deploy',
                 'description': 'A hook',
-                'notification_path': '/deploy',
+                'notification_path': '/abc123def4',
                 'secret': None,
             },
             'tps': None,
@@ -571,13 +780,13 @@ class WebhookEndpointsTestCase(unittest.TestCase):
         self.mock_encryptor.encrypt.assert_not_called()
 
     def test_patch_webhook_with_rules(self) -> None:
-        """Test patching a webhook that has rules stored as a JSON string."""
         existing_record = {
             'webhook': {
+                'id': 'abc123def4',
                 'name': 'Deploy Hook',
                 'slug': 'deploy',
                 'description': 'Old',
-                'notification_path': '/deploy',
+                'notification_path': '/abc123def4',
                 'secret': None,
             },
             'tps': None,
@@ -594,10 +803,11 @@ class WebhookEndpointsTestCase(unittest.TestCase):
         }
         updated_record = {
             'webhook': {
+                'id': 'abc123def4',
                 'name': 'Deploy Hook',
                 'slug': 'deploy',
                 'description': 'New',
-                'notification_path': '/deploy',
+                'notification_path': '/abc123def4',
                 'secret': None,
             },
             'tps': None,
@@ -629,10 +839,18 @@ class WebhookEndpointsTestCase(unittest.TestCase):
 
     # -- Delete --
 
-    def test_delete_webhook(self) -> None:
+    def test_delete_webhook_by_slug(self) -> None:
         self.mock_db.execute.return_value = [{'deleted': 1}]
         response = self.client.delete(
             '/organizations/engineering/webhooks/github-events',
+        )
+
+        self.assertEqual(response.status_code, 204)
+
+    def test_delete_webhook_by_id(self) -> None:
+        self.mock_db.execute.return_value = [{'deleted': 1}]
+        response = self.client.delete(
+            '/organizations/engineering/webhooks/abc123def4',
         )
 
         self.assertEqual(response.status_code, 204)
@@ -670,10 +888,7 @@ class WebhookEndpointsTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         data = response.json()
         self.assertEqual(len(data['rules']), 1)
-        self.assertEqual(
-            data['rules'][0]['handler_config'],
-            {},
-        )
+        self.assertEqual(data['rules'][0]['handler_config'], {})
 
     def test_rules_with_null_entries_filtered(self) -> None:
         record = copy.deepcopy(self.webhook_record)
@@ -715,6 +930,39 @@ class WebhookEndpointsTestCase(unittest.TestCase):
             response.json()['rules'][0]['handler_config'],
             ['step1', 'step2'],
         )
+
+    # -- Slug / id generation helpers --
+
+    def test_slugify_basic(self) -> None:
+        from imbi_api.endpoints.webhooks import _slugify
+
+        self.assertEqual(_slugify('GitHub Push Events'), 'github-push-events')
+        self.assertEqual(_slugify('hello world'), 'hello-world')
+        self.assertEqual(_slugify('  spaces  '), 'spaces')
+        self.assertEqual(_slugify(''), 'hook')
+        self.assertEqual(_slugify('x'), 'x0')
+
+    def test_compute_webhook_slug_with_service(self) -> None:
+        from imbi_api.endpoints.webhooks import _compute_webhook_slug
+
+        result = _compute_webhook_slug('github', 'Push Events')
+        self.assertEqual(result, 'github-push-events')
+
+    def test_compute_webhook_slug_without_service(self) -> None:
+        from imbi_api.endpoints.webhooks import _compute_webhook_slug
+
+        result = _compute_webhook_slug(None, 'Deploy Hook')
+        self.assertEqual(result, 'deploy-hook')
+
+    def test_generate_id_is_nanoid(self) -> None:
+        from imbi_api.endpoints.webhooks import _generate_id
+
+        generated = _generate_id()
+        self.assertEqual(len(generated), 21)
+        valid_chars = set(
+            '_-0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
+        )
+        self.assertTrue(all(c in valid_chars for c in generated))
 
 
 class ProjectServicesEndpointsTestCase(unittest.TestCase):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -406,8 +406,6 @@ class WebhookCreateModelTestCase(unittest.TestCase):
     ) -> dict[str, object]:
         defaults: dict[str, object] = {
             'name': 'GitHub Events',
-            'slug': 'github-events',
-            'notification_path': '/webhooks/github',
         }
         defaults.update(overrides)
         return defaults
@@ -416,32 +414,9 @@ class WebhookCreateModelTestCase(unittest.TestCase):
         obj = domain_models.WebhookCreate.model_validate(
             self._valid_payload(),
         )
-        self.assertEqual(obj.slug, 'github-events')
         self.assertIsNone(obj.secret)
         self.assertEqual(obj.rules, [])
         self.assertIsNone(obj.third_party_service_slug)
-
-    def test_slug_pattern_rejects_uppercase(self) -> None:
-        with self.assertRaises(pydantic.ValidationError):
-            domain_models.WebhookCreate.model_validate(
-                self._valid_payload(slug='Bad-Slug'),
-            )
-
-    def test_slug_too_short(self) -> None:
-        with self.assertRaises(pydantic.ValidationError):
-            domain_models.WebhookCreate.model_validate(
-                self._valid_payload(slug='x'),
-            )
-
-    def test_notification_path_must_start_with_slash(
-        self,
-    ) -> None:
-        with self.assertRaises(pydantic.ValidationError):
-            domain_models.WebhookCreate.model_validate(
-                self._valid_payload(
-                    notification_path='no-slash',
-                ),
-            )
 
     def test_identifier_selector_requires_tps(self) -> None:
         with self.assertRaises(pydantic.ValidationError):
@@ -607,6 +582,7 @@ class WebhookResponseFromGraphRecordTestCase(unittest.TestCase):
     ) -> dict[str, object]:
         record: dict[str, object] = {
             'webhook': {
+                'id': 'wh_test0001',
                 'name': 'Test Webhook',
                 'slug': 'test-webhook',
                 'notification_path': '/webhooks/test',


### PR DESCRIPTION
## Summary

Webhook slugs, IDs, and notification paths are now fully system-managed, eliminating slug collisions and making the notification URL stable and unforgeable.

## Problem

Previously, callers had to supply a `slug` and `notification_path` when creating a webhook, which led to collision risk and no stable surrogate key. There was also no way to look up a webhook by a key that survived a rename.

## Solution

- **`slug`** — auto-generated as `{service_slug}-{slugified_name}` (or just the name part when no service), read/write after creation so users can rename
- **`id`** — nanoid (21-char URL-safe string), generated at creation, never changes; replaces the earlier `tiny_id` hex string
- **`notification_path`** — always `/{id}`, read-only (400 if patched)
- `GET`/`PATCH`/`DELETE` `/{webhook}` accepts either `slug` or `id` as the identifier
- Slug auto-regenerates when `third_party_service_slug` is patched (unless `/slug` is also in the same patch); explicit slug wins
- Slug collisions on create or PATCH return 409
- `PATCH` uses `id` as the stable write key so renaming the slug in the same request works correctly

## Impact

- API callers must stop sending `slug` and `notification_path` in create payloads (both are now ignored / removed from the schema)
- Existing webhooks stored with the old `tiny_id` property name must be migrated to `id` (schema migration required alongside the `imbi-common` index change)
- All 44 unit tests pass; webhooks endpoint coverage is 97%