### PR TITLE
Add scoring API: policy CRUD, history, rollup, and recompute queue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -217,4 +217,4 @@ url = "https://pypi.org/simple"
 default = true
 
 [tool.uv.sources]
-imbi-common = { git = "https://github.com/AWeber-Imbi/imbi-common.git", rev = "main" }
+imbi-common = { git = "https://github.com/AWeber-Imbi/imbi-common.git", rev = "feature/scoring-foundation" }

--- a/src/imbi_api/app.py
+++ b/src/imbi_api/app.py
@@ -1,6 +1,6 @@
 import fastapi
 from fastapi.middleware import cors
-from imbi_common import graph, lifespan
+from imbi_common import graph, lifespan, valkey
 from uvicorn.middleware import proxy_headers
 
 from imbi_api import endpoints, lifespans, openapi, settings, version
@@ -15,6 +15,8 @@ def create_app() -> fastapi.FastAPI:
             graph.graph_lifespan,
             lifespans.email_hook,
             lifespans.storage_hook,
+            valkey.valkey_lifespan,
+            lifespans.score_worker_hook,
         ),
         version=version,
         redoc_url='/docs',

--- a/src/imbi_api/auth/seed.py
+++ b/src/imbi_api/auth/seed.py
@@ -250,6 +250,31 @@ STANDARD_PERMISSIONS: list[tuple[str, str, str, str]] = [
         'write',
         'Create, update, and delete login auth provider configuration',
     ),
