### PR TITLE
Add events log, score trend, and per-project rescore

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -217,4 +217,4 @@ url = "https://pypi.org/simple"
 default = true
 
 [tool.uv.sources]
-imbi-common = { git = "https://github.com/AWeber-Imbi/imbi-common.git", rev = "feature/scoring-foundation" }
+imbi-common = { git = "https://github.com/AWeber-Imbi/imbi-common.git", rev = "main" }

--- a/src/imbi_api/domain/scoring.py
+++ b/src/imbi_api/domain/scoring.py
@@ -23,6 +23,7 @@ __all__ = [
     'ScoreHistoryPoint',
     'ScoreHistoryResponse',
     'ScoreRollupRow',
+    'ScoreTrend',
     'ScoringPolicy',
 ]
 
@@ -63,6 +64,7 @@ class PolicyUpdate(pydantic.BaseModel):
 class RescoreRequest(pydantic.BaseModel):
     model_config = pydantic.ConfigDict(extra='forbid')
 
+    project_id: str | None = None
     project_type_slug: str | None = None
     blueprint_slug: str | None = None
     policy_slug: str | None = None
@@ -70,6 +72,13 @@ class RescoreRequest(pydantic.BaseModel):
 
 class RescoreResponse(pydantic.BaseModel):
     enqueued: int
+
+
+class ScoreTrend(pydantic.BaseModel):
+    current: float | None
+    previous: float | None
+    delta: float | None
+    period_days: int
 
 
 class ScoreHistoryPoint(pydantic.BaseModel):

--- a/src/imbi_api/endpoints/__init__.py
+++ b/src/imbi_api/endpoints/__init__.py
@@ -6,6 +6,7 @@ from .auth import auth_router
 from .auth_providers import auth_providers_router
 from .blueprints import blueprint_router
 from .client_credentials import client_credentials_router
+from .events import events_router
 from .local_auth import local_auth_router
 from .mfa import mfa_router
 from .operations_log import operations_log_router
@@ -26,6 +27,7 @@ prefixed_routers: list[fastapi.APIRouter] = [
     auth_router,
     blueprint_router,
     client_credentials_router,
+    events_router,
     local_auth_router,
     mfa_router,
     operations_log_router,

--- a/src/imbi_api/endpoints/events.py
+++ b/src/imbi_api/endpoints/events.py
@@ -1,0 +1,264 @@
+"""Events log endpoints.
+
+System-generated events (project attribute changes, etc.) are written here
+internally. These are read-only from the API's perspective.
+
+The global router lives at /events; the project-scoped router is mounted at
+/organizations/{org_slug}/projects/{project_id}/events.
+"""
+
+from __future__ import annotations
+
+import base64
+import datetime
+import typing
+import urllib.parse
+
+import fastapi
+import fastapi.encoders
+import fastapi.responses
+import pydantic
+from imbi_common import clickhouse
+
+from imbi_api.auth import permissions
+
+events_router = fastapi.APIRouter(prefix='/events', tags=['Events'])
+events_project_router = fastapi.APIRouter(tags=['Events'])
+
+DEFAULT_LIMIT: int = 50
+MAX_LIMIT: int = 500
+
+
+class EventRecord(pydantic.BaseModel):
+    id: str
+    project_id: str
+    recorded_at: datetime.datetime
+    type: str
+    third_party_service: str
+    attributed_to: str
+    metadata: dict[str, typing.Any]
+    payload: dict[str, typing.Any]
+
+
+class EventsPage(pydantic.BaseModel):
+    data: list[EventRecord]
+
+
+def _encode_cursor(recorded_at: datetime.datetime, entry_id: str) -> str:
+    raw = f'{recorded_at.isoformat()}|{entry_id}'.encode()
+    return base64.urlsafe_b64encode(raw).rstrip(b'=').decode('ascii')
+
+
+def _decode_cursor(cursor: str) -> tuple[datetime.datetime, str] | None:
+    if not cursor:
+        return None
+    padding = '=' * (-len(cursor) % 4)
+    try:
+        raw = base64.urlsafe_b64decode(cursor + padding).decode('utf-8')
+    except (ValueError, UnicodeDecodeError):
+        return None
+    if '|' not in raw:
+        return None
+    ts_str, _, entry_id = raw.partition('|')
+    if not entry_id:
+        return None
+    try:
+        ts = datetime.datetime.fromisoformat(ts_str)
+    except ValueError:
+        return None
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=datetime.UTC)
+    return ts.astimezone(datetime.UTC), entry_id
+
+
+def _parse_iso(value: str, field_name: str) -> datetime.datetime:
+    try:
+        parsed = datetime.datetime.fromisoformat(value)
+    except ValueError as err:
+        raise fastapi.HTTPException(
+            status_code=400,
+            detail=f'Invalid ISO timestamp for {field_name!r}',
+        ) from err
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=datetime.UTC)
+    return parsed.astimezone(datetime.UTC)
+
+
+def _build_link_header(
+    request: fastapi.Request,
+    next_cursor: str | None,
+) -> str:
+    url = request.url
+    base_params = {
+        k: v for k, v in request.query_params.multi_items() if k != 'cursor'
+    }
+
+    def _url_with(params: dict[str, str]) -> str:
+        scheme_host_path = f'{url.scheme}://{url.netloc}{url.path}'
+        if not params:
+            return scheme_host_path
+        return f'{scheme_host_path}?{urllib.parse.urlencode(params)}'
+
+    links = [f'<{_url_with(base_params)}>; rel="first"']
+    if next_cursor is not None:
+        next_params = dict(base_params)
+        next_params['cursor'] = next_cursor
+        links.append(f'<{_url_with(next_params)}>; rel="next"')
+    return ', '.join(links)
+
+
+def _row_to_response(row: dict[str, typing.Any]) -> dict[str, typing.Any]:
+    out: dict[str, typing.Any] = {}
+    for k, v in row.items():
+        if isinstance(v, datetime.datetime) and v.tzinfo is None:
+            v = v.replace(tzinfo=datetime.UTC)
+        out[k] = v
+    return out
+
+
+_FILTER_FIELDS: tuple[str, ...] = (
+    'project_id',
+    'type',
+    'attributed_to',
+    'third_party_service',
+)
+
+
+async def _list_impl(
+    *,
+    request: fastapi.Request,
+    limit: int = DEFAULT_LIMIT,
+    cursor: str | None = None,
+    forced_filters: dict[str, str] | None = None,
+    query_filters: dict[str, str | None] | None = None,
+    since: str | None = None,
+    until: str | None = None,
+) -> fastapi.Response:
+    if limit < 1 or limit > MAX_LIMIT:
+        raise fastapi.HTTPException(
+            status_code=400,
+            detail=f'limit must be 1..{MAX_LIMIT}',
+        )
+
+    clauses: list[str] = []
+    params: dict[str, typing.Any] = {}
+
+    all_filters: dict[str, str | None] = {
+        **(query_filters or {}),
+        **(forced_filters or {}),
+    }
+
+    for field in _FILTER_FIELDS:
+        value = all_filters.get(field)
+        if value is not None:
+            clauses.append(f'{field} = {{{field}:String}}')
+            params[field] = value
+
+    if since is not None:
+        params['since'] = _parse_iso(since, 'since')
+        clauses.append('recorded_at >= {since:DateTime64(3)}')
+    if until is not None:
+        params['until'] = _parse_iso(until, 'until')
+        clauses.append('recorded_at < {until:DateTime64(3)}')
+
+    if cursor is not None:
+        decoded = _decode_cursor(cursor)
+        if decoded is None:
+            raise fastapi.HTTPException(
+                status_code=400, detail='Invalid cursor'
+            )
+        cursor_ts, cursor_id = decoded
+        params['cursor_ts'] = cursor_ts
+        params['cursor_id'] = cursor_id
+        clauses.append(
+            '(recorded_at, id) < '
+            '({cursor_ts:DateTime64(3)}, {cursor_id:String})'
+        )
+
+    where = ' AND '.join(clauses) if clauses else '1=1'
+    params['row_limit'] = limit + 1
+    sql: str = (
+        'SELECT * FROM events WHERE '  # noqa: S608
+        + where
+        + ' ORDER BY recorded_at DESC, id DESC LIMIT {row_limit:UInt32}'
+    )
+
+    rows = await clickhouse.query(sql, params)
+    next_cursor: str | None = None
+    if len(rows) > limit:
+        rows.pop()
+        last = rows[-1]
+        next_cursor = _encode_cursor(last['recorded_at'], last['id'])
+
+    body = {'data': [_row_to_response(r) for r in rows]}
+    response = fastapi.responses.JSONResponse(
+        fastapi.encoders.jsonable_encoder(body)
+    )
+    response.headers['Link'] = _build_link_header(request, next_cursor)
+    return response
+
+
+@events_router.get('/', response_model=EventsPage)
+async def list_events(
+    request: fastapi.Request,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('project:read'),
+        ),
+    ],
+    limit: int = DEFAULT_LIMIT,
+    cursor: str | None = None,
+    project_id: str | None = None,
+    type: str | None = None,
+    attributed_to: str | None = None,
+    since: str | None = None,
+    until: str | None = None,
+) -> fastapi.Response:
+    """List events (newest first, keyset paginated)."""
+    return await _list_impl(
+        request=request,
+        limit=limit,
+        cursor=cursor,
+        query_filters={
+            'project_id': project_id,
+            'type': type,
+            'attributed_to': attributed_to,
+        },
+        since=since,
+        until=until,
+    )
+
+
+@events_project_router.get('/', response_model=EventsPage)
+async def list_project_events(
+    request: fastapi.Request,
+    org_slug: str,
+    project_id: str,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('project:read'),
+        ),
+    ],
+    limit: int = DEFAULT_LIMIT,
+    cursor: str | None = None,
+    type: str | None = None,
+    attributed_to: str | None = None,
+    since: str | None = None,
+    until: str | None = None,
+) -> fastapi.Response:
+    """List events for a specific project."""
+    del org_slug
+    return await _list_impl(
+        request=request,
+        limit=limit,
+        cursor=cursor,
+        forced_filters={'project_id': project_id},
+        query_filters={
+            'type': type,
+            'attributed_to': attributed_to,
+        },
+        since=since,
+        until=until,
+    )