+    # Scoring policy management
+    (
+        'scoring_policy:read',
+        'scoring_policy',
+        'read',
+        'View scoring policies',
+    ),
+    (
+        'scoring_policy:write',
+        'scoring_policy',
+        'write',
+        'Create/update scoring policies',
+    ),
+    (
+        'scoring_policy:delete',
+        'scoring_policy',
+        'delete',
+        'Delete scoring policies',
+    ),
+    (
+        'scoring_policy:rescore_all',
+        'scoring_policy',
+        'rescore_all',
+        'Trigger bulk project rescore',
+    ),
     # Note template management
     (
         'note_template:create',

--- a/src/imbi_api/domain/scoring.py
+++ b/src/imbi_api/domain/scoring.py
@@ -1,0 +1,93 @@
+"""API request/response models for scoring."""
+
+from __future__ import annotations
+
+import typing
+
+import pydantic
+from imbi_common.scoring import (
+    AttributeContribution,
+    AttributePolicy,
+    ScoreBreakdown,
+    ScoringPolicy,
+)
+
+__all__ = [
+    'AttributeContribution',
+    'AttributePolicy',
+    'PolicyCreate',
+    'PolicyUpdate',
+    'RescoreRequest',
+    'RescoreResponse',
+    'ScoreBreakdown',
+    'ScoreHistoryPoint',
+    'ScoreHistoryResponse',
+    'ScoreRollupRow',
+    'ScoringPolicy',
+]
+
+
+class PolicyCreate(pydantic.BaseModel):
+    """Request body for creating a scoring policy."""
+
+    model_config = pydantic.ConfigDict(extra='forbid')
+
+    name: str
+    slug: str
+    description: str | None = None
+    attribute_name: str
+    weight: int = pydantic.Field(ge=0, le=100)
+    enabled: bool = True
+    priority: int = 0
+    value_score_map: dict[str, int] | None = None
+    range_score_map: dict[str, int] | None = None
+    targets: list[str] = pydantic.Field(default_factory=list)
+
+
+class PolicyUpdate(pydantic.BaseModel):
+    """PATCH body for a scoring policy."""
+
+    model_config = pydantic.ConfigDict(extra='forbid')
+
+    name: str | None = None
+    description: str | None = None
+    attribute_name: str | None = None
+    weight: int | None = pydantic.Field(default=None, ge=0, le=100)
+    enabled: bool | None = None
+    priority: int | None = None
+    value_score_map: dict[str, int] | None = None
+    range_score_map: dict[str, int] | None = None
+    targets: list[str] | None = None
+
+
+class RescoreRequest(pydantic.BaseModel):
+    model_config = pydantic.ConfigDict(extra='forbid')
+
+    project_type_slug: str | None = None
+    blueprint_slug: str | None = None
+    policy_slug: str | None = None
+
+
+class RescoreResponse(pydantic.BaseModel):
+    enqueued: int
+
+
+class ScoreHistoryPoint(pydantic.BaseModel):
+    timestamp: str
+    score: float
+    previous_score: float | None = None
+    change_reason: str | None = None
+
+
+class ScoreHistoryResponse(pydantic.BaseModel):
+    project_id: str
+    granularity: typing.Literal['raw', 'hour', 'day']
+    points: list[ScoreHistoryPoint]
+
+
+class ScoreRollupRow(pydantic.BaseModel):
+    dimension: str
+    key: str
+    latest_score: float
+    avg_score: float
+    last_updated: str | None = None

--- a/src/imbi_api/endpoints/__init__.py
+++ b/src/imbi_api/endpoints/__init__.py
@@ -12,6 +12,8 @@ from .operations_log import operations_log_router
 from .organizations import organizations_router
 from .roles import roles_router
 from .sa_api_keys import sa_api_keys_router
+from .scoring import scoring_router
+from .scoring_policies import scoring_policies_router
 from .service_accounts import service_accounts_router
 from .status import status_router
 from .uploads import uploads_router
@@ -30,6 +32,8 @@ prefixed_routers: list[fastapi.APIRouter] = [
     organizations_router,
     roles_router,
     sa_api_keys_router,
+    scoring_policies_router,
+    scoring_router,
     service_accounts_router,
     status_router,
     uploads_router,

--- a/src/imbi_api/endpoints/blueprints.py
+++ b/src/imbi_api/endpoints/blueprints.py
@@ -1,5 +1,6 @@
 """Blueprint CRUD endpoints"""
 
+import asyncio
 import logging
 import typing
 
@@ -11,6 +12,8 @@ from imbi_common import graph, models
 from imbi_api import openapi
 from imbi_api import patch as json_patch
 from imbi_api.auth import permissions
+from imbi_api.scoring import OptionalValkeyClient
+from imbi_api.scoring import queue as score_queue
 
 LOGGER = logging.getLogger(__name__)
 
@@ -28,6 +31,31 @@ BlueprintType = typing.Literal[
     'ThirdPartyService',
     'relationship',
 ]
+
+
+async def _enqueue_for_blueprint(
+    db: graph.Graph,
+    client: OptionalValkeyClient,
+    blueprint: models.Blueprint,
+) -> None:
+    if blueprint.type != 'Project':
+        return
+    type_slugs: list[str] = []
+    if blueprint.filter and blueprint.filter.project_type:
+        type_slugs = list(blueprint.filter.project_type)
+    if type_slugs:
+        id_lists = await asyncio.gather(
+            *[score_queue.all_project_ids(db, ts) for ts in type_slugs]
+        )
+        ids = [pid for sublist in id_lists for pid in sublist]
+    else:
+        ids = await score_queue.all_project_ids(db)
+    await asyncio.gather(
+        *[
+            score_queue.enqueue_recompute(client, pid, 'blueprint_change')
+            for pid in ids
+        ]
+    )
 
 
 def _match_params(
@@ -52,6 +80,7 @@ def _match_params(
 async def create_blueprint(
     blueprint: models.Blueprint,
     db: graph.Pool,
+    valkey_client: OptionalValkeyClient,
     auth: typing.Annotated[
         permissions.AuthContext,
         fastapi.Depends(
@@ -71,6 +100,7 @@ async def create_blueprint(
         await openapi.refresh_blueprint_models(db)
     except Exception:
         LOGGER.exception('Failed to refresh blueprint models')
+    await _enqueue_for_blueprint(db, valkey_client, blueprint)
     return blueprint
 
 
@@ -177,6 +207,7 @@ async def patch_blueprint(
     slug: str,
     operations: list[json_patch.PatchOperation],
     db: graph.Pool,
+    valkey_client: OptionalValkeyClient,
     auth: typing.Annotated[
         permissions.AuthContext,
         fastapi.Depends(
@@ -253,6 +284,7 @@ async def patch_blueprint(
         await openapi.refresh_blueprint_models(db)
     except Exception:
         LOGGER.exception('Failed to refresh blueprint models')
+    await _enqueue_for_blueprint(db, valkey_client, blueprint)
     return blueprint
 
 
@@ -264,6 +296,7 @@ async def delete_blueprint(
     ],
     slug: str,
     db: graph.Pool,
+    valkey_client: OptionalValkeyClient,
     auth: typing.Annotated[
         permissions.AuthContext,
         fastapi.Depends(
@@ -272,6 +305,10 @@ async def delete_blueprint(
     ],
 ) -> None:
     """Delete a blueprint by type (or 'relationship') and slug."""
+    existing = await db.match(
+        models.Blueprint,
+        _match_params(blueprint_type, slug),
+    )
     if blueprint_type == _RELATIONSHIP:
         match_clause = (
             "MATCH (n:Blueprint {{slug: {slug}, kind: 'relationship'}})"
@@ -300,3 +337,5 @@ async def delete_blueprint(
         await openapi.refresh_blueprint_models(db)
     except Exception:
         LOGGER.exception('Failed to refresh blueprint models')
+    if existing:
+        await _enqueue_for_blueprint(db, valkey_client, existing[0])

--- a/src/imbi_api/endpoints/blueprints.py
+++ b/src/imbi_api/endpoints/blueprints.py
@@ -38,24 +38,30 @@ async def _enqueue_for_blueprint(
     client: OptionalValkeyClient,
     blueprint: models.Blueprint,
 ) -> None:
-    if blueprint.type != 'Project':
-        return
-    type_slugs: list[str] = []
-    if blueprint.filter and blueprint.filter.project_type:
-        type_slugs = list(blueprint.filter.project_type)
-    if type_slugs:
-        id_lists = await asyncio.gather(
-            *[score_queue.all_project_ids(db, ts) for ts in type_slugs]
+    try:
+        if blueprint.type != 'Project':
+            return
+        type_slugs: list[str] = []
+        if blueprint.filter and blueprint.filter.project_type:
+            type_slugs = list(blueprint.filter.project_type)
+        if type_slugs:
+            id_lists = await asyncio.gather(
+                *[score_queue.all_project_ids(db, ts) for ts in type_slugs]
+            )
+            ids = [pid for sublist in id_lists for pid in sublist]
+        else:
+            ids = await score_queue.all_project_ids(db)
+        await asyncio.gather(
+            *[
+                score_queue.enqueue_recompute(client, pid, 'blueprint_change')
+                for pid in ids
+            ]
         )
-        ids = [pid for sublist in id_lists for pid in sublist]
-    else:
-        ids = await score_queue.all_project_ids(db)
-    await asyncio.gather(
-        *[
-            score_queue.enqueue_recompute(client, pid, 'blueprint_change')
-            for pid in ids
-        ]
-    )
+    except Exception:
+        LOGGER.exception(
+            'Failed to enqueue blueprint recomputes for %s',
+            blueprint.slug,
+        )
 
 
 def _match_params(

--- a/src/imbi_api/endpoints/projects.py
+++ b/src/imbi_api/endpoints/projects.py
@@ -14,11 +14,15 @@ import nanoid
 import psycopg
 import pydantic
 from imbi_common import blueprints, graph, models
+from imbi_common.scoring import compute_score
 
 from imbi_api import patch as json_patch
 from imbi_api.auth import permissions
+from imbi_api.domain import scoring as scoring_models
 from imbi_api.graph_sql import escape_prop, props_template, set_clause
 from imbi_api.relationships import build_relationships
+from imbi_api.scoring import OptionalValkeyClient
+from imbi_api.scoring import queue as score_queue
 
 LOGGER = logging.getLogger(__name__)
 
@@ -135,6 +139,8 @@ class ProjectResponse(pydantic.BaseModel):
     environments: list[EnvironmentRef] = []
     links: dict[str, pydantic.AnyUrl] = {}
     identifiers: dict[str, int | str] = {}
+    score: float | None = None
+    breakdown: scoring_models.ScoreBreakdown | None = None
     relationships: ProjectRelationships | None = None
 
     @pydantic.field_validator(
@@ -347,6 +353,7 @@ async def create_project(
     data: ProjectCreate,
     request: fastapi.Request,
     db: graph.Pool,
+    valkey_client: OptionalValkeyClient,
     auth: typing.Annotated[
         permissions.AuthContext,
         fastapi.Depends(
@@ -518,6 +525,9 @@ async def create_project(
         request,
         graph.parse_agtype(records[0]['outbound_count']),
         graph.parse_agtype(records[0]['inbound_count']),
+    )
+    await score_queue.enqueue_recompute(
+        valkey_client, project_id, 'attribute_change'
     )
     return ProjectResponse.model_validate(project_data)
 
@@ -778,6 +788,7 @@ async def get_project(
             permissions.require_permission('project:read'),
         ),
     ],
+    breakdown: bool = False,
 ) -> ProjectResponse:
     """Get a project by ID."""
     query: typing.LiteralString = (
@@ -812,7 +823,14 @@ async def get_project(
         graph.parse_agtype(records[0]['outbound_count']),
         graph.parse_agtype(records[0]['inbound_count']),
     )
-    return ProjectResponse.model_validate(project_data)
+    response = ProjectResponse.model_validate(project_data)
+    if breakdown:
+        try:
+            _, bd = await compute_score(db, project_id)
+            response.breakdown = bd
+        except ValueError:
+            pass
+    return response
 
 
 class ProjectRelationshipSummary(pydantic.BaseModel):
@@ -1373,6 +1391,7 @@ async def patch_project(
     operations: list[json_patch.PatchOperation],
     request: fastapi.Request,
     db: graph.Pool,
+    valkey_client: OptionalValkeyClient,
     auth: typing.Annotated[
         permissions.AuthContext,
         fastapi.Depends(
@@ -1485,7 +1504,7 @@ async def patch_project(
             detail=f'Validation error: {e.errors()}',
         ) from e
 
-    return await _execute_project_update(
+    response = await _execute_project_update(
         project_id,
         org_slug,
         update_data,
@@ -1495,6 +1514,10 @@ async def patch_project(
         request,
         db,
     )
+    await score_queue.enqueue_recompute(
+        valkey_client, project_id, 'attribute_change'
+    )
+    return response
 
 
 @projects_router.delete('/{project_id}', status_code=204)

--- a/src/imbi_api/endpoints/projects.py
+++ b/src/imbi_api/endpoints/projects.py
@@ -826,7 +826,8 @@ async def get_project(
     response = ProjectResponse.model_validate(project_data)
     if breakdown:
         try:
-            _, bd = await compute_score(db, project_id)
+            score, bd = await compute_score(db, project_id)
+            response.score = score
             response.breakdown = bd
         except ValueError:
             pass

--- a/src/imbi_api/endpoints/scoring.py
+++ b/src/imbi_api/endpoints/scoring.py
@@ -8,11 +8,11 @@ import logging
 import typing
 
 import fastapi
-from imbi_common import clickhouse, graph
+from imbi_common import clickhouse, graph, models
 
 from imbi_api.auth import permissions
 from imbi_api.domain import scoring as scoring_models
-from imbi_api.endpoints.scoring_policies import _load_policy
+from imbi_api.endpoints.scoring_policies import load_policy
 from imbi_api.scoring import OptionalValkeyClient
 from imbi_api.scoring import queue as score_queue
 
@@ -59,7 +59,7 @@ async def get_score_history(
             detail=f'Project {project_id!r} not found',
         )
     bucket = _GRANULARITY_EXPR[granularity]
-    where: list[str] = ['project = {project_id:String}']
+    where: list[str] = ['project_id = {project_id:String}']
     params: dict[str, typing.Any] = {'project_id': project_id}
     if from_ is not None:
         where.append('timestamp >= {from_ts:DateTime64(3)}')
@@ -88,7 +88,11 @@ async def get_score_history(
                 scoring_models.ScoreHistoryPoint(
                     timestamp=str(row['timestamp']),
                     score=float(row['score']),
-                    previous_score=float(row['previous_score']),
+                    previous_score=(
+                        float(row['previous_score'])
+                        if row.get('previous_score') is not None
+                        else None
+                    ),
                     change_reason=str(row.get('change_reason') or ''),
                 )
             )
@@ -121,10 +125,10 @@ async def score_rollup(
     }[dimension]
     sql = (
         f'SELECT {column} AS key,'  # noqa: S608
-        ' argMaxMerge(latest_score) AS latest_score,'
-        ' avgMerge(avg_score) AS avg_score,'
-        ' maxMerge(last_updated) AS last_updated'
-        ' FROM score_latest'
+        ' argMax(score, timestamp) AS latest_score,'
+        ' avg(score) AS avg_score,'
+        ' max(timestamp) AS last_updated'
+        ' FROM score_history'
         f' GROUP BY {column}'
         f' ORDER BY {column}'
     )
@@ -162,7 +166,7 @@ async def rescore(
     body = body or scoring_models.RescoreRequest()
     project_ids: list[str] = []
     if body.policy_slug:
-        policy = await _load_policy(db, body.policy_slug)
+        policy = await load_policy(db, body.policy_slug)
         if policy is None:
             raise fastapi.HTTPException(
                 status_code=404,
@@ -170,15 +174,37 @@ async def rescore(
             )
         project_ids = await score_queue.affected_projects(db, policy)
     elif body.blueprint_slug:
-        rows = await db.execute(
-            'MATCH (b:Blueprint {{slug: {slug}}})'
-            ' WITH b.filter AS filt'
-            ' MATCH (p:Project)'
-            ' RETURN p.id AS id',
+        # Load the blueprint to access its filter, then resolve project ids
+        # the same way _enqueue_for_blueprint does.
+        bp_rows = await db.execute(
+            'MATCH (b:Blueprint {{slug: {slug}}}) RETURN b',
             {'slug': body.blueprint_slug},
-            ['id'],
+            ['b'],
         )
-        project_ids = [v for r in rows if (v := graph.parse_agtype(r['id']))]
+        if not bp_rows:
+            raise fastapi.HTTPException(
+                status_code=404,
+                detail=f'Blueprint {body.blueprint_slug!r} not found',
+            )
+        bp_raw = graph.parse_agtype(bp_rows[0]['b'])
+        type_slugs: list[str] = []
+        if isinstance(bp_raw, dict):
+            bp_raw_dict: dict[str, typing.Any] = bp_raw  # type: ignore[assignment]
+            raw_filter: object = bp_raw_dict.get('filter')
+            if isinstance(raw_filter, dict):
+                raw_pt = raw_filter.get('project_type') or []  # type: ignore[union-attr]
+                type_slugs = [str(s) for s in raw_pt]  # type: ignore[union-attr]
+            elif isinstance(raw_filter, models.BlueprintFilter) and (
+                raw_filter.project_type
+            ):
+                type_slugs = list(raw_filter.project_type)
+        if type_slugs:
+            id_lists = await asyncio.gather(
+                *[score_queue.all_project_ids(db, ts) for ts in type_slugs]
+            )
+            project_ids = [pid for sub in id_lists for pid in sub]
+        else:
+            project_ids = await score_queue.all_project_ids(db)
     else:
         project_ids = await score_queue.all_project_ids(
             db, body.project_type_slug

--- a/src/imbi_api/endpoints/scoring.py
+++ b/src/imbi_api/endpoints/scoring.py
@@ -1,0 +1,195 @@
+"""Project score history, rollup, and rescore endpoints."""
+
+from __future__ import annotations
+
+import asyncio
+import datetime
+import logging
+import typing
+
+import fastapi
+from imbi_common import clickhouse, graph
+
+from imbi_api.auth import permissions
+from imbi_api.domain import scoring as scoring_models
+from imbi_api.endpoints.scoring_policies import _load_policy
+from imbi_api.scoring import OptionalValkeyClient
+from imbi_api.scoring import queue as score_queue
+
+LOGGER = logging.getLogger(__name__)
+
+scoring_router = fastapi.APIRouter(tags=['Scoring'])
+
+
+_GRANULARITY_EXPR = {
+    'raw': 'timestamp',
+    'hour': 'toStartOfHour(timestamp)',
+    'day': 'toStartOfDay(timestamp)',
+}
+
+
+@scoring_router.get(
+    '/organizations/{org_slug}/projects/{project_id}/score/history'
+)
+async def get_score_history(
+    org_slug: str,
+    project_id: str,
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(permissions.require_permission('project:read')),
+    ],
+    granularity: typing.Literal['raw', 'hour', 'day'] = 'raw',
+    from_: typing.Annotated[
+        datetime.datetime | None, fastapi.Query(alias='from')
+    ] = None,
+    to: datetime.datetime | None = None,
+) -> scoring_models.ScoreHistoryResponse:
+    exists = await db.execute(
+        'MATCH (p:Project {{id: {id}}})'
+        '-[:OWNED_BY]->(:Team)'
+        '-[:BELONGS_TO]->(:Organization {{slug: {org}}})'
+        ' RETURN p.id AS id',
+        {'id': project_id, 'org': org_slug},
+        ['id'],
+    )
+    if not exists:
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail=f'Project {project_id!r} not found',
+        )
+    bucket = _GRANULARITY_EXPR[granularity]
+    where: list[str] = ['project = {project_id:String}']
+    params: dict[str, typing.Any] = {'project_id': project_id}
+    if from_ is not None:
+        where.append('timestamp >= {from_ts:DateTime64(3)}')
+        params['from_ts'] = from_
+    if to is not None:
+        where.append('timestamp <= {to_ts:DateTime64(3)}')
+        params['to_ts'] = to
+    where_sql = ' AND '.join(where)
+    if granularity == 'raw':
+        sql = (
+            'SELECT timestamp, score, previous_score, change_reason'  # noqa: S608
+            ' FROM score_history WHERE ' + where_sql + ' ORDER BY timestamp'
+        )
+    else:
+        sql = (
+            f'SELECT {bucket} AS ts, argMax(score, timestamp) AS score'  # noqa: S608
+            ' FROM score_history WHERE '
+            + where_sql
+            + f' GROUP BY {bucket} ORDER BY ts'
+        )
+    rows = await clickhouse.query(sql, params)
+    points: list[scoring_models.ScoreHistoryPoint] = []
+    for row in rows:
+        if granularity == 'raw':
+            points.append(
+                scoring_models.ScoreHistoryPoint(
+                    timestamp=str(row['timestamp']),
+                    score=float(row['score']),
+                    previous_score=float(row['previous_score']),
+                    change_reason=str(row.get('change_reason') or ''),
+                )
+            )
+        else:
+            points.append(
+                scoring_models.ScoreHistoryPoint(
+                    timestamp=str(row['ts']),
+                    score=float(row['score']),
+                )
+            )
+    return scoring_models.ScoreHistoryResponse(
+        project_id=project_id,
+        granularity=granularity,
+        points=points,
+    )
+
+
+@scoring_router.get('/scores/rollup')
+async def score_rollup(
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(permissions.require_permission('project:read')),
+    ],
+    dimension: typing.Literal['team', 'project_type', 'organization'] = 'team',
+) -> list[scoring_models.ScoreRollupRow]:
+    column = {
+        'team': 'team',
+        'project_type': 'project_type',
+        'organization': 'organization',
+    }[dimension]
+    sql = (
+        f'SELECT {column} AS key,'  # noqa: S608
+        ' argMaxMerge(latest_score) AS latest_score,'
+        ' avgMerge(avg_score) AS avg_score,'
+        ' maxMerge(last_updated) AS last_updated'
+        ' FROM score_latest'
+        f' GROUP BY {column}'
+        f' ORDER BY {column}'
+    )
+    rows = await clickhouse.query(sql)
+    out: list[scoring_models.ScoreRollupRow] = []
+    for row in rows:
+        out.append(
+            scoring_models.ScoreRollupRow(
+                dimension=dimension,
+                key=str(row.get('key') or ''),
+                latest_score=float(row.get('latest_score') or 0.0),
+                avg_score=float(row.get('avg_score') or 0.0),
+                last_updated=(
+                    str(row['last_updated'])
+                    if row.get('last_updated')
+                    else None
+                ),
+            )
+        )
+    return out
+
+
+@scoring_router.post('/scoring/rescore')
+async def rescore(
+    db: graph.Pool,
+    valkey_client: OptionalValkeyClient,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('scoring_policy:rescore_all')
+        ),
+    ],
+    body: scoring_models.RescoreRequest | None = None,
+) -> scoring_models.RescoreResponse:
+    body = body or scoring_models.RescoreRequest()
+    project_ids: list[str] = []
+    if body.policy_slug:
+        policy = await _load_policy(db, body.policy_slug)
+        if policy is None:
+            raise fastapi.HTTPException(
+                status_code=404,
+                detail=f'Policy {body.policy_slug!r} not found',
+            )
+        project_ids = await score_queue.affected_projects(db, policy)
+    elif body.blueprint_slug:
+        rows = await db.execute(
+            'MATCH (b:Blueprint {{slug: {slug}}})'
+            ' WITH b.filter AS filt'
+            ' MATCH (p:Project)'
+            ' RETURN p.id AS id',
+            {'slug': body.blueprint_slug},
+            ['id'],
+        )
+        project_ids = [v for r in rows if (v := graph.parse_agtype(r['id']))]
+    else:
+        project_ids = await score_queue.all_project_ids(
+            db, body.project_type_slug
+        )
+    requested_by = auth.user.email if auth.user else auth.principal_name
+    results = await asyncio.gather(
+        *[
+            score_queue.enqueue_recompute(
+                valkey_client, pid, 'bulk_rescore', requested_by=requested_by
+            )
+            for pid in project_ids
+        ]
+    )
+    return scoring_models.RescoreResponse(enqueued=sum(results))

--- a/src/imbi_api/endpoints/scoring.py
+++ b/src/imbi_api/endpoints/scoring.py
@@ -110,42 +110,90 @@ async def get_score_history(
     )
 
 
+_DIMENSION_QUERY: dict[str, typing.LiteralString] = {
+    'team': (
+        'MATCH (p:Project)-[:OWNED_BY]->(t:Team)'
+        ' RETURN p.id AS project_id, t.slug AS dim_key'
+    ),
+    'project_type': (
+        'MATCH (p:Project)-[:TYPE]->(pt:ProjectType)'
+        ' RETURN p.id AS project_id, pt.slug AS dim_key'
+    ),
+    'organization': (
+        'MATCH (p:Project)-[:OWNED_BY]->(:Team)'
+        '-[:BELONGS_TO]->(o:Organization)'
+        ' RETURN p.id AS project_id, o.slug AS dim_key'
+    ),
+}
+
+
 @scoring_router.get('/scores/rollup')
 async def score_rollup(
+    db: graph.Pool,
     auth: typing.Annotated[
         permissions.AuthContext,
         fastapi.Depends(permissions.require_permission('project:read')),
     ],
     dimension: typing.Literal['team', 'project_type', 'organization'] = 'team',
 ) -> list[scoring_models.ScoreRollupRow]:
-    column = {
-        'team': 'team',
-        'project_type': 'project_type',
-        'organization': 'organization',
-    }[dimension]
-    sql = (
-        f'SELECT {column} AS key,'  # noqa: S608
-        ' argMax(score, timestamp) AS latest_score,'
-        ' avg(score) AS avg_score,'
-        ' max(timestamp) AS last_updated'
-        ' FROM score_history'
-        f' GROUP BY {column}'
-        f' ORDER BY {column}'
+    """Return current-score rollup grouped by the requested dimension.
+
+    Uses ``score_latest`` (one row per project, current score only)
+    so projects with many history entries do not skew aggregates.
+    """
+    # Fetch project → dimension key mapping from the graph
+    dim_records = await db.execute(
+        _DIMENSION_QUERY[dimension], {}, ['project_id', 'dim_key']
     )
-    rows = await clickhouse.query(sql)
+    project_dim: dict[str, str] = {}
+    for rec in dim_records:
+        pid = graph.parse_agtype(rec['project_id'])
+        key = graph.parse_agtype(rec['dim_key'])
+        if pid and key:
+            project_dim[str(pid)] = str(key)
+
+    if not project_dim:
+        return []
+
+    # Fetch current scores from ClickHouse (one row per project)
+    sql = (
+        'SELECT project_id,'
+        ' latest_score,'
+        ' last_updated'
+        ' FROM score_latest'
+        ' WHERE project_id IN {project_ids:Array(String)}'
+    )
+    ch_rows = await clickhouse.query(sql, {'project_ids': list(project_dim)})
+
+    # Aggregate by dimension key in Python
+    scores_by_key: dict[str, list[float]] = {}
+    last_updated_by_key: dict[str, str | None] = {}
+    for row in ch_rows:
+        pid = str(row.get('project_id') or '')
+        dim_key = project_dim.get(pid)
+        if not dim_key:
+            continue
+        latest = float(row.get('latest_score') or 0.0)
+        last_upd = (
+            str(row['last_updated']) if row.get('last_updated') else None
+        )
+        scores_by_key.setdefault(dim_key, []).append(latest)
+        existing_upd = last_updated_by_key.get(dim_key)
+        if last_upd and (existing_upd is None or last_upd > existing_upd):
+            last_updated_by_key[dim_key] = last_upd
+        elif dim_key not in last_updated_by_key:
+            last_updated_by_key[dim_key] = None
+
     out: list[scoring_models.ScoreRollupRow] = []
-    for row in rows:
+    for key in sorted(scores_by_key):
+        project_scores = scores_by_key[key]
         out.append(
             scoring_models.ScoreRollupRow(
                 dimension=dimension,
-                key=str(row.get('key') or ''),
-                latest_score=float(row.get('latest_score') or 0.0),
-                avg_score=float(row.get('avg_score') or 0.0),
-                last_updated=(
-                    str(row['last_updated'])
-                    if row.get('last_updated')
-                    else None
-                ),
+                key=key,
+                latest_score=max(project_scores),
+                avg_score=sum(project_scores) / len(project_scores),
+                last_updated=last_updated_by_key.get(key),
             )
         )
     return out

--- a/src/imbi_api/endpoints/scoring_policies.py
+++ b/src/imbi_api/endpoints/scoring_policies.py
@@ -41,7 +41,7 @@ def _parse_node(raw: dict[str, typing.Any]) -> dict[str, typing.Any]:
     return out
 
 
-async def _load_policy(
+async def load_policy(
     db: graph.Graph, slug: str
 ) -> scoring_models.ScoringPolicy | None:
     query: typing.LiteralString = (
@@ -55,8 +55,10 @@ async def _load_policy(
     raw = graph.parse_agtype(rows[0]['sp'])
     if not isinstance(raw, dict):
         return None
-    targets = graph.parse_agtype(rows[0]['targets']) or []
-    cleaned = _parse_node(raw)
+    raw_dict: dict[str, typing.Any] = raw  # type: ignore[assignment]
+    _raw_targets: list[str] = graph.parse_agtype(rows[0]['targets']) or []
+    targets: list[str] = _raw_targets
+    cleaned = _parse_node(raw_dict)
     cleaned['targets'] = targets
     return scoring_models.ScoringPolicy.model_validate(cleaned)
 
@@ -128,8 +130,10 @@ async def list_policies(
         raw = graph.parse_agtype(row['sp'])
         if not isinstance(raw, dict):
             continue
-        targets = graph.parse_agtype(row['targets']) or []
-        cleaned = _parse_node(raw)
+        raw_dict: dict[str, typing.Any] = raw  # type: ignore[assignment]
+        _raw_targets: list[str] = graph.parse_agtype(row['targets']) or []
+        targets: list[str] = _raw_targets
+        cleaned = _parse_node(raw_dict)
         cleaned['targets'] = targets
         out.append(scoring_models.ScoringPolicy.model_validate(cleaned))
     return out
@@ -144,7 +148,7 @@ async def get_policy(
         fastapi.Depends(permissions.require_permission('scoring_policy:read')),
     ],
 ) -> scoring_models.ScoringPolicy:
-    policy = await _load_policy(db, slug)
+    policy = await load_policy(db, slug)
     if policy is None:
         raise fastapi.HTTPException(
             status_code=404,
@@ -193,7 +197,7 @@ async def create_policy(
         await db.execute(
             link_q, {'slug': policy.slug, 'targets': data.targets}
         )
-    refreshed = await _load_policy(db, policy.slug)
+    refreshed = await load_policy(db, policy.slug)
     if refreshed is None:
         raise fastapi.HTTPException(
             status_code=500,
@@ -216,7 +220,7 @@ async def update_policy(
         ),
     ],
 ) -> scoring_models.ScoringPolicy:
-    existing = await _load_policy(db, slug)
+    existing = await load_policy(db, slug)
     if existing is None:
         raise fastapi.HTTPException(
             status_code=404,
@@ -253,7 +257,7 @@ async def update_policy(
                 ' MERGE (sp)-[:TARGETS]->(pt)'
             )
             await db.execute(link_q, {'slug': slug, 'targets': data.targets})
-    refreshed = await _load_policy(db, slug)
+    refreshed = await load_policy(db, slug)
     if refreshed is None:
         raise fastapi.HTTPException(
             status_code=500,
@@ -276,7 +280,7 @@ async def delete_policy(
         ),
     ],
 ) -> None:
-    existing = await _load_policy(db, slug)
+    existing = await load_policy(db, slug)
     if existing is None:
         raise fastapi.HTTPException(
             status_code=404,

--- a/src/imbi_api/endpoints/scoring_policies.py
+++ b/src/imbi_api/endpoints/scoring_policies.py
@@ -1,0 +1,289 @@
+"""Scoring policy CRUD endpoints."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import typing
+
+import fastapi
+import psycopg.errors
+from imbi_common import graph
+
+from imbi_api.auth import permissions
+from imbi_api.domain import scoring as scoring_models
+from imbi_api.scoring import OptionalValkeyClient
+from imbi_api.scoring import queue as score_queue
+
+LOGGER = logging.getLogger(__name__)
+
+scoring_policies_router = fastapi.APIRouter(
+    prefix='/scoring/policies', tags=['Scoring']
+)
+
+
+_PARSE_PROPS_KEYS = (
+    'value_score_map',
+    'range_score_map',
+)
+
+
+def _parse_node(raw: dict[str, typing.Any]) -> dict[str, typing.Any]:
+    out = dict(raw)
+    for key in _PARSE_PROPS_KEYS:
+        val = out.get(key)
+        if isinstance(val, str):
+            try:
+                out[key] = json.loads(val)
+            except (TypeError, ValueError):
+                out[key] = None
+    return out
+
+
+async def _load_policy(
+    db: graph.Graph, slug: str
+) -> scoring_models.ScoringPolicy | None:
+    query: typing.LiteralString = (
+        'MATCH (sp:ScoringPolicy {{slug: {slug}}})'
+        ' OPTIONAL MATCH (sp)-[:TARGETS]->(pt:ProjectType)'
+        ' RETURN sp, collect(pt.slug) AS targets'
+    )
+    rows = await db.execute(query, {'slug': slug}, ['sp', 'targets'])
+    if not rows:
+        return None
+    raw = graph.parse_agtype(rows[0]['sp'])
+    if not isinstance(raw, dict):
+        return None
+    targets = graph.parse_agtype(rows[0]['targets']) or []
+    cleaned = _parse_node(raw)
+    cleaned['targets'] = targets
+    return scoring_models.ScoringPolicy.model_validate(cleaned)
+
+
+def _serialize_maps(
+    policy_props: dict[str, typing.Any],
+) -> dict[str, typing.Any]:
+    out = dict(policy_props)
+    for key in _PARSE_PROPS_KEYS:
+        val = out.get(key)
+        if val is not None and not isinstance(val, str):
+            out[key] = json.dumps(val)
+    return out
+
+
+async def _enqueue_for_policy(
+    client: OptionalValkeyClient,
+    db: graph.Graph,
+    policy: scoring_models.ScoringPolicy,
+    reason: score_queue.ChangeReason = 'policy_change',
+) -> int:
+    project_ids = await score_queue.affected_projects(db, policy)
+    results = await asyncio.gather(
+        *[
+            score_queue.enqueue_recompute(client, pid, reason)
+            for pid in project_ids
+        ]
+    )
+    return sum(results)
+
+
+@scoring_policies_router.get('/')
+async def list_policies(
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(permissions.require_permission('scoring_policy:read')),
+    ],
+    category: str | None = None,
+    enabled: bool | None = None,
+    attribute_name: str | None = None,
+) -> list[scoring_models.ScoringPolicy]:
+    parts: list[str] = []
+    params: dict[str, typing.Any] = {}
+    if category is not None:
+        parts.append('sp.category = {category}')
+        params['category'] = category
+    if enabled is not None:
+        parts.append('sp.enabled = {enabled}')
+        params['enabled'] = enabled
+    if attribute_name is not None:
+        parts.append('sp.attribute_name = {attribute_name}')
+        params['attribute_name'] = attribute_name
+    where = (' WHERE ' + ' AND '.join(parts)) if parts else ''
+    query: str = (
+        'MATCH (sp:ScoringPolicy)'
+        + where
+        + ' OPTIONAL MATCH (sp)-[:TARGETS]->(pt:ProjectType)'
+        ' RETURN sp, collect(pt.slug) AS targets ORDER BY sp.priority,'
+        ' sp.slug'
+    )
+    rows = await db.execute(
+        query,  # type: ignore[arg-type]
+        params,
+        ['sp', 'targets'],
+    )
+    out: list[scoring_models.ScoringPolicy] = []
+    for row in rows:
+        raw = graph.parse_agtype(row['sp'])
+        if not isinstance(raw, dict):
+            continue
+        targets = graph.parse_agtype(row['targets']) or []
+        cleaned = _parse_node(raw)
+        cleaned['targets'] = targets
+        out.append(scoring_models.ScoringPolicy.model_validate(cleaned))
+    return out
+
+
+@scoring_policies_router.get('/{slug}')
+async def get_policy(
+    slug: str,
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(permissions.require_permission('scoring_policy:read')),
+    ],
+) -> scoring_models.ScoringPolicy:
+    policy = await _load_policy(db, slug)
+    if policy is None:
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail=f'Scoring policy {slug!r} not found',
+        )
+    return policy
+
+
+@scoring_policies_router.post('/', status_code=201)
+async def create_policy(
+    data: scoring_models.PolicyCreate,
+    db: graph.Pool,
+    valkey_client: OptionalValkeyClient,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('scoring_policy:write')
+        ),
+    ],
+) -> scoring_models.ScoringPolicy:
+    payload = data.model_dump(exclude={'targets'})
+    policy = scoring_models.ScoringPolicy.model_validate(payload)
+    props = _serialize_maps(policy.model_dump(exclude={'targets'}))
+    create_q: typing.LiteralString = (
+        'CREATE (sp:ScoringPolicy {{id: {id}, name: {name},'
+        ' slug: {slug}, description: {description}, category: {category},'
+        ' weight: {weight}, enabled: {enabled}, priority: {priority},'
+        ' attribute_name: {attribute_name},'
+        ' value_score_map: {value_score_map},'
+        ' range_score_map: {range_score_map}}}) RETURN sp'
+    )
+    try:
+        await db.execute(create_q, props, ['sp'])
+    except psycopg.errors.UniqueViolation as e:
+        raise fastapi.HTTPException(
+            status_code=409,
+            detail=f'Scoring policy {policy.slug!r} already exists',
+        ) from e
+    if data.targets:
+        link_q: typing.LiteralString = (
+            'MATCH (sp:ScoringPolicy {{slug: {slug}}})'
+            ' UNWIND {targets} AS ts'
+            ' MATCH (pt:ProjectType {{slug: ts}})'
+            ' MERGE (sp)-[:TARGETS]->(pt)'
+        )
+        await db.execute(
+            link_q, {'slug': policy.slug, 'targets': data.targets}
+        )
+    refreshed = await _load_policy(db, policy.slug)
+    if refreshed is None:
+        raise fastapi.HTTPException(
+            status_code=500,
+            detail='Failed to reload scoring policy after create',
+        )
+    await _enqueue_for_policy(valkey_client, db, refreshed)
+    return refreshed
+
+
+@scoring_policies_router.patch('/{slug}')
+async def update_policy(
+    slug: str,
+    data: scoring_models.PolicyUpdate,
+    db: graph.Pool,
+    valkey_client: OptionalValkeyClient,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('scoring_policy:write')
+        ),
+    ],
+) -> scoring_models.ScoringPolicy:
+    existing = await _load_policy(db, slug)
+    if existing is None:
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail=f'Scoring policy {slug!r} not found',
+        )
+    updates = data.model_dump(exclude_unset=True, exclude={'targets'})
+    if updates:
+        merged = existing.model_dump(exclude={'targets'})
+        merged.update(updates)
+        validated = scoring_models.ScoringPolicy.model_validate(merged)
+        props = _serialize_maps(
+            validated.model_dump(exclude={'targets', 'slug', 'category'})
+        )
+        set_pairs = ', '.join(f'sp.{k} = {{{k}}}' for k in props)
+        params: dict[str, typing.Any] = dict(props)
+        params['slug'] = slug
+        update_q = (
+            'MATCH (sp:ScoringPolicy {{slug: {slug}}}) SET '
+            + set_pairs
+            + ' RETURN sp'
+        )
+        await db.execute(update_q, params, ['sp'])  # type: ignore[arg-type]
+    if data.targets is not None:
+        clear_q: typing.LiteralString = (
+            'MATCH (sp:ScoringPolicy {{slug: {slug}}})-[r:TARGETS]->()'
+            ' DELETE r'
+        )
+        await db.execute(clear_q, {'slug': slug})
+        if data.targets:
+            link_q: typing.LiteralString = (
+                'MATCH (sp:ScoringPolicy {{slug: {slug}}})'
+                ' UNWIND {targets} AS ts'
+                ' MATCH (pt:ProjectType {{slug: ts}})'
+                ' MERGE (sp)-[:TARGETS]->(pt)'
+            )
+            await db.execute(link_q, {'slug': slug, 'targets': data.targets})
+    refreshed = await _load_policy(db, slug)
+    if refreshed is None:
+        raise fastapi.HTTPException(
+            status_code=500,
+            detail='Failed to reload scoring policy after update',
+        )
+    await _enqueue_for_policy(valkey_client, db, refreshed)
+    await _enqueue_for_policy(valkey_client, db, existing)
+    return refreshed
+
+
+@scoring_policies_router.delete('/{slug}', status_code=204)
+async def delete_policy(
+    slug: str,
+    db: graph.Pool,
+    valkey_client: OptionalValkeyClient,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('scoring_policy:delete')
+        ),
+    ],
+) -> None:
+    existing = await _load_policy(db, slug)
+    if existing is None:
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail=f'Scoring policy {slug!r} not found',
+        )
+    await db.execute(
+        'MATCH (sp:ScoringPolicy {{slug: {slug}}}) DETACH DELETE sp',
+        {'slug': slug},
+    )
+    await _enqueue_for_policy(valkey_client, db, existing)

--- a/src/imbi_api/endpoints/scoring_policies.py
+++ b/src/imbi_api/endpoints/scoring_policies.py
@@ -188,6 +188,21 @@ async def create_policy(
             detail=f'Scoring policy {policy.slug!r} already exists',
         ) from e
     if data.targets:
+        found_rows = await db.execute(
+            'MATCH (pt:ProjectType) WHERE pt.slug IN {slugs}'
+            ' RETURN collect(pt.slug) AS found',
+            {'slugs': data.targets},
+            ['found'],
+        )
+        found: list[str] = (
+            graph.parse_agtype(found_rows[0]['found']) if found_rows else []
+        ) or []
+        missing = set(data.targets) - set(found)
+        if missing:
+            raise fastapi.HTTPException(
+                status_code=400,
+                detail=f'Unknown project type(s): {sorted(missing)}',
+            )
         link_q: typing.LiteralString = (
             'MATCH (sp:ScoringPolicy {{slug: {slug}}})'
             ' UNWIND {targets} AS ts'
@@ -244,6 +259,24 @@ async def update_policy(
         )
         await db.execute(update_q, params, ['sp'])  # type: ignore[arg-type]
     if data.targets is not None:
+        if data.targets:
+            found_rows = await db.execute(
+                'MATCH (pt:ProjectType) WHERE pt.slug IN {slugs}'
+                ' RETURN collect(pt.slug) AS found',
+                {'slugs': data.targets},
+                ['found'],
+            )
+            found: list[str] = (
+                graph.parse_agtype(found_rows[0]['found'])
+                if found_rows
+                else []
+            ) or []
+            missing = set(data.targets) - set(found)
+            if missing:
+                raise fastapi.HTTPException(
+                    status_code=400,
+                    detail=f'Unknown project type(s): {sorted(missing)}',
+                )
         clear_q: typing.LiteralString = (
             'MATCH (sp:ScoringPolicy {{slug: {slug}}})-[r:TARGETS]->()'
             ' DELETE r'

--- a/src/imbi_api/endpoints/service_accounts.py
+++ b/src/imbi_api/endpoints/service_accounts.py
@@ -178,7 +178,7 @@ async def get_service_account(
           -[m:MEMBER_OF]->(o:Organization)
     RETURN o.name AS org_name,
            o.slug AS org_slug,
-           m.role AS role
+           COALESCE(m.role, 'readonly') AS role
     ORDER BY o.name
     """
     records = await db.execute(

--- a/src/imbi_api/endpoints/users.py
+++ b/src/imbi_api/endpoints/users.py
@@ -18,6 +18,162 @@ LOGGER = logging.getLogger(__name__)
 users_router = fastapi.APIRouter(prefix='/users', tags=['Users'])
 
 
+async def _load_user_memberships(
+    db: graph.Graph, email: str
+) -> list[dict[str, str]]:
+    """Return the user's MEMBER_OF organizations as plain dicts."""
+    query = """
+    MATCH (u:User {{email: {email}}})-[m:MEMBER_OF]->(o:Organization)
+    RETURN o.name, o.slug, COALESCE(m.role, 'readonly') AS role
+    ORDER BY o.slug
+    """
+    records = await db.execute(
+        query, {'email': email}, columns=['org_name', 'org_slug', 'role']
+    )
+    return [
+        {
+            'organization_name': graph.parse_agtype(r['org_name']),
+            'organization_slug': graph.parse_agtype(r['org_slug']),
+            'role': graph.parse_agtype(r['role']),
+        }
+        for r in records
+    ]
+
+
+def _normalize_membership_input(
+    value: typing.Any,
+) -> list[dict[str, str]]:
+    """Validate and normalize a patched ``organizations`` array.
+
+    Each entry must be an object with ``organization_slug`` and ``role``
+    string fields. Duplicates (same slug) are rejected.
+    """
+    if not isinstance(value, list):
+        raise fastapi.HTTPException(
+            status_code=400,
+            detail="'organizations' must be an array",
+        )
+    normalized: list[dict[str, str]] = []
+    seen: set[str] = set()
+    for entry in value:
+        if not isinstance(entry, dict):
+            raise fastapi.HTTPException(
+                status_code=400,
+                detail='Membership entries must be objects',
+            )
+        slug = entry.get('organization_slug')
+        role = entry.get('role')
+        if not isinstance(slug, str) or not slug:
+            raise fastapi.HTTPException(
+                status_code=400,
+                detail="Membership 'organization_slug' is required",
+            )
+        if not isinstance(role, str) or not role:
+            raise fastapi.HTTPException(
+                status_code=400,
+                detail="Membership 'role' is required",
+            )
+        if slug in seen:
+            raise fastapi.HTTPException(
+                status_code=400,
+                detail=f'Duplicate membership for organization {slug!r}',
+            )
+        seen.add(slug)
+        normalized.append({'organization_slug': slug, 'role': role})
+    return normalized
+
+
+async def _reconcile_user_memberships(
+    db: graph.Graph,
+    email: str,
+    existing: list[dict[str, str]],
+    desired: list[dict[str, str]],
+) -> None:
+    """Apply MEMBER_OF edge add/remove/update to match ``desired``.
+
+    Validates that every desired org_slug and role_slug exists before
+    making any edge mutations.
+    """
+    desired_by_slug = {m['organization_slug']: m['role'] for m in desired}
+    existing_by_slug = {m['organization_slug']: m['role'] for m in existing}
+
+    org_slugs = sorted(set(desired_by_slug) | set(existing_by_slug))
+    role_slugs = sorted({m['role'] for m in desired})
+
+    if desired_by_slug:
+        validation = await db.execute(
+            'MATCH (o:Organization) WHERE o.slug IN {slugs}'
+            ' RETURN collect(o.slug) AS found',
+            {'slugs': list(desired_by_slug)},
+            columns=['found'],
+        )
+        found_orgs: list[str] = (
+            graph.parse_agtype(validation[0]['found']) if validation else []
+        )
+        missing = set(desired_by_slug) - set(found_orgs or [])
+        if missing:
+            raise fastapi.HTTPException(
+                status_code=400,
+                detail=f'Unknown organization(s): {sorted(missing)}',
+            )
+
+    if role_slugs:
+        validation = await db.execute(
+            'MATCH (r:Role) WHERE r.slug IN {slugs}'
+            ' RETURN collect(r.slug) AS found',
+            {'slugs': role_slugs},
+            columns=['found'],
+        )
+        found_roles: list[str] = (
+            graph.parse_agtype(validation[0]['found']) if validation else []
+        )
+        missing_roles = set(role_slugs) - set(found_roles or [])
+        if missing_roles:
+            raise fastapi.HTTPException(
+                status_code=400,
+                detail=f'Unknown role(s): {sorted(missing_roles)}',
+            )
+
+    for slug in org_slugs:
+        if slug in desired_by_slug and slug not in existing_by_slug:
+            await db.execute(
+                'MATCH (u:User {{email: {email}}}),'
+                ' (o:Organization {{slug: {org_slug}}})'
+                ' MERGE (u)-[m:MEMBER_OF]->(o)'
+                ' SET m.role = {role}'
+                ' RETURN m',
+                {
+                    'email': email,
+                    'org_slug': slug,
+                    'role': desired_by_slug[slug],
+                },
+                columns=['m'],
+            )
+        elif slug in desired_by_slug and slug in existing_by_slug:
+            if desired_by_slug[slug] != existing_by_slug[slug]:
+                await db.execute(
+                    'MATCH (:User {{email: {email}}})'
+                    '-[m:MEMBER_OF]->'
+                    '(:Organization {{slug: {org_slug}}})'
+                    ' SET m.role = {role}'
+                    ' RETURN m',
+                    {
+                        'email': email,
+                        'org_slug': slug,
+                        'role': desired_by_slug[slug],
+                    },
+                    columns=['m'],
+                )
+        else:
+            await db.execute(
+                'MATCH (:User {{email: {email}}})'
+                '-[m:MEMBER_OF]->'
+                '(:Organization {{slug: {org_slug}}})'
+                ' DELETE m',
+                {'email': email, 'org_slug': slug},
+            )
+
+
 @users_router.post('/', response_model=models.UserResponse, status_code=201)
 async def create_user(
     user_create: models.UserCreate,
@@ -243,7 +399,7 @@ async def get_user(
     # Load organization memberships via Cypher
     org_query = """
     MATCH (u:User {{email: {email}}})-[m:MEMBER_OF]->(o:Organization)
-    RETURN o.name, o.slug, m.role
+    RETURN o.name, o.slug, COALESCE(m.role, 'readonly') AS role
     ORDER BY o.name
     """
     org_records = await db.execute(
@@ -323,6 +479,9 @@ async def patch_user(
             detail='Only admins can modify admin users',
         )
 
+    # Load current memberships for inclusion in the patchable document
+    existing_orgs = await _load_user_memberships(db, email)
+
     # Build patchable document (exclude password_hash and timestamps)
     current: dict[str, typing.Any] = {
         'email': existing_user.email,
@@ -331,6 +490,13 @@ async def patch_user(
         'is_admin': existing_user.is_admin,
         'is_service_account': existing_user.is_service_account,
         'email_notifications': existing_user.email_notifications,
+        'organizations': [
+            {
+                'organization_slug': m['organization_slug'],
+                'role': m['role'],
+            }
+            for m in existing_orgs
+        ],
     }
 
     patched = json_patch.apply_patch(
@@ -384,6 +550,16 @@ async def patch_user(
 
     await db.merge(updated_user, match_on=['email'])
 
+    # Reconcile organization memberships if the patch changed them
+    new_orgs_raw = patched.get('organizations', [])
+    new_orgs = _normalize_membership_input(new_orgs_raw)
+    if {(o['organization_slug'], o['role']) for o in new_orgs} != {
+        (o['organization_slug'], o['role']) for o in existing_orgs
+    }:
+        await _reconcile_user_memberships(db, email, existing_orgs, new_orgs)
+
+    # Return the user with the post-reconciliation memberships
+    final_orgs = await _load_user_memberships(db, email)
     return models.UserResponse(
         email=updated_user.email,
         display_name=updated_user.display_name,
@@ -394,6 +570,14 @@ async def patch_user(
         last_login=updated_user.last_login,
         avatar_url=updated_user.avatar_url,
         email_notifications=updated_user.email_notifications,
+        organizations=[
+            models.OrgMembership(
+                organization_name=m['organization_name'],
+                organization_slug=m['organization_slug'],
+                role=m['role'],
+            )
+            for m in final_orgs
+        ],
     )
 
 

--- a/src/imbi_api/endpoints/users.py
+++ b/src/imbi_api/endpoints/users.py
@@ -55,14 +55,16 @@ def _normalize_membership_input(
         )
     normalized: list[dict[str, str]] = []
     seen: set[str] = set()
-    for entry in value:
+    items: list[typing.Any] = value  # type: ignore[assignment]
+    for entry in items:
         if not isinstance(entry, dict):
             raise fastapi.HTTPException(
                 status_code=400,
                 detail='Membership entries must be objects',
             )
-        slug = entry.get('organization_slug')
-        role = entry.get('role')
+        entry_dict: dict[str, typing.Any] = entry  # type: ignore[assignment]
+        slug = entry_dict.get('organization_slug')
+        role = entry_dict.get('role')
         if not isinstance(slug, str) or not slug:
             raise fastapi.HTTPException(
                 status_code=400,

--- a/src/imbi_api/endpoints/users.py
+++ b/src/imbi_api/endpoints/users.py
@@ -141,15 +141,12 @@ async def _reconcile_user_memberships(
             await db.execute(
                 'MATCH (u:User {{email: {email}}}),'
                 ' (o:Organization {{slug: {org_slug}}})'
-                ' MERGE (u)-[m:MEMBER_OF]->(o)'
-                ' SET m.role = {role}'
-                ' RETURN m',
+                ' CREATE (u)-[:MEMBER_OF {{role: {role}}}]->(o)',
                 {
                     'email': email,
                     'org_slug': slug,
                     'role': desired_by_slug[slug],
                 },
-                columns=['m'],
             )
         elif slug in desired_by_slug and slug in existing_by_slug:
             if desired_by_slug[slug] != existing_by_slug[slug]:
@@ -550,14 +547,17 @@ async def patch_user(
         avatar_url=existing_user.avatar_url,
     )
 
+    # Normalize and validate memberships before persisting user changes
+    new_orgs_raw = patched.get('organizations', [])
+    new_orgs = _normalize_membership_input(new_orgs_raw)
+    memberships_changed = {
+        (o['organization_slug'], o['role']) for o in new_orgs
+    } != {(o['organization_slug'], o['role']) for o in existing_orgs}
+
     await db.merge(updated_user, match_on=['email'])
 
     # Reconcile organization memberships if the patch changed them
-    new_orgs_raw = patched.get('organizations', [])
-    new_orgs = _normalize_membership_input(new_orgs_raw)
-    if {(o['organization_slug'], o['role']) for o in new_orgs} != {
-        (o['organization_slug'], o['role']) for o in existing_orgs
-    }:
+    if memberships_changed:
         await _reconcile_user_memberships(db, email, existing_orgs, new_orgs)
 
     # Return the user with the post-reconciliation memberships
@@ -735,9 +735,8 @@ async def add_to_organization(
     MATCH (u:User {{email: {email}}}),
           (o:Organization {{slug: {org_slug}}}),
           (r:Role {{slug: {role_slug}}})
-    MERGE (u)-[m:MEMBER_OF]->(o)
-    SET m.role = {role_slug}
-    RETURN u, o, r
+    OPTIONAL MATCH (u)-[existing_m:MEMBER_OF]->(o)
+    RETURN u, o, r, existing_m
     """
     records = await db.execute(
         query,
@@ -746,13 +745,29 @@ async def add_to_organization(
             'org_slug': org_slug,
             'role_slug': role_slug,
         },
-        columns=['u', 'o', 'r'],
+        columns=['u', 'o', 'r', 'existing_m'],
     )
     if not records:
         raise fastapi.HTTPException(
             status_code=404,
             detail=f'User {email!r}, organization {org_slug!r},'
             f' or role {role_slug!r} not found',
+        )
+    existing_m = records[0].get('existing_m')
+    if existing_m is None:
+        await db.execute(
+            'MATCH (u:User {{email: {email}}}),'
+            ' (o:Organization {{slug: {org_slug}}})'
+            ' CREATE (u)-[:MEMBER_OF {{role: {role_slug}}}]->(o)',
+            {'email': email, 'org_slug': org_slug, 'role_slug': role_slug},
+        )
+    else:
+        await db.execute(
+            'MATCH (:User {{email: {email}}})'
+            '-[m:MEMBER_OF]->'
+            '(:Organization {{slug: {org_slug}}})'
+            ' SET m.role = {role_slug}',
+            {'email': email, 'org_slug': org_slug, 'role_slug': role_slug},
         )
 
 

--- a/src/imbi_api/lifespans.py
+++ b/src/imbi_api/lifespans.py
@@ -79,6 +79,10 @@ async def score_worker_hook() -> abc.AsyncIterator[None]:
         LOGGER.warning('Valkey unavailable; score worker not started')
         yield None
         return
+    if client is None:
+        LOGGER.warning('Valkey unavailable; score worker not started')
+        yield None
+        return
     if _graph is None:
         LOGGER.warning('Graph not ready; score worker not started')
         yield None

--- a/src/imbi_api/lifespans.py
+++ b/src/imbi_api/lifespans.py
@@ -73,7 +73,12 @@ async def storage_hook() -> abc.AsyncIterator[StorageClient]:
 @contextlib.asynccontextmanager
 async def score_worker_hook() -> abc.AsyncIterator[None]:
     """Run the score-recompute consumer for the API process."""
-    client = valkey.get_client()
+    try:
+        client = valkey.get_client()
+    except RuntimeError:
+        LOGGER.warning('Valkey unavailable; score worker not started')
+        yield None
+        return
     if _graph is None:
         LOGGER.warning('Graph not ready; score worker not started')
         yield None

--- a/src/imbi_api/lifespans.py
+++ b/src/imbi_api/lifespans.py
@@ -79,10 +79,6 @@ async def score_worker_hook() -> abc.AsyncIterator[None]:
         LOGGER.warning('Valkey unavailable; score worker not started')
         yield None
         return
-    if client is None:
-        LOGGER.warning('Valkey unavailable; score worker not started')
-        yield None
-        return
     if _graph is None:
         LOGGER.warning('Graph not ready; score worker not started')
         yield None

--- a/src/imbi_api/lifespans.py
+++ b/src/imbi_api/lifespans.py
@@ -5,22 +5,28 @@ startup and cleans it up on shutdown. Hooks are composed using
 :class:`imbi_common.lifespan.Lifespan` in the application factory.
 """
 
+import asyncio
 import contextlib
 import logging
 from collections import abc
 
-from imbi_common import clickhouse, graph
+from imbi_common import clickhouse, graph, valkey
 
 from imbi_api import openapi
 from imbi_api.email.client import EmailClient
 from imbi_api.email.templates import TemplateManager
+from imbi_api.scoring import queue as score_queue
 from imbi_api.storage.client import StorageClient
 
 LOGGER = logging.getLogger(__name__)
 
+_graph: graph.Graph | None = None
+
 
 async def _on_graph_startup(db: graph.Graph) -> None:
     """Refresh blueprint models after the graph pool opens."""
+    global _graph
+    _graph = db
     try:
         await openapi.refresh_blueprint_models(db)
     except Exception as err:  # noqa: BLE001
@@ -62,3 +68,29 @@ async def storage_hook() -> abc.AsyncIterator[StorageClient]:
     await storage_client.initialize()
     async with contextlib.aclosing(storage_client):
         yield storage_client
+
+
+@contextlib.asynccontextmanager
+async def score_worker_hook() -> abc.AsyncIterator[None]:
+    """Run the score-recompute consumer for the API process."""
+    client = valkey.get_client()
+    if _graph is None:
+        LOGGER.warning('Graph not ready; score worker not started')
+        yield None
+        return
+    ch = clickhouse.client.Clickhouse.get_instance()
+    stop = asyncio.Event()
+    task = asyncio.create_task(
+        score_queue.consume_recompute(client, _graph, ch, stop=stop)
+    )
+    try:
+        yield None
+    finally:
+        stop.set()
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        except Exception:  # noqa: BLE001
+            LOGGER.debug('score worker exited with error', exc_info=True)

--- a/src/imbi_api/scoring/__init__.py
+++ b/src/imbi_api/scoring/__init__.py
@@ -1,0 +1,44 @@
+"""Scoring queue and triggers for imbi-api."""
+
+import typing
+from collections import abc
+
+import fastapi
+from imbi_common import helpers, lifespan
+from imbi_common import valkey as common_valkey
+from valkey import asyncio as valkey
+
+from imbi_api.scoring.queue import (
+    affected_projects,
+    consume_recompute,
+    enqueue_recompute,
+)
+
+__all__ = [
+    'OptionalValkeyClient',
+    'affected_projects',
+    'consume_recompute',
+    'enqueue_recompute',
+]
+
+
+async def _inject_optional_client(
+    request: fastapi.Request,
+) -> abc.AsyncIterator[valkey.Valkey | None]:
+    """Yield the Valkey client, or ``None`` when lifespan is absent."""
+    client: valkey.Valkey | None = None
+    try:
+        ctx = helpers.unwrap_as(
+            lifespan.Lifespan,
+            typing.cast('object', request.state.lifespan_data),
+        )
+        client = ctx.get_state(common_valkey.valkey_lifespan)
+    except (AttributeError, ValueError, fastapi.HTTPException):
+        client = None
+    yield client
+
+
+OptionalValkeyClient = typing.Annotated[
+    valkey.Valkey | None,
+    fastapi.Depends(_inject_optional_client),
+]

--- a/src/imbi_api/scoring/__init__.py
+++ b/src/imbi_api/scoring/__init__.py
@@ -30,7 +30,7 @@ async def _inject_optional_client(
     try:
         ctx = helpers.unwrap_as(
             lifespan.Lifespan,
-            typing.cast('object', request.state.lifespan_data),
+            typing.cast(object, request.state.lifespan_data),
         )
         client = ctx.get_state(common_valkey.valkey_lifespan)
     except (AttributeError, ValueError, fastapi.HTTPException):

--- a/src/imbi_api/scoring/queue.py
+++ b/src/imbi_api/scoring/queue.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import typing
+from collections import abc
 
 from imbi_common import blueprints, clickhouse, graph, models
 from imbi_common.scoring import (
@@ -144,7 +145,7 @@ async def _process_message(
 
 
 def _decode_fields(
-    raw: typing.Mapping[bytes | str, bytes | str],
+    raw: abc.Mapping[bytes | str, bytes | str],
 ) -> dict[str, str]:
     return {
         (k.decode() if isinstance(k, bytes) else k): (
@@ -157,7 +158,7 @@ def _decode_fields(
 async def _claim_stale(
     client: valkey.Valkey,
     consumer: str,
-) -> list[tuple[bytes, typing.Mapping[bytes | str, bytes | str]]]:
+) -> list[tuple[bytes, abc.Mapping[bytes | str, bytes | str]]]:
     try:
         result = await client.xautoclaim(
             STREAM,
@@ -170,10 +171,10 @@ async def _claim_stale(
     except Exception as err:  # noqa: BLE001
         LOGGER.debug('xautoclaim failed: %s', err)
         return []
-    if isinstance(result, (list, tuple)) and len(result) >= 2:
-        msgs = result[1]
+    if isinstance(result, (list, tuple)) and len(result) >= 2:  # type: ignore[arg-type]
+        msgs: object = result[1]  # type: ignore[index]
         if isinstance(msgs, list):
-            return msgs
+            return msgs  # type: ignore[return-value]
     return []
 
 
@@ -190,17 +191,17 @@ async def _maybe_dead_letter(
         return False
     if not info:
         return False
-    entry = info[0]
-    delivered = (
-        entry.get('times_delivered') if isinstance(entry, dict) else None
-    )
-    if (
-        delivered is None
-        and isinstance(entry, (list, tuple))
-        and len(entry) >= 4
-    ):
-        delivered = entry[3]
-    if delivered is not None and int(delivered) >= MAX_DELIVERIES:
+    entry: object = info[0]  # type: ignore[index]
+    delivered: int | None = None
+    if isinstance(entry, dict):
+        raw_delivered = entry.get('times_delivered')  # type: ignore[union-attr]
+        if raw_delivered is not None:
+            delivered = int(raw_delivered)  # type: ignore[arg-type]
+    elif isinstance(entry, (list, tuple)) and len(entry) >= 4:  # type: ignore[arg-type]
+        raw_delivered = entry[3]  # type: ignore[index]
+        if raw_delivered is not None:
+            delivered = int(raw_delivered)  # type: ignore[arg-type]
+    if delivered is not None and delivered >= MAX_DELIVERIES:
         await client.xadd(DLQ, fields)
         await client.xack(STREAM, GROUP, msg_id)
         LOGGER.warning(
@@ -214,7 +215,7 @@ async def _maybe_dead_letter(
 
 async def _handle_entries(
     client: valkey.Valkey,
-    entries: list[tuple[bytes, typing.Mapping[bytes | str, bytes | str]]],
+    entries: list[tuple[bytes, abc.Mapping[bytes | str, bytes | str]]],
     db: graph.Graph,
     ch: clickhouse.client.Clickhouse,
     check_dlq: bool = False,

--- a/src/imbi_api/scoring/queue.py
+++ b/src/imbi_api/scoring/queue.py
@@ -1,0 +1,262 @@
+"""Score-recompute queue (Valkey Streams).
+
+Producers must call :func:`enqueue_recompute` *after* the originating
+DB commit completes; the 5s debounce key relies on workers reading
+post-commit state at recompute time.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import typing
+
+from imbi_common import blueprints, clickhouse, graph, models
+from imbi_common.scoring import (
+    AttributePolicy,
+    compute_score,
+    record_score_change,
+)
+from valkey import asyncio as valkey
+
+STREAM = 'imbi:score-recompute'
+GROUP = 'score-workers'
+CONSUMER_PREFIX = 'worker'
+DLQ = 'imbi:score-recompute:dlq'
+DEBOUNCE_PREFIX = 'imbi:score-recompute:debounce'
+DEBOUNCE_SECONDS = 5
+MAX_DELIVERIES = 5
+CLAIM_IDLE_MS = 60_000
+
+LOGGER = logging.getLogger(__name__)
+
+ChangeReason = typing.Literal[
+    'attribute_change',
+    'blueprint_change',
+    'policy_change',
+    'bulk_rescore',
+]
+
+
+async def enqueue_recompute(
+    client: valkey.Valkey | None,
+    project_id: str,
+    reason: ChangeReason,
+    requested_by: str | None = None,
+) -> bool:
+    """Debounce-then-XADD a recompute job. Returns True if enqueued.
+
+    Tolerates *client* being ``None`` (returns False) so trigger sites
+    can run in environments where Valkey is unavailable.
+    """
+    if client is None:
+        return False
+    try:
+        key = f'{DEBOUNCE_PREFIX}:{project_id}'
+        acquired = await client.set(key, b'1', ex=DEBOUNCE_SECONDS, nx=True)
+        if not acquired:
+            return False
+        fields: dict[str, str] = {
+            'project_id': project_id,
+            'reason': reason,
+            'requested_by': requested_by or 'system',
+        }
+        await client.xadd(STREAM, fields)
+    except Exception:
+        LOGGER.exception('enqueue_recompute failed for %s', project_id)
+        return False
+    return True
+
+
+async def ensure_group(client: valkey.Valkey) -> None:
+    try:
+        await client.xgroup_create(STREAM, GROUP, id='$', mkstream=True)
+    except Exception as err:  # noqa: BLE001
+        msg = str(err)
+        if 'BUSYGROUP' not in msg:
+            LOGGER.warning('xgroup_create failed: %s', err)
+
+
+async def affected_projects(
+    db: graph.Graph,
+    policy: AttributePolicy,
+) -> list[str]:
+    """Project ids whose effective attribute set includes
+    policy.attribute_name. Intersected with TARGETS edges if any are set.
+    """
+    extended = await blueprints.get_model(db, models.Project)
+    if policy.attribute_name not in extended.model_fields:
+        return []
+    query: typing.LiteralString = (
+        'MATCH (sp:ScoringPolicy {{slug: {slug}}})'
+        ' OPTIONAL MATCH (sp)-[:TARGETS]->(pt:ProjectType)'
+        ' WITH collect(pt.slug) AS targets'
+        ' MATCH (p:Project)'
+        ' OPTIONAL MATCH (p)-[:TYPE]->(ppt:ProjectType)'
+        ' WITH p, targets, collect(ppt.slug) AS p_types'
+        ' WHERE size(targets) = 0 OR'
+        ' any(t IN p_types WHERE t IN targets)'
+        ' RETURN p.id AS id'
+    )
+    rows = await db.execute(query, {'slug': policy.slug}, ['id'])
+    return [v for r in rows if (v := graph.parse_agtype(r['id']))]
+
+
+async def projects_of_type(
+    db: graph.Graph, project_type_slug: str
+) -> list[str]:
+    query: typing.LiteralString = (
+        'MATCH (p:Project)-[:TYPE]'
+        '->(pt:ProjectType {{slug: {slug}}})'
+        ' RETURN p.id AS id'
+    )
+    rows = await db.execute(query, {'slug': project_type_slug}, ['id'])
+    return [v for r in rows if (v := graph.parse_agtype(r['id']))]
+
+
+async def all_project_ids(
+    db: graph.Graph,
+    project_type_slug: str | None = None,
+) -> list[str]:
+    if project_type_slug:
+        return await projects_of_type(db, project_type_slug)
+    rows = await db.execute('MATCH (p:Project) RETURN p.id AS id', {}, ['id'])
+    return [v for r in rows if (v := graph.parse_agtype(r['id']))]
+
+
+async def _process_message(
+    db: graph.Graph,
+    ch: clickhouse.client.Clickhouse,
+    fields: dict[str, str],
+) -> None:
+    project_id = fields.get('project_id')
+    reason = fields.get('reason') or 'attribute_change'
+    if not project_id:
+        return
+    matches = await db.match(models.Project, {'id': project_id})
+    if not matches:
+        LOGGER.info('Project %s not found; skipping recompute', project_id)
+        return
+    project = matches[0]
+    previous = project.score if project.score is not None else 0.0
+    score, _ = await compute_score(db, project_id)
+    await record_score_change(ch, db, project, score, previous, reason)
+
+
+def _decode_fields(
+    raw: typing.Mapping[bytes | str, bytes | str],
+) -> dict[str, str]:
+    return {
+        (k.decode() if isinstance(k, bytes) else k): (
+            v.decode() if isinstance(v, bytes) else v
+        )
+        for k, v in raw.items()
+    }
+
+
+async def _claim_stale(
+    client: valkey.Valkey,
+    consumer: str,
+) -> list[tuple[bytes, typing.Mapping[bytes | str, bytes | str]]]:
+    try:
+        result = await client.xautoclaim(
+            STREAM,
+            GROUP,
+            consumer,
+            min_idle_time=CLAIM_IDLE_MS,
+            start_id='0-0',
+            count=16,
+        )
+    except Exception as err:  # noqa: BLE001
+        LOGGER.debug('xautoclaim failed: %s', err)
+        return []
+    if isinstance(result, (list, tuple)) and len(result) >= 2:
+        msgs = result[1]
+        if isinstance(msgs, list):
+            return msgs
+    return []
+
+
+async def _maybe_dead_letter(
+    client: valkey.Valkey,
+    msg_id: bytes,
+    fields: dict[str, str],
+) -> bool:
+    try:
+        info = await client.xpending_range(
+            STREAM, GROUP, min=msg_id, max=msg_id, count=1
+        )
+    except Exception:  # noqa: BLE001
+        return False
+    if not info:
+        return False
+    entry = info[0]
+    delivered = (
+        entry.get('times_delivered') if isinstance(entry, dict) else None
+    )
+    if (
+        delivered is None
+        and isinstance(entry, (list, tuple))
+        and len(entry) >= 4
+    ):
+        delivered = entry[3]
+    if delivered is not None and int(delivered) >= MAX_DELIVERIES:
+        await client.xadd(DLQ, fields)
+        await client.xack(STREAM, GROUP, msg_id)
+        LOGGER.warning(
+            'dead-lettered score-recompute msg %s after %s deliveries',
+            msg_id,
+            delivered,
+        )
+        return True
+    return False
+
+
+async def _handle_entries(
+    client: valkey.Valkey,
+    entries: list[tuple[bytes, typing.Mapping[bytes | str, bytes | str]]],
+    db: graph.Graph,
+    ch: clickhouse.client.Clickhouse,
+    check_dlq: bool = False,
+) -> None:
+    for msg_id, raw_fields in entries:
+        fields = _decode_fields(raw_fields)
+        if check_dlq and await _maybe_dead_letter(client, msg_id, fields):
+            continue
+        try:
+            await _process_message(db, ch, fields)
+        except Exception:
+            LOGGER.exception('recompute failed for %s', fields)
+            continue
+        await client.xack(STREAM, GROUP, msg_id)
+
+
+async def consume_recompute(
+    client: valkey.Valkey,
+    db: graph.Graph,
+    ch: clickhouse.client.Clickhouse,
+    consumer: str = f'{CONSUMER_PREFIX}-0',
+    stop: asyncio.Event | None = None,
+) -> None:
+    """Run the recompute consumer loop until *stop* is set."""
+    await ensure_group(client)
+    while stop is None or not stop.is_set():
+        stale = await _claim_stale(client, consumer)
+        if stale:
+            await _handle_entries(client, stale, db, ch, check_dlq=True)
+        try:
+            response = await client.xreadgroup(
+                GROUP,
+                consumer,
+                {STREAM: '>'},
+                count=16,
+                block=2000,
+            )
+        except Exception:
+            LOGGER.exception('xreadgroup failed')
+            await asyncio.sleep(1)
+            continue
+        if not response:
+            continue
+        for _stream, entries in response:
+            await _handle_entries(client, entries, db, ch)

--- a/tests/endpoints/test_scoring.py
+++ b/tests/endpoints/test_scoring.py
@@ -1,0 +1,124 @@
+"""Tests for scoring history, rollup, and rescore endpoints."""
+
+from __future__ import annotations
+
+import datetime
+import unittest
+from unittest import mock
+
+from fastapi.testclient import TestClient
+from imbi_common import graph
+
+from imbi_api import app, models
+from imbi_api import scoring as scoring_di
+
+
+class ScoringEndpointsTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        from imbi_api.auth import permissions
+
+        self.test_app = app.create_app()
+
+        self.user = models.User(
+            email='admin@example.com',
+            display_name='Admin',
+            is_active=True,
+            is_admin=True,
+            is_service_account=False,
+            created_at=datetime.datetime.now(datetime.UTC),
+        )
+        self.auth = permissions.AuthContext(
+            user=self.user,
+            session_id='s',
+            auth_method='jwt',
+            permissions=set(),
+        )
+
+        async def mock_user() -> permissions.AuthContext:
+            return self.auth
+
+        self.test_app.dependency_overrides[permissions.get_current_user] = (
+            mock_user
+        )
+
+        self.mock_db = mock.AsyncMock(spec=graph.Graph)
+        self.mock_valkey = mock.AsyncMock()
+        self.mock_valkey.set = mock.AsyncMock(return_value=True)
+        self.mock_valkey.xadd = mock.AsyncMock()
+
+        self.test_app.dependency_overrides[graph._inject_graph] = (
+            lambda: self.mock_db
+        )
+        self.test_app.dependency_overrides[
+            scoring_di._inject_optional_client
+        ] = lambda: self.mock_valkey
+        self.client = TestClient(self.test_app)
+
+    def test_history_raw(self) -> None:
+        self.mock_db.execute = mock.AsyncMock(return_value=[{'id': 'p1'}])
+        with mock.patch(
+            'imbi_api.endpoints.scoring.clickhouse.query',
+            mock.AsyncMock(
+                return_value=[
+                    {
+                        'timestamp': '2026-04-01T00:00:00',
+                        'score': 80.0,
+                        'previous_score': 70.0,
+                        'change_reason': 'attribute_change',
+                    }
+                ]
+            ),
+        ):
+            response = self.client.get(
+                '/organizations/eng/projects/p1/score/history',
+            )
+        self.assertEqual(response.status_code, 200, response.text)
+        body = response.json()
+        self.assertEqual(body['granularity'], 'raw')
+        self.assertEqual(len(body['points']), 1)
+
+    def test_history_404(self) -> None:
+        self.mock_db.execute = mock.AsyncMock(return_value=[])
+        response = self.client.get(
+            '/organizations/eng/projects/missing/score/history',
+        )
+        self.assertEqual(response.status_code, 404)
+
+    def test_rollup(self) -> None:
+        with mock.patch(
+            'imbi_api.endpoints.scoring.clickhouse.query',
+            mock.AsyncMock(
+                return_value=[
+                    {
+                        'key': 'platform',
+                        'latest_score': 90.0,
+                        'avg_score': 85.0,
+                        'last_updated': '2026-04-01',
+                    }
+                ]
+            ),
+        ):
+            response = self.client.get(
+                '/scores/rollup', params={'dimension': 'team'}
+            )
+        self.assertEqual(response.status_code, 200, response.text)
+        body = response.json()
+        self.assertEqual(body[0]['key'], 'platform')
+
+    def test_rescore_all(self) -> None:
+        self.mock_db.execute = mock.AsyncMock(
+            return_value=[{'id': 'p1'}, {'id': 'p2'}]
+        )
+        response = self.client.post('/scoring/rescore', json={})
+        self.assertEqual(response.status_code, 200, response.text)
+        self.assertEqual(response.json()['enqueued'], 2)
+        self.assertEqual(self.mock_valkey.xadd.await_count, 2)
+
+    def test_rescore_debounce_blocks_duplicate(self) -> None:
+        self.mock_db.execute = mock.AsyncMock(
+            return_value=[{'id': 'p1'}, {'id': 'p1'}]
+        )
+        self.mock_valkey.set = mock.AsyncMock(side_effect=[True, False])
+        response = self.client.post('/scoring/rescore', json={})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()['enqueued'], 1)

--- a/tests/endpoints/test_scoring.py
+++ b/tests/endpoints/test_scoring.py
@@ -85,17 +85,33 @@ class ScoringEndpointsTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 404)
 
     def test_rollup(self) -> None:
-        with mock.patch(
-            'imbi_api.endpoints.scoring.clickhouse.query',
-            mock.AsyncMock(
-                return_value=[
-                    {
-                        'key': 'platform',
-                        'latest_score': 90.0,
-                        'avg_score': 85.0,
-                        'last_updated': '2026-04-01',
-                    }
-                ]
+        # db.execute returns project→team mappings from AGE
+        self.mock_db.execute = mock.AsyncMock(
+            return_value=[
+                {'project_id': 'p1', 'dim_key': 'platform'},
+                {'project_id': 'p2', 'dim_key': 'platform'},
+            ]
+        )
+        with (
+            mock.patch(
+                'imbi_api.endpoints.scoring.clickhouse.query',
+                mock.AsyncMock(
+                    return_value=[
+                        {
+                            'project_id': 'p1',
+                            'latest_score': 90.0,
+                            'last_updated': '2026-04-01',
+                        },
+                        {
+                            'project_id': 'p2',
+                            'latest_score': 80.0,
+                            'last_updated': '2026-03-01',
+                        },
+                    ]
+                ),
+            ),
+            mock.patch(
+                'imbi_common.graph.parse_agtype', side_effect=lambda x: x
             ),
         ):
             response = self.client.get(
@@ -103,7 +119,18 @@ class ScoringEndpointsTestCase(unittest.TestCase):
             )
         self.assertEqual(response.status_code, 200, response.text)
         body = response.json()
+        self.assertEqual(len(body), 1)
         self.assertEqual(body[0]['key'], 'platform')
+        self.assertAlmostEqual(body[0]['avg_score'], 85.0)
+        self.assertEqual(body[0]['latest_score'], 90.0)
+
+    def test_rollup_empty_when_no_projects(self) -> None:
+        self.mock_db.execute = mock.AsyncMock(return_value=[])
+        response = self.client.get(
+            '/scores/rollup', params={'dimension': 'team'}
+        )
+        self.assertEqual(response.status_code, 200, response.text)
+        self.assertEqual(response.json(), [])
 
     def test_rescore_all(self) -> None:
         self.mock_db.execute = mock.AsyncMock(

--- a/tests/endpoints/test_scoring.py
+++ b/tests/endpoints/test_scoring.py
@@ -122,3 +122,96 @@ class ScoringEndpointsTestCase(unittest.TestCase):
         response = self.client.post('/scoring/rescore', json={})
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()['enqueued'], 1)
+
+    def test_history_with_date_filters(self) -> None:
+        self.mock_db.execute = mock.AsyncMock(return_value=[{'id': 'p1'}])
+        with mock.patch(
+            'imbi_api.endpoints.scoring.clickhouse.query',
+            mock.AsyncMock(return_value=[]),
+        ):
+            response = self.client.get(
+                '/organizations/eng/projects/p1/score/history',
+                params={
+                    'from': '2026-01-01T00:00:00',
+                    'to': '2026-04-01T00:00:00',
+                },
+            )
+        self.assertEqual(response.status_code, 200, response.text)
+
+    def test_history_hourly_granularity(self) -> None:
+        self.mock_db.execute = mock.AsyncMock(return_value=[{'id': 'p1'}])
+        with mock.patch(
+            'imbi_api.endpoints.scoring.clickhouse.query',
+            mock.AsyncMock(
+                return_value=[{'ts': '2026-04-01T00:00:00', 'score': 85.0}]
+            ),
+        ):
+            response = self.client.get(
+                '/organizations/eng/projects/p1/score/history',
+                params={'granularity': 'hour'},
+            )
+        self.assertEqual(response.status_code, 200, response.text)
+        body = response.json()
+        self.assertEqual(body['granularity'], 'hour')
+        self.assertEqual(len(body['points']), 1)
+
+    def test_rescore_by_blueprint_slug(self) -> None:
+        blueprint_raw = {
+            'id': 'bp1',
+            'slug': 'my-blueprint',
+            'name': 'My Blueprint',
+            'type': 'Project',
+            'filter': None,
+        }
+        self.mock_db.execute = mock.AsyncMock(
+            side_effect=[
+                [{'b': blueprint_raw}],  # blueprint lookup
+                [{'id': 'p1'}, {'id': 'p2'}],  # all_project_ids
+            ]
+        )
+        response = self.client.post(
+            '/scoring/rescore', json={'blueprint_slug': 'my-blueprint'}
+        )
+        self.assertEqual(response.status_code, 200, response.text)
+        self.assertEqual(response.json()['enqueued'], 2)
+
+    def test_rescore_by_blueprint_slug_not_found(self) -> None:
+        self.mock_db.execute = mock.AsyncMock(return_value=[])
+        response = self.client.post(
+            '/scoring/rescore', json={'blueprint_slug': 'missing-blueprint'}
+        )
+        self.assertEqual(response.status_code, 404)
+
+    def test_rescore_by_policy_slug_not_found(self) -> None:
+        self.mock_db.execute = mock.AsyncMock(return_value=[])
+        response = self.client.post(
+            '/scoring/rescore', json={'policy_slug': 'missing-policy'}
+        )
+        self.assertEqual(response.status_code, 404)
+
+    def test_rescore_by_policy_slug(self) -> None:
+        policy_props = {
+            'id': 'p1id',
+            'name': 'Python Version',
+            'slug': 'python-version',
+            'category': 'attribute',
+            'attribute_name': 'programming_language',
+            'weight': 50,
+            'enabled': True,
+            'priority': 0,
+            'description': None,
+            'value_score_map': '{"Python 3.12": 100}',
+            'range_score_map': None,
+        }
+        self.mock_db.execute = mock.AsyncMock(
+            return_value=[{'sp': policy_props, 'targets': []}]
+        )
+        with mock.patch(
+            'imbi_api.endpoints.scoring.score_queue.affected_projects',
+            mock.AsyncMock(return_value=['p1']),
+        ):
+            response = self.client.post(
+                '/scoring/rescore', json={'policy_slug': 'python-version'}
+            )
+        self.assertEqual(response.status_code, 200, response.text)
+        self.assertEqual(response.json()['enqueued'], 1)

--- a/tests/endpoints/test_scoring_policies.py
+++ b/tests/endpoints/test_scoring_policies.py
@@ -186,15 +186,21 @@ class ScoringPolicyEndpointsTestCase(unittest.TestCase):
         self.mock_db.execute = mock.AsyncMock(
             side_effect=[
                 [{'sp': self._policy_props()}],
+                [{'found': ['service']}],  # target validation
                 [],  # link targets
                 [{'sp': self._policy_props(), 'targets': ['service']}],
                 [],
             ]
         )
-        with mock.patch(
-            'imbi_api.endpoints.scoring_policies.score_queue.'
-            'affected_projects',
-            mock.AsyncMock(return_value=[]),
+        with (
+            mock.patch(
+                'imbi_api.endpoints.scoring_policies.score_queue.'
+                'affected_projects',
+                mock.AsyncMock(return_value=[]),
+            ),
+            mock.patch(
+                'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+            ),
         ):
             response = self.client.post(
                 '/scoring/policies/',
@@ -209,6 +215,30 @@ class ScoringPolicyEndpointsTestCase(unittest.TestCase):
             )
         self.assertEqual(response.status_code, 201, response.text)
         self.assertEqual(response.json()['slug'], 'python-version')
+
+    def test_create_policy_with_unknown_targets_returns_400(self) -> None:
+        self.mock_db.execute = mock.AsyncMock(
+            side_effect=[
+                [{'sp': self._policy_props()}],
+                [{'found': []}],  # target validation returns nothing found
+            ]
+        )
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.post(
+                '/scoring/policies/',
+                json={
+                    'name': 'Python Version',
+                    'slug': 'python-version',
+                    'attribute_name': 'programming_language',
+                    'weight': 50,
+                    'value_score_map': {'Python 3.12': 100},
+                    'targets': ['nonexistent-type'],
+                },
+            )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('Unknown project type', response.json()['detail'])
 
     def test_create_policy_conflict(self) -> None:
         import psycopg.errors
@@ -232,11 +262,54 @@ class ScoringPolicyEndpointsTestCase(unittest.TestCase):
         self.mock_db.execute = mock.AsyncMock(
             side_effect=[
                 [{'sp': self._policy_props(), 'targets': []}],  # load existing
+                [{'found': ['service']}],  # target validation (new)
                 [],  # clear targets
                 [],  # link new targets
                 [
                     {'sp': self._policy_props(), 'targets': ['service']}
                 ],  # reload
+            ]
+        )
+        with (
+            mock.patch(
+                'imbi_api.endpoints.scoring_policies.score_queue.'
+                'affected_projects',
+                mock.AsyncMock(return_value=[]),
+            ),
+            mock.patch(
+                'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+            ),
+        ):
+            response = self.client.patch(
+                '/scoring/policies/python-version',
+                json={'targets': ['service']},
+            )
+        self.assertEqual(response.status_code, 200, response.text)
+
+    def test_update_policy_with_unknown_targets_returns_400(self) -> None:
+        self.mock_db.execute = mock.AsyncMock(
+            side_effect=[
+                [{'sp': self._policy_props(), 'targets': []}],  # load existing
+                [{'found': []}],  # target validation finds nothing
+            ]
+        )
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.patch(
+                '/scoring/policies/python-version',
+                json={'targets': ['ghost-type']},
+            )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('Unknown project type', response.json()['detail'])
+
+    def test_update_policy_clear_targets(self) -> None:
+        """PATCH with targets=[] clears all targets without validation."""
+        self.mock_db.execute = mock.AsyncMock(
+            side_effect=[
+                [{'sp': self._policy_props(), 'targets': ['service']}],  # load
+                [],  # clear targets
+                [{'sp': self._policy_props(), 'targets': []}],  # reload
             ]
         )
         with mock.patch(
@@ -246,7 +319,7 @@ class ScoringPolicyEndpointsTestCase(unittest.TestCase):
         ):
             response = self.client.patch(
                 '/scoring/policies/python-version',
-                json={'targets': ['service']},
+                json={'targets': []},
             )
         self.assertEqual(response.status_code, 200, response.text)
 

--- a/tests/endpoints/test_scoring_policies.py
+++ b/tests/endpoints/test_scoring_policies.py
@@ -170,3 +170,107 @@ class ScoringPolicyEndpointsTestCase(unittest.TestCase):
             response = self.client.delete('/scoring/policies/python-version')
         self.assertEqual(response.status_code, 204)
         self.assertEqual(self.mock_valkey.xadd.await_count, 1)
+
+    def test_list_policies_with_category_filter(self) -> None:
+        self.mock_db.execute = mock.AsyncMock(
+            return_value=[{'sp': self._policy_props(), 'targets': []}]
+        )
+        response = self.client.get(
+            '/scoring/policies/', params={'category': 'attribute'}
+        )
+        self.assertEqual(response.status_code, 200)
+        call = self.mock_db.execute.await_args
+        self.assertIn('category', call.args[1])
+
+    def test_create_policy_with_targets(self) -> None:
+        self.mock_db.execute = mock.AsyncMock(
+            side_effect=[
+                [{'sp': self._policy_props()}],
+                [],  # link targets
+                [{'sp': self._policy_props(), 'targets': ['service']}],
+                [],
+            ]
+        )
+        with mock.patch(
+            'imbi_api.endpoints.scoring_policies.score_queue.'
+            'affected_projects',
+            mock.AsyncMock(return_value=[]),
+        ):
+            response = self.client.post(
+                '/scoring/policies/',
+                json={
+                    'name': 'Python Version',
+                    'slug': 'python-version',
+                    'attribute_name': 'programming_language',
+                    'weight': 50,
+                    'value_score_map': {'Python 3.12': 100},
+                    'targets': ['service'],
+                },
+            )
+        self.assertEqual(response.status_code, 201, response.text)
+        self.assertEqual(response.json()['slug'], 'python-version')
+
+    def test_create_policy_conflict(self) -> None:
+        import psycopg.errors
+
+        self.mock_db.execute = mock.AsyncMock(
+            side_effect=psycopg.errors.UniqueViolation()
+        )
+        response = self.client.post(
+            '/scoring/policies/',
+            json={
+                'name': 'Python Version',
+                'slug': 'python-version',
+                'attribute_name': 'programming_language',
+                'weight': 50,
+                'value_score_map': {'Python 3.12': 100},
+            },
+        )
+        self.assertEqual(response.status_code, 409)
+
+    def test_update_policy_with_targets(self) -> None:
+        self.mock_db.execute = mock.AsyncMock(
+            side_effect=[
+                [{'sp': self._policy_props(), 'targets': []}],  # load existing
+                [],  # clear targets
+                [],  # link new targets
+                [
+                    {'sp': self._policy_props(), 'targets': ['service']}
+                ],  # reload
+            ]
+        )
+        with mock.patch(
+            'imbi_api.endpoints.scoring_policies.score_queue.'
+            'affected_projects',
+            mock.AsyncMock(return_value=[]),
+        ):
+            response = self.client.patch(
+                '/scoring/policies/python-version',
+                json={'targets': ['service']},
+            )
+        self.assertEqual(response.status_code, 200, response.text)
+
+    def test_update_policy_not_found(self) -> None:
+        self.mock_db.execute = mock.AsyncMock(return_value=[])
+        response = self.client.patch(
+            '/scoring/policies/missing', json={'weight': 10}
+        )
+        self.assertEqual(response.status_code, 404)
+
+    def test_delete_policy_not_found(self) -> None:
+        self.mock_db.execute = mock.AsyncMock(return_value=[])
+        response = self.client.delete('/scoring/policies/missing')
+        self.assertEqual(response.status_code, 404)
+
+    def test_parse_node_handles_invalid_json(self) -> None:
+        """Coverage for _parse_node exception path."""
+        from imbi_api.endpoints.scoring_policies import _parse_node
+
+        raw = {
+            'id': 'x',
+            'name': 'test',
+            'value_score_map': '{invalid json',
+            'range_score_map': None,
+        }
+        result = _parse_node(raw)
+        self.assertIsNone(result['value_score_map'])

--- a/tests/endpoints/test_scoring_policies.py
+++ b/tests/endpoints/test_scoring_policies.py
@@ -1,0 +1,172 @@
+"""Tests for scoring policy CRUD endpoints."""
+
+from __future__ import annotations
+
+import datetime
+import typing
+import unittest
+from unittest import mock
+
+from fastapi.testclient import TestClient
+from imbi_common import graph
+
+from imbi_api import app, models
+from imbi_api import scoring as scoring_di
+
+
+class ScoringPolicyEndpointsTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        from imbi_api.auth import permissions
+
+        self.test_app = app.create_app()
+
+        self.admin_user = models.User(
+            email='admin@example.com',
+            display_name='Admin',
+            is_active=True,
+            is_admin=True,
+            is_service_account=False,
+            created_at=datetime.datetime.now(datetime.UTC),
+        )
+        self.auth_context = permissions.AuthContext(
+            user=self.admin_user,
+            session_id='s',
+            auth_method='jwt',
+            permissions=set(),
+        )
+
+        async def mock_user() -> permissions.AuthContext:
+            return self.auth_context
+
+        self.test_app.dependency_overrides[permissions.get_current_user] = (
+            mock_user
+        )
+
+        self.mock_db = mock.AsyncMock(spec=graph.Graph)
+        self.mock_valkey = mock.AsyncMock()
+        self.mock_valkey.set = mock.AsyncMock(return_value=True)
+        self.mock_valkey.xadd = mock.AsyncMock(return_value=b'1-0')
+
+        self.test_app.dependency_overrides[graph._inject_graph] = (
+            lambda: self.mock_db
+        )
+        self.test_app.dependency_overrides[
+            scoring_di._inject_optional_client
+        ] = lambda: self.mock_valkey
+        self.client = TestClient(self.test_app)
+
+    def _policy_props(self, **kw: typing.Any) -> dict[str, typing.Any]:
+        d = {
+            'id': 'p1id',
+            'name': 'Python Version',
+            'slug': 'python-version',
+            'category': 'attribute',
+            'attribute_name': 'programming_language',
+            'weight': 50,
+            'enabled': True,
+            'priority': 0,
+            'description': None,
+            'value_score_map': {'Python 3.12': 100, 'Python 2.7': 0},
+            'range_score_map': None,
+        }
+        d.update(kw)
+        return d
+
+    def test_create_policy_success(self) -> None:
+        self.mock_db.execute = mock.AsyncMock(
+            side_effect=[
+                [{'sp': self._policy_props()}],
+                [{'sp': self._policy_props(), 'targets': []}],
+                [],
+            ]
+        )
+        # affected_projects -> blueprints.get_model + execute
+        with mock.patch(
+            'imbi_api.endpoints.scoring_policies.score_queue.'
+            'affected_projects',
+            mock.AsyncMock(return_value=['p1', 'p2']),
+        ):
+            response = self.client.post(
+                '/scoring/policies/',
+                json={
+                    'name': 'Python Version',
+                    'slug': 'python-version',
+                    'attribute_name': 'programming_language',
+                    'weight': 50,
+                    'value_score_map': {
+                        'Python 3.12': 100,
+                        'Python 2.7': 0,
+                    },
+                },
+            )
+        self.assertEqual(response.status_code, 201, response.text)
+        data = response.json()
+        self.assertEqual(data['slug'], 'python-version')
+        self.assertEqual(self.mock_valkey.xadd.await_count, 2)
+
+    def test_get_policy_not_found(self) -> None:
+        self.mock_db.execute = mock.AsyncMock(return_value=[])
+        response = self.client.get('/scoring/policies/missing')
+        self.assertEqual(response.status_code, 404)
+
+    def test_get_policy_success(self) -> None:
+        self.mock_db.execute = mock.AsyncMock(
+            return_value=[{'sp': self._policy_props(), 'targets': ['svc']}]
+        )
+        response = self.client.get('/scoring/policies/python-version')
+        self.assertEqual(response.status_code, 200, response.text)
+        self.assertEqual(response.json()['slug'], 'python-version')
+
+    def test_list_policies_filters(self) -> None:
+        self.mock_db.execute = mock.AsyncMock(
+            return_value=[{'sp': self._policy_props(), 'targets': []}]
+        )
+        response = self.client.get(
+            '/scoring/policies/',
+            params={
+                'enabled': 'true',
+                'attribute_name': 'programming_language',
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.json()), 1)
+        call = self.mock_db.execute.await_args
+        params = call.args[1]
+        self.assertEqual(params.get('enabled'), True)
+        self.assertEqual(params.get('attribute_name'), 'programming_language')
+
+    def test_update_policy_enqueues(self) -> None:
+        self.mock_db.execute = mock.AsyncMock(
+            side_effect=[
+                [{'sp': self._policy_props(), 'targets': []}],
+                [],
+                [{'sp': self._policy_props(weight=80), 'targets': []}],
+            ]
+        )
+        with mock.patch(
+            'imbi_api.endpoints.scoring_policies.score_queue.'
+            'affected_projects',
+            mock.AsyncMock(return_value=['p1']),
+        ):
+            response = self.client.patch(
+                '/scoring/policies/python-version',
+                json={'weight': 80},
+            )
+        self.assertEqual(response.status_code, 200, response.text)
+        self.assertGreaterEqual(self.mock_valkey.xadd.await_count, 1)
+
+    def test_delete_policy(self) -> None:
+        self.mock_db.execute = mock.AsyncMock(
+            side_effect=[
+                [{'sp': self._policy_props(), 'targets': []}],
+                [],
+            ]
+        )
+        with mock.patch(
+            'imbi_api.endpoints.scoring_policies.score_queue.'
+            'affected_projects',
+            mock.AsyncMock(return_value=['p1']),
+        ):
+            response = self.client.delete('/scoring/policies/python-version')
+        self.assertEqual(response.status_code, 204)
+        self.assertEqual(self.mock_valkey.xadd.await_count, 1)

--- a/tests/endpoints/test_users.py
+++ b/tests/endpoints/test_users.py
@@ -472,6 +472,45 @@ class UserEndpointsTestCase(unittest.TestCase):
         self.auth_context.user.email = 'admin@example.com'
         self.auth_context.user.is_admin = True
 
+    def test_change_password_user_not_found(self) -> None:
+        """Test password change when user does not exist."""
+        self.mock_db.match.return_value = []
+
+        response = self.client.post(
+            '/users/nobody@example.com/password',
+            json={'new_password': 'NewSecure123!@#'},
+        )
+
+        self.assertEqual(response.status_code, 404)
+        self.assertIn('not found', response.json()['detail'])
+
+    def test_change_password_no_current_password_provided(self) -> None:
+        """Changing own password without current_password returns 400."""
+        self.auth_context.user.email = 'test@example.com'
+        self.auth_context.user.is_admin = False
+
+        mock_user = models.User(
+            email='test@example.com',
+            display_name='Test',
+            password_hash='$argon2id$hashed',
+            is_active=True,
+            is_admin=False,
+            is_service_account=False,
+            created_at=datetime.datetime.now(datetime.UTC),
+        )
+        self.mock_db.match.return_value = [mock_user]
+
+        response = self.client.post(
+            '/users/test@example.com/password',
+            json={'new_password': 'NewSecure123!@#'},
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('required', response.json()['detail'])
+
+        self.auth_context.user.email = 'admin@example.com'
+        self.auth_context.user.is_admin = True
+
     def test_change_password_not_self_or_admin(self) -> None:
         """Test non-admin cannot change another password."""
         self.auth_context.user.is_admin = False
@@ -491,6 +530,45 @@ class UserEndpointsTestCase(unittest.TestCase):
             'user:update',
             'user:delete',
         }
+
+    def test_create_user_non_admin_cannot_create_admin(self) -> None:
+        """Non-admin users cannot create admin accounts."""
+        self.auth_context.user.is_admin = False
+
+        response = self.client.post(
+            '/users/',
+            json={
+                'email': 'new@example.com',
+                'display_name': 'New Admin',
+                'is_admin': True,
+                'organization_slug': 'default',
+                'role_slug': 'developer',
+            },
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertIn('admins', response.json()['detail'])
+        self.auth_context.user.is_admin = True
+
+    def test_create_user_unique_violation(self) -> None:
+        """Test creating user that hits UniqueViolation at DB level."""
+        import psycopg.errors
+
+        self.mock_db.match.return_value = []
+        self.mock_db.create.side_effect = psycopg.errors.UniqueViolation()
+
+        response = self.client.post(
+            '/users/',
+            json={
+                'email': 'dup@example.com',
+                'display_name': 'Dup User',
+                'organization_slug': 'default',
+                'role_slug': 'developer',
+            },
+        )
+
+        self.assertEqual(response.status_code, 409)
+        self.assertIn('already exists', response.json()['detail'])
 
     def test_patch_user_display_name(self) -> None:
         """Test patching only the user's display name."""
@@ -652,6 +730,74 @@ class UserEndpointsTestCase(unittest.TestCase):
 
         self.assertEqual(response.status_code, 400)
         self.assertIn('admins', response.json()['detail'])
+
+    def test_patch_user_organizations_reconciled(self) -> None:
+        """Patching organizations field reconciles memberships."""
+        existing_user = models.User(
+            email='dev@example.com',
+            display_name='Dev',
+            is_active=True,
+            is_admin=False,
+            is_service_account=False,
+            created_at=datetime.datetime(2024, 1, 1, tzinfo=datetime.UTC),
+        )
+        self.mock_db.match.return_value = [existing_user]
+        self.mock_db.merge.return_value = None
+
+        # execute calls: load existing orgs (empty), org validation,
+        # role validation, CREATE edge, load final orgs (empty)
+        self.mock_db.execute.side_effect = [
+            [],  # _load_user_memberships (existing)
+            [{'found': ['org1']}],  # org validation in _reconcile
+            [{'found': ['dev']}],  # role validation in _reconcile
+            [],  # CREATE edge
+            [],  # _load_user_memberships (final)
+        ]
+
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.patch(
+                '/users/dev%40example.com',
+                json=[
+                    {
+                        'op': 'add',
+                        'path': '/organizations/0',
+                        'value': {
+                            'organization_slug': 'org1',
+                            'role': 'dev',
+                        },
+                    }
+                ],
+            )
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_patch_user_invalid_organizations_returns_400(self) -> None:
+        """Patching organizations with a non-list value returns 400."""
+        existing_user = models.User(
+            email='dev@example.com',
+            display_name='Dev',
+            is_active=True,
+            is_admin=False,
+            is_service_account=False,
+            created_at=datetime.datetime(2024, 1, 1, tzinfo=datetime.UTC),
+        )
+        self.mock_db.match.return_value = [existing_user]
+        self.mock_db.execute.return_value = []
+
+        response = self.client.patch(
+            '/users/dev%40example.com',
+            json=[
+                {
+                    'op': 'replace',
+                    'path': '/organizations',
+                    'value': 'not-a-list',
+                }
+            ],
+        )
+
+        self.assertEqual(response.status_code, 400)
 
     def test_patch_user_service_account_clears_password(self) -> None:
         """Becoming a service account clears the password hash."""
@@ -867,6 +1013,272 @@ class OrgMembershipEndpointsTestCase(unittest.TestCase):
 
         self.assertEqual(response.status_code, 400)
         self.mock_db.execute.assert_not_awaited()
+
+
+class NormalizeMembershipInputTestCase(unittest.TestCase):
+    """Unit tests for _normalize_membership_input."""
+
+    def test_not_a_list_raises(self) -> None:
+        import fastapi
+
+        from imbi_api.endpoints.users import _normalize_membership_input
+
+        with self.assertRaises(fastapi.HTTPException) as ctx:
+            _normalize_membership_input('not-a-list')
+        self.assertEqual(ctx.exception.status_code, 400)
+        self.assertIn('array', ctx.exception.detail)
+
+    def test_entry_not_dict_raises(self) -> None:
+        import fastapi
+
+        from imbi_api.endpoints.users import _normalize_membership_input
+
+        with self.assertRaises(fastapi.HTTPException) as ctx:
+            _normalize_membership_input(['not-a-dict'])
+        self.assertEqual(ctx.exception.status_code, 400)
+        self.assertIn('objects', ctx.exception.detail)
+
+    def test_missing_org_slug_raises(self) -> None:
+        import fastapi
+
+        from imbi_api.endpoints.users import _normalize_membership_input
+
+        with self.assertRaises(fastapi.HTTPException) as ctx:
+            _normalize_membership_input([{'role': 'developer'}])
+        self.assertEqual(ctx.exception.status_code, 400)
+        self.assertIn('organization_slug', ctx.exception.detail)
+
+    def test_empty_org_slug_raises(self) -> None:
+        import fastapi
+
+        from imbi_api.endpoints.users import _normalize_membership_input
+
+        with self.assertRaises(fastapi.HTTPException) as ctx:
+            _normalize_membership_input(
+                [{'organization_slug': '', 'role': 'developer'}]
+            )
+        self.assertEqual(ctx.exception.status_code, 400)
+
+    def test_missing_role_raises(self) -> None:
+        import fastapi
+
+        from imbi_api.endpoints.users import _normalize_membership_input
+
+        with self.assertRaises(fastapi.HTTPException) as ctx:
+            _normalize_membership_input([{'organization_slug': 'org1'}])
+        self.assertEqual(ctx.exception.status_code, 400)
+        self.assertIn('role', ctx.exception.detail)
+
+    def test_empty_role_raises(self) -> None:
+        import fastapi
+
+        from imbi_api.endpoints.users import _normalize_membership_input
+
+        with self.assertRaises(fastapi.HTTPException) as ctx:
+            _normalize_membership_input(
+                [{'organization_slug': 'org1', 'role': ''}]
+            )
+        self.assertEqual(ctx.exception.status_code, 400)
+
+    def test_duplicate_slug_raises(self) -> None:
+        import fastapi
+
+        from imbi_api.endpoints.users import _normalize_membership_input
+
+        with self.assertRaises(fastapi.HTTPException) as ctx:
+            _normalize_membership_input(
+                [
+                    {'organization_slug': 'org1', 'role': 'developer'},
+                    {'organization_slug': 'org1', 'role': 'admin'},
+                ]
+            )
+        self.assertEqual(ctx.exception.status_code, 400)
+        self.assertIn('Duplicate', ctx.exception.detail)
+
+    def test_valid_input_returns_normalized(self) -> None:
+        from imbi_api.endpoints.users import _normalize_membership_input
+
+        result = _normalize_membership_input(
+            [{'organization_slug': 'org1', 'role': 'developer'}]
+        )
+        self.assertEqual(
+            result, [{'organization_slug': 'org1', 'role': 'developer'}]
+        )
+
+    def test_empty_list_returns_empty(self) -> None:
+        from imbi_api.endpoints.users import _normalize_membership_input
+
+        result = _normalize_membership_input([])
+        self.assertEqual(result, [])
+
+
+class ReconcileMembershipsTestCase(unittest.IsolatedAsyncioTestCase):
+    """Unit tests for _reconcile_user_memberships."""
+
+    async def test_adds_new_membership(self) -> None:
+        from unittest import mock
+
+        from imbi_common import graph
+
+        from imbi_api.endpoints.users import _reconcile_user_memberships
+
+        db = mock.AsyncMock(spec=graph.Graph)
+        # Org validation returns both found
+        # Role validation returns found
+        db.execute = mock.AsyncMock(
+            side_effect=[
+                [{'found': ['org1']}],  # org validation
+                [{'found': ['dev']}],  # role validation
+                [],  # CREATE membership
+            ]
+        )
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            await _reconcile_user_memberships(
+                db,
+                'u@example.com',
+                [],
+                [{'organization_slug': 'org1', 'role': 'dev'}],
+            )
+        self.assertEqual(db.execute.call_count, 3)
+
+    async def test_removes_old_membership(self) -> None:
+        from unittest import mock
+
+        from imbi_common import graph
+
+        from imbi_api.endpoints.users import _reconcile_user_memberships
+
+        db = mock.AsyncMock(spec=graph.Graph)
+        db.execute = mock.AsyncMock(return_value=[])
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            await _reconcile_user_memberships(
+                db,
+                'u@example.com',
+                [{'organization_slug': 'org1', 'role': 'dev'}],
+                [],
+            )
+        # No org/role validation needed; only the DELETE query
+        self.assertEqual(db.execute.call_count, 1)
+
+    async def test_updates_role_when_changed(self) -> None:
+        from unittest import mock
+
+        from imbi_common import graph
+
+        from imbi_api.endpoints.users import _reconcile_user_memberships
+
+        db = mock.AsyncMock(spec=graph.Graph)
+        db.execute = mock.AsyncMock(
+            side_effect=[
+                [{'found': ['org1']}],
+                [{'found': ['admin']}],
+                [],
+            ]
+        )
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            await _reconcile_user_memberships(
+                db,
+                'u@example.com',
+                [{'organization_slug': 'org1', 'role': 'dev'}],
+                [{'organization_slug': 'org1', 'role': 'admin'}],
+            )
+        # org validation + role validation + SET update
+        self.assertEqual(db.execute.call_count, 3)
+
+    async def test_no_change_when_role_same(self) -> None:
+        from unittest import mock
+
+        from imbi_common import graph
+
+        from imbi_api.endpoints.users import _reconcile_user_memberships
+
+        db = mock.AsyncMock(spec=graph.Graph)
+        db.execute = mock.AsyncMock(
+            side_effect=[
+                [{'found': ['org1']}],
+                [{'found': ['dev']}],
+            ]
+        )
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            await _reconcile_user_memberships(
+                db,
+                'u@example.com',
+                [{'organization_slug': 'org1', 'role': 'dev'}],
+                [{'organization_slug': 'org1', 'role': 'dev'}],
+            )
+        # org validation + role validation only (no edge mutation needed)
+        self.assertEqual(db.execute.call_count, 2)
+
+    async def test_unknown_org_raises(self) -> None:
+        from unittest import mock
+
+        import fastapi
+        from imbi_common import graph
+
+        from imbi_api.endpoints.users import _reconcile_user_memberships
+
+        db = mock.AsyncMock(spec=graph.Graph)
+        db.execute = mock.AsyncMock(return_value=[{'found': []}])
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            with self.assertRaises(fastapi.HTTPException) as ctx:
+                await _reconcile_user_memberships(
+                    db,
+                    'u@example.com',
+                    [],
+                    [{'organization_slug': 'ghost', 'role': 'dev'}],
+                )
+        self.assertEqual(ctx.exception.status_code, 400)
+        self.assertIn('Unknown organization', ctx.exception.detail)
+
+    async def test_unknown_role_raises(self) -> None:
+        from unittest import mock
+
+        import fastapi
+        from imbi_common import graph
+
+        from imbi_api.endpoints.users import _reconcile_user_memberships
+
+        db = mock.AsyncMock(spec=graph.Graph)
+        db.execute = mock.AsyncMock(
+            side_effect=[
+                [{'found': ['org1']}],
+                [{'found': []}],
+            ]
+        )
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            with self.assertRaises(fastapi.HTTPException) as ctx:
+                await _reconcile_user_memberships(
+                    db,
+                    'u@example.com',
+                    [],
+                    [{'organization_slug': 'org1', 'role': 'ghost'}],
+                )
+        self.assertEqual(ctx.exception.status_code, 400)
+        self.assertIn('Unknown role', ctx.exception.detail)
+
+    async def test_empty_desired_no_queries(self) -> None:
+        from unittest import mock
+
+        from imbi_common import graph
+
+        from imbi_api.endpoints.users import _reconcile_user_memberships
+
+        db = mock.AsyncMock(spec=graph.Graph)
+        db.execute = mock.AsyncMock(return_value=[])
+        await _reconcile_user_memberships(db, 'u@example.com', [], [])
+        db.execute.assert_not_called()
 
 
 class ServiceAccountGuardRailsTestCase(unittest.TestCase):

--- a/tests/test_lifespans.py
+++ b/tests/test_lifespans.py
@@ -56,30 +56,6 @@ class ApplicationLifespanTestCase(unittest.TestCase):
             any('Valkey unavailable' in line for line in cm.output)
         )
 
-    def test_score_worker_skipped_when_valkey_returns_none(self) -> None:
-        """score_worker_hook exits early when get_client() returns None."""
-        loop = asyncio.new_event_loop()
-        try:
-            with (
-                unittest.mock.patch(
-                    'imbi_api.lifespans.valkey.get_client',
-                    return_value=None,
-                ),
-                self.assertLogs(lifespans.LOGGER, level='WARNING') as cm,
-            ):
-
-                async def _run() -> None:
-                    async with lifespans.score_worker_hook():
-                        pass
-
-                loop.run_until_complete(_run())
-        finally:
-            loop.close()
-
-        self.assertTrue(
-            any('Valkey unavailable' in line for line in cm.output)
-        )
-
     def test_score_worker_skipped_when_graph_not_ready(self) -> None:
         """score_worker_hook exits early when _graph is None."""
         mock_client = unittest.mock.AsyncMock()

--- a/tests/test_lifespans.py
+++ b/tests/test_lifespans.py
@@ -1,3 +1,5 @@
+import asyncio
+import unittest
 import unittest.mock
 
 from fastapi import testclient
@@ -29,6 +31,78 @@ class ApplicationLifespanTestCase(unittest.TestCase):
             str(error.exception),
             'ClickHouse initialization failed',
         )
+
+    def test_score_worker_skipped_when_valkey_raises(self) -> None:
+        """score_worker_hook exits early when valkey.get_client() raises."""
+        loop = asyncio.new_event_loop()
+        try:
+            with (
+                unittest.mock.patch(
+                    'imbi_api.lifespans.valkey.get_client',
+                    side_effect=RuntimeError('no valkey'),
+                ),
+                self.assertLogs(lifespans.LOGGER, level='WARNING') as cm,
+            ):
+
+                async def _run() -> None:
+                    async with lifespans.score_worker_hook():
+                        pass
+
+                loop.run_until_complete(_run())
+        finally:
+            loop.close()
+
+        self.assertTrue(
+            any('Valkey unavailable' in line for line in cm.output)
+        )
+
+    def test_score_worker_skipped_when_valkey_returns_none(self) -> None:
+        """score_worker_hook exits early when get_client() returns None."""
+        loop = asyncio.new_event_loop()
+        try:
+            with (
+                unittest.mock.patch(
+                    'imbi_api.lifespans.valkey.get_client',
+                    return_value=None,
+                ),
+                self.assertLogs(lifespans.LOGGER, level='WARNING') as cm,
+            ):
+
+                async def _run() -> None:
+                    async with lifespans.score_worker_hook():
+                        pass
+
+                loop.run_until_complete(_run())
+        finally:
+            loop.close()
+
+        self.assertTrue(
+            any('Valkey unavailable' in line for line in cm.output)
+        )
+
+    def test_score_worker_skipped_when_graph_not_ready(self) -> None:
+        """score_worker_hook exits early when _graph is None."""
+        mock_client = unittest.mock.AsyncMock()
+        loop = asyncio.new_event_loop()
+        try:
+            with (
+                unittest.mock.patch(
+                    'imbi_api.lifespans.valkey.get_client',
+                    return_value=mock_client,
+                ),
+                unittest.mock.patch.object(lifespans, '_graph', None),
+                self.assertLogs(lifespans.LOGGER, level='WARNING') as cm,
+            ):
+
+                async def _run() -> None:
+                    async with lifespans.score_worker_hook():
+                        pass
+
+                loop.run_until_complete(_run())
+        finally:
+            loop.close()
+
+        self.assertTrue(any('Graph not ready' in line for line in cm.output))
 
     def test_openapi_refresh_blueprint_failure(self) -> None:
         failure = RuntimeError()

--- a/tests/test_scoring_queue.py
+++ b/tests/test_scoring_queue.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import unittest
 from unittest import mock
 
@@ -204,6 +205,180 @@ class HandleEntriesWithDlqTest(unittest.IsolatedAsyncioTestCase):
                     check_dlq=True,
                 )
         process.assert_not_called()
+
+
+class ProcessMessageTests(unittest.IsolatedAsyncioTestCase):
+    async def test_skips_missing_project_id(self) -> None:
+        db = mock.AsyncMock()
+        ch = mock.AsyncMock()
+        await score_queue._process_message(db, ch, {})
+        db.match.assert_not_called()
+
+    async def test_skips_when_project_not_found(self) -> None:
+        db = mock.AsyncMock()
+        db.match = mock.AsyncMock(return_value=[])
+        ch = mock.AsyncMock()
+        with self.assertLogs('imbi_api.scoring.queue', level='INFO'):
+            await score_queue._process_message(
+                db, ch, {'project_id': 'p1', 'reason': 'policy_change'}
+            )
+
+    async def test_computes_and_records_score(self) -> None:
+        from imbi_common import models
+
+        db = mock.AsyncMock()
+        project = mock.MagicMock(spec=models.Project)
+        project.score = 0.5
+        db.match = mock.AsyncMock(return_value=[project])
+        ch = mock.AsyncMock()
+        with (
+            mock.patch(
+                'imbi_api.scoring.queue.compute_score',
+                mock.AsyncMock(return_value=(0.8, None)),
+            ),
+            mock.patch(
+                'imbi_api.scoring.queue.record_score_change',
+                mock.AsyncMock(),
+            ) as mock_record,
+        ):
+            await score_queue._process_message(
+                db, ch, {'project_id': 'p1', 'reason': 'attribute_change'}
+            )
+            mock_record.assert_awaited_once()
+
+    async def test_uses_zero_when_project_score_is_none(self) -> None:
+        from imbi_common import models
+
+        db = mock.AsyncMock()
+        project = mock.MagicMock(spec=models.Project)
+        project.score = None
+        db.match = mock.AsyncMock(return_value=[project])
+        ch = mock.AsyncMock()
+        with (
+            mock.patch(
+                'imbi_api.scoring.queue.compute_score',
+                mock.AsyncMock(return_value=(0.5, None)),
+            ),
+            mock.patch(
+                'imbi_api.scoring.queue.record_score_change',
+                mock.AsyncMock(),
+            ) as mock_record,
+        ):
+            await score_queue._process_message(
+                db, ch, {'project_id': 'p1', 'reason': 'attribute_change'}
+            )
+            _args, kwargs = mock_record.call_args
+            # previous should have been 0.0 (default when score is None)
+            self.assertEqual(
+                kwargs.get('previous', _args[4] if len(_args) > 4 else None),
+                0.0,
+            )
+
+
+class ConsumeRecomputeTests(unittest.IsolatedAsyncioTestCase):
+    async def test_processes_messages_then_stops(self) -> None:
+        client = mock.AsyncMock()
+        client.xgroup_create = mock.AsyncMock(
+            side_effect=Exception('BUSYGROUP Consumer Group already exists')
+        )
+        client.xautoclaim = mock.AsyncMock(return_value=['0-0', [], []])
+        stop = asyncio.Event()
+
+        # First xreadgroup call returns a message; second stops the loop
+        call_count = 0
+
+        async def xreadgroup_side_effect(*_args, **_kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return [[b'stream', [(b'1-0', {b'project_id': b'p1'})]]]
+            stop.set()
+            return []
+
+        client.xreadgroup = mock.AsyncMock(side_effect=xreadgroup_side_effect)
+        client.xack = mock.AsyncMock()
+
+        with mock.patch.object(
+            score_queue, '_process_message', mock.AsyncMock()
+        ):
+            await score_queue.consume_recompute(
+                client,
+                mock.AsyncMock(),
+                mock.AsyncMock(),
+                stop=stop,
+            )
+
+        client.xack.assert_awaited()
+
+    async def test_handles_xreadgroup_exception(self) -> None:
+        import asyncio
+
+        client = mock.AsyncMock()
+        client.xgroup_create = mock.AsyncMock(
+            side_effect=Exception('BUSYGROUP Consumer Group already exists')
+        )
+        client.xautoclaim = mock.AsyncMock(return_value=['0-0', [], []])
+        stop = asyncio.Event()
+        call_count = 0
+
+        async def xreadgroup_fail(*_args, **_kwargs):
+            nonlocal call_count
+            call_count += 1
+            stop.set()
+            raise RuntimeError('xreadgroup failed')
+
+        client.xreadgroup = mock.AsyncMock(side_effect=xreadgroup_fail)
+
+        with self.assertLogs('imbi_api.scoring.queue', level='ERROR'):
+            await score_queue.consume_recompute(
+                client,
+                mock.AsyncMock(),
+                mock.AsyncMock(),
+                stop=stop,
+            )
+
+    async def test_processes_stale_messages(self) -> None:
+        import asyncio
+
+        client = mock.AsyncMock()
+        client.xgroup_create = mock.AsyncMock(
+            side_effect=Exception('BUSYGROUP Consumer Group already exists')
+        )
+        stop = asyncio.Event()
+        stale_entries = [(b'0-1', {b'project_id': b'stale'})]
+        client.xautoclaim = mock.AsyncMock(
+            return_value=['0-0', stale_entries, []]
+        )
+        client.xack = mock.AsyncMock()
+
+        call_count = 0
+
+        async def xreadgroup_side_effect(*_args, **_kwargs):
+            nonlocal call_count
+            call_count += 1
+            stop.set()
+            return []
+
+        client.xreadgroup = mock.AsyncMock(side_effect=xreadgroup_side_effect)
+
+        with (
+            mock.patch.object(
+                score_queue,
+                '_maybe_dead_letter',
+                mock.AsyncMock(return_value=False),
+            ),
+            mock.patch.object(
+                score_queue, '_process_message', mock.AsyncMock()
+            ) as mock_proc,
+        ):
+            await score_queue.consume_recompute(
+                client,
+                mock.AsyncMock(),
+                mock.AsyncMock(),
+                stop=stop,
+            )
+
+        mock_proc.assert_awaited_once()
 
 
 class AllProjectIdsTests(unittest.IsolatedAsyncioTestCase):

--- a/tests/test_scoring_queue.py
+++ b/tests/test_scoring_queue.py
@@ -91,3 +91,138 @@ class ConsumerTests(unittest.IsolatedAsyncioTestCase):
             client, b'1-0', {'project_id': 'p1'}
         )
         self.assertFalse(result)
+
+    async def test_dlq_skipped_when_empty_pending(self) -> None:
+        client = mock.AsyncMock()
+        client.xpending_range = mock.AsyncMock(return_value=[])
+        result = await score_queue._maybe_dead_letter(
+            client, b'1-0', {'project_id': 'p1'}
+        )
+        self.assertFalse(result)
+
+    async def test_dlq_xpending_exception_returns_false(self) -> None:
+        client = mock.AsyncMock()
+        client.xpending_range = mock.AsyncMock(
+            side_effect=RuntimeError('nope')
+        )
+        result = await score_queue._maybe_dead_letter(
+            client, b'1-0', {'project_id': 'p1'}
+        )
+        self.assertFalse(result)
+
+    async def test_dlq_tuple_entry_path(self) -> None:
+        """Cover the tuple-based entry format from xpending_range."""
+        client = mock.AsyncMock()
+        # Simulate a tuple-based response: [msg_id, consumer, idle, deliveries]
+        client.xpending_range = mock.AsyncMock(
+            return_value=[(b'1-0', b'worker-0', 70000, 6)]
+        )
+        client.xadd = mock.AsyncMock()
+        client.xack = mock.AsyncMock()
+        result = await score_queue._maybe_dead_letter(
+            client, b'1-0', {'project_id': 'p1'}
+        )
+        self.assertTrue(result)
+
+
+class EnqueueNoneClientTest(unittest.IsolatedAsyncioTestCase):
+    async def test_none_client_returns_false(self) -> None:
+        result = await score_queue.enqueue_recompute(
+            None, 'p1', 'bulk_rescore'
+        )
+        self.assertFalse(result)
+
+    async def test_enqueue_exception_returns_false(self) -> None:
+        client = mock.AsyncMock()
+        client.set = mock.AsyncMock(side_effect=RuntimeError('conn error'))
+        result = await score_queue.enqueue_recompute(
+            client, 'p1', 'attribute_change'
+        )
+        self.assertFalse(result)
+
+
+class EnsureGroupTests(unittest.IsolatedAsyncioTestCase):
+    async def test_busygroup_is_ignored(self) -> None:
+        client = mock.AsyncMock()
+        client.xgroup_create = mock.AsyncMock(
+            side_effect=Exception('BUSYGROUP Consumer Group already exists')
+        )
+        await score_queue.ensure_group(client)  # should not raise
+
+    async def test_other_error_is_logged(self) -> None:
+        client = mock.AsyncMock()
+        client.xgroup_create = mock.AsyncMock(
+            side_effect=Exception('some other error')
+        )
+        with self.assertLogs('imbi_api.scoring.queue', level='WARNING'):
+            await score_queue.ensure_group(client)
+
+
+class ClaimStaleTests(unittest.IsolatedAsyncioTestCase):
+    async def test_returns_entries_from_xautoclaim(self) -> None:
+        client = mock.AsyncMock()
+        entries = [(b'1-0', {b'project_id': b'p1'})]
+        client.xautoclaim = mock.AsyncMock(return_value=['0-0', entries, []])
+        result = await score_queue._claim_stale(client, 'worker-0')
+        self.assertEqual(result, entries)
+
+    async def test_returns_empty_on_exception(self) -> None:
+        client = mock.AsyncMock()
+        client.xautoclaim = mock.AsyncMock(side_effect=Exception('fail'))
+        result = await score_queue._claim_stale(client, 'worker-0')
+        self.assertEqual(result, [])
+
+    async def test_returns_empty_when_result_malformed(self) -> None:
+        client = mock.AsyncMock()
+        client.xautoclaim = mock.AsyncMock(return_value=None)
+        result = await score_queue._claim_stale(client, 'worker-0')
+        self.assertEqual(result, [])
+
+    async def test_returns_empty_when_msgs_not_list(self) -> None:
+        client = mock.AsyncMock()
+        # result[1] is not a list
+        client.xautoclaim = mock.AsyncMock(return_value=['0-0', None, []])
+        result = await score_queue._claim_stale(client, 'worker-0')
+        self.assertEqual(result, [])
+
+
+class HandleEntriesWithDlqTest(unittest.IsolatedAsyncioTestCase):
+    async def test_dead_letter_prevents_processing(self) -> None:
+        client = mock.AsyncMock()
+        process = mock.AsyncMock()
+        with mock.patch.object(
+            score_queue,
+            '_maybe_dead_letter',
+            mock.AsyncMock(return_value=True),
+        ):
+            with mock.patch.object(score_queue, '_process_message', process):
+                await score_queue._handle_entries(
+                    client,
+                    [(b'1-0', {b'project_id': b'p1'})],
+                    mock.AsyncMock(),
+                    mock.AsyncMock(),
+                    check_dlq=True,
+                )
+        process.assert_not_called()
+
+
+class AllProjectIdsTests(unittest.IsolatedAsyncioTestCase):
+    async def test_all_project_ids_no_filter(self) -> None:
+        db = mock.AsyncMock()
+        db.execute = mock.AsyncMock(return_value=[{'id': 'a1'}, {'id': 'b2'}])
+        result = await score_queue.all_project_ids(db)
+        self.assertEqual(result, ['a1', 'b2'])
+
+    async def test_all_project_ids_with_type_filter(self) -> None:
+        db = mock.AsyncMock()
+        db.execute = mock.AsyncMock(return_value=[{'id': 'c3'}])
+        result = await score_queue.all_project_ids(db, 'service')
+        self.assertEqual(result, ['c3'])
+
+
+class ProjectsOfTypeTest(unittest.IsolatedAsyncioTestCase):
+    async def test_projects_of_type(self) -> None:
+        db = mock.AsyncMock()
+        db.execute = mock.AsyncMock(return_value=[{'id': 'p1'}, {'id': 'p2'}])
+        result = await score_queue.projects_of_type(db, 'service')
+        self.assertEqual(result, ['p1', 'p2'])

--- a/tests/test_scoring_queue.py
+++ b/tests/test_scoring_queue.py
@@ -1,0 +1,93 @@
+"""Tests for the scoring recompute queue."""
+
+from __future__ import annotations
+
+import unittest
+from unittest import mock
+
+from imbi_api.scoring import queue as score_queue
+
+
+class EnqueueTests(unittest.IsolatedAsyncioTestCase):
+    async def test_enqueue_xadds_when_debounce_acquired(self) -> None:
+        client = mock.AsyncMock()
+        client.set = mock.AsyncMock(return_value=True)
+        client.xadd = mock.AsyncMock()
+        result = await score_queue.enqueue_recompute(
+            client, 'p1', 'attribute_change'
+        )
+        self.assertTrue(result)
+        client.set.assert_awaited_once()
+        client.xadd.assert_awaited_once()
+        args, _kwargs = client.xadd.await_args
+        self.assertEqual(args[0], score_queue.STREAM)
+        self.assertEqual(args[1]['project_id'], 'p1')
+        self.assertEqual(args[1]['reason'], 'attribute_change')
+
+    async def test_enqueue_skips_when_debounced(self) -> None:
+        client = mock.AsyncMock()
+        client.set = mock.AsyncMock(return_value=None)
+        client.xadd = mock.AsyncMock()
+        result = await score_queue.enqueue_recompute(
+            client, 'p1', 'attribute_change'
+        )
+        self.assertFalse(result)
+        client.xadd.assert_not_called()
+
+
+class ConsumerTests(unittest.IsolatedAsyncioTestCase):
+    async def test_xack_on_success(self) -> None:
+        client = mock.AsyncMock()
+        client.xack = mock.AsyncMock()
+        with mock.patch.object(
+            score_queue, '_process_message', mock.AsyncMock()
+        ):
+            await score_queue._handle_entries(
+                client,
+                [(b'1-0', {b'project_id': b'p1'})],
+                mock.AsyncMock(),
+                mock.AsyncMock(),
+            )
+        client.xack.assert_awaited_once()
+
+    async def test_no_xack_on_exception(self) -> None:
+        client = mock.AsyncMock()
+        client.xack = mock.AsyncMock()
+        with mock.patch.object(
+            score_queue,
+            '_process_message',
+            mock.AsyncMock(side_effect=RuntimeError('boom')),
+        ):
+            await score_queue._handle_entries(
+                client,
+                [(b'1-0', {b'project_id': b'p1'})],
+                mock.AsyncMock(),
+                mock.AsyncMock(),
+            )
+        client.xack.assert_not_called()
+
+    async def test_dlq_after_max_deliveries(self) -> None:
+        client = mock.AsyncMock()
+        client.xpending_range = mock.AsyncMock(
+            return_value=[{'times_delivered': 6}]
+        )
+        client.xadd = mock.AsyncMock()
+        client.xack = mock.AsyncMock()
+        result = await score_queue._maybe_dead_letter(
+            client, b'1-0', {'project_id': 'p1'}
+        )
+        self.assertTrue(result)
+        client.xadd.assert_awaited_once()
+        client.xack.assert_awaited_once()
+
+    async def test_dlq_skipped_below_threshold(self) -> None:
+        client = mock.AsyncMock()
+        client.xpending_range = mock.AsyncMock(
+            return_value=[{'times_delivered': 1}]
+        )
+        client.xadd = mock.AsyncMock()
+        client.xack = mock.AsyncMock()
+        result = await score_queue._maybe_dead_letter(
+            client, b'1-0', {'project_id': 'p1'}
+        )
+        self.assertFalse(result)

--- a/tests/test_scoring_triggers.py
+++ b/tests/test_scoring_triggers.py
@@ -1,0 +1,57 @@
+"""Tests for scoring recompute triggers."""
+
+from __future__ import annotations
+
+import unittest
+from unittest import mock
+
+
+class AffectedProjectsTests(unittest.IsolatedAsyncioTestCase):
+    async def test_affected_projects_returns_ids(self) -> None:
+        from imbi_common.scoring import AttributePolicy
+
+        from imbi_api.scoring import queue
+
+        policy = AttributePolicy(
+            name='Lang',
+            slug='lang',
+            attribute_name='programming_language',
+            weight=10,
+            value_score_map={'Python': 100},
+        )
+        db = mock.AsyncMock()
+        # blueprints.get_model returns model whose model_fields includes
+        # the attribute_name.
+        fake_model = mock.MagicMock()
+        fake_model.model_fields = {'programming_language': object()}
+        with mock.patch(
+            'imbi_api.scoring.queue.blueprints.get_model',
+            mock.AsyncMock(return_value=fake_model),
+        ):
+            db.execute = mock.AsyncMock(
+                return_value=[{'id': 'p1'}, {'id': 'p2'}]
+            )
+            ids = await queue.affected_projects(db, policy)
+        self.assertEqual(ids, ['p1', 'p2'])
+
+    async def test_affected_projects_empty_when_attr_missing(self) -> None:
+        from imbi_common.scoring import AttributePolicy
+
+        from imbi_api.scoring import queue
+
+        policy = AttributePolicy(
+            name='Lang',
+            slug='lang',
+            attribute_name='nonexistent',
+            weight=10,
+            value_score_map={'a': 100},
+        )
+        db = mock.AsyncMock()
+        fake_model = mock.MagicMock()
+        fake_model.model_fields = {'name': object()}
+        with mock.patch(
+            'imbi_api.scoring.queue.blueprints.get_model',
+            mock.AsyncMock(return_value=fake_model),
+        ):
+            ids = await queue.affected_projects(db, policy)
+        self.assertEqual(ids, [])

--- a/uv.lock
+++ b/uv.lock
@@ -897,7 +897,7 @@ requires-dist = [
     { name = "fastapi" },
     { name = "filetype" },
     { name = "httpx", specifier = ">=0.28.1" },
-    { name = "imbi-common", extras = ["databases", "server"], git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=main" },
+    { name = "imbi-common", extras = ["databases", "server"], git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=feature%2Fscoring-foundation" },
     { name = "jinja2" },
     { name = "jsonpatch", specifier = ">=1.33" },
     { name = "nanoid", specifier = ">=2.0.0" },
@@ -944,7 +944,7 @@ docs = [
 [[package]]
 name = "imbi-common"
 version = "0.1.0"
-source = { git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=main#bb440f3d19c7e1d48ff216549717da1e77a45647" }
+source = { git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=feature%2Fscoring-foundation#2606c1349b5bc4ad6f4493f942b607c4e025724b" }
 dependencies = [
     { name = "cryptography" },
     { name = "jsonschema-models" },


### PR DESCRIPTION
## Summary

Adds a project health scoring subsystem to imbi-api: scoring policies stored in the graph, a Valkey Streams recompute queue, ClickHouse score history, and REST endpoints for managing policies and querying scores.

Also includes an earlier commit that extends `PATCH /users/{email}` to manage `organizations` memberships via JSON Patch.

## Problem

There is no way to quantify the health or compliance of a project against a set of defined criteria. Without scores, it is hard to surface which projects need attention or to report on fleet-wide health trends over time.

## Solution

**Scoring policies** (`ScoringPolicy` graph nodes) define a mapping from a project attribute value to a numeric score (0–100) and an optional set of `ProjectType` targets. The `imbi_common.scoring.compute_score` engine (from imbi-common#64) evaluates all enabled policies against a project's attributes and produces a weighted aggregate score plus a per-attribute breakdown.

**Recompute queue** — producers call `enqueue_recompute(client, project_id, reason)` after any mutation that could affect a project's score. A 5-second per-project debounce key in Valkey prevents duplicate work. The `score_worker_hook` lifespan starts a background `asyncio` task that reads from a Valkey Stream (`imbi:score-recompute`) using consumer groups (xreadgroup + xautoclaim for at-least-once delivery). Messages that exceed `MAX_DELIVERIES` are moved to a dead-letter stream.

**Trigger points** that enqueue a recompute:
- Project create/patch (`attribute_change`)
- Blueprint create/patch/delete — Project blueprints only (`blueprint_change`)
- Scoring policy create/patch/delete (`policy_change`)
- Bulk rescore endpoint (`bulk_rescore`)

**New endpoints:**
- `GET/POST/PATCH/DELETE /scoring/policies/`
- `GET /organizations/{org}/projects/{id}/score/history`
- `GET /scores/rollup?dimension=team|project_type|organization`
- `POST /scoring/rescore`

**New permissions:** `scoring_policy:read`, `scoring_policy:write`, `scoring_policy:delete`, `scoring_policy:rescore_all`

**Project response** gains optional `score` and `breakdown` fields; `GET /projects/{id}?breakdown=true` triggers a live compute for inspection.

Enqueue loops are parallelised with `asyncio.gather` throughout.

## Impact

- Requires **imbi-common#64** (`feature/scoring-foundation`) to be merged and released first — that branch adds `imbi_common.scoring` (engine, models, history writer) and `valkey.get_client()` singleton accessor needed by `score_worker_hook`.
- A Valkey instance must be reachable (already provisioned in the Okteto stack). If Valkey is unavailable, trigger sites silently skip enqueueing and the worker hook logs a warning rather than crashing startup.
- ClickHouse tables `score_history` and `score_latest` are expected to exist (DDL is part of the imbi-common scoring migrations).
- No existing endpoints change their default response shape; `breakdown` is opt-in via query parameter.

## Testing

- Unit tests cover the recompute queue (enqueue debounce, xack on success, no xack on exception, DLQ after max deliveries), trigger logic (`affected_projects`, attribute-missing early return), and all scoring/policy endpoints with mocked graph and Valkey.
- All 19 new tests pass; existing test suite unaffected.