--- a/src/imbi_api/endpoints/organizations.py
+++ b/src/imbi_api/endpoints/organizations.py
@@ -14,6 +14,7 @@ from imbi_api.auth import permissions
 from imbi_api.relationships import build_relationships
 
 from .environments import environments_router
+from .events import events_project_router
 from .link_definitions import link_definitions_router
 from .note_templates import note_templates_router
 from .notes import notes_project_router, notes_router
@@ -59,6 +60,10 @@ organizations_router.include_router(
 organizations_router.include_router(
     webhooks_router,
     prefix='/{org_slug}/webhooks',
+)
+organizations_router.include_router(
+    events_project_router,
+    prefix='/{org_slug}/projects/{project_id}/events',
 )
 organizations_router.include_router(
     operations_log_project_router,

--- a/src/imbi_api/endpoints/projects.py
+++ b/src/imbi_api/endpoints/projects.py
@@ -14,6 +14,7 @@ import nanoid
 import psycopg
 import pydantic
 from imbi_common import blueprints, graph, models
+from imbi_common.clickhouse import client as ch_client
 from imbi_common.scoring import compute_score
 
 from imbi_api import patch as json_patch
@@ -244,6 +245,73 @@ async def _validate_env_slugs(
         raise fastapi.HTTPException(
             status_code=422,
             detail=(f'Environment slug(s) not found: {sorted(missing)!r}'),
+        )
+
+
+_EVENT_SKIP_FIELDS: frozenset[str] = frozenset(
+    {
+        'id',
+        'created_at',
+        'updated_at',
+        'score',
+        'breakdown',
+        'relationships',
+    }
+)
+
+
+async def _emit_change_events(
+    project_id: str,
+    principal: str,
+    before: dict[str, typing.Any],
+    after: dict[str, typing.Any],
+) -> None:
+    """Emit one events row per changed field into ClickHouse.
+
+    Errors are logged but do not bubble up — the graph write already
+    succeeded and we do not want a ClickHouse hiccup to fail the request.
+    """
+    now = datetime.datetime.now(datetime.UTC)
+    rows: list[list[typing.Any]] = []
+    for key in set(before) | set(after):
+        if key in _EVENT_SKIP_FIELDS:
+            continue
+        old_val = before.get(key)
+        new_val = after.get(key)
+        if old_val == new_val:
+            continue
+        rows.append(
+            [
+                nanoid.generate(),
+                project_id,
+                now,
+                'project-change',
+                'internal',
+                principal,
+                {},
+                {'field': key, 'old': old_val, 'new': new_val},
+            ]
+        )
+    if not rows:
+        return
+    try:
+        await ch_client.Clickhouse.get_instance().insert(
+            'events',
+            rows,
+            [
+                'id',
+                'project_id',
+                'recorded_at',
+                'type',
+                'third_party_service',
+                'attributed_to',
+                'metadata',
+                'payload',
+            ],
+        )
+    except Exception:
+        LOGGER.exception(
+            'Failed to emit change events for project %s', project_id
         )
 
 
@@ -827,8 +895,9 @@ async def get_project(
     if breakdown:
         try:
             score, bd = await compute_score(db, project_id)
-            response.score = score
-            response.breakdown = bd
+            if score is not None:
+                response.score = score
+                response.breakdown = bd
         except ValueError:
             pass
     return response
@@ -1494,6 +1563,7 @@ async def patch_project(
         **extras,
     }
 
+    before_snapshot = dict(patchable)
     patched = json_patch.apply_patch(patchable, operations)
 
     try:
@@ -1517,6 +1587,12 @@ async def patch_project(
     )
     await score_queue.enqueue_recompute(
         valkey_client, project_id, 'attribute_change'
+    )
+    await _emit_change_events(
+        project_id,
+        auth.principal_name,
+        before_snapshot,
+        patched,
     )
     return response
 

--- a/src/imbi_api/endpoints/scoring.py
+++ b/src/imbi_api/endpoints/scoring.py
@@ -110,6 +110,55 @@ async def get_score_history(
     )
 
 
+@scoring_router.get(
+    '/organizations/{org_slug}/projects/{project_id}/score/trend'
+)
+async def get_score_trend(
+    org_slug: str,
+    project_id: str,
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(permissions.require_permission('project:read')),
+    ],
+    days: int = 30,
+) -> scoring_models.ScoreTrend:
+    """Return the current score and its change over the last *days* days."""
+    rows = await db.execute(
+        'MATCH (p:Project {{id: {id}}})'
+        '-[:OWNED_BY]->(:Team)'
+        '-[:BELONGS_TO]->(:Organization {{slug: {org}}})'
+        ' RETURN p.score AS score',
+        {'id': project_id, 'org': org_slug},
+        ['score'],
+    )
+    if not rows:
+        raise fastapi.HTTPException(
+            status_code=404, detail=f'Project {project_id!r} not found'
+        )
+    raw_score = graph.parse_agtype(rows[0]['score'])
+    current = float(raw_score) if raw_score is not None else None
+    prev_rows = await clickhouse.query(
+        'SELECT score FROM score_history'
+        ' WHERE project_id = {project_id:String}'
+        ' AND timestamp <= now() - INTERVAL {days:UInt16} DAY'
+        ' ORDER BY timestamp DESC LIMIT 1',
+        {'project_id': project_id, 'days': days},
+    )
+    previous = float(prev_rows[0]['score']) if prev_rows else None
+    delta = (
+        round(current - previous, 2)
+        if current is not None and previous is not None
+        else None
+    )
+    return scoring_models.ScoreTrend(
+        current=current,
+        previous=previous,
+        delta=delta,
+        period_days=days,
+    )
+
+
 _DIMENSION_QUERY: dict[str, typing.LiteralString] = {
     'team': (
         'MATCH (p:Project)-[:OWNED_BY]->(t:Team)'
@@ -213,7 +262,9 @@ async def rescore(
 ) -> scoring_models.RescoreResponse:
     body = body or scoring_models.RescoreRequest()
     project_ids: list[str] = []
-    if body.policy_slug:
+    if body.project_id:
+        project_ids = [body.project_id]
+    elif body.policy_slug:
         policy = await load_policy(db, body.policy_slug)
         if policy is None:
             raise fastapi.HTTPException(

--- a/src/imbi_api/endpoints/scoring_policies.py
+++ b/src/imbi_api/endpoints/scoring_policies.py
@@ -11,6 +11,7 @@ import fastapi
 import psycopg.errors
 from imbi_common import graph
 
+from imbi_api import patch as json_patch
 from imbi_api.auth import permissions
 from imbi_api.domain import scoring as scoring_models
 from imbi_api.scoring import OptionalValkeyClient
@@ -222,10 +223,15 @@ async def create_policy(
     return refreshed
 
 
+_POLICY_READONLY_PATHS: frozenset[str] = json_patch.READONLY_PATHS | frozenset(
+    ['/slug', '/category']
+)
+
+
 @scoring_policies_router.patch('/{slug}')
 async def update_policy(
     slug: str,
-    data: scoring_models.PolicyUpdate,
+    operations: list[json_patch.PatchOperation],
     db: graph.Pool,
     valkey_client: OptionalValkeyClient,
     auth: typing.Annotated[
@@ -235,35 +241,48 @@ async def update_policy(
         ),
     ],
 ) -> scoring_models.ScoringPolicy:
+    """Partially update a scoring policy using JSON Patch (RFC 6902).
+
+    The fields ``slug`` and ``category`` are immutable and cannot be patched.
+    ``targets`` (a list of project-type slugs) may be replaced via a JSON
+    Pointer ``/targets`` replace operation.
+    """
     existing = await load_policy(db, slug)
     if existing is None:
         raise fastapi.HTTPException(
             status_code=404,
             detail=f'Scoring policy {slug!r} not found',
         )
-    updates = data.model_dump(exclude_unset=True, exclude={'targets'})
-    if updates:
-        merged = existing.model_dump(exclude={'targets'})
-        merged.update(updates)
-        validated = scoring_models.ScoringPolicy.model_validate(merged)
-        props = _serialize_maps(
-            validated.model_dump(exclude={'targets', 'slug', 'category'})
-        )
-        set_pairs = ', '.join(f'sp.{k} = {{{k}}}' for k in props)
-        params: dict[str, typing.Any] = dict(props)
-        params['slug'] = slug
-        update_q = (
-            'MATCH (sp:ScoringPolicy {{slug: {slug}}}) SET '
-            + set_pairs
-            + ' RETURN sp'
-        )
-        await db.execute(update_q, params, ['sp'])  # type: ignore[arg-type]
-    if data.targets is not None:
-        if data.targets:
+    document: dict[str, typing.Any] = existing.model_dump()
+    patched = json_patch.apply_patch(
+        document, operations, readonly_paths=_POLICY_READONLY_PATHS
+    )
+    new_targets: list[str] = patched.get('targets', existing.targets)
+    try:
+        validated = scoring_models.ScoringPolicy.model_validate(patched)
+    except Exception as exc:
+        raise fastapi.HTTPException(
+            status_code=400,
+            detail=f'Invalid patch result: {exc}',
+        ) from exc
+    props = _serialize_maps(
+        validated.model_dump(exclude={'targets', 'slug', 'category'})
+    )
+    set_pairs = ', '.join(f'sp.{k} = {{{k}}}' for k in props)
+    params: dict[str, typing.Any] = dict(props)
+    params['slug'] = slug
+    update_q = (
+        'MATCH (sp:ScoringPolicy {{slug: {slug}}}) SET '
+        + set_pairs
+        + ' RETURN sp'
+    )
+    await db.execute(update_q, params, ['sp'])  # type: ignore[arg-type]
+    if set(new_targets) != set(existing.targets):
+        if new_targets:
             found_rows = await db.execute(
                 'MATCH (pt:ProjectType) WHERE pt.slug IN {slugs}'
                 ' RETURN collect(pt.slug) AS found',
-                {'slugs': data.targets},
+                {'slugs': new_targets},
                 ['found'],
             )
             found: list[str] = (
@@ -271,7 +290,7 @@ async def update_policy(
                 if found_rows
                 else []
             ) or []
-            missing = set(data.targets) - set(found)
+            missing = set(new_targets) - set(found)
             if missing:
                 raise fastapi.HTTPException(
                     status_code=400,
@@ -282,14 +301,14 @@ async def update_policy(
             ' DELETE r'
         )
         await db.execute(clear_q, {'slug': slug})
-        if data.targets:
+        if new_targets:
             link_q: typing.LiteralString = (
                 'MATCH (sp:ScoringPolicy {{slug: {slug}}})'
                 ' UNWIND {targets} AS ts'
                 ' MATCH (pt:ProjectType {{slug: ts}})'
                 ' MERGE (sp)-[:TARGETS]->(pt)'
             )
-            await db.execute(link_q, {'slug': slug, 'targets': data.targets})
+            await db.execute(link_q, {'slug': slug, 'targets': new_targets})
     refreshed = await load_policy(db, slug)
     if refreshed is None:
         raise fastapi.HTTPException(

--- a/src/imbi_api/lifespans.py
+++ b/src/imbi_api/lifespans.py
@@ -85,6 +85,7 @@ async def score_worker_hook() -> abc.AsyncIterator[None]:
         return
     ch = clickhouse.client.Clickhouse.get_instance()
     stop = asyncio.Event()
+    LOGGER.info('Score recompute worker starting')
     task = asyncio.create_task(
         score_queue.consume_recompute(client, _graph, ch, stop=stop)
     )
@@ -98,4 +99,4 @@ async def score_worker_hook() -> abc.AsyncIterator[None]:
         except asyncio.CancelledError:
             pass
         except Exception:  # noqa: BLE001
-            LOGGER.debug('score worker exited with error', exc_info=True)
+            LOGGER.warning('Score worker exited with error', exc_info=True)

--- a/src/imbi_api/scoring/queue.py
+++ b/src/imbi_api/scoring/queue.py
@@ -15,6 +15,7 @@ from collections import abc
 from imbi_common import blueprints, clickhouse, graph, models
 from imbi_common.scoring import (
     AttributePolicy,
+    clear_score,
     compute_score,
     record_score_change,
 )
@@ -88,19 +89,19 @@ async def affected_projects(
     extended = await blueprints.get_model(db, models.Project)
     if policy.attribute_name not in extended.model_fields:
         return []
-    query: typing.LiteralString = (
-        'MATCH (sp:ScoringPolicy {{slug: {slug}}})'
-        ' OPTIONAL MATCH (sp)-[:TARGETS]->(pt:ProjectType)'
-        ' WITH collect(pt.slug) AS targets'
-        ' MATCH (p:Project)'
-        ' OPTIONAL MATCH (p)-[:TYPE]->(ppt:ProjectType)'
-        ' WITH p, targets, collect(ppt.slug) AS p_types'
-        ' WHERE size(targets) = 0 OR'
-        ' any(t IN p_types WHERE t IN targets)'
-        ' RETURN p.id AS id'
+    if not policy.targets:
+        return await all_project_ids(db)
+    id_lists = await asyncio.gather(
+        *[projects_of_type(db, slug) for slug in policy.targets]
     )
-    rows = await db.execute(query, {'slug': policy.slug}, ['id'])
-    return [v for r in rows if (v := graph.parse_agtype(r['id']))]
+    seen: set[str] = set()
+    result: list[str] = []
+    for pids in id_lists:
+        for pid in pids:
+            if pid not in seen:
+                seen.add(pid)
+                result.append(pid)
+    return result
 
 
 async def projects_of_type(
@@ -140,8 +141,22 @@ async def _process_message(
         return
     project = matches[0]
     previous = project.score if project.score is not None else 0.0
-    score, _ = await compute_score(db, project_id)
-    await record_score_change(ch, db, project, score, previous, reason)
+    LOGGER.info(
+        'Recomputing score for project %s (reason: %s)', project_id, reason
+    )
+    score, breakdown = await compute_score(db, project_id)
+    if score is None:
+        LOGGER.info(
+            'No applicable policies for %s; clearing score', project_id
+        )
+        await clear_score(db, project)
+    else:
+        LOGGER.info(
+            'Project %s score: %.1f -> %.1f', project_id, previous, score
+        )
+        await record_score_change(
+            ch, db, project, score, previous, reason, breakdown
+        )
 
 
 def _decode_fields(
@@ -241,6 +256,9 @@ async def consume_recompute(
 ) -> None:
     """Run the recompute consumer loop until *stop* is set."""
     await ensure_group(client)
+    LOGGER.info(
+        'Score recompute consumer loop running (consumer=%s)', consumer
+    )
     while stop is None or not stop.is_set():
         stale = await _claim_stale(client, consumer)
         if stale:

--- a/tests/endpoints/test_events.py
+++ b/tests/endpoints/test_events.py
@@ -1,0 +1,288 @@
+"""Tests for the events log endpoints."""
+
+from __future__ import annotations
+
+import datetime
+import typing
+import unittest
+from unittest import mock
+
+from fastapi import testclient
+from imbi_common import graph
+
+from imbi_api import app
+from imbi_api import models as api_models
+from imbi_api.auth import permissions as api_permissions
+from imbi_api.endpoints import events
+
+
+def _row(
+    *,
+    recorded_at: datetime.datetime | None = None,
+    entry_id: str = 'evt-1',
+    project_id: str = 'p1',
+) -> dict[str, typing.Any]:
+    return {
+        'id': entry_id,
+        'project_id': project_id,
+        'recorded_at': recorded_at
+        or datetime.datetime(2026, 4, 1, 12, 0, tzinfo=datetime.UTC),
+        'type': 'project-change',
+        'third_party_service': 'internal',
+        'attributed_to': 'alice@example.com',
+        'metadata': {},
+        'payload': {'field': 'name', 'old': 'A', 'new': 'B'},
+    }
+
+
+class _EventsTestBase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.test_app = app.create_app()
+        self.user = api_models.User(
+            email='alice@example.com',
+            display_name='Alice',
+            is_active=True,
+            is_admin=True,
+            is_service_account=False,
+            created_at=datetime.datetime.now(datetime.UTC),
+        )
+        self.auth = api_permissions.AuthContext(
+            user=self.user,
+            session_id='s',
+            auth_method='jwt',
+            permissions=set(),
+        )
+
+        async def _current_user() -> api_permissions.AuthContext:
+            return self.auth
+
+        self.test_app.dependency_overrides[
+            api_permissions.get_current_user
+        ] = _current_user
+
+        self.mock_db = mock.AsyncMock(spec=graph.Graph)
+        self.test_app.dependency_overrides[graph._inject_graph] = (
+            lambda: self.mock_db
+        )
+
+        self.query_patcher = mock.patch(
+            'imbi_common.clickhouse.query',
+            new_callable=mock.AsyncMock,
+        )
+        self.mock_query = self.query_patcher.start()
+        self.addCleanup(self.query_patcher.stop)
+
+        self.client = testclient.TestClient(self.test_app)
+        self.addCleanup(self.client.close)
+
+
+class CursorCodecTests(unittest.TestCase):
+    def test_round_trip(self) -> None:
+        ts = datetime.datetime(2026, 4, 1, 12, 0, tzinfo=datetime.UTC)
+        encoded = events._encode_cursor(ts, 'evt-1')
+        decoded = events._decode_cursor(encoded)
+        self.assertIsNotNone(decoded)
+        assert decoded is not None
+        decoded_ts, decoded_id = decoded
+        self.assertEqual(decoded_ts, ts)
+        self.assertEqual(decoded_id, 'evt-1')
+
+    def test_decode_empty_returns_none(self) -> None:
+        self.assertIsNone(events._decode_cursor(''))
+
+    def test_decode_invalid_base64_returns_none(self) -> None:
+        # Non-utf8 bytes via raw b64
+        import base64
+
+        bad = base64.urlsafe_b64encode(b'\xff\xfe\xfd').rstrip(b'=').decode()
+        self.assertIsNone(events._decode_cursor(bad))
+
+    def test_decode_missing_separator_returns_none(self) -> None:
+        import base64
+
+        payload = (
+            base64.urlsafe_b64encode(b'no-separator').rstrip(b'=').decode()
+        )
+        self.assertIsNone(events._decode_cursor(payload))
+
+    def test_decode_empty_id_returns_none(self) -> None:
+        import base64
+
+        payload = (
+            base64.urlsafe_b64encode(b'2026-04-01T12:00:00|')
+            .rstrip(b'=')
+            .decode()
+        )
+        self.assertIsNone(events._decode_cursor(payload))
+
+    def test_decode_invalid_timestamp_returns_none(self) -> None:
+        import base64
+
+        payload = (
+            base64.urlsafe_b64encode(b'not-a-timestamp|evt-1')
+            .rstrip(b'=')
+            .decode()
+        )
+        self.assertIsNone(events._decode_cursor(payload))
+
+    def test_naive_timestamp_gets_utc(self) -> None:
+        import base64
+
+        payload = (
+            base64.urlsafe_b64encode(b'2026-04-01T12:00:00|evt-1')
+            .rstrip(b'=')
+            .decode()
+        )
+        decoded = events._decode_cursor(payload)
+        assert decoded is not None
+        ts, _ = decoded
+        self.assertEqual(ts.tzinfo, datetime.UTC)
+
+
+class ParseIsoTests(unittest.TestCase):
+    def test_invalid_raises_400(self) -> None:
+        import fastapi
+
+        with self.assertRaises(fastapi.HTTPException) as ctx:
+            events._parse_iso('garbage', 'since')
+        self.assertEqual(ctx.exception.status_code, 400)
+
+    def test_naive_treated_as_utc(self) -> None:
+        result = events._parse_iso('2026-04-01T12:00:00', 'since')
+        self.assertEqual(result.tzinfo, datetime.UTC)
+
+
+class RowToResponseTests(unittest.TestCase):
+    def test_naive_datetime_made_utc(self) -> None:
+        # ClickHouse may return naive datetimes; the helper must
+        # stamp them as UTC.
+        naive = datetime.datetime(  # noqa: DTZ001
+            2026, 4, 1, 12, 0
+        )
+        out = events._row_to_response({'recorded_at': naive, 'id': 'a'})
+        recorded = out['recorded_at']
+        assert isinstance(recorded, datetime.datetime)
+        self.assertEqual(recorded.tzinfo, datetime.UTC)
+
+
+class GlobalListTests(_EventsTestBase):
+    def test_list_returns_200(self) -> None:
+        self.mock_query.return_value = [_row()]
+        response = self.client.get('/events/')
+        self.assertEqual(response.status_code, 200, response.text)
+        body = response.json()
+        self.assertEqual(len(body['data']), 1)
+        self.assertEqual(body['data'][0]['id'], 'evt-1')
+        self.assertIn('Link', response.headers)
+        self.assertIn('rel="first"', response.headers['Link'])
+
+    def test_list_with_filters(self) -> None:
+        self.mock_query.return_value = [_row()]
+        response = self.client.get(
+            '/events/',
+            params={
+                'project_id': 'p1',
+                'type': 'project-change',
+                'attributed_to': 'alice@example.com',
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        call = self.mock_query.await_args
+        params = call.args[1]
+        self.assertEqual(params['project_id'], 'p1')
+        self.assertEqual(params['type'], 'project-change')
+        self.assertEqual(params['attributed_to'], 'alice@example.com')
+
+    def test_list_with_since_until(self) -> None:
+        self.mock_query.return_value = []
+        response = self.client.get(
+            '/events/',
+            params={
+                'since': '2026-03-01T00:00:00Z',
+                'until': '2026-04-01T00:00:00Z',
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        call = self.mock_query.await_args
+        sql = call.args[0]
+        self.assertIn('recorded_at >=', sql)
+        self.assertIn('recorded_at <', sql)
+
+    def test_list_with_invalid_since_returns_400(self) -> None:
+        response = self.client.get('/events/', params={'since': 'garbage'})
+        self.assertEqual(response.status_code, 400)
+
+    def test_list_with_invalid_limit_returns_400(self) -> None:
+        response = self.client.get('/events/', params={'limit': 0})
+        self.assertEqual(response.status_code, 400)
+
+    def test_list_with_too_large_limit_returns_400(self) -> None:
+        response = self.client.get('/events/', params={'limit': 10_000})
+        self.assertEqual(response.status_code, 400)
+
+    def test_list_emits_next_cursor_when_more_rows(self) -> None:
+        rows = [
+            _row(
+                entry_id=f'evt-{i}',
+                recorded_at=datetime.datetime(
+                    2026, 4, i + 1, tzinfo=datetime.UTC
+                ),
+            )
+            for i in range(3)
+        ]
+        self.mock_query.return_value = rows
+        response = self.client.get('/events/', params={'limit': 2})
+        self.assertEqual(response.status_code, 200)
+        body = response.json()
+        # Should drop the extra row used for pagination detection
+        self.assertEqual(len(body['data']), 2)
+        link = response.headers['Link']
+        self.assertIn('rel="next"', link)
+        self.assertIn('cursor=', link)
+
+    def test_list_with_invalid_cursor_returns_400(self) -> None:
+        self.mock_query.return_value = []
+        response = self.client.get('/events/', params={'cursor': '!!!'})
+        self.assertEqual(response.status_code, 400)
+
+    def test_list_with_valid_cursor_filters_query(self) -> None:
+        self.mock_query.return_value = []
+        cursor = events._encode_cursor(
+            datetime.datetime(2026, 4, 1, tzinfo=datetime.UTC), 'evt-x'
+        )
+        response = self.client.get('/events/', params={'cursor': cursor})
+        self.assertEqual(response.status_code, 200)
+        call = self.mock_query.await_args
+        sql = call.args[0]
+        params = call.args[1]
+        self.assertIn('cursor_ts', params)
+        self.assertEqual(params['cursor_id'], 'evt-x')
+        self.assertIn('(recorded_at, id) <', sql)
+
+
+class ProjectScopedListTests(_EventsTestBase):
+    def test_list_for_project(self) -> None:
+        self.mock_query.return_value = [_row()]
+        response = self.client.get('/organizations/eng/projects/p1/events/')
+        self.assertEqual(response.status_code, 200, response.text)
+        call = self.mock_query.await_args
+        params = call.args[1]
+        # forced filter overrides query filter
+        self.assertEqual(params['project_id'], 'p1')
+
+    def test_link_header_omits_cursor_in_first(self) -> None:
+        self.mock_query.return_value = []
+        response = self.client.get(
+            '/organizations/eng/projects/p1/events/',
+            params={'type': 'project-change'},
+        )
+        self.assertEqual(response.status_code, 200)
+        link = response.headers['Link']
+        self.assertIn('rel="first"', link)
+        # The first link must not carry a cursor query param
+        first = link.split(',')[0]
+        self.assertNotIn('cursor=', first)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/endpoints/test_projects.py
+++ b/tests/endpoints/test_projects.py
@@ -1035,3 +1035,78 @@ class DeleteProjectRelationshipTestCase(_RelationshipsTestBase):
 
         self.assertEqual(response.status_code, 404)
         self.assertIn('not found', response.json()['detail'])
+
+
+class EmitChangeEventsTestCase(unittest.IsolatedAsyncioTestCase):
+    """Tests for the project-change events emitter."""
+
+    async def test_no_changes_skips_clickhouse_insert(self) -> None:
+        from imbi_api.endpoints import projects
+
+        with mock.patch(
+            'imbi_api.endpoints.projects.ch_client.Clickhouse.get_instance'
+        ) as mock_get:
+            await projects._emit_change_events(
+                'p1', 'alice', {'name': 'A'}, {'name': 'A'}
+            )
+        mock_get.assert_not_called()
+
+    async def test_emits_one_row_per_changed_field(self) -> None:
+        from imbi_api.endpoints import projects
+
+        mock_instance = mock.AsyncMock()
+        mock_instance.insert = mock.AsyncMock()
+        with mock.patch(
+            'imbi_api.endpoints.projects.ch_client.Clickhouse.get_instance',
+            return_value=mock_instance,
+        ):
+            await projects._emit_change_events(
+                'p1',
+                'alice',
+                {'name': 'A', 'description': 'old', 'id': 'p1'},
+                {'name': 'B', 'description': 'new', 'id': 'p1'},
+            )
+        mock_instance.insert.assert_awaited_once()
+        args = mock_instance.insert.await_args.args
+        self.assertEqual(args[0], 'events')
+        rows = args[1]
+        self.assertEqual(len(rows), 2)
+        # `id` was in skip-list so it should not appear
+        fields = {row[7]['field'] for row in rows}
+        self.assertEqual(fields, {'name', 'description'})
+
+    async def test_skip_list_excludes_score_and_relationships(self) -> None:
+        from imbi_api.endpoints import projects
+
+        mock_instance = mock.AsyncMock()
+        mock_instance.insert = mock.AsyncMock()
+        with mock.patch(
+            'imbi_api.endpoints.projects.ch_client.Clickhouse.get_instance',
+            return_value=mock_instance,
+        ):
+            await projects._emit_change_events(
+                'p1',
+                'alice',
+                {'score': 10, 'relationships': []},
+                {'score': 20, 'relationships': [{'a': 1}]},
+            )
+        # All changes filtered out — no insert call
+        mock_instance.insert.assert_not_awaited()
+
+    async def test_clickhouse_failure_is_logged_not_raised(self) -> None:
+        from imbi_api.endpoints import projects
+
+        mock_instance = mock.AsyncMock()
+        mock_instance.insert = mock.AsyncMock(side_effect=RuntimeError('boom'))
+        with (
+            mock.patch(
+                'imbi_api.endpoints.projects.ch_client.Clickhouse.'
+                'get_instance',
+                return_value=mock_instance,
+            ),
+            self.assertLogs('imbi_api.endpoints.projects', level='ERROR'),
+        ):
+            # Must not raise even when ClickHouse insert fails
+            await projects._emit_change_events(
+                'p1', 'alice', {'name': 'A'}, {'name': 'B'}
+            )

--- a/tests/endpoints/test_scoring.py
+++ b/tests/endpoints/test_scoring.py
@@ -242,3 +242,12 @@ class ScoringEndpointsTestCase(unittest.TestCase):
             )
         self.assertEqual(response.status_code, 200, response.text)
         self.assertEqual(response.json()['enqueued'], 1)
+
+    def test_rescore_by_project_id(self) -> None:
+        response = self.client.post(
+            '/scoring/rescore', json={'project_id': 'proj-abc'}
+        )
+        self.assertEqual(response.status_code, 200, response.text)
+        self.assertEqual(response.json()['enqueued'], 1)
+        args = self.mock_valkey.xadd.call_args.args
+        self.assertEqual(args[1]['project_id'], 'proj-abc')

--- a/tests/endpoints/test_scoring.py
+++ b/tests/endpoints/test_scoring.py
@@ -251,3 +251,55 @@ class ScoringEndpointsTestCase(unittest.TestCase):
         self.assertEqual(response.json()['enqueued'], 1)
         args = self.mock_valkey.xadd.call_args.args
         self.assertEqual(args[1]['project_id'], 'proj-abc')
+
+    def test_score_trend_returns_delta(self) -> None:
+        self.mock_db.execute = mock.AsyncMock(
+            return_value=[{'score': 90.0}],
+        )
+        with (
+            mock.patch(
+                'imbi_api.endpoints.scoring.clickhouse.query',
+                mock.AsyncMock(return_value=[{'score': 80.0}]),
+            ),
+            mock.patch(
+                'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+            ),
+        ):
+            response = self.client.get(
+                '/organizations/eng/projects/p1/score/trend',
+                params={'days': 30},
+            )
+        self.assertEqual(response.status_code, 200, response.text)
+        body = response.json()
+        self.assertEqual(body['current'], 90.0)
+        self.assertEqual(body['previous'], 80.0)
+        self.assertEqual(body['delta'], 10.0)
+        self.assertEqual(body['period_days'], 30)
+
+    def test_score_trend_handles_missing_history(self) -> None:
+        self.mock_db.execute = mock.AsyncMock(
+            return_value=[{'score': 90.0}],
+        )
+        with (
+            mock.patch(
+                'imbi_api.endpoints.scoring.clickhouse.query',
+                mock.AsyncMock(return_value=[]),
+            ),
+            mock.patch(
+                'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+            ),
+        ):
+            response = self.client.get(
+                '/organizations/eng/projects/p1/score/trend',
+            )
+        self.assertEqual(response.status_code, 200, response.text)
+        body = response.json()
+        self.assertIsNone(body['previous'])
+        self.assertIsNone(body['delta'])
+
+    def test_score_trend_404_when_project_missing(self) -> None:
+        self.mock_db.execute = mock.AsyncMock(return_value=[])
+        response = self.client.get(
+            '/organizations/eng/projects/missing/score/trend',
+        )
+        self.assertEqual(response.status_code, 404)

--- a/tests/endpoints/test_scoring_policies.py
+++ b/tests/endpoints/test_scoring_policies.py
@@ -150,7 +150,7 @@ class ScoringPolicyEndpointsTestCase(unittest.TestCase):
         ):
             response = self.client.patch(
                 '/scoring/policies/python-version',
-                json={'weight': 80},
+                json=[{'op': 'replace', 'path': '/weight', 'value': 80}],
             )
         self.assertEqual(response.status_code, 200, response.text)
         self.assertGreaterEqual(self.mock_valkey.xadd.await_count, 1)
@@ -262,6 +262,7 @@ class ScoringPolicyEndpointsTestCase(unittest.TestCase):
         self.mock_db.execute = mock.AsyncMock(
             side_effect=[
                 [{'sp': self._policy_props(), 'targets': []}],  # load existing
+                [],  # SET props
                 [{'found': ['service']}],  # target validation (new)
                 [],  # clear targets
                 [],  # link new targets
@@ -282,7 +283,13 @@ class ScoringPolicyEndpointsTestCase(unittest.TestCase):
         ):
             response = self.client.patch(
                 '/scoring/policies/python-version',
-                json={'targets': ['service']},
+                json=[
+                    {
+                        'op': 'replace',
+                        'path': '/targets',
+                        'value': ['service'],
+                    }
+                ],
             )
         self.assertEqual(response.status_code, 200, response.text)
 
@@ -290,6 +297,7 @@ class ScoringPolicyEndpointsTestCase(unittest.TestCase):
         self.mock_db.execute = mock.AsyncMock(
             side_effect=[
                 [{'sp': self._policy_props(), 'targets': []}],  # load existing
+                [],  # SET props
                 [{'found': []}],  # target validation finds nothing
             ]
         )
@@ -298,7 +306,13 @@ class ScoringPolicyEndpointsTestCase(unittest.TestCase):
         ):
             response = self.client.patch(
                 '/scoring/policies/python-version',
-                json={'targets': ['ghost-type']},
+                json=[
+                    {
+                        'op': 'replace',
+                        'path': '/targets',
+                        'value': ['ghost-type'],
+                    }
+                ],
             )
         self.assertEqual(response.status_code, 400)
         self.assertIn('Unknown project type', response.json()['detail'])
@@ -308,6 +322,7 @@ class ScoringPolicyEndpointsTestCase(unittest.TestCase):
         self.mock_db.execute = mock.AsyncMock(
             side_effect=[
                 [{'sp': self._policy_props(), 'targets': ['service']}],  # load
+                [],  # SET props
                 [],  # clear targets
                 [{'sp': self._policy_props(), 'targets': []}],  # reload
             ]
@@ -319,14 +334,15 @@ class ScoringPolicyEndpointsTestCase(unittest.TestCase):
         ):
             response = self.client.patch(
                 '/scoring/policies/python-version',
-                json={'targets': []},
+                json=[{'op': 'replace', 'path': '/targets', 'value': []}],
             )
         self.assertEqual(response.status_code, 200, response.text)
 
     def test_update_policy_not_found(self) -> None:
         self.mock_db.execute = mock.AsyncMock(return_value=[])
         response = self.client.patch(
-            '/scoring/policies/missing', json={'weight': 10}
+            '/scoring/policies/missing',
+            json=[{'op': 'replace', 'path': '/weight', 'value': 10}],
         )
         self.assertEqual(response.status_code, 404)
 

--- a/tests/test_scoring_queue.py
+++ b/tests/test_scoring_queue.py
@@ -401,3 +401,90 @@ class ProjectsOfTypeTest(unittest.IsolatedAsyncioTestCase):
         db.execute = mock.AsyncMock(return_value=[{'id': 'p1'}, {'id': 'p2'}])
         result = await score_queue.projects_of_type(db, 'service')
         self.assertEqual(result, ['p1', 'p2'])
+
+
+class AffectedProjectsTests(unittest.IsolatedAsyncioTestCase):
+    def _policy(
+        self, attribute_name: str, targets: list[str] | None = None
+    ) -> object:
+        from imbi_common.scoring import models as sm
+
+        return sm.AttributePolicy(
+            name='p',
+            slug='p',
+            attribute_name=attribute_name,
+            weight=10,
+            value_score_map={'py': 100},
+            targets=targets or [],
+        )
+
+    async def test_unknown_attribute_returns_empty(self) -> None:
+        from imbi_common import models
+
+        class _Extended(models.Project):
+            lang: str | None = None
+
+        db = mock.AsyncMock()
+        with mock.patch(
+            'imbi_api.scoring.queue.blueprints.get_model',
+            mock.AsyncMock(return_value=_Extended),
+        ):
+            result = await score_queue.affected_projects(
+                db, self._policy('unknown_attr')
+            )
+        self.assertEqual([], result)
+        db.execute.assert_not_called()
+
+    async def test_no_targets_returns_all_projects(self) -> None:
+        from imbi_common import models
+
+        class _Extended(models.Project):
+            lang: str | None = None
+
+        db = mock.AsyncMock()
+        db.execute = mock.AsyncMock(return_value=[{'id': 'p1'}, {'id': 'p2'}])
+        with mock.patch(
+            'imbi_api.scoring.queue.blueprints.get_model',
+            mock.AsyncMock(return_value=_Extended),
+        ):
+            result = await score_queue.affected_projects(
+                db, self._policy('lang')
+            )
+        self.assertEqual(['p1', 'p2'], result)
+
+    async def test_targets_restricts_to_matching_types(self) -> None:
+        from imbi_common import models
+
+        class _Extended(models.Project):
+            lang: str | None = None
+
+        db = mock.AsyncMock()
+        db.execute = mock.AsyncMock(return_value=[{'id': 'p3'}])
+        with mock.patch(
+            'imbi_api.scoring.queue.blueprints.get_model',
+            mock.AsyncMock(return_value=_Extended),
+        ):
+            result = await score_queue.affected_projects(
+                db, self._policy('lang', targets=['api'])
+            )
+        self.assertEqual(['p3'], result)
+        args = db.execute.call_args.args
+        self.assertIn('{slug}', args[0])
+
+    async def test_targets_deduplicates_across_types(self) -> None:
+        from imbi_common import models
+
+        class _Extended(models.Project):
+            lang: str | None = None
+
+        db = mock.AsyncMock()
+        db.execute = mock.AsyncMock(return_value=[{'id': 'p1'}])
+        with mock.patch(
+            'imbi_api.scoring.queue.blueprints.get_model',
+            mock.AsyncMock(return_value=_Extended),
+        ):
+            result = await score_queue.affected_projects(
+                db, self._policy('lang', targets=['api', 'service'])
+            )
+        self.assertEqual(['p1'], result)
+        self.assertEqual(2, db.execute.await_count)

--- a/tests/test_scoring_queue.py
+++ b/tests/test_scoring_queue.py
@@ -3,10 +3,14 @@
 from __future__ import annotations
 
 import asyncio
+import typing
 import unittest
 from unittest import mock
 
 from imbi_api.scoring import queue as score_queue
+
+if typing.TYPE_CHECKING:
+    from imbi_common.scoring import models as sm
 
 
 class EnqueueTests(unittest.IsolatedAsyncioTestCase):
@@ -405,8 +409,10 @@ class ProjectsOfTypeTest(unittest.IsolatedAsyncioTestCase):
 
 class AffectedProjectsTests(unittest.IsolatedAsyncioTestCase):
     def _policy(
-        self, attribute_name: str, targets: list[str] | None = None
-    ) -> object:
+        self,
+        attribute_name: str,
+        targets: list[str] | None = None,
+    ) -> sm.AttributePolicy:
         from imbi_common.scoring import models as sm
 
         return sm.AttributePolicy(

--- a/uv.lock
+++ b/uv.lock
@@ -897,7 +897,7 @@ requires-dist = [
     { name = "fastapi" },
     { name = "filetype" },
     { name = "httpx", specifier = ">=0.28.1" },
-    { name = "imbi-common", extras = ["databases", "server"], git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=feature%2Fscoring-foundation" },
+    { name = "imbi-common", extras = ["databases", "server"], git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=main" },
     { name = "jinja2" },
     { name = "jsonpatch", specifier = ">=1.33" },
     { name = "nanoid", specifier = ">=2.0.0" },
@@ -944,7 +944,7 @@ docs = [
 [[package]]
 name = "imbi-common"
 version = "0.1.0"
-source = { git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=feature%2Fscoring-foundation#2606c1349b5bc4ad6f4493f942b607c4e025724b" }
+source = { git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=main#1998b91c01f7164219c6fdaf86032362a63dc7bd" }
 dependencies = [
     { name = "cryptography" },
     { name = "jsonschema-models" },


### PR DESCRIPTION
## Summary

- Add read-only events log endpoints (`GET /events`, `GET /organizations/{org}/projects/{id}/events`) with cursor pagination and time/type filters, backed by the ClickHouse `events` table.
- Emit one ClickHouse `events` row per changed field on project PATCH so the events log reflects attribute history.
- Add `GET /organizations/{org}/projects/{id}/score/trend` returning current score, score N days ago, and the delta.
- Add `project_id` to `RescoreRequest` for one-shot single-project rescoring.
- Switch `PATCH /scoring/policies/{slug}` from a `PolicyUpdate` body to RFC 6902 JSON Patch (matching projects/users); `slug` and `category` are immutable.
- Simplify `affected_projects` to use the existing `projects_of_type` helper, fanned out with `asyncio.gather`; clear the project's `score` when no applicable policies remain.

## Problem

The events log ClickHouse table existed but had no read API and no producer for project-attribute changes, so the audit trail was empty and unreadable. There was also no way to ask the API "how has this project's score moved this month?", and bulk-rescore could not target a single project, forcing callers to pick a coarser scope (policy, blueprint, or project type).

## Solution

**Events read API.** `imbi_api/endpoints/events.py` exposes a global `/events` and a project-scoped `/organizations/{org}/projects/{id}/events` router. Both share `_list_impl`, which does keyset pagination over `(recorded_at DESC, id DESC)`, supports `since`/`until` ISO filters plus `type` / `attributed_to` (and `project_id` on the global route), caps `limit` at 500, base64-url-encodes cursors, and emits a `Link: ...; rel="first"|"next"` header.

**Project change events.** `_emit_change_events` in `endpoints/projects.py` runs after the graph PATCH has succeeded and writes one `events` row per changed top-level field, capturing `{field, old, new}` in the payload column. Skips id/timestamps and the derived `score`/`breakdown`/`relationships` fields. Failures are logged but do not bubble up — the source-of-truth write already committed.

**Score trend.** `get_score_trend` reads the project's current `p.score` from the graph and the most recent `score_history` row at or before `now() - INTERVAL <days> DAY` from ClickHouse, returning current/previous/delta plus the period.

**Single-project rescore.** `RescoreRequest.project_id`, when set, short-circuits the `affected_projects` walk and enqueues a single recompute job.

**Policy JSON Patch.** `update_policy` now accepts a `list[PatchOperation]`, applies `_POLICY_READONLY_PATHS = READONLY_PATHS | {/slug, /category}`, validates the result against `ScoringPolicy`, and replaces the `TARGETS` edges only when the set actually changed.

**`affected_projects` cleanup.** The previous single-Cypher query was replaced with a `projects_of_type` fan-out parallelised by `asyncio.gather`, falling back to `all_project_ids` when the policy has no targets. `_process_message` now calls `imbi_common.scoring.clear_score` when `compute_score` returns `None`, so removing the last applicable policy actually clears the project's score instead of leaving it stale.

## Impact

- Requires the imbi-common version on `main` (`1998b91`) — adds `clear_score` and the missing-policies handling that `_process_message` now relies on.
- The ClickHouse `events` table DDL is already shipped via imbi-common; no new migrations.
- New permission-bearing endpoints reuse existing scopes (`project:read`, `scoring_policy:rescore_all`); no new permissions.

## Test plan

- [x] New test: rescoring by `project_id` enqueues exactly one job for that project.
- [x] New tests for `affected_projects`: unknown attribute returns empty; empty targets returns all projects; target list restricts to matching project types and deduplicates across overlapping types.
- [x] All 45 scoring tests pass locally; ruff + format clean on changed files.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)