### PR TITLE
Add plugin infrastructure for project configuration and logs

### DIFF
--- a/src/imbi_api/auth/seed.py
+++ b/src/imbi_api/auth/seed.py
@@ -300,6 +300,44 @@ STANDARD_PERMISSIONS: list[tuple[str, str, str, str]] = [
         'delete',
         'Delete note templates',
     ),
+    # Plugin management
+    (
+        'admin:plugins:read',
+        'admin',
+        'plugins:read',
+        'View installed plugins',
+    ),
+    (
+        'admin:plugins:manage',
+        'admin',
+        'plugins:manage',
+        'Install and uninstall plugins',
+    ),
+    # Project plugin access
+    (
+        'project:configuration:read',
+        'project',
+        'configuration:read',
+        'Read project configuration via plugins',
+    ),
+    (
+        'project:configuration:read_secrets',
+        'project',
+        'configuration:read_secrets',
+        'Read secret configuration values via plugins',
+    ),
+    (
+        'project:configuration:write',
+        'project',
+        'configuration:write',
+        'Write project configuration via plugins',
+    ),
+    (
+        'project:logs:read',
+        'project',
+        'logs:read',
+        'Read project logs via plugins',
+    ),
 ]
 
 # Default role definitions

--- a/src/imbi_api/domain/models.py
+++ b/src/imbi_api/domain/models.py
@@ -20,10 +20,14 @@ __all__ = [
     'ClientCredentialCreate',
     'ClientCredentialCreateResponse',
     'ClientCredentialResponse',
+    'ConfigKeyResponse',
+    'ConfigKeyValueResponse',
     'EmptyRelationship',
     'ExistsInCreate',
     'ExistsInResponse',
     'LocalAuthConfig',
+    'LogEntryResponse',
+    'LogResultResponse',
     'MembershipProperties',
     'OAuth2TokenResponse',
     'OAuthIdentity',
@@ -31,6 +35,11 @@ __all__ = [
     'OrganizationEdge',
     'PasswordChangeRequest',
     'Permission',
+    'PluginAssignmentCreate',
+    'PluginAssignmentResponse',
+    'PluginCreate',
+    'PluginResponse',
+    'PluginUpdate',
     'ResourcePermission',
     'Role',
     'ServiceAccount',
@@ -682,6 +691,7 @@ SECRET_FIELDS = (
     'webhook_secret',
     'private_key',
     'signing_secret',
+    'plugin_credentials',
 )
 
 
@@ -783,6 +793,97 @@ class ServiceApplicationSecrets(pydantic.BaseModel):
     webhook_secret: str | None = None
     private_key: str | None = None
     signing_secret: str | None = None
+
+
+# -- Plugin models --------------------------------------------------------
+
+
+class PluginCreate(pydantic.BaseModel):
+    """Request model for creating a Plugin node."""
+
+    plugin_slug: str = pydantic.Field(min_length=1, max_length=64)
+    label: str = pydantic.Field(min_length=1, max_length=128)
+    options: dict[str, typing.Any] = pydantic.Field(default_factory=dict)
+    service_application_slug: str | None = None
+
+
+class PluginUpdate(pydantic.BaseModel):
+    """Request model for updating a Plugin node."""
+
+    label: str = pydantic.Field(min_length=1, max_length=128)
+    options: dict[str, typing.Any] = pydantic.Field(default_factory=dict)
+
+
+class PluginResponse(pydantic.BaseModel):
+    """Response model for a Plugin node."""
+
+    id: str
+    plugin_slug: str
+    label: str
+    options: dict[str, typing.Any] = {}
+    api_version: int
+    status: typing.Literal['active', 'unavailable'] = 'active'
+    service_slug: str | None = None
+
+
+class PluginAssignmentCreate(pydantic.BaseModel):
+    """Request model for assigning a plugin to a project-type or project."""
+
+    plugin_id: str
+    tab: typing.Literal['configuration', 'logs']
+    default: bool = False
+    options: dict[str, typing.Any] = pydantic.Field(default_factory=dict)
+
+
+class PluginAssignmentResponse(pydantic.BaseModel):
+    """Response model for a plugin assignment."""
+
+    plugin_id: str
+    plugin_slug: str
+    label: str
+    tab: typing.Literal['configuration', 'logs']
+    default: bool
+    options: dict[str, typing.Any] = {}
+    source: typing.Literal['project', 'project_type', 'merged'] = (
+        'project_type'
+    )
+
+
+# -- Configuration / Logs response models ---------------------------------
+
+
+class ConfigKeyResponse(pydantic.BaseModel):
+    """Response model for a configuration key (no value)."""
+
+    key: str
+    data_type: str
+    last_modified: datetime.datetime | None = None
+    secret: bool = False
+
+
+class ConfigKeyValueResponse(ConfigKeyResponse):
+    """Response model for a configuration key with its value."""
+
+    value: str
+
+
+class LogEntryResponse(pydantic.BaseModel):
+    """Response model for a single log entry."""
+
+    model_config = pydantic.ConfigDict(extra='allow')
+
+    timestamp: datetime.datetime
+    message: str
+    level: str | None = None
+    raw: dict[str, typing.Any] = {}
+
+
+class LogResultResponse(pydantic.BaseModel):
+    """Paginated log search result."""
+
+    entries: list[LogEntryResponse]
+    next_cursor: str | None = None
+    total: int | None = None
 
 
 class OAuth2TokenResponse(pydantic.BaseModel):

--- a/src/imbi_api/endpoints/__init__.py
+++ b/src/imbi_api/endpoints/__init__.py
@@ -1,6 +1,7 @@
 import fastapi
 
 from .admin import admin_router
+from .admin_plugins import admin_plugins_router
 from .api_keys import api_keys_router
 from .auth import auth_router
 from .auth_providers import auth_providers_router
@@ -21,6 +22,7 @@ from .uploads import uploads_router
 from .users import users_router
 
 prefixed_routers: list[fastapi.APIRouter] = [
+    admin_plugins_router,
     admin_router,
     api_keys_router,
     auth_providers_router,

--- a/src/imbi_api/endpoints/admin_plugins.py
+++ b/src/imbi_api/endpoints/admin_plugins.py
@@ -1,0 +1,137 @@
+"""Admin plugin management endpoints."""
+
+import typing
+
+import fastapi
+from imbi_common.plugins.errors import (  # type: ignore[import-not-found]
+    PluginNotFoundError,
+)
+from imbi_common.plugins.registry import (  # type: ignore[import-not-found]
+    get_plugin,
+    list_plugins,
+)
+
+from imbi_api.auth import permissions
+from imbi_api.plugins import catalog, installer
+from imbi_api.plugins.lifecycle import get_unavailable_slugs
+
+admin_plugins_router = fastapi.APIRouter(tags=['Admin: Plugins'])
+
+
+@admin_plugins_router.get('/plugins')
+async def list_installed_plugins(
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('admin:plugins:read'),
+        ),
+    ],
+) -> dict[str, typing.Any]:
+    """List installed plugins and unavailable slugs."""
+    entries = list_plugins()
+    installed = [
+        {
+            'slug': e.manifest.slug,
+            'name': e.manifest.name,
+            'plugin_type': e.manifest.plugin_type,
+            'api_version': e.manifest.api_version,
+            'package': e.package_name,
+            'version': e.package_version,
+        }
+        for e in entries
+    ]
+    return {
+        'installed': installed,
+        'unavailable': get_unavailable_slugs(),
+    }
+
+
+@admin_plugins_router.get('/plugins/catalog')
+async def list_plugin_catalog(
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('admin:plugins:manage'),
+        ),
+    ],
+) -> list[catalog.CatalogEntry]:
+    """List the plugin catalog with install status."""
+    return catalog.list_catalog_entries()
+
+
+@admin_plugins_router.get('/plugins/{slug}')
+async def get_installed_plugin(
+    slug: str,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('admin:plugins:read'),
+        ),
+    ],
+) -> dict[str, typing.Any]:
+    """Get details for a single installed plugin."""
+    try:
+        entry = get_plugin(slug)
+    except PluginNotFoundError as exc:
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail=f'Plugin {slug!r} is not installed',
+        ) from exc
+    return {
+        'slug': entry.manifest.slug,
+        'name': entry.manifest.name,
+        'description': entry.manifest.description,
+        'plugin_type': entry.manifest.plugin_type,
+        'api_version': entry.manifest.api_version,
+        'cacheable': entry.manifest.cacheable,
+        'package': entry.package_name,
+        'version': entry.package_version,
+        'options': [o.model_dump() for o in entry.manifest.options],
+        'credentials': [c.model_dump() for c in entry.manifest.credentials],
+        'data_types': [d.model_dump() for d in entry.manifest.data_types],
+    }
+
+
+@admin_plugins_router.post('/plugins/install')
+async def install_plugin(
+    body: dict[str, str | None],
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('admin:plugins:manage'),
+        ),
+    ],
+) -> dict[str, typing.Any]:
+    """Install a plugin package at runtime."""
+    package = body.get('package')
+    if not package:
+        raise fastapi.HTTPException(
+            status_code=400, detail='package is required'
+        )
+    version = body.get('version')
+    try:
+        result = await installer.install_package(package, version)
+    except installer.InstallError as e:
+        raise fastapi.HTTPException(status_code=400, detail=str(e)) from e
+    return {
+        'loaded': result.loaded,
+        'errors': result.errors,
+        'skipped': result.skipped,
+    }
+
+
+@admin_plugins_router.delete('/plugins/installed/{package}', status_code=204)
+async def uninstall_plugin(
+    package: str,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('admin:plugins:manage'),
+        ),
+    ],
+) -> None:
+    """Uninstall a plugin package at runtime."""
+    try:
+        await installer.uninstall_package(package)
+    except installer.InstallError as e:
+        raise fastapi.HTTPException(status_code=400, detail=str(e)) from e

--- a/src/imbi_api/endpoints/admin_plugins.py
+++ b/src/imbi_api/endpoints/admin_plugins.py
@@ -3,10 +3,10 @@
 import typing
 
 import fastapi
-from imbi_common.plugins.errors import (  # type: ignore[import-not-found]
+from imbi_common.plugins.errors import (
     PluginNotFoundError,
 )
-from imbi_common.plugins.registry import (  # type: ignore[import-not-found]
+from imbi_common.plugins.registry import (
     get_plugin,
     list_plugins,
 )

--- a/src/imbi_api/endpoints/organizations.py
+++ b/src/imbi_api/endpoints/organizations.py
@@ -19,9 +19,14 @@ from .link_definitions import link_definitions_router
 from .note_templates import note_templates_router
 from .notes import notes_project_router, notes_router
 from .operations_log import operations_log_project_router
+from .project_configuration import project_configuration_router
+from .project_logs import project_logs_router
+from .project_plugins import project_plugins_router
+from .project_type_plugins import project_type_plugins_router
 from .project_types import project_types_router
 from .projects import projects_router
 from .releases import releases_router
+from .service_plugins import service_plugins_router
 from .tags import tags_router
 from .teams import teams_router
 from .third_party_services import third_party_services_router
@@ -92,6 +97,26 @@ organizations_router.include_router(
 organizations_router.include_router(
     note_templates_router,
     prefix='/{org_slug}/note-templates',
+)
+organizations_router.include_router(
+    service_plugins_router,
+    prefix='/{org_slug}/third-party-services/{slug}/plugins',
+)
+organizations_router.include_router(
+    project_type_plugins_router,
+    prefix='/{org_slug}/project-types/{pt_slug}/plugins',
+)
+organizations_router.include_router(
+    project_plugins_router,
+    prefix='/{org_slug}/projects/{project_id}/plugins',
+)
+organizations_router.include_router(
+    project_configuration_router,
+    prefix='/{org_slug}/projects/{project_id}/configuration',
+)
+organizations_router.include_router(
+    project_logs_router,
+    prefix='/{org_slug}/projects/{project_id}/logs',
 )
 
 

--- a/src/imbi_api/endpoints/project_configuration.py
+++ b/src/imbi_api/endpoints/project_configuration.py
@@ -1,0 +1,311 @@
+"""Project configuration plugin endpoints."""
+
+import json
+import logging
+import os
+import typing
+
+import fastapi
+from imbi_common import graph, valkey
+from imbi_common.clickhouse import client as ch_client
+from imbi_common.plugins.base import (  # type: ignore[import-not-found]
+    ConfigValue,
+    PluginContext,
+)
+from imbi_common.plugins.errors import (  # type: ignore[import-not-found]
+    PluginCredentialsMissing,
+)
+
+from imbi_api.auth import permissions
+from imbi_api.domain import models
+from imbi_api.plugins import call_with_timeout
+from imbi_api.plugins.credentials import get_plugin_credentials
+from imbi_api.plugins.resolution import resolve_plugin
+
+LOGGER = logging.getLogger(__name__)
+
+_CACHE_TTL = int(os.environ.get('IMBI_PLUGIN_CACHE_TTL', '60'))
+
+project_configuration_router = fastapi.APIRouter(
+    tags=['Project: Configuration'],
+)
+
+
+def _cache_key(plugin_id: str, project_id: str) -> str:
+    return f'imbi:plugin-cache:{plugin_id}:{project_id}:list'
+
+
+async def _invalidate_cache(plugin_id: str, project_id: str) -> None:
+    try:
+        client = valkey.get_client()
+        await client.delete(_cache_key(plugin_id, project_id))
+    except Exception:  # noqa: BLE001
+        LOGGER.debug('Cache invalidate failed', exc_info=True)
+
+
+@project_configuration_router.get('/')
+async def get_configuration(
+    org_slug: str,
+    project_id: str,
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('project:configuration:read'),
+        ),
+    ],
+    source: str | None = fastapi.Query(default=None),
+    environment: str | None = fastapi.Query(default=None),
+) -> list[models.ConfigKeyResponse]:
+    """List configuration keys for a project via the assigned plugin."""
+    resolved = await resolve_plugin(db, project_id, 'configuration', source)
+    ctx = PluginContext(
+        project_id=project_id,
+        project_slug='',
+        org_slug=org_slug,
+        environment=environment,
+        assignment_options=resolved.options,
+    )
+    try:
+        credentials = await get_plugin_credentials(
+            db, resolved.plugin_id, resolved.entry
+        )
+    except PluginCredentialsMissing as exc:
+        raise fastapi.HTTPException(
+            status_code=503,
+            detail=str(exc),
+        ) from exc
+
+    cache_key = _cache_key(resolved.plugin_id, project_id)
+    try:
+        client = valkey.get_client()
+    except Exception:  # noqa: BLE001
+        LOGGER.debug('Cache client unavailable', exc_info=True)
+        client = None
+
+    if client is not None:
+        try:
+            cached = await client.get(cache_key)
+            if cached:
+                return [
+                    models.ConfigKeyResponse(**k) for k in json.loads(cached)
+                ]
+        except Exception:  # noqa: BLE001
+            LOGGER.debug('Cache read failed', exc_info=True)
+
+    handler = resolved.entry.handler_cls()
+    keys = await call_with_timeout(handler.list_keys(ctx, credentials))
+
+    result = [
+        models.ConfigKeyResponse(
+            key=k.key,
+            data_type=k.data_type,
+            last_modified=k.last_modified,
+            secret=k.secret,
+        )
+        for k in keys
+    ]
+    if client is not None:
+        try:
+            payload = json.dumps([r.model_dump(mode='json') for r in result])
+            await client.setex(cache_key, _CACHE_TTL, payload)
+        except Exception:  # noqa: BLE001
+            LOGGER.debug('Cache write failed', exc_info=True)
+
+    return result
+
+
+@project_configuration_router.post('/values:fetch')
+async def fetch_values(
+    org_slug: str,
+    project_id: str,
+    body: dict[str, typing.Any],
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission(
+                'project:configuration:read_secrets',
+            ),
+        ),
+    ],
+    source: str | None = fastapi.Query(default=None),
+    environment: str | None = fastapi.Query(default=None),
+) -> list[models.ConfigKeyValueResponse]:
+    """Fetch values for specific configuration keys."""
+    resolved = await resolve_plugin(db, project_id, 'configuration', source)
+    ctx = PluginContext(
+        project_id=project_id,
+        project_slug='',
+        org_slug=org_slug,
+        environment=environment,
+        assignment_options=resolved.options,
+    )
+    try:
+        credentials = await get_plugin_credentials(
+            db, resolved.plugin_id, resolved.entry
+        )
+    except PluginCredentialsMissing as exc:
+        raise fastapi.HTTPException(
+            status_code=503,
+            detail=str(exc),
+        ) from exc
+
+    keys: list[str] | None = body.get('keys')
+    handler = resolved.entry.handler_cls()
+    values = await call_with_timeout(
+        handler.get_values(ctx, credentials, keys)
+    )
+
+    return [
+        models.ConfigKeyValueResponse(
+            key=v.key,
+            data_type=v.data_type,
+            last_modified=v.last_modified,
+            secret=v.secret,
+            value=v.value,
+        )
+        for v in values
+    ]
+
+
+@project_configuration_router.put('/{key:path}')
+async def set_configuration_value(
+    org_slug: str,
+    project_id: str,
+    key: str,
+    body: ConfigValue,
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('project:configuration:write'),
+        ),
+    ],
+    source: str | None = fastapi.Query(default=None),
+    environment: str | None = fastapi.Query(default=None),
+) -> models.ConfigKeyResponse:
+    """Set a configuration value via the assigned plugin."""
+    resolved = await resolve_plugin(db, project_id, 'configuration', source)
+    ctx = PluginContext(
+        project_id=project_id,
+        project_slug='',
+        org_slug=org_slug,
+        environment=environment,
+        assignment_options=resolved.options,
+    )
+    try:
+        credentials = await get_plugin_credentials(
+            db, resolved.plugin_id, resolved.entry
+        )
+    except PluginCredentialsMissing as exc:
+        raise fastapi.HTTPException(
+            status_code=503,
+            detail=str(exc),
+        ) from exc
+
+    handler = resolved.entry.handler_cls()
+    result_key = await call_with_timeout(
+        handler.set_value(ctx, credentials, key, body)
+    )
+
+    await _invalidate_cache(resolved.plugin_id, project_id)
+    await _write_audit(
+        project_id=project_id,
+        actor=auth.principal_name,
+        action='set_value',
+        plugin_slug=resolved.plugin_slug,
+        key=key,
+        data_type=body.data_type,
+        secret=body.secret,
+    )
+    return models.ConfigKeyResponse(
+        key=result_key.key,
+        data_type=result_key.data_type,
+        last_modified=result_key.last_modified,
+        secret=result_key.secret,
+    )
+
+
+@project_configuration_router.delete('/{key:path}', status_code=204)
+async def delete_configuration_key(
+    org_slug: str,
+    project_id: str,
+    key: str,
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('project:configuration:write'),
+        ),
+    ],
+    source: str | None = fastapi.Query(default=None),
+    environment: str | None = fastapi.Query(default=None),
+) -> None:
+    """Delete a configuration key via the assigned plugin."""
+    resolved = await resolve_plugin(db, project_id, 'configuration', source)
+    ctx = PluginContext(
+        project_id=project_id,
+        project_slug='',
+        org_slug=org_slug,
+        environment=environment,
+        assignment_options=resolved.options,
+    )
+    try:
+        credentials = await get_plugin_credentials(
+            db, resolved.plugin_id, resolved.entry
+        )
+    except PluginCredentialsMissing as exc:
+        raise fastapi.HTTPException(
+            status_code=503,
+            detail=str(exc),
+        ) from exc
+
+    handler = resolved.entry.handler_cls()
+    await call_with_timeout(handler.delete_key(ctx, credentials, key))
+
+    await _invalidate_cache(resolved.plugin_id, project_id)
+    await _write_audit(
+        project_id=project_id,
+        actor=auth.principal_name,
+        action='delete_key',
+        plugin_slug=resolved.plugin_slug,
+        key=key,
+        data_type='',
+        secret=False,
+    )
+
+
+async def _write_audit(
+    *,
+    project_id: str,
+    actor: str,
+    action: str,
+    plugin_slug: str,
+    key: str,
+    data_type: str,
+    secret: bool,
+) -> None:
+    try:
+        ch = ch_client.Clickhouse.get_instance()
+        await ch.insert(
+            'operations_log',
+            [
+                [
+                    project_id,
+                    action,
+                    actor,
+                    json.dumps(
+                        {
+                            'plugin_slug': plugin_slug,
+                            'key': key,
+                            'data_type': data_type,
+                            'secret': secret,
+                        }
+                    ),
+                ]
+            ],
+            ['project_id', 'action', 'actor', 'metadata'],
+        )
+    except Exception:  # noqa: BLE001
+        LOGGER.warning('Failed to write plugin audit log', exc_info=True)

--- a/src/imbi_api/endpoints/project_configuration.py
+++ b/src/imbi_api/endpoints/project_configuration.py
@@ -1,13 +1,15 @@
 """Project configuration plugin endpoints."""
 
+import datetime
 import json
 import logging
 import os
 import typing
 
 import fastapi
-from imbi_common import graph, valkey
-from imbi_common.clickhouse import client as ch_client
+import nanoid
+from imbi_common import clickhouse, graph, valkey
+from imbi_common import models as common_models
 from imbi_common.plugins.base import (
     ConfigurationPlugin,
     ConfigValue,
@@ -32,16 +34,69 @@ project_configuration_router = fastapi.APIRouter(
 )
 
 
-def _cache_key(plugin_id: str, project_id: str) -> str:
-    return f'imbi:plugin-cache:{plugin_id}:{project_id}:list'
+def _cache_key(
+    plugin_id: str,
+    project_id: str,
+    source: str | None,
+    environment: str | None,
+) -> str:
+    """Compose a per-(plugin, project, source, environment) cache key.
+
+    ``list_keys`` results are context-dependent: switching ``source`` or
+    ``environment`` can change which keys the plugin returns. Including
+    both in the cache key prevents stale cross-context responses.
+    """
+    src = source or '_'
+    env = environment or '_'
+    return f'imbi:plugin-cache:{plugin_id}:{project_id}:{src}:{env}:list'
 
 
-async def _invalidate_cache(plugin_id: str, project_id: str) -> None:
+async def _invalidate_cache(
+    plugin_id: str,
+    project_id: str,
+) -> None:
+    """Drop every cached list response for a plugin/project pair.
+
+    Writes invalidate across all (source, environment) combinations
+    because we don't always know which contexts have cached entries.
+    Falls back to a key scan via ``KEYS`` since the namespace is small
+    and writes are infrequent.
+    """
     try:
         client = valkey.get_client()
-        await client.delete(_cache_key(plugin_id, project_id))
+        pattern = f'imbi:plugin-cache:{plugin_id}:{project_id}:*:list'
+        keys: list[bytes | str] = await client.keys(pattern)  # pyright: ignore[reportUnknownMemberType]
+        if keys:
+            await client.delete(*keys)
     except Exception:  # noqa: BLE001
         LOGGER.debug('Cache invalidate failed', exc_info=True)
+
+
+async def _lookup_project_slug(
+    db: graph.Graph,
+    project_id: str,
+) -> str:
+    """Look up the project's slug for audit-log writes.
+
+    Returns an empty string if the project can't be matched — the audit
+    record still wins more value than failing the user's write.
+    """
+    query: typing.LiteralString = (
+        'MATCH (p:Project {{id: {project_id}}}) RETURN p.slug AS slug'
+    )
+    try:
+        records = await db.execute(
+            query,
+            {'project_id': project_id},
+            ['slug'],
+        )
+    except Exception:  # noqa: BLE001
+        LOGGER.debug('Project slug lookup failed', exc_info=True)
+        return ''
+    if not records:
+        return ''
+    parsed = graph.parse_agtype(records[0]['slug'])
+    return str(parsed) if parsed else ''
 
 
 @project_configuration_router.get('/')
@@ -77,7 +132,7 @@ async def get_configuration(
             detail=str(exc),
         ) from exc
 
-    cache_key = _cache_key(resolved.plugin_id, project_id)
+    cache_key = _cache_key(resolved.plugin_id, project_id, source, environment)
     try:
         client = valkey.get_client()
     except Exception:  # noqa: BLE001
@@ -211,9 +266,12 @@ async def set_configuration_value(
     )
 
     await _invalidate_cache(resolved.plugin_id, project_id)
+    project_slug = await _lookup_project_slug(db, project_id)
     await _write_audit(
         project_id=project_id,
-        actor=auth.principal_name,
+        project_slug=project_slug,
+        environment_slug=environment or '',
+        recorded_by=auth.principal_name,
         action='set_value',
         plugin_slug=resolved.plugin_slug,
         key=key,
@@ -266,9 +324,12 @@ async def delete_configuration_key(
     await call_with_timeout(handler.delete_key(ctx, credentials, key))
 
     await _invalidate_cache(resolved.plugin_id, project_id)
+    project_slug = await _lookup_project_slug(db, project_id)
     await _write_audit(
         project_id=project_id,
-        actor=auth.principal_name,
+        project_slug=project_slug,
+        environment_slug=environment or '',
+        recorded_by=auth.principal_name,
         action='delete_key',
         plugin_slug=resolved.plugin_slug,
         key=key,
@@ -280,33 +341,54 @@ async def delete_configuration_key(
 async def _write_audit(
     *,
     project_id: str,
-    actor: str,
+    project_slug: str,
+    environment_slug: str,
+    recorded_by: str,
     action: str,
     plugin_slug: str,
     key: str,
     data_type: str,
     secret: bool,
 ) -> None:
-    try:
-        ch = ch_client.Clickhouse.get_instance()
-        await ch.insert(
-            'operations_log',
-            [
-                [
-                    project_id,
-                    action,
-                    actor,
-                    json.dumps(
-                        {
-                            'plugin_slug': plugin_slug,
-                            'key': key,
-                            'data_type': data_type,
-                            'secret': secret,
-                        }
-                    ),
-                ]
-            ],
-            ['project_id', 'action', 'actor', 'metadata'],
-        )
-    except Exception:  # noqa: BLE001
-        LOGGER.warning('Failed to write plugin audit log', exc_info=True)
+    """Write a configuration-change audit row to ``operations_log``.
+
+    Uses the canonical ``OperationLog`` model so the row matches the
+    schema used by ``operations_log.py``. ``entry_type`` is fixed to
+    ``'Configured'`` per the Literal in ``imbi_common.models``; the
+    plugin/key/data_type/secret payload is encoded in ``description`` as
+    JSON so consumers can decode the exact change without us having to
+    extend the schema.
+
+    Audit failures are intentionally **not** swallowed: a write that
+    succeeded against the plugin but failed to be recorded would leave
+    the operations log silently inconsistent. Letting the exception
+    propagate surfaces the bad state to the caller (and to monitoring).
+    """
+    description = json.dumps(
+        {
+            'action': action,
+            'plugin_slug': plugin_slug,
+            'key': key,
+            'data_type': data_type,
+            'secret': secret,
+        },
+        sort_keys=True,
+    )
+    entry = common_models.OperationLog(
+        id=nanoid.generate(),
+        recorded_at=datetime.datetime.now(datetime.UTC),
+        recorded_by=recorded_by,
+        performed_by=recorded_by,
+        project_id=project_id,
+        project_slug=project_slug,
+        environment_slug=environment_slug,
+        entry_type='Configured',
+        description=description,
+    )
+    row = entry.model_dump(by_alias=True, mode='python')
+    row['is_deleted'] = 1 if entry.is_deleted else 0
+    await clickhouse.client.Clickhouse.get_instance().insert(
+        'operations_log',
+        [list(row.values())],
+        list(row.keys()),
+    )

--- a/src/imbi_api/endpoints/project_configuration.py
+++ b/src/imbi_api/endpoints/project_configuration.py
@@ -8,11 +8,12 @@ import typing
 import fastapi
 from imbi_common import graph, valkey
 from imbi_common.clickhouse import client as ch_client
-from imbi_common.plugins.base import (  # type: ignore[import-not-found]
+from imbi_common.plugins.base import (
+    ConfigurationPlugin,
     ConfigValue,
     PluginContext,
 )
-from imbi_common.plugins.errors import (  # type: ignore[import-not-found]
+from imbi_common.plugins.errors import (
     PluginCredentialsMissing,
 )
 
@@ -93,7 +94,7 @@ async def get_configuration(
         except Exception:  # noqa: BLE001
             LOGGER.debug('Cache read failed', exc_info=True)
 
-    handler = resolved.entry.handler_cls()
+    handler = typing.cast(ConfigurationPlugin, resolved.entry.handler_cls())
     keys = await call_with_timeout(handler.list_keys(ctx, credentials))
 
     result = [
@@ -152,7 +153,7 @@ async def fetch_values(
         ) from exc
 
     keys: list[str] | None = body.get('keys')
-    handler = resolved.entry.handler_cls()
+    handler = typing.cast(ConfigurationPlugin, resolved.entry.handler_cls())
     values = await call_with_timeout(
         handler.get_values(ctx, credentials, keys)
     )
@@ -204,7 +205,7 @@ async def set_configuration_value(
             detail=str(exc),
         ) from exc
 
-    handler = resolved.entry.handler_cls()
+    handler = typing.cast(ConfigurationPlugin, resolved.entry.handler_cls())
     result_key = await call_with_timeout(
         handler.set_value(ctx, credentials, key, body)
     )
@@ -261,7 +262,7 @@ async def delete_configuration_key(
             detail=str(exc),
         ) from exc
 
-    handler = resolved.entry.handler_cls()
+    handler = typing.cast(ConfigurationPlugin, resolved.entry.handler_cls())
     await call_with_timeout(handler.delete_key(ctx, credentials, key))
 
     await _invalidate_cache(resolved.plugin_id, project_id)

--- a/src/imbi_api/endpoints/project_logs.py
+++ b/src/imbi_api/endpoints/project_logs.py
@@ -1,0 +1,182 @@
+"""Project logs plugin endpoints."""
+
+import datetime
+import logging
+import typing
+
+import fastapi
+from imbi_common import graph
+from imbi_common.plugins.base import (  # type: ignore[import-not-found]
+    LogFilter,
+    LogQuery,
+    PluginContext,
+)
+from imbi_common.plugins.errors import (  # type: ignore[import-not-found]
+    CursorExpiredError,
+    PluginCredentialsMissing,
+)
+
+from imbi_api.auth import permissions
+from imbi_api.domain import models
+from imbi_api.plugins import call_with_timeout
+from imbi_api.plugins.credentials import get_plugin_credentials
+from imbi_api.plugins.resolution import resolve_plugin
+
+LOGGER = logging.getLogger(__name__)
+
+project_logs_router = fastapi.APIRouter(tags=['Project: Logs'])
+
+_VALID_FILTER_OPS = frozenset({'eq', 'ne', 'contains', 'starts_with', 'regex'})
+
+
+def _parse_filters(raw: list[str]) -> list[LogFilter]:
+    """Parse ``?filter=field:op:value`` query strings."""
+    filters: list[LogFilter] = []
+    for item in raw:
+        parts = item.split(':', 2)
+        if len(parts) != 3:
+            raise fastapi.HTTPException(
+                status_code=400,
+                detail=(
+                    f'Invalid filter format {item!r}; expected field:op:value'
+                ),
+            )
+        field, op, value = parts
+        if op not in _VALID_FILTER_OPS:
+            raise fastapi.HTTPException(
+                status_code=400,
+                detail=(
+                    f'Unknown filter op {op!r};'
+                    f' allowed: {sorted(_VALID_FILTER_OPS)}'
+                ),
+            )
+        filters.append(LogFilter(field=field, op=op, value=value))  # type: ignore[arg-type]
+    return filters
+
+
+@project_logs_router.get('/')
+async def search_logs(
+    org_slug: str,
+    project_id: str,
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('project:logs:read'),
+        ),
+    ],
+    source: str | None = fastapi.Query(default=None),
+    environment: str | None = fastapi.Query(default=None),
+    start_time: str | None = fastapi.Query(default=None),
+    end_time: str | None = fastapi.Query(default=None),
+    cursor: str | None = fastapi.Query(default=None),
+    limit: int = fastapi.Query(default=100, ge=1, le=1000),
+    filter: list[str] = fastapi.Query(default_factory=list),  # noqa: B008
+) -> models.LogResultResponse:
+    """Search project logs via the assigned logs plugin."""
+    resolved = await resolve_plugin(db, project_id, 'logs', source)
+
+    now = datetime.datetime.now(datetime.UTC)
+    try:
+        start_dt = (
+            datetime.datetime.fromisoformat(start_time)
+            if start_time
+            else now - datetime.timedelta(minutes=30)
+        )
+        end_dt = datetime.datetime.fromisoformat(end_time) if end_time else now
+    except ValueError as exc:
+        raise fastapi.HTTPException(
+            status_code=400,
+            detail=f'Invalid datetime format: {exc}',
+        ) from exc
+
+    filters = _parse_filters(filter)
+    query = LogQuery(
+        start_time=start_dt,
+        end_time=end_dt,
+        filters=filters,
+        limit=limit,
+        cursor=cursor,
+    )
+
+    ctx = PluginContext(
+        project_id=project_id,
+        project_slug='',
+        org_slug=org_slug,
+        environment=environment,
+        assignment_options=resolved.options,
+    )
+    try:
+        credentials = await get_plugin_credentials(
+            db, resolved.plugin_id, resolved.entry
+        )
+    except PluginCredentialsMissing as exc:
+        raise fastapi.HTTPException(
+            status_code=503,
+            detail=str(exc),
+        ) from exc
+
+    handler = resolved.entry.handler_cls()
+    try:
+        result = await call_with_timeout(
+            handler.search(ctx, credentials, query)
+        )
+    except CursorExpiredError as exc:
+        raise fastapi.HTTPException(
+            status_code=409,
+            detail={
+                'error': 'cursor_expired',
+                'message': str(exc),
+            },
+        ) from exc
+
+    return models.LogResultResponse(
+        entries=[
+            models.LogEntryResponse(
+                timestamp=e.timestamp,
+                message=e.message,
+                level=e.level,
+                raw=e.raw,
+            )
+            for e in result.entries
+        ],
+        next_cursor=result.next_cursor,
+        total=result.total,
+    )
+
+
+@project_logs_router.get('/schema')
+async def get_log_schema(
+    org_slug: str,
+    project_id: str,
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('project:logs:read'),
+        ),
+    ],
+    source: str | None = fastapi.Query(default=None),
+    environment: str | None = fastapi.Query(default=None),
+) -> list[dict[str, typing.Any]]:
+    """Get the log schema (available fields) for the assigned logs plugin."""
+    resolved = await resolve_plugin(db, project_id, 'logs', source)
+    ctx = PluginContext(
+        project_id=project_id,
+        project_slug='',
+        org_slug=org_slug,
+        environment=environment,
+        assignment_options=resolved.options,
+    )
+    try:
+        credentials = await get_plugin_credentials(
+            db, resolved.plugin_id, resolved.entry
+        )
+    except PluginCredentialsMissing as exc:
+        raise fastapi.HTTPException(
+            status_code=503,
+            detail=str(exc),
+        ) from exc
+
+    handler = resolved.entry.handler_cls()
+    return await call_with_timeout(handler.schema(ctx, credentials))

--- a/src/imbi_api/endpoints/project_logs.py
+++ b/src/imbi_api/endpoints/project_logs.py
@@ -72,7 +72,10 @@ async def search_logs(
     end_time: str | None = fastapi.Query(default=None),
     cursor: str | None = fastapi.Query(default=None),
     limit: int = fastapi.Query(default=100, ge=1, le=1000),
-    filter: list[str] = fastapi.Query(default_factory=list),  # noqa: B008
+    raw_filters: list[str] = fastapi.Query(  # noqa: B008
+        default_factory=list,
+        alias='filter',
+    ),
 ) -> models.LogResultResponse:
     """Search project logs via the assigned logs plugin."""
     resolved = await resolve_plugin(db, project_id, 'logs', source)
@@ -91,7 +94,15 @@ async def search_logs(
             detail=f'Invalid datetime format: {exc}',
         ) from exc
 
-    filters = _parse_filters(filter)
+    # ``fromisoformat`` accepts naive timestamps; coerce them to UTC so
+    # plugin handlers always receive aware datetimes (matches the pattern
+    # in events.py / operations_log.py).
+    if start_dt.tzinfo is None:
+        start_dt = start_dt.replace(tzinfo=datetime.UTC)
+    if end_dt.tzinfo is None:
+        end_dt = end_dt.replace(tzinfo=datetime.UTC)
+
+    filters = _parse_filters(raw_filters)
     query = LogQuery(
         start_time=start_dt,
         end_time=end_dt,

--- a/src/imbi_api/endpoints/project_logs.py
+++ b/src/imbi_api/endpoints/project_logs.py
@@ -6,12 +6,13 @@ import typing
 
 import fastapi
 from imbi_common import graph
-from imbi_common.plugins.base import (  # type: ignore[import-not-found]
+from imbi_common.plugins.base import (
     LogFilter,
     LogQuery,
+    LogsPlugin,
     PluginContext,
 )
-from imbi_common.plugins.errors import (  # type: ignore[import-not-found]
+from imbi_common.plugins.errors import (
     CursorExpiredError,
     PluginCredentialsMissing,
 )
@@ -116,7 +117,7 @@ async def search_logs(
             detail=str(exc),
         ) from exc
 
-    handler = resolved.entry.handler_cls()
+    handler = typing.cast(LogsPlugin, resolved.entry.handler_cls())
     try:
         result = await call_with_timeout(
             handler.search(ctx, credentials, query)
@@ -178,5 +179,5 @@ async def get_log_schema(
             detail=str(exc),
         ) from exc
 
-    handler = resolved.entry.handler_cls()
+    handler = typing.cast(LogsPlugin, resolved.entry.handler_cls())
     return await call_with_timeout(handler.schema(ctx, credentials))

--- a/src/imbi_api/endpoints/project_plugins.py
+++ b/src/imbi_api/endpoints/project_plugins.py
@@ -1,0 +1,155 @@
+"""Plugin assignment endpoints for projects."""
+
+import json
+import typing
+
+import fastapi
+from imbi_common import graph
+
+from imbi_api.auth import permissions
+from imbi_api.domain import models
+from imbi_api.graph_sql import props_template
+from imbi_api.plugins.assignments import (
+    PluginAssignmentRow,
+    build_assignment_response,
+    validate_one_default_per_tab,
+)
+
+project_plugins_router = fastapi.APIRouter(tags=['Project Plugins'])
+
+
+@project_plugins_router.get('/')
+async def get_project_plugins(
+    org_slug: str,
+    project_id: str,
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('project:read'),
+        ),
+    ],
+) -> list[models.PluginAssignmentResponse]:
+    """Merged view: project-type defaults + project overrides."""
+    query: typing.LiteralString = """
+    MATCH (proj:Project {{id: {project_id}}})
+          -[:OWNED_BY]->(:Team)-[:BELONGS_TO]->
+          (o:Organization {{slug: {org_slug}}})
+    OPTIONAL MATCH (proj)-[:TYPE]->(pt:ProjectType)
+                   -[pte:USES_PLUGIN]->(p2:Plugin)
+    WITH proj, collect({{plugin: p2{{.*}}, edge: pte{{.*}},
+                         src: 'project_type'}}) AS pt_rows
+    OPTIONAL MATCH (proj)-[pe:USES_PLUGIN]->(p:Plugin)
+    WITH pt_rows, collect({{plugin: p{{.*}}, edge: pe{{.*}},
+                            src: 'project'}}) AS proj_rows
+    RETURN pt_rows, proj_rows
+    """
+    records = await db.execute(
+        query,
+        {'project_id': project_id, 'org_slug': org_slug},
+        ['pt_rows', 'proj_rows'],
+    )
+    if not records:
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail='Project not found',
+        )
+
+    pt_rows: list[dict[str, typing.Any]] = (
+        graph.parse_agtype(records[0]['pt_rows']) or []
+    )
+    proj_rows: list[dict[str, typing.Any]] = (
+        graph.parse_agtype(records[0]['proj_rows']) or []
+    )
+
+    merged: dict[str, dict[str, typing.Any]] = {}
+    for row in pt_rows:
+        plugin = graph.parse_agtype(row.get('plugin'))
+        if plugin and plugin.get('id'):
+            merged[plugin['id']] = {
+                'plugin': plugin,
+                'edge': graph.parse_agtype(row.get('edge')) or {},
+                'source': 'project_type',
+            }
+    for row in proj_rows:
+        plugin = graph.parse_agtype(row.get('plugin'))
+        if plugin and plugin.get('id'):
+            merged[plugin['id']] = {
+                'plugin': plugin,
+                'edge': graph.parse_agtype(row.get('edge')) or {},
+                'source': 'project',
+            }
+
+    return [
+        build_assignment_response(v['plugin'], v['edge'], v['source'])
+        for v in merged.values()
+        if v['plugin'].get('id')
+    ]
+
+
+@project_plugins_router.put('/')
+async def replace_project_plugins(
+    org_slug: str,
+    project_id: str,
+    assignments: list[models.PluginAssignmentCreate],
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('project:write'),
+        ),
+    ],
+) -> list[models.PluginAssignmentResponse]:
+    """Replace project-level plugin overrides."""
+    rows: list[PluginAssignmentRow] = [
+        PluginAssignmentRow(
+            plugin_id=a.plugin_id,
+            tab=a.tab,
+            default=a.default,
+            options=a.options,
+        )
+        for a in assignments
+    ]
+
+    if rows:
+        try:
+            validate_one_default_per_tab(rows)
+        except ValueError as exc:
+            raise fastapi.HTTPException(
+                status_code=400,
+                detail=str(exc),
+            ) from exc
+
+    delete_query: typing.LiteralString = """
+    MATCH (proj:Project {{id: {project_id}}})
+    OPTIONAL MATCH (proj)-[e:USES_PLUGIN]->()
+    DELETE e
+    RETURN count(e) AS deleted
+    """
+    await db.execute(
+        delete_query,
+        {'project_id': project_id},
+        ['deleted'],
+    )
+
+    for row in rows:
+        edge_props = {
+            'tab': row['tab'],
+            'default': row['default'],
+            'options': json.dumps(row['options']),
+        }
+        create_query: str = (
+            'MATCH (proj:Project {{id: {project_id}}})'
+            ' MATCH (p:Plugin {{id: {plugin_id}}})'
+            f' CREATE (proj)-[:USES_PLUGIN {props_template(edge_props)}]->(p)'
+        )
+        await db.execute(
+            create_query,
+            {
+                'project_id': project_id,
+                'plugin_id': row['plugin_id'],
+                **edge_props,
+            },
+        )
+
+    return await get_project_plugins(org_slug, project_id, db, auth)

--- a/src/imbi_api/endpoints/project_plugins.py
+++ b/src/imbi_api/endpoints/project_plugins.py
@@ -120,15 +120,45 @@ async def replace_project_plugins(
                 detail=str(exc),
             ) from exc
 
+    # Pre-validate every submitted plugin_id before any destructive
+    # delete runs. Otherwise an unknown id silently no-ops and the
+    # endpoint reports success with a partially dropped assignment set.
+    if rows:
+        plugin_ids = sorted({row['plugin_id'] for row in rows})
+        validate_query: typing.LiteralString = """
+        UNWIND {plugin_ids} AS pid
+        OPTIONAL MATCH (p:Plugin {{id: pid}})
+        RETURN count(DISTINCT p) AS found
+        """
+        found_records = await db.execute(
+            validate_query,
+            {'plugin_ids': plugin_ids},
+            ['found'],
+        )
+        found = (
+            graph.parse_agtype(found_records[0]['found'])
+            if found_records
+            else 0
+        )
+        if found != len(plugin_ids):
+            raise fastapi.HTTPException(
+                status_code=404,
+                detail='One or more plugin IDs are invalid',
+            )
+
+    # Scope mutations to the org via the project's team→org chain so a
+    # caller from another org can't modify edges by guessing project_id.
     delete_query: typing.LiteralString = """
     MATCH (proj:Project {{id: {project_id}}})
+          -[:OWNED_BY]->(:Team)-[:BELONGS_TO]->
+          (:Organization {{slug: {org_slug}}})
     OPTIONAL MATCH (proj)-[e:USES_PLUGIN]->()
     DELETE e
     RETURN count(e) AS deleted
     """
     await db.execute(
         delete_query,
-        {'project_id': project_id},
+        {'project_id': project_id, 'org_slug': org_slug},
         ['deleted'],
     )
 
@@ -140,6 +170,8 @@ async def replace_project_plugins(
         }
         create_query: str = (
             'MATCH (proj:Project {{id: {project_id}}})'
+            ' -[:OWNED_BY]->(:Team)-[:BELONGS_TO]->'
+            ' (:Organization {{slug: {org_slug}}})'
             ' MATCH (p:Plugin {{id: {plugin_id}}})'
             f' CREATE (proj)-[:USES_PLUGIN {props_template(edge_props)}]->(p)'
         )
@@ -147,6 +179,7 @@ async def replace_project_plugins(
             create_query,
             {
                 'project_id': project_id,
+                'org_slug': org_slug,
                 'plugin_id': row['plugin_id'],
                 **edge_props,
             },

--- a/src/imbi_api/endpoints/project_type_plugins.py
+++ b/src/imbi_api/endpoints/project_type_plugins.py
@@ -1,0 +1,126 @@
+"""Plugin assignment endpoints for project types."""
+
+import json
+import typing
+
+import fastapi
+from imbi_common import graph
+
+from imbi_api.auth import permissions
+from imbi_api.domain import models
+from imbi_api.graph_sql import props_template
+from imbi_api.plugins.assignments import (
+    PluginAssignmentRow,
+    build_assignment_response,
+    validate_one_default_per_tab,
+)
+
+project_type_plugins_router = fastapi.APIRouter(
+    tags=['Project Type Plugins'],
+)
+
+
+def _from_record(
+    record: dict[str, typing.Any],
+    source: typing.Literal['project', 'project_type', 'merged'],
+) -> models.PluginAssignmentResponse:
+    plugin = graph.parse_agtype(record['plugin'])
+    edge = graph.parse_agtype(record.get('edge', '{}')) or {}
+    return build_assignment_response(plugin, edge, source)
+
+
+@project_type_plugins_router.get('/')
+async def list_project_type_plugins(
+    org_slug: str,
+    pt_slug: str,
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('project_type:read'),
+        ),
+    ],
+) -> list[models.PluginAssignmentResponse]:
+    """List default plugin assignments for a project type."""
+    query: typing.LiteralString = """
+    MATCH (pt:ProjectType {{slug: {pt_slug}}})
+          -[:BELONGS_TO]->(o:Organization {{slug: {org_slug}}})
+    MATCH (pt)-[e:USES_PLUGIN]->(p:Plugin)
+    RETURN p{{.*}} AS plugin, e{{.*}} AS edge
+    ORDER BY p.label
+    """
+    records = await db.execute(
+        query,
+        {'pt_slug': pt_slug, 'org_slug': org_slug},
+        ['plugin', 'edge'],
+    )
+    return [_from_record(r, 'project_type') for r in records]
+
+
+@project_type_plugins_router.put('/')
+async def replace_project_type_plugins(
+    org_slug: str,
+    pt_slug: str,
+    assignments: list[models.PluginAssignmentCreate],
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('project_type:update'),
+        ),
+    ],
+) -> list[models.PluginAssignmentResponse]:
+    """Replace all plugin assignments for a project type."""
+    rows: list[PluginAssignmentRow] = [
+        PluginAssignmentRow(
+            plugin_id=a.plugin_id,
+            tab=a.tab,
+            default=a.default,
+            options=a.options,
+        )
+        for a in assignments
+    ]
+    try:
+        validate_one_default_per_tab(rows)
+    except ValueError as exc:
+        raise fastapi.HTTPException(
+            status_code=400,
+            detail=str(exc),
+        ) from exc
+
+    delete_query: typing.LiteralString = """
+    MATCH (pt:ProjectType {{slug: {pt_slug}}})
+          -[:BELONGS_TO]->(o:Organization {{slug: {org_slug}}})
+    OPTIONAL MATCH (pt)-[e:USES_PLUGIN]->()
+    DELETE e
+    RETURN count(e) AS deleted
+    """
+    await db.execute(
+        delete_query,
+        {'pt_slug': pt_slug, 'org_slug': org_slug},
+        ['deleted'],
+    )
+
+    for row in rows:
+        edge_props = {
+            'tab': row['tab'],
+            'default': row['default'],
+            'options': json.dumps(row['options']),
+        }
+        merge_query: str = (
+            'MATCH (pt:ProjectType {{slug: {pt_slug}}})'
+            ' -[:BELONGS_TO]->(o:Organization {{slug: {org_slug}}})'
+            ' MATCH (p:Plugin {{id: {plugin_id}}})'
+            f' CREATE (pt)-[:USES_PLUGIN {props_template(edge_props)}]->(p)'
+        )
+        await db.execute(
+            merge_query,
+            {
+                'pt_slug': pt_slug,
+                'org_slug': org_slug,
+                'plugin_id': row['plugin_id'],
+                **edge_props,
+            },
+        )
+
+    return await list_project_type_plugins(org_slug, pt_slug, db, auth)

--- a/src/imbi_api/endpoints/project_type_plugins.py
+++ b/src/imbi_api/endpoints/project_type_plugins.py
@@ -88,6 +88,34 @@ async def replace_project_type_plugins(
             detail=str(exc),
         ) from exc
 
+    # Validate every submitted plugin_id before destructive deletes.
+    # Otherwise an unknown id is silently dropped on re-create and the
+    # endpoint can return success with a partially cleared assignment
+    # set (the existing edges have been deleted, but the new edges to
+    # invalid plugin ids are never created).
+    if rows:
+        plugin_ids = sorted({row['plugin_id'] for row in rows})
+        validate_query: typing.LiteralString = """
+        UNWIND {plugin_ids} AS pid
+        OPTIONAL MATCH (p:Plugin {{id: pid}})
+        RETURN count(DISTINCT p) AS found
+        """
+        found_records = await db.execute(
+            validate_query,
+            {'plugin_ids': plugin_ids},
+            ['found'],
+        )
+        found = (
+            graph.parse_agtype(found_records[0]['found'])
+            if found_records
+            else 0
+        )
+        if found != len(plugin_ids):
+            raise fastapi.HTTPException(
+                status_code=404,
+                detail='One or more plugin IDs are invalid',
+            )
+
     delete_query: typing.LiteralString = """
     MATCH (pt:ProjectType {{slug: {pt_slug}}})
           -[:BELONGS_TO]->(o:Organization {{slug: {org_slug}}})

--- a/src/imbi_api/endpoints/project_type_plugins.py
+++ b/src/imbi_api/endpoints/project_type_plugins.py
@@ -25,8 +25,8 @@ def _from_record(
     source: typing.Literal['project', 'project_type', 'merged'],
 ) -> models.PluginAssignmentResponse:
     plugin = graph.parse_agtype(record['plugin'])
-    edge = graph.parse_agtype(record.get('edge', '{}')) or {}
-    return build_assignment_response(plugin, edge, source)
+    edge = graph.parse_agtype(record.get('edge', '{}')) or {}  # pyright: ignore[reportUnknownVariableType,reportUnknownArgumentType]
+    return build_assignment_response(plugin, edge, source)  # pyright: ignore[reportUnknownArgumentType]
 
 
 @project_type_plugins_router.get('/')

--- a/src/imbi_api/endpoints/service_plugins.py
+++ b/src/imbi_api/endpoints/service_plugins.py
@@ -1,0 +1,256 @@
+"""Plugin CRUD endpoints for third-party services."""
+
+import json
+import typing
+
+import fastapi
+import nanoid
+from imbi_common import graph
+from imbi_common.plugins.errors import (  # type: ignore[import-not-found]
+    PluginNotFoundError,
+)
+from imbi_common.plugins.registry import (  # type: ignore[import-not-found]
+    get_plugin,
+    list_plugins,
+)
+
+from imbi_api.auth import permissions
+from imbi_api.domain import models
+from imbi_api.graph_sql import props_template, set_clause
+from imbi_api.plugins import parse_options as _parse_options
+
+service_plugins_router = fastapi.APIRouter(tags=['Service Plugins'])
+
+
+def _registry_slugs() -> set[str]:
+    return {e.manifest.slug for e in list_plugins()}
+
+
+def _build_plugin_response(
+    record: dict[str, typing.Any],
+    registry_slugs: set[str],
+) -> models.PluginResponse:
+    plugin = graph.parse_agtype(record['plugin'])
+    svc = graph.parse_agtype(record.get('svc')) if record.get('svc') else {}
+    slug = plugin['plugin_slug']
+    return models.PluginResponse(
+        id=plugin['id'],
+        plugin_slug=slug,
+        label=plugin['label'],
+        options=_parse_options(plugin.get('options')),
+        api_version=plugin.get('api_version', 1),
+        status='active' if slug in registry_slugs else 'unavailable',
+        service_slug=svc.get('slug') if svc else None,
+    )
+
+
+@service_plugins_router.get('/')
+async def list_service_plugins(
+    org_slug: str,
+    slug: str,
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('third_party_service:read'),
+        ),
+    ],
+) -> list[models.PluginResponse]:
+    """List Plugin nodes linked to a third-party service."""
+    query: typing.LiteralString = """
+    MATCH (p:Plugin)<-[:HAS_PLUGIN]-(s:ThirdPartyService {{slug: {svc_slug}}})
+          -[:BELONGS_TO]->(o:Organization {{slug: {org_slug}}})
+    RETURN p{{.*}} AS plugin, s{{.*}} AS svc
+    ORDER BY p.label
+    """
+    records = await db.execute(
+        query,
+        {'svc_slug': slug, 'org_slug': org_slug},
+        ['plugin', 'svc'],
+    )
+    registry = _registry_slugs()
+    return [_build_plugin_response(r, registry) for r in records]
+
+
+@service_plugins_router.post('/', status_code=201)
+async def create_service_plugin(
+    org_slug: str,
+    slug: str,
+    data: models.PluginCreate,
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('third_party_service:update'),
+        ),
+    ],
+) -> models.PluginResponse:
+    """Create a Plugin node linked to a third-party service."""
+    try:
+        entry = get_plugin(data.plugin_slug)
+    except PluginNotFoundError as exc:
+        raise fastapi.HTTPException(
+            status_code=400,
+            detail=f'Plugin {data.plugin_slug!r} is not installed',
+        ) from exc
+
+    check_query: typing.LiteralString = """
+    MATCH (p:Plugin {{label: {label}}})<-[:HAS_PLUGIN]-
+          (s:ThirdPartyService {{slug: {svc_slug}}})
+          -[:BELONGS_TO]->(o:Organization {{slug: {org_slug}}})
+    RETURN count(p) AS cnt
+    """
+    check = await db.execute(
+        check_query,
+        {'label': data.label, 'svc_slug': slug, 'org_slug': org_slug},
+        ['cnt'],
+    )
+    if check and graph.parse_agtype(check[0]['cnt']) > 0:
+        raise fastapi.HTTPException(
+            status_code=409,
+            detail=(
+                f'Plugin with label {data.label!r} already exists'
+                f' in service {slug!r}'
+            ),
+        )
+
+    plugin_id = nanoid.generate()
+    options_str = json.dumps(data.options)
+    props: dict[str, typing.Any] = {
+        'id': plugin_id,
+        'plugin_slug': data.plugin_slug,
+        'label': data.label,
+        'options': options_str,
+        'api_version': entry.manifest.api_version,
+    }
+    tpl = props_template(props)
+
+    create_query: str = (
+        'MATCH (s:ThirdPartyService {{slug: {svc_slug}}})'
+        ' -[:BELONGS_TO]->(o:Organization {{slug: {org_slug}}})'
+        f' CREATE (p:Plugin {tpl})'
+        ' CREATE (s)-[:HAS_PLUGIN]->(p)'
+        ' RETURN p{{.*}} AS plugin, s{{.*}} AS svc'
+    )
+    records = await db.execute(
+        create_query,
+        {'svc_slug': slug, 'org_slug': org_slug, **props},
+        ['plugin', 'svc'],
+    )
+    if not records:
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail=f'Third-party service {slug!r} not found',
+        )
+    return _build_plugin_response(records[0], _registry_slugs())
+
+
+@service_plugins_router.put('/{plugin_id}')
+async def update_service_plugin(
+    org_slug: str,
+    slug: str,
+    plugin_id: str,
+    data: models.PluginUpdate,
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('third_party_service:update'),
+        ),
+    ],
+) -> models.PluginResponse:
+    """Update a Plugin node's label and options."""
+    options_str = json.dumps(data.options)
+    props: dict[str, typing.Any] = {
+        'label': data.label,
+        'options': options_str,
+    }
+    set_stmt = set_clause('p', props)
+
+    update_query: str = (
+        'MATCH (p:Plugin {{id: {plugin_id}}})'
+        '<-[:HAS_PLUGIN]-(s:ThirdPartyService {{slug: {svc_slug}}})'
+        ' -[:BELONGS_TO]->(o:Organization {{slug: {org_slug}}})'
+        f' {set_stmt}'
+        ' RETURN p{{.*}} AS plugin, s{{.*}} AS svc'
+    )
+    records = await db.execute(
+        update_query,
+        {
+            'plugin_id': plugin_id,
+            'svc_slug': slug,
+            'org_slug': org_slug,
+            **props,
+        },
+        ['plugin', 'svc'],
+    )
+    if not records:
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail=f'Plugin {plugin_id!r} not found in service {slug!r}',
+        )
+    return _build_plugin_response(records[0], _registry_slugs())
+
+
+@service_plugins_router.delete('/{plugin_id}', status_code=204)
+async def delete_service_plugin(
+    org_slug: str,
+    slug: str,
+    plugin_id: str,
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('third_party_service:update'),
+        ),
+    ],
+    force: bool = fastapi.Query(default=False),
+) -> None:
+    """Delete a Plugin node.
+
+    Rejects if any USES_PLUGIN edges still reference it unless
+    ``?force=true`` is passed by an admin.
+    """
+    if not force:
+        ref_query: typing.LiteralString = """
+        MATCH ()-[r:USES_PLUGIN]->(p:Plugin {{id: {plugin_id}}})
+        RETURN count(r) AS cnt
+        """
+        ref_records = await db.execute(
+            ref_query,
+            {'plugin_id': plugin_id},
+            ['cnt'],
+        )
+        refs = graph.parse_agtype(ref_records[0]['cnt']) if ref_records else 0
+        if refs and refs > 0:
+            raise fastapi.HTTPException(
+                status_code=409,
+                detail=(
+                    f'Plugin {plugin_id!r} is still assigned to'
+                    f' {refs} project(s) or project-type(s);'
+                    f' use ?force=true to override'
+                ),
+            )
+
+    delete_query: typing.LiteralString = """
+    MATCH (p:Plugin {{id: {plugin_id}}})
+    <-[:HAS_PLUGIN]-(s:ThirdPartyService {{slug: {svc_slug}}})
+    -[:BELONGS_TO]->(o:Organization {{slug: {org_slug}}})
+    DETACH DELETE p
+    RETURN count(p) AS deleted
+    """
+    records = await db.execute(
+        delete_query,
+        {
+            'plugin_id': plugin_id,
+            'svc_slug': slug,
+            'org_slug': org_slug,
+        },
+        ['deleted'],
+    )
+    deleted = graph.parse_agtype(records[0]['deleted']) if records else 0
+    if not records or deleted == 0:
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail=f'Plugin {plugin_id!r} not found in service {slug!r}',
+        )

--- a/src/imbi_api/endpoints/service_plugins.py
+++ b/src/imbi_api/endpoints/service_plugins.py
@@ -160,6 +160,34 @@ async def update_service_plugin(
     ],
 ) -> models.PluginResponse:
     """Update a Plugin node's label and options."""
+    # Mirror the duplicate-label check from ``create_service_plugin`` so
+    # rename via PUT can't bypass uniqueness within the service.
+    dup_check_query: typing.LiteralString = """
+    MATCH (p:Plugin)<-[:HAS_PLUGIN]-
+          (s:ThirdPartyService {{slug: {svc_slug}}})
+          -[:BELONGS_TO]->(o:Organization {{slug: {org_slug}}})
+    WHERE p.label = {label} AND p.id <> {plugin_id}
+    RETURN count(p) AS cnt
+    """
+    dup_check = await db.execute(
+        dup_check_query,
+        {
+            'svc_slug': slug,
+            'org_slug': org_slug,
+            'label': data.label,
+            'plugin_id': plugin_id,
+        },
+        ['cnt'],
+    )
+    if dup_check and graph.parse_agtype(dup_check[0]['cnt']) > 0:
+        raise fastapi.HTTPException(
+            status_code=409,
+            detail=(
+                f'Plugin with label {data.label!r} already exists'
+                f' in service {slug!r}'
+            ),
+        )
+
     options_str = json.dumps(data.options)
     props: dict[str, typing.Any] = {
         'label': data.label,
@@ -211,6 +239,14 @@ async def delete_service_plugin(
     Rejects if any USES_PLUGIN edges still reference it unless
     ``?force=true`` is passed by an admin.
     """
+    # ``force=true`` bypasses the in-use-by-projects safeguard, so it
+    # must require admin privileges to match the docstring contract.
+    if force and not auth.is_admin:
+        raise fastapi.HTTPException(
+            status_code=403,
+            detail='force delete requires admin privileges',
+        )
+
     if not force:
         ref_query: typing.LiteralString = """
         MATCH ()-[r:USES_PLUGIN]->(p:Plugin {{id: {plugin_id}}})

--- a/src/imbi_api/endpoints/service_plugins.py
+++ b/src/imbi_api/endpoints/service_plugins.py
@@ -6,10 +6,10 @@ import typing
 import fastapi
 import nanoid
 from imbi_common import graph
-from imbi_common.plugins.errors import (  # type: ignore[import-not-found]
+from imbi_common.plugins.errors import (
     PluginNotFoundError,
 )
-from imbi_common.plugins.registry import (  # type: ignore[import-not-found]
+from imbi_common.plugins.registry import (
     get_plugin,
     list_plugins,
 )
@@ -31,7 +31,7 @@ def _build_plugin_response(
     registry_slugs: set[str],
 ) -> models.PluginResponse:
     plugin = graph.parse_agtype(record['plugin'])
-    svc = graph.parse_agtype(record.get('svc')) if record.get('svc') else {}
+    svc = graph.parse_agtype(record.get('svc')) if record.get('svc') else {}  # pyright: ignore[reportUnknownVariableType,reportUnknownArgumentType]
     slug = plugin['plugin_slug']
     return models.PluginResponse(
         id=plugin['id'],
@@ -40,7 +40,7 @@ def _build_plugin_response(
         options=_parse_options(plugin.get('options')),
         api_version=plugin.get('api_version', 1),
         status='active' if slug in registry_slugs else 'unavailable',
-        service_slug=svc.get('slug') if svc else None,
+        service_slug=svc.get('slug') if svc else None,  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType]
     )
 
 

--- a/src/imbi_api/lifespans.py
+++ b/src/imbi_api/lifespans.py
@@ -15,6 +15,7 @@ from imbi_common import clickhouse, graph, valkey
 from imbi_api import openapi
 from imbi_api.email.client import EmailClient
 from imbi_api.email.templates import TemplateManager
+from imbi_api.plugins import lifecycle as plugin_lifecycle
 from imbi_api.scoring import queue as score_queue
 from imbi_api.storage.client import StorageClient
 
@@ -24,16 +25,17 @@ _graph: graph.Graph | None = None
 
 
 async def _on_graph_startup(db: graph.Graph) -> None:
-    """Refresh blueprint models after the graph pool opens."""
+    """Refresh blueprint models and load plugins after the graph pool opens."""
     global _graph
     _graph = db
     try:
         await openapi.refresh_blueprint_models(db)
     except Exception as err:  # noqa: BLE001
-        LOGGER.warning(
-            'Failed to refresh blueprint models: %s',
-            err,
-        )
+        LOGGER.warning('Failed to refresh blueprint models: %s', err)
+    try:
+        await plugin_lifecycle.startup_load_plugins(db)
+    except Exception as err:  # noqa: BLE001
+        LOGGER.warning('Failed to load plugins: %s', err)
 
 
 graph.set_on_startup(_on_graph_startup)

--- a/src/imbi_api/plugins/__init__.py
+++ b/src/imbi_api/plugins/__init__.py
@@ -1,0 +1,40 @@
+"""Plugin infrastructure for imbi-api."""
+
+import asyncio
+import json
+import os
+import typing
+from collections.abc import Awaitable
+
+import fastapi
+
+PLUGIN_TIMEOUT_SECONDS = float(
+    os.environ.get('IMBI_PLUGIN_TIMEOUT_SECONDS', '10')
+)
+
+
+def parse_options(raw: typing.Any) -> dict[str, typing.Any]:
+    """Parse a Plugin/edge ``options`` value to a dict.
+
+    AGE returns property maps as JSON strings on round-trip; for nested
+    dict properties we serialize on write and decode here on read.
+    """
+    if isinstance(raw, str):
+        parsed: dict[str, typing.Any] = json.loads(raw)
+        return parsed
+    return raw or {}
+
+
+async def call_with_timeout[T](coro: Awaitable[T]) -> T:
+    """Run a plugin handler call with the configured timeout.
+
+    Maps :class:`TimeoutError` to a 503 response with ``Retry-After``.
+    """
+    try:
+        return await asyncio.wait_for(coro, timeout=PLUGIN_TIMEOUT_SECONDS)
+    except TimeoutError as exc:
+        raise fastapi.HTTPException(
+            status_code=503,
+            detail='Plugin timed out',
+            headers={'Retry-After': '5'},
+        ) from exc

--- a/src/imbi_api/plugins/assignments.py
+++ b/src/imbi_api/plugins/assignments.py
@@ -1,0 +1,53 @@
+"""Plugin assignment validation and shared response helpers."""
+
+import typing
+
+from imbi_api.domain import models
+from imbi_api.plugins import parse_options
+
+
+class PluginAssignmentRow(typing.TypedDict):
+    plugin_id: str
+    tab: typing.Literal['configuration', 'logs']
+    default: bool
+    options: dict[str, typing.Any]
+
+
+def validate_one_default_per_tab(
+    assignments: list[PluginAssignmentRow],
+) -> None:
+    """Ensure exactly one default per tab in the assignment list.
+
+    Raises:
+        ValueError: If a tab has 0 or >1 defaults.
+    """
+    by_tab: dict[str, list[bool]] = {}
+    for row in assignments:
+        by_tab.setdefault(row['tab'], []).append(row['default'])
+
+    for tab, defaults in by_tab.items():
+        count = sum(1 for d in defaults if d)
+        if count == 0:
+            raise ValueError(f'Tab {tab!r} has no default plugin assignment')
+        if count > 1:
+            raise ValueError(
+                f'Tab {tab!r} has {count} default plugin assignments;'
+                f' exactly one is required'
+            )
+
+
+def build_assignment_response(
+    plugin: dict[str, typing.Any],
+    edge: dict[str, typing.Any],
+    source: typing.Literal['project', 'project_type', 'merged'],
+) -> models.PluginAssignmentResponse:
+    """Build a PluginAssignmentResponse from parsed plugin/edge dicts."""
+    return models.PluginAssignmentResponse(
+        plugin_id=plugin['id'],
+        plugin_slug=plugin['plugin_slug'],
+        label=plugin['label'],
+        tab=edge.get('tab', 'configuration'),
+        default=bool(edge.get('default', False)),
+        options=parse_options(edge.get('options')),
+        source=source,
+    )

--- a/src/imbi_api/plugins/catalog.py
+++ b/src/imbi_api/plugins/catalog.py
@@ -1,0 +1,64 @@
+"""Plugin catalog — known packages and install status."""
+
+import logging
+import pathlib
+import tomllib
+import typing
+
+from imbi_common.plugins.registry import (  # type: ignore[import-not-found]
+    list_plugins,
+)
+
+LOGGER = logging.getLogger(__name__)
+
+
+class CatalogEntry(typing.TypedDict):
+    package: str
+    version: str
+    slugs: list[str]
+    author: str
+    description: str
+    docs_url: str
+    status: typing.Literal['installed', 'not_installed', 'update_available']
+
+
+def _load_catalog_toml() -> list[dict[str, typing.Any]]:
+    catalog_path = pathlib.Path(__file__).parent / 'catalog.toml'
+    with catalog_path.open('rb') as fh:
+        data = tomllib.load(fh)
+    plugins: list[dict[str, typing.Any]] = data.get('plugins', [])
+    return plugins
+
+
+_CATALOG_RAW: list[dict[str, typing.Any]] = _load_catalog_toml()
+
+
+def allowed_packages() -> frozenset[str]:
+    """Return the set of package names declared in the catalog."""
+    return frozenset(e['package'] for e in _CATALOG_RAW)
+
+
+def list_catalog_entries() -> list[CatalogEntry]:
+    """Cross-reference catalog entries against the registry."""
+    installed = {e.package_name: e for e in list_plugins()}
+    result: list[CatalogEntry] = []
+    for entry in _CATALOG_RAW:
+        pkg = entry['package']
+        if pkg in installed:
+            status: typing.Literal[
+                'installed', 'not_installed', 'update_available'
+            ] = 'installed'
+        else:
+            status = 'not_installed'
+        result.append(
+            CatalogEntry(
+                package=pkg,
+                version=entry.get('version', ''),
+                slugs=entry.get('slugs', []),
+                author=entry.get('author', ''),
+                description=entry.get('description', ''),
+                docs_url=entry.get('docs_url', ''),
+                status=status,
+            )
+        )
+    return result

--- a/src/imbi_api/plugins/catalog.py
+++ b/src/imbi_api/plugins/catalog.py
@@ -5,7 +5,7 @@ import pathlib
 import tomllib
 import typing
 
-from imbi_common.plugins.registry import (  # type: ignore[import-not-found]
+from imbi_common.plugins.registry import (
     list_plugins,
 )
 

--- a/src/imbi_api/plugins/catalog.py
+++ b/src/imbi_api/plugins/catalog.py
@@ -19,7 +19,9 @@ class CatalogEntry(typing.TypedDict):
     author: str
     description: str
     docs_url: str
-    status: typing.Literal['installed', 'not_installed', 'update_available']
+    # ``update_available`` was previously declared but never produced;
+    # added back if/when version-comparison detection lands.
+    status: typing.Literal['installed', 'not_installed']
 
 
 def _load_catalog_toml() -> list[dict[str, typing.Any]]:
@@ -44,17 +46,16 @@ def list_catalog_entries() -> list[CatalogEntry]:
     result: list[CatalogEntry] = []
     for entry in _CATALOG_RAW:
         pkg = entry['package']
-        if pkg in installed:
-            status: typing.Literal[
-                'installed', 'not_installed', 'update_available'
-            ] = 'installed'
-        else:
-            status = 'not_installed'
+        status: typing.Literal['installed', 'not_installed'] = (
+            'installed' if pkg in installed else 'not_installed'
+        )
         result.append(
             CatalogEntry(
                 package=pkg,
                 version=entry.get('version', ''),
-                slugs=entry.get('slugs', []),
+                # Copy so callers mutating the response can't reach
+                # back into the cached _CATALOG_RAW data.
+                slugs=list(entry.get('slugs', [])),
                 author=entry.get('author', ''),
                 description=entry.get('description', ''),
                 docs_url=entry.get('docs_url', ''),

--- a/src/imbi_api/plugins/catalog.toml
+++ b/src/imbi_api/plugins/catalog.toml
@@ -1,0 +1,15 @@
+[[plugins]]
+package = "imbi-plugin-ssm"
+version = ">=1.0,<2"
+slugs = ["ssm"]
+author = "AWeber / Imbi"
+description = "AWS SSM Parameter Store configuration."
+docs_url = "https://docs.imbi.app/plugins/ssm"
+
+[[plugins]]
+package = "imbi-plugin-logzio"
+version = ">=1.0,<2"
+slugs = ["logzio"]
+author = "AWeber / Imbi"
+description = "Logz.io log search."
+docs_url = "https://docs.imbi.app/plugins/logzio"

--- a/src/imbi_api/plugins/credentials.py
+++ b/src/imbi_api/plugins/credentials.py
@@ -1,0 +1,66 @@
+"""Credential retrieval for plugin instances."""
+
+import json
+import logging
+import typing
+
+from imbi_common import graph
+from imbi_common.auth.encryption import TokenEncryption
+from imbi_common.plugins.errors import (  # type: ignore[import-not-found]
+    PluginCredentialsMissing,
+)
+from imbi_common.plugins.registry import (  # type: ignore[import-not-found]
+    RegistryEntry,
+)
+
+LOGGER = logging.getLogger(__name__)
+
+
+async def get_plugin_credentials(
+    db: graph.Graph,
+    plugin_id: str,
+    entry: RegistryEntry,
+) -> dict[str, str]:
+    """Fetch and decrypt plugin credentials from the graph.
+
+    Traverses Plugin <- HAS_PLUGIN - ThirdPartyService
+    -> HAS_APPLICATION -> ServiceApplication and decrypts
+    the plugin_credentials field.
+
+    Raises:
+        PluginCredentialsMissing: If required credentials are absent.
+    """
+    query: typing.LiteralString = """
+    MATCH (p:Plugin {id: {plugin_id}})
+    <-[:HAS_PLUGIN]-(s:ThirdPartyService)
+    -[:HAS_APPLICATION]->(a:ServiceApplication)
+    RETURN a.plugin_credentials AS creds
+    """
+    records = await db.execute(
+        query,
+        {'plugin_id': plugin_id},
+        ['creds'],
+    )
+    if not records or records[0].get('creds') is None:
+        creds_raw: str | None = None
+    else:
+        creds_raw = graph.parse_agtype(records[0]['creds'])
+
+    if creds_raw:
+        encryptor = TokenEncryption.get_instance()
+        decrypted_str = encryptor.decrypt(creds_raw)
+        if decrypted_str:
+            credentials: dict[str, str] = json.loads(decrypted_str)
+        else:
+            credentials = {}
+    else:
+        credentials = {}
+
+    required_fields = [f for f in entry.manifest.credentials if f.required]
+    missing = [f.name for f in required_fields if f.name not in credentials]
+    if missing:
+        raise PluginCredentialsMissing(
+            f'Missing required credentials for plugin '
+            f'{entry.manifest.slug!r}: {missing}'
+        )
+    return credentials

--- a/src/imbi_api/plugins/credentials.py
+++ b/src/imbi_api/plugins/credentials.py
@@ -6,10 +6,10 @@ import typing
 
 from imbi_common import graph
 from imbi_common.auth.encryption import TokenEncryption
-from imbi_common.plugins.errors import (  # type: ignore[import-not-found]
+from imbi_common.plugins.errors import (
     PluginCredentialsMissing,
 )
-from imbi_common.plugins.registry import (  # type: ignore[import-not-found]
+from imbi_common.plugins.registry import (
     RegistryEntry,
 )
 

--- a/src/imbi_api/plugins/credentials.py
+++ b/src/imbi_api/plugins/credentials.py
@@ -30,11 +30,17 @@ async def get_plugin_credentials(
     Raises:
         PluginCredentialsMissing: If required credentials are absent.
     """
+    # ``ThirdPartyService.service_application`` is a single edge in the
+    # domain model, so this MATCH cannot legally fan out to multiple
+    # apps. ``LIMIT 1`` is defensive — if a misbehaving migration ever
+    # writes more than one ``HAS_APPLICATION`` edge we want the read to
+    # fail closed (missing credentials) rather than pick at random.
     query: typing.LiteralString = """
-    MATCH (p:Plugin {id: {plugin_id}})
+    MATCH (p:Plugin {{id: {plugin_id}}})
     <-[:HAS_PLUGIN]-(s:ThirdPartyService)
     -[:HAS_APPLICATION]->(a:ServiceApplication)
     RETURN a.plugin_credentials AS creds
+    LIMIT 1
     """
     records = await db.execute(
         query,
@@ -46,21 +52,37 @@ async def get_plugin_credentials(
     else:
         creds_raw = graph.parse_agtype(records[0]['creds'])
 
+    credentials: dict[str, typing.Any] = {}
     if creds_raw:
-        encryptor = TokenEncryption.get_instance()
-        decrypted_str = encryptor.decrypt(creds_raw)
+        # Treat decrypt failures and JSON parse errors as "no credentials"
+        # rather than silently passing an empty dict that satisfies a
+        # ``key in dict`` check downstream.
+        try:
+            decrypted_str = TokenEncryption.get_instance().decrypt(creds_raw)
+        except Exception:  # noqa: BLE001
+            LOGGER.warning(
+                'Plugin credentials decrypt failed for plugin_id=%s',
+                plugin_id,
+            )
+            decrypted_str = None
         if decrypted_str:
-            credentials: dict[str, str] = json.loads(decrypted_str)
-        else:
-            credentials = {}
-    else:
-        credentials = {}
+            try:
+                credentials = json.loads(decrypted_str)
+            except json.JSONDecodeError:
+                LOGGER.warning(
+                    'Plugin credentials JSON parse failed for plugin_id=%s',
+                    plugin_id,
+                )
+                credentials = {}
 
     required_fields = [f for f in entry.manifest.credentials if f.required]
-    missing = [f.name for f in required_fields if f.name not in credentials]
+    # ``null`` JSON values must be treated as missing — otherwise
+    # ``{"token": null}`` would slip past the presence check and reach
+    # the plugin handler as if the secret were configured.
+    missing = [f.name for f in required_fields if not credentials.get(f.name)]
     if missing:
         raise PluginCredentialsMissing(
             f'Missing required credentials for plugin '
             f'{entry.manifest.slug!r}: {missing}'
         )
-    return credentials
+    return {k: str(v) for k, v in credentials.items() if v is not None}

--- a/src/imbi_api/plugins/installer.py
+++ b/src/imbi_api/plugins/installer.py
@@ -1,0 +1,96 @@
+"""Runtime plugin installation via uv pip."""
+
+import asyncio
+import logging
+import os
+
+from imbi_common.plugins.registry import (  # type: ignore[import-not-found]
+    LoadResult,
+    reload_plugins,
+)
+
+from imbi_api.plugins import catalog
+
+LOGGER = logging.getLogger(__name__)
+
+_INSTALL_TIMEOUT = int(os.environ.get('IMBI_PLUGINS_INSTALL_TIMEOUT', '120'))
+_INSTALL_ENABLED = (
+    os.environ.get('IMBI_PLUGINS_INSTALL_ENABLED', 'true').lower() != 'false'
+)
+
+_ALLOWED_PACKAGES: frozenset[str] = catalog.allowed_packages()
+
+
+class InstallError(Exception):
+    """Raised when uv pip install fails."""
+
+
+async def install_package(name: str, version: str | None = None) -> LoadResult:
+    """Install a plugin package at runtime via uv pip.
+
+    Raises:
+        InstallError: If install is disabled, package not in catalog,
+            or uv exits non-zero.
+    """
+    if not _INSTALL_ENABLED:
+        raise InstallError(
+            'Runtime plugin installation is disabled '
+            '(IMBI_PLUGINS_INSTALL_ENABLED=false)'
+        )
+    if name not in _ALLOWED_PACKAGES:
+        raise InstallError(f'Package {name!r} is not in the plugin catalog')
+    spec = f'{name}=={version}' if version else name
+    proc = await asyncio.create_subprocess_exec(
+        'uv',
+        'pip',
+        'install',
+        spec,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    try:
+        stdout, stderr = await asyncio.wait_for(
+            proc.communicate(), timeout=_INSTALL_TIMEOUT
+        )
+    except TimeoutError as exc:
+        proc.kill()
+        raise InstallError(
+            f'Install of {spec!r} timed out after {_INSTALL_TIMEOUT}s'
+        ) from exc
+
+    if proc.returncode != 0:
+        raise InstallError(
+            f'uv pip install {spec!r} failed '
+            f'(exit {proc.returncode}): {stderr.decode()}'
+        )
+    LOGGER.info('Installed %r: %s', spec, stdout.decode().strip())
+    return reload_plugins()
+
+
+async def uninstall_package(name: str) -> LoadResult:
+    """Uninstall a plugin package at runtime."""
+    if not _INSTALL_ENABLED:
+        raise InstallError('Runtime plugin installation is disabled')
+    proc = await asyncio.create_subprocess_exec(
+        'uv',
+        'pip',
+        'uninstall',
+        '--yes',
+        name,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    try:
+        _stdout, stderr = await asyncio.wait_for(
+            proc.communicate(), timeout=_INSTALL_TIMEOUT
+        )
+    except TimeoutError as exc:
+        proc.kill()
+        raise InstallError(f'Uninstall of {name!r} timed out') from exc
+
+    if proc.returncode != 0:
+        raise InstallError(
+            f'uv pip uninstall {name!r} failed: {stderr.decode()}'
+        )
+    LOGGER.info('Uninstalled %r', name)
+    return reload_plugins()

--- a/src/imbi_api/plugins/installer.py
+++ b/src/imbi_api/plugins/installer.py
@@ -4,7 +4,7 @@ import asyncio
 import logging
 import os
 
-from imbi_common.plugins.registry import (  # type: ignore[import-not-found]
+from imbi_common.plugins.registry import (
     LoadResult,
     reload_plugins,
 )

--- a/src/imbi_api/plugins/installer.py
+++ b/src/imbi_api/plugins/installer.py
@@ -54,6 +54,9 @@ async def install_package(name: str, version: str | None = None) -> LoadResult:
         )
     except TimeoutError as exc:
         proc.kill()
+        # Drain pipes / reap the child so the asyncio transport closes
+        # cleanly — otherwise repeated timeouts leak fds + ResourceWarnings.
+        await proc.wait()
         raise InstallError(
             f'Install of {spec!r} timed out after {_INSTALL_TIMEOUT}s'
         ) from exc
@@ -71,6 +74,10 @@ async def uninstall_package(name: str) -> LoadResult:
     """Uninstall a plugin package at runtime."""
     if not _INSTALL_ENABLED:
         raise InstallError('Runtime plugin installation is disabled')
+    # Mirror the install allowlist: never let an admin uninstall a package
+    # that isn't a curated plugin (e.g., runtime-critical deps).
+    if name not in _ALLOWED_PACKAGES:
+        raise InstallError(f'Package {name!r} is not in the plugin catalog')
     proc = await asyncio.create_subprocess_exec(
         'uv',
         'pip',
@@ -86,6 +93,7 @@ async def uninstall_package(name: str) -> LoadResult:
         )
     except TimeoutError as exc:
         proc.kill()
+        await proc.wait()
         raise InstallError(f'Uninstall of {name!r} timed out') from exc
 
     if proc.returncode != 0:

--- a/src/imbi_api/plugins/lifecycle.py
+++ b/src/imbi_api/plugins/lifecycle.py
@@ -1,0 +1,58 @@
+"""Plugin registry lifecycle — startup audit and unavailable tracking."""
+
+import logging
+
+from imbi_common import graph
+from imbi_common.plugins.registry import (  # type: ignore[import-not-found]
+    list_plugins,
+    load_plugins,
+)
+
+LOGGER = logging.getLogger(__name__)
+
+_unavailable_slugs: list[str] = []
+
+
+def get_unavailable_slugs() -> list[str]:
+    """Return slugs that exist in the graph but not the registry."""
+    return list(_unavailable_slugs)
+
+
+async def startup_load_plugins(db: graph.Graph) -> None:
+    """Load plugins and audit for unavailable graph nodes."""
+    result = load_plugins()
+    LOGGER.info(
+        'Plugin registry loaded: %d loaded, %d errors, %d skipped',
+        len(result.loaded),
+        len(result.errors),
+        len(result.skipped),
+    )
+    for slug, err in result.errors.items():
+        LOGGER.error('Plugin load error for %r: %s', slug, err)
+
+    await _audit_unavailable(db)
+
+
+async def _audit_unavailable(db: graph.Graph) -> None:
+    """Find Plugin nodes whose slug is not in the registry."""
+    global _unavailable_slugs
+    registered = {e.manifest.slug for e in list_plugins()}
+    query: str = 'MATCH (p:Plugin) RETURN DISTINCT p.plugin_slug AS slug'
+    try:
+        records = await db.execute(query, {}, ['slug'])
+    except Exception:  # noqa: BLE001
+        LOGGER.warning('Failed to audit unavailable plugins', exc_info=True)
+        return
+
+    graph_slugs = {
+        graph.parse_agtype(r['slug'])
+        for r in records
+        if r.get('slug') is not None
+    }
+    unavailable = sorted(graph_slugs - registered)
+    _unavailable_slugs = unavailable
+    if unavailable:
+        LOGGER.error(
+            'Unavailable plugins (in graph but not registry): %s',
+            unavailable,
+        )

--- a/src/imbi_api/plugins/lifecycle.py
+++ b/src/imbi_api/plugins/lifecycle.py
@@ -3,7 +3,7 @@
 import logging
 
 from imbi_common import graph
-from imbi_common.plugins.registry import (  # type: ignore[import-not-found]
+from imbi_common.plugins.registry import (
     list_plugins,
     load_plugins,
 )

--- a/src/imbi_api/plugins/reload.py
+++ b/src/imbi_api/plugins/reload.py
@@ -1,0 +1,78 @@
+"""Valkey pub/sub subscriber for cross-pod plugin reload."""
+
+import asyncio
+import contextlib
+import logging
+from collections.abc import AsyncIterator
+
+from imbi_common import graph, valkey
+from imbi_common.plugins.registry import (  # type: ignore[import-not-found]
+    reload_plugins,
+)
+from valkey import asyncio as _valkey_asyncio
+
+from imbi_api.plugins.lifecycle import _audit_unavailable
+
+LOGGER = logging.getLogger(__name__)
+
+_CHANNEL = 'imbi:plugins:reload'
+
+
+async def _subscribe_reload(
+    client: _valkey_asyncio.Valkey,
+    db: graph.Graph,
+    stop: asyncio.Event,
+) -> None:
+    pubsub = client.pubsub()
+    await pubsub.subscribe(_CHANNEL)
+    LOGGER.info('Plugin reload subscriber started on channel %r', _CHANNEL)
+    try:
+        while not stop.is_set():
+            try:
+                msg = await asyncio.wait_for(
+                    pubsub.get_message(ignore_subscribe_messages=True),
+                    timeout=1.0,
+                )
+            except TimeoutError:
+                continue
+            if msg is not None:
+                LOGGER.info('Plugin reload triggered via pub/sub')
+                reload_plugins()
+                await _audit_unavailable(db)
+    except asyncio.CancelledError:
+        pass
+    finally:
+        await pubsub.unsubscribe(_CHANNEL)
+
+
+@contextlib.asynccontextmanager
+async def plugin_reload_hook(
+    db: graph.Graph | None = None,
+) -> AsyncIterator[None]:
+    """Async context manager that runs the Valkey reload subscriber."""
+    try:
+        client = valkey.get_client()
+    except RuntimeError:
+        LOGGER.warning('Valkey unavailable; plugin reload not started')
+        yield
+        return
+    if db is None:
+        LOGGER.warning('Graph not ready; plugin reload not started')
+        yield
+        return
+    stop = asyncio.Event()
+    task = asyncio.create_task(_subscribe_reload(client, db, stop))
+    try:
+        yield
+    finally:
+        stop.set()
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+
+async def publish_reload(
+    client: _valkey_asyncio.Valkey,
+) -> None:
+    """Publish a reload notification to all pods."""
+    await client.publish(_CHANNEL, 'reload')

--- a/src/imbi_api/plugins/reload.py
+++ b/src/imbi_api/plugins/reload.py
@@ -6,12 +6,14 @@ import logging
 from collections.abc import AsyncIterator
 
 from imbi_common import graph, valkey
-from imbi_common.plugins.registry import (  # type: ignore[import-not-found]
+from imbi_common.plugins.registry import (
     reload_plugins,
 )
 from valkey import asyncio as _valkey_asyncio
 
-from imbi_api.plugins.lifecycle import _audit_unavailable
+from imbi_api.plugins.lifecycle import (
+    _audit_unavailable,  # pyright: ignore[reportPrivateUsage]
+)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -24,13 +26,13 @@ async def _subscribe_reload(
     stop: asyncio.Event,
 ) -> None:
     pubsub = client.pubsub()
-    await pubsub.subscribe(_CHANNEL)
+    await pubsub.subscribe(_CHANNEL)  # pyright: ignore[reportUnknownMemberType]
     LOGGER.info('Plugin reload subscriber started on channel %r', _CHANNEL)
     try:
         while not stop.is_set():
             try:
-                msg = await asyncio.wait_for(
-                    pubsub.get_message(ignore_subscribe_messages=True),
+                msg = await asyncio.wait_for(  # pyright: ignore[reportUnknownVariableType,reportUnknownArgumentType]
+                    pubsub.get_message(ignore_subscribe_messages=True),  # pyright: ignore[reportUnknownArgumentType,reportUnknownMemberType]
                     timeout=1.0,
                 )
             except TimeoutError:
@@ -42,7 +44,7 @@ async def _subscribe_reload(
     except asyncio.CancelledError:
         pass
     finally:
-        await pubsub.unsubscribe(_CHANNEL)
+        await pubsub.unsubscribe(_CHANNEL)  # pyright: ignore[reportUnknownMemberType]
 
 
 @contextlib.asynccontextmanager
@@ -75,4 +77,4 @@ async def publish_reload(
     client: _valkey_asyncio.Valkey,
 ) -> None:
     """Publish a reload notification to all pods."""
-    await client.publish(_CHANNEL, 'reload')
+    await client.publish(_CHANNEL, 'reload')  # pyright: ignore[reportUnknownMemberType]

--- a/src/imbi_api/plugins/resolution.py
+++ b/src/imbi_api/plugins/resolution.py
@@ -1,0 +1,132 @@
+"""Plugin resolution — find the correct plugin for a project+tab."""
+
+import logging
+import typing
+
+import fastapi
+from imbi_common import graph
+from imbi_common.plugins.errors import (  # type: ignore[import-not-found]
+    PluginNotFoundError,
+    PluginUnavailableError,
+)
+from imbi_common.plugins.registry import (  # type: ignore[import-not-found]
+    RegistryEntry,
+    get_plugin,
+)
+
+from imbi_api.plugins import parse_options
+
+LOGGER = logging.getLogger(__name__)
+
+
+class ResolvedPlugin(typing.NamedTuple):
+    plugin_id: str
+    plugin_slug: str
+    entry: RegistryEntry
+    options: dict[str, typing.Any]
+
+
+async def resolve_plugin(
+    db: graph.Graph,
+    project_id: str,
+    tab: str,
+    source: str | None,
+) -> ResolvedPlugin:
+    """Find the plugin assigned to a project for a given tab.
+
+    Merges project-type defaults with project-level overrides.
+    If multiple plugins are assigned, ``source`` selects which one
+    (by plugin_id); without ``source``, the default is used.
+
+    Raises:
+        fastapi.HTTPException 404: No plugin assigned.
+        fastapi.HTTPException 400: Multiple plugins but no source given.
+        PluginUnavailableError: Plugin node exists but slug not in registry.
+    """
+    query: typing.LiteralString = """
+    MATCH (proj:Project {id: {project_id}})
+    OPTIONAL MATCH (proj)-[pe:USES_PLUGIN]->(p:Plugin)
+    WHERE pe.tab = {tab}
+    OPTIONAL MATCH (proj)-[:TYPE]->(pt:ProjectType)
+      -[pte:USES_PLUGIN]->(p2:Plugin)
+    WHERE pte.tab = {tab}
+    WITH
+      collect(DISTINCT {id: p.id, slug: p.plugin_slug,
+                         options: p.options, default: pe.default,
+                         src: 'project'})
+       AS proj_plugins,
+      collect(DISTINCT {id: p2.id, slug: p2.plugin_slug,
+                         options: p2.options, default: pte.default,
+                         src: 'project_type'})
+       AS pt_plugins
+    RETURN proj_plugins, pt_plugins
+    """
+    records = await db.execute(
+        query,
+        {'project_id': project_id, 'tab': tab},
+        ['proj_plugins', 'pt_plugins'],
+    )
+    if not records:
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail='Project not found',
+        )
+
+    proj_plugins: list[dict[str, typing.Any]] = (
+        graph.parse_agtype(records[0]['proj_plugins']) or []
+    )
+    pt_plugins: list[dict[str, typing.Any]] = (
+        graph.parse_agtype(records[0]['pt_plugins']) or []
+    )
+
+    # Project overrides project-type; merge by plugin id
+    merged: dict[str, dict[str, typing.Any]] = {}
+    for p in pt_plugins:
+        if p.get('id'):
+            merged[p['id']] = p
+    for p in proj_plugins:
+        if p.get('id'):
+            merged[p['id']] = p
+
+    candidates = [p for p in merged.values() if p.get('id')]
+    if not candidates:
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail=f'No plugin assigned to tab {tab!r} for this project',
+        )
+
+    if source:
+        chosen = next((p for p in candidates if p['id'] == source), None)
+        if chosen is None:
+            raise fastapi.HTTPException(
+                status_code=404,
+                detail=f'Plugin {source!r} not assigned to this project',
+            )
+    elif len(candidates) == 1:
+        chosen = candidates[0]
+    else:
+        defaults = [p for p in candidates if p.get('default')]
+        if not defaults:
+            raise fastapi.HTTPException(
+                status_code=400,
+                detail=(
+                    'Multiple plugins assigned; specify ?source=<plugin_id>'
+                ),
+            )
+        chosen = defaults[0]
+
+    plugin_id: str = chosen['id']
+    plugin_slug: str = chosen['slug']
+    options = parse_options(chosen.get('options'))
+
+    try:
+        entry = get_plugin(plugin_slug)
+    except PluginNotFoundError as exc:
+        raise PluginUnavailableError(plugin_slug) from exc
+
+    return ResolvedPlugin(
+        plugin_id=plugin_id,
+        plugin_slug=plugin_slug,
+        entry=entry,
+        options=options,
+    )

--- a/src/imbi_api/plugins/resolution.py
+++ b/src/imbi_api/plugins/resolution.py
@@ -43,21 +43,25 @@ async def resolve_plugin(
         fastapi.HTTPException 400: Multiple plugins but no source given.
         PluginUnavailableError: Plugin node exists but slug not in registry.
     """
+    # Cypher map literals must double-escape their braces so the
+    # ``SQL.format()``-based template renderer doesn't treat them as
+    # replacement fields. ``options`` is read from the edge (``pe`` /
+    # ``pte``) so per-assignment overrides reach the plugin handler.
     query: typing.LiteralString = """
-    MATCH (proj:Project {id: {project_id}})
+    MATCH (proj:Project {{id: {project_id}}})
     OPTIONAL MATCH (proj)-[pe:USES_PLUGIN]->(p:Plugin)
     WHERE pe.tab = {tab}
     OPTIONAL MATCH (proj)-[:TYPE]->(pt:ProjectType)
       -[pte:USES_PLUGIN]->(p2:Plugin)
     WHERE pte.tab = {tab}
     WITH
-      collect(DISTINCT {id: p.id, slug: p.plugin_slug,
-                         options: p.options, default: pe.default,
-                         src: 'project'})
+      collect(DISTINCT {{id: p.id, slug: p.plugin_slug,
+                         options: pe.options, default: pe.default,
+                         src: 'project'}})
        AS proj_plugins,
-      collect(DISTINCT {id: p2.id, slug: p2.plugin_slug,
-                         options: p2.options, default: pte.default,
-                         src: 'project_type'})
+      collect(DISTINCT {{id: p2.id, slug: p2.plugin_slug,
+                         options: pte.options, default: pte.default,
+                         src: 'project_type'}})
        AS pt_plugins
     RETURN proj_plugins, pt_plugins
     """
@@ -105,7 +109,22 @@ async def resolve_plugin(
     elif len(candidates) == 1:
         chosen = candidates[0]
     else:
-        defaults = [p for p in candidates if p.get('default')]
+        # Project-level defaults must win over project-type defaults
+        # (project assignments override project-type assignments). The
+        # merge dict preserves the project-type entry's insertion order
+        # when a project entry overwrites it, so we can't rely on
+        # iteration order — explicitly partition by ``src`` instead.
+        project_defaults = [
+            p
+            for p in candidates
+            if p.get('src') == 'project' and p.get('default')
+        ]
+        type_defaults = [
+            p
+            for p in candidates
+            if p.get('src') == 'project_type' and p.get('default')
+        ]
+        defaults = project_defaults or type_defaults
         if not defaults:
             raise fastapi.HTTPException(
                 status_code=400,

--- a/src/imbi_api/plugins/resolution.py
+++ b/src/imbi_api/plugins/resolution.py
@@ -5,11 +5,11 @@ import typing
 
 import fastapi
 from imbi_common import graph
-from imbi_common.plugins.errors import (  # type: ignore[import-not-found]
+from imbi_common.plugins.errors import (
     PluginNotFoundError,
     PluginUnavailableError,
 )
-from imbi_common.plugins.registry import (  # type: ignore[import-not-found]
+from imbi_common.plugins.registry import (
     RegistryEntry,
     get_plugin,
 )

--- a/tests/endpoints/test_admin_plugins.py
+++ b/tests/endpoints/test_admin_plugins.py
@@ -1,0 +1,113 @@
+"""Tests for admin plugin management endpoints."""
+
+import datetime
+import unittest
+from unittest import mock
+
+from fastapi import testclient
+
+from imbi_api import app, models
+from imbi_api.auth import password, permissions
+
+
+class AdminPluginsEndpointTestCase(unittest.TestCase):
+    """Test cases for /plugins admin endpoints."""
+
+    def setUp(self) -> None:
+        self.test_app = app.create_app()
+        self.test_user = models.User(
+            email='admin@example.com',
+            display_name='Admin User',
+            is_active=True,
+            is_admin=True,
+            password_hash=password.hash_password('testpassword123'),
+            created_at=datetime.datetime.now(datetime.UTC),
+        )
+        self.admin_context = permissions.AuthContext(
+            user=self.test_user,
+            session_id='test-session',
+            auth_method='jwt',
+            permissions={'admin:plugins:read', 'admin:plugins:manage'},
+        )
+
+        async def mock_get_current_user() -> permissions.AuthContext:
+            return self.admin_context
+
+        self.test_app.dependency_overrides[permissions.get_current_user] = (
+            mock_get_current_user
+        )
+
+    def test_list_installed_plugins_empty(self) -> None:
+        with (
+            mock.patch(
+                'imbi_api.endpoints.admin_plugins.list_plugins',
+                return_value=[],
+            ),
+            mock.patch(
+                'imbi_api.endpoints.admin_plugins.get_unavailable_slugs',
+                return_value=[],
+            ),
+        ):
+            with testclient.TestClient(self.test_app) as client:
+                response = client.get('/plugins')
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertIn('installed', data)
+        self.assertIn('unavailable', data)
+        self.assertEqual(data['installed'], [])
+        self.assertEqual(data['unavailable'], [])
+
+    def test_get_plugin_not_found(self) -> None:
+        from imbi_common.plugins.errors import PluginNotFoundError
+
+        with mock.patch(
+            'imbi_api.endpoints.admin_plugins.get_plugin',
+            side_effect=PluginNotFoundError('no-such-plugin'),
+        ):
+            with testclient.TestClient(self.test_app) as client:
+                response = client.get('/plugins/no-such-plugin')
+        self.assertEqual(response.status_code, 404)
+
+    def test_list_catalog(self) -> None:
+        from imbi_api.plugins.catalog import CatalogEntry
+
+        entries: list[CatalogEntry] = [
+            CatalogEntry(
+                package='imbi-plugin-ssm',
+                version='>=1.0,<2',
+                slugs=['ssm'],
+                author='AWeber / Imbi',
+                description='AWS SSM Parameter Store.',
+                docs_url='https://docs.imbi.app/plugins/ssm',
+                status='not_installed',
+            )
+        ]
+        with mock.patch(
+            'imbi_api.endpoints.admin_plugins.catalog.list_catalog_entries',
+            return_value=entries,
+        ):
+            with testclient.TestClient(self.test_app) as client:
+                response = client.get('/plugins/catalog')
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertIsInstance(data, list)
+        self.assertEqual(data[0]['package'], 'imbi-plugin-ssm')
+
+    def test_install_plugin_missing_package(self) -> None:
+        with testclient.TestClient(self.test_app) as client:
+            response = client.post('/plugins/install', json={})
+        self.assertEqual(response.status_code, 400)
+
+    def test_install_plugin_not_in_catalog(self) -> None:
+        from imbi_api.plugins.installer import InstallError
+
+        with mock.patch(
+            'imbi_api.endpoints.admin_plugins.installer.install_package',
+            side_effect=InstallError('not in catalog'),
+        ):
+            with testclient.TestClient(self.test_app) as client:
+                response = client.post(
+                    '/plugins/install',
+                    json={'package': 'unknown-pkg'},
+                )
+        self.assertEqual(response.status_code, 400)

--- a/tests/endpoints/test_project_configuration.py
+++ b/tests/endpoints/test_project_configuration.py
@@ -1,0 +1,502 @@
+"""Tests for project configuration plugin endpoints."""
+
+import asyncio
+import datetime
+import json
+import unittest
+from unittest import mock
+
+from fastapi import testclient
+from imbi_common import graph
+from imbi_common.plugins.base import (
+    ConfigKey,
+    ConfigKeyWithValue,
+    ConfigurationPlugin,
+    PluginManifest,
+)
+from imbi_common.plugins.errors import (
+    PluginCredentialsMissing,
+)
+from imbi_common.plugins.registry import RegistryEntry
+
+from imbi_api import app, models
+from imbi_api.auth import password, permissions
+from imbi_api.plugins.resolution import ResolvedPlugin
+
+
+class _FakeConfigurationPlugin(ConfigurationPlugin):
+    manifest = PluginManifest(
+        slug='ssm',
+        name='SSM',
+        plugin_type='configuration',
+    )
+
+    async def list_keys(self, ctx, credentials):  # type: ignore[override]
+        return [
+            ConfigKey(
+                key='/foo',
+                data_type='string',
+                last_modified=datetime.datetime(
+                    2026, 1, 1, tzinfo=datetime.UTC
+                ),
+                secret=False,
+            )
+        ]
+
+    async def get_values(self, ctx, credentials, keys=None):  # type: ignore[override]
+        return [
+            ConfigKeyWithValue(
+                key='/foo',
+                data_type='string',
+                last_modified=None,
+                secret=False,
+                value='bar',
+            )
+        ]
+
+    async def set_value(self, ctx, credentials, key, value):  # type: ignore[override]
+        return ConfigKey(
+            key=key,
+            data_type=value.data_type,
+            last_modified=datetime.datetime(2026, 1, 1, tzinfo=datetime.UTC),
+            secret=value.secret,
+        )
+
+    async def delete_key(self, ctx, credentials, key):  # type: ignore[override]
+        return None
+
+
+def _entry() -> RegistryEntry:
+    return RegistryEntry(
+        handler_cls=_FakeConfigurationPlugin,
+        manifest=_FakeConfigurationPlugin.manifest,
+        package_name='imbi-plugin-ssm',
+        package_version='1.0.0',
+    )
+
+
+def _resolved() -> ResolvedPlugin:
+    return ResolvedPlugin(
+        plugin_id='p1',
+        plugin_slug='ssm',
+        entry=_entry(),
+        options={},
+    )
+
+
+class ProjectConfigurationEndpointTestCase(unittest.TestCase):
+    """Mock patches MUST be applied INSIDE the TestClient context.
+
+    Patching ``valkey.get_client`` outside the TestClient context applies
+    the mock during lifespan startup, where the score-worker hook also
+    calls ``valkey.get_client()`` and would receive the test's AsyncMock.
+    The score-worker task then loops against the fake client and never
+    exits, causing pytest to hang indefinitely. Always:
+
+        with TestClient(app) as client:
+            with mock.patch(...):
+                response = client.get(...)
+    """
+
+    def setUp(self) -> None:
+        self.test_app = app.create_app()
+        self.test_user = models.User(
+            email='admin@example.com',
+            display_name='Admin User',
+            is_active=True,
+            is_admin=True,
+            password_hash=password.hash_password('testpassword123'),
+            created_at=datetime.datetime.now(datetime.UTC),
+        )
+        self.auth_context = permissions.AuthContext(
+            user=self.test_user,
+            session_id='test-session',
+            auth_method='jwt',
+            permissions={
+                'project:configuration:read',
+                'project:configuration:read_secrets',
+                'project:configuration:write',
+            },
+        )
+
+        async def mock_get_current_user() -> permissions.AuthContext:
+            return self.auth_context
+
+        self.test_app.dependency_overrides[permissions.get_current_user] = (
+            mock_get_current_user
+        )
+        self.mock_db = mock.AsyncMock(spec=graph.Graph)
+        self.test_app.dependency_overrides[graph._inject_graph] = (
+            lambda: self.mock_db
+        )
+
+    def test_get_configuration_credentials_missing(self) -> None:
+        with testclient.TestClient(self.test_app) as client:
+            with (
+                mock.patch(
+                    'imbi_api.endpoints.project_configuration.resolve_plugin',
+                    return_value=_resolved(),
+                ),
+                mock.patch(
+                    'imbi_api.endpoints.project_configuration'
+                    '.get_plugin_credentials',
+                    side_effect=PluginCredentialsMissing('no token'),
+                ),
+            ):
+                response = client.get(
+                    '/organizations/myorg/projects/proj1/configuration/'
+                )
+        self.assertEqual(response.status_code, 503)
+
+    def test_get_configuration_cache_miss_writes(self) -> None:
+        valkey_client = mock.AsyncMock()
+        valkey_client.get.return_value = None
+        with testclient.TestClient(self.test_app) as client:
+            with (
+                mock.patch(
+                    'imbi_api.endpoints.project_configuration.resolve_plugin',
+                    return_value=_resolved(),
+                ),
+                mock.patch(
+                    'imbi_api.endpoints.project_configuration'
+                    '.get_plugin_credentials',
+                    return_value={},
+                ),
+                mock.patch(
+                    'imbi_api.endpoints.project_configuration'
+                    '.valkey.get_client',
+                    return_value=valkey_client,
+                ),
+            ):
+                response = client.get(
+                    '/organizations/myorg/projects/proj1/configuration/'
+                )
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]['key'], '/foo')
+        valkey_client.setex.assert_awaited_once()
+
+    def test_get_configuration_cache_hit(self) -> None:
+        cached = json.dumps(
+            [
+                {
+                    'key': '/cached',
+                    'data_type': 'string',
+                    'last_modified': None,
+                    'secret': False,
+                }
+            ]
+        )
+        valkey_client = mock.AsyncMock()
+        valkey_client.get.return_value = cached
+        with testclient.TestClient(self.test_app) as client:
+            with (
+                mock.patch(
+                    'imbi_api.endpoints.project_configuration.resolve_plugin',
+                    return_value=_resolved(),
+                ),
+                mock.patch(
+                    'imbi_api.endpoints.project_configuration'
+                    '.get_plugin_credentials',
+                    return_value={},
+                ),
+                mock.patch(
+                    'imbi_api.endpoints.project_configuration'
+                    '.valkey.get_client',
+                    return_value=valkey_client,
+                ),
+            ):
+                response = client.get(
+                    '/organizations/myorg/projects/proj1/configuration/'
+                )
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data[0]['key'], '/cached')
+        valkey_client.setex.assert_not_called()
+
+    def test_get_configuration_no_valkey(self) -> None:
+        with testclient.TestClient(self.test_app) as client:
+            with (
+                mock.patch(
+                    'imbi_api.endpoints.project_configuration.resolve_plugin',
+                    return_value=_resolved(),
+                ),
+                mock.patch(
+                    'imbi_api.endpoints.project_configuration'
+                    '.get_plugin_credentials',
+                    return_value={},
+                ),
+                mock.patch(
+                    'imbi_api.endpoints.project_configuration'
+                    '.valkey.get_client',
+                    side_effect=RuntimeError('no valkey'),
+                ),
+            ):
+                response = client.get(
+                    '/organizations/myorg/projects/proj1/configuration/'
+                )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.json()), 1)
+
+    def test_fetch_values(self) -> None:
+        with testclient.TestClient(self.test_app) as client:
+            with (
+                mock.patch(
+                    'imbi_api.endpoints.project_configuration.resolve_plugin',
+                    return_value=_resolved(),
+                ),
+                mock.patch(
+                    'imbi_api.endpoints.project_configuration'
+                    '.get_plugin_credentials',
+                    return_value={},
+                ),
+            ):
+                response = client.post(
+                    '/organizations/myorg/projects/proj1/'
+                    'configuration/values:fetch',
+                    json={'keys': ['/foo']},
+                )
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data[0]['value'], 'bar')
+
+    def test_fetch_values_credentials_missing(self) -> None:
+        with testclient.TestClient(self.test_app) as client:
+            with (
+                mock.patch(
+                    'imbi_api.endpoints.project_configuration.resolve_plugin',
+                    return_value=_resolved(),
+                ),
+                mock.patch(
+                    'imbi_api.endpoints.project_configuration'
+                    '.get_plugin_credentials',
+                    side_effect=PluginCredentialsMissing('missing'),
+                ),
+            ):
+                response = client.post(
+                    '/organizations/myorg/projects/proj1/'
+                    'configuration/values:fetch',
+                    json={'keys': ['/foo']},
+                )
+        self.assertEqual(response.status_code, 503)
+
+    def test_set_configuration_value(self) -> None:
+        # NOTE: ``_write_audit`` writes to ClickHouse with an ad-hoc column
+        # set ([project_id, action, actor, metadata]) that does NOT match
+        # the canonical operations_log schema. The function swallows any
+        # exception, so a failed audit insert won't break the response.
+        # The simplify pass already flagged this; this test does not assert
+        # on the column shape — only that the audit attempt is made and the
+        # response succeeds.
+        ch = mock.MagicMock()
+        ch.insert = mock.AsyncMock()
+        valkey_client = mock.AsyncMock()
+        with testclient.TestClient(self.test_app) as client:
+            with (
+                mock.patch(
+                    'imbi_api.endpoints.project_configuration.resolve_plugin',
+                    return_value=_resolved(),
+                ),
+                mock.patch(
+                    'imbi_api.endpoints.project_configuration'
+                    '.get_plugin_credentials',
+                    return_value={},
+                ),
+                mock.patch(
+                    'imbi_api.endpoints.project_configuration'
+                    '.valkey.get_client',
+                    return_value=valkey_client,
+                ),
+                mock.patch(
+                    'imbi_api.endpoints.project_configuration'
+                    '.ch_client.Clickhouse.get_instance',
+                    return_value=ch,
+                ),
+            ):
+                response = client.put(
+                    '/organizations/myorg/projects/proj1/configuration/foo',
+                    json={
+                        'data_type': 'string',
+                        'value': 'bar',
+                        'secret': False,
+                    },
+                )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()['key'], 'foo')
+        valkey_client.delete.assert_awaited_once()
+        ch.insert.assert_awaited_once()
+
+    def test_set_configuration_value_credentials_missing(self) -> None:
+        with testclient.TestClient(self.test_app) as client:
+            with (
+                mock.patch(
+                    'imbi_api.endpoints.project_configuration.resolve_plugin',
+                    return_value=_resolved(),
+                ),
+                mock.patch(
+                    'imbi_api.endpoints.project_configuration'
+                    '.get_plugin_credentials',
+                    side_effect=PluginCredentialsMissing('missing'),
+                ),
+            ):
+                response = client.put(
+                    '/organizations/myorg/projects/proj1/configuration/foo',
+                    json={
+                        'data_type': 'string',
+                        'value': 'bar',
+                        'secret': False,
+                    },
+                )
+        self.assertEqual(response.status_code, 503)
+
+    def test_set_configuration_value_audit_failure_swallowed(self) -> None:
+        ch = mock.MagicMock()
+        ch.insert = mock.AsyncMock(side_effect=RuntimeError('CH down'))
+        valkey_client = mock.AsyncMock()
+        with testclient.TestClient(self.test_app) as client:
+            with (
+                mock.patch(
+                    'imbi_api.endpoints.project_configuration.resolve_plugin',
+                    return_value=_resolved(),
+                ),
+                mock.patch(
+                    'imbi_api.endpoints.project_configuration'
+                    '.get_plugin_credentials',
+                    return_value={},
+                ),
+                mock.patch(
+                    'imbi_api.endpoints.project_configuration'
+                    '.valkey.get_client',
+                    return_value=valkey_client,
+                ),
+                mock.patch(
+                    'imbi_api.endpoints.project_configuration'
+                    '.ch_client.Clickhouse.get_instance',
+                    return_value=ch,
+                ),
+            ):
+                response = client.put(
+                    '/organizations/myorg/projects/proj1/configuration/foo',
+                    json={
+                        'data_type': 'string',
+                        'value': 'bar',
+                        'secret': True,
+                    },
+                )
+        self.assertEqual(response.status_code, 200)
+
+    def test_delete_configuration_key(self) -> None:
+        ch = mock.MagicMock()
+        ch.insert = mock.AsyncMock()
+        valkey_client = mock.AsyncMock()
+        with testclient.TestClient(self.test_app) as client:
+            with (
+                mock.patch(
+                    'imbi_api.endpoints.project_configuration.resolve_plugin',
+                    return_value=_resolved(),
+                ),
+                mock.patch(
+                    'imbi_api.endpoints.project_configuration'
+                    '.get_plugin_credentials',
+                    return_value={},
+                ),
+                mock.patch(
+                    'imbi_api.endpoints.project_configuration'
+                    '.valkey.get_client',
+                    return_value=valkey_client,
+                ),
+                mock.patch(
+                    'imbi_api.endpoints.project_configuration'
+                    '.ch_client.Clickhouse.get_instance',
+                    return_value=ch,
+                ),
+            ):
+                response = client.delete(
+                    '/organizations/myorg/projects/proj1/configuration/foo'
+                )
+        self.assertEqual(response.status_code, 204)
+        valkey_client.delete.assert_awaited_once()
+
+    def test_delete_configuration_key_credentials_missing(self) -> None:
+        with testclient.TestClient(self.test_app) as client:
+            with (
+                mock.patch(
+                    'imbi_api.endpoints.project_configuration.resolve_plugin',
+                    return_value=_resolved(),
+                ),
+                mock.patch(
+                    'imbi_api.endpoints.project_configuration'
+                    '.get_plugin_credentials',
+                    side_effect=PluginCredentialsMissing('missing'),
+                ),
+            ):
+                response = client.delete(
+                    '/organizations/myorg/projects/proj1/configuration/foo'
+                )
+        self.assertEqual(response.status_code, 503)
+
+    def test_invalidate_cache_swallows_errors(self) -> None:
+        from imbi_api.endpoints.project_configuration import (
+            _invalidate_cache,
+        )
+
+        async def _run() -> None:
+            with mock.patch(
+                'imbi_api.endpoints.project_configuration.valkey.get_client',
+                side_effect=RuntimeError('no valkey'),
+            ):
+                await _invalidate_cache('p1', 'proj1')
+
+        asyncio.run(_run())
+
+    def test_get_configuration_cache_read_error_swallowed(self) -> None:
+        valkey_client = mock.AsyncMock()
+        valkey_client.get.side_effect = RuntimeError('bad cache')
+        with testclient.TestClient(self.test_app) as client:
+            with (
+                mock.patch(
+                    'imbi_api.endpoints.project_configuration.resolve_plugin',
+                    return_value=_resolved(),
+                ),
+                mock.patch(
+                    'imbi_api.endpoints.project_configuration'
+                    '.get_plugin_credentials',
+                    return_value={},
+                ),
+                mock.patch(
+                    'imbi_api.endpoints.project_configuration'
+                    '.valkey.get_client',
+                    return_value=valkey_client,
+                ),
+            ):
+                response = client.get(
+                    '/organizations/myorg/projects/proj1/configuration/'
+                )
+        self.assertEqual(response.status_code, 200)
+
+    def test_get_configuration_cache_write_error_swallowed(self) -> None:
+        valkey_client = mock.AsyncMock()
+        valkey_client.get.return_value = None
+        valkey_client.setex.side_effect = RuntimeError('full disk')
+        with testclient.TestClient(self.test_app) as client:
+            with (
+                mock.patch(
+                    'imbi_api.endpoints.project_configuration.resolve_plugin',
+                    return_value=_resolved(),
+                ),
+                mock.patch(
+                    'imbi_api.endpoints.project_configuration'
+                    '.get_plugin_credentials',
+                    return_value={},
+                ),
+                mock.patch(
+                    'imbi_api.endpoints.project_configuration'
+                    '.valkey.get_client',
+                    return_value=valkey_client,
+                ),
+            ):
+                response = client.get(
+                    '/organizations/myorg/projects/proj1/configuration/'
+                )
+        self.assertEqual(response.status_code, 200)

--- a/tests/endpoints/test_project_configuration.py
+++ b/tests/endpoints/test_project_configuration.py
@@ -1,13 +1,27 @@
-"""Tests for project configuration plugin endpoints."""
+"""Tests for project configuration plugin endpoints.
+
+These tests run against the real Valkey and ClickHouse instances
+provisioned by ``docker compose up`` (started via ``just test``). The
+plugin handler and the AGE graph are still mocked — neither has a
+test-friendly fixture today (plugin packages are not installed in the
+test env, and Cypher mutations require seeded graph data) — but cache
+hits/invalidations and audit-log writes are exercised end-to-end.
+"""
+
+from __future__ import annotations
 
 import asyncio
 import datetime
 import json
+import typing
 import unittest
+import uuid
 from unittest import mock
 
 from fastapi import testclient
+from imbi_common import clickhouse as imbi_clickhouse
 from imbi_common import graph
+from imbi_common import settings as imbi_settings
 from imbi_common.plugins.base import (
     ConfigKey,
     ConfigKeyWithValue,
@@ -18,6 +32,7 @@ from imbi_common.plugins.errors import (
     PluginCredentialsMissing,
 )
 from imbi_common.plugins.registry import RegistryEntry
+from valkey import asyncio as valkey_asyncio
 
 from imbi_api import app, models
 from imbi_api.auth import password, permissions
@@ -75,27 +90,29 @@ def _entry() -> RegistryEntry:
     )
 
 
-def _resolved() -> ResolvedPlugin:
+def _resolved(plugin_id: str) -> ResolvedPlugin:
     return ResolvedPlugin(
-        plugin_id='p1',
+        plugin_id=plugin_id,
         plugin_slug='ssm',
         entry=_entry(),
         options={},
     )
 
 
+def _short_id() -> str:
+    """Random short id so cache keys / audit rows don't collide."""
+    return uuid.uuid4().hex[:12]
+
+
 class ProjectConfigurationEndpointTestCase(unittest.TestCase):
-    """Mock patches MUST be applied INSIDE the TestClient context.
+    """End-to-end tests with real Valkey + ClickHouse.
 
-    Patching ``valkey.get_client`` outside the TestClient context applies
-    the mock during lifespan startup, where the score-worker hook also
-    calls ``valkey.get_client()`` and would receive the test's AsyncMock.
-    The score-worker task then loops against the fake client and never
-    exits, causing pytest to hang indefinitely. Always:
-
-        with TestClient(app) as client:
-            with mock.patch(...):
-                response = client.get(...)
+    Mock patches MUST be applied INSIDE the TestClient context. Patching
+    ``valkey.get_client`` outside the TestClient context applies the mock
+    during lifespan startup, where the score-worker hook also calls
+    ``valkey.get_client()`` and would receive the test's AsyncMock. The
+    score-worker task then loops against the fake client and never exits,
+    causing pytest to hang indefinitely.
     """
 
     def setUp(self) -> None:
@@ -126,16 +143,98 @@ class ProjectConfigurationEndpointTestCase(unittest.TestCase):
             mock_get_current_user
         )
         self.mock_db = mock.AsyncMock(spec=graph.Graph)
+        # Default: project-slug lookup returns no rows → audit writes
+        # use empty project_slug. Tests that care can override.
+        self.mock_db.execute.return_value = []
         self.test_app.dependency_overrides[graph._inject_graph] = (
             lambda: self.mock_db
         )
+
+        self.plugin_id = f'p-{_short_id()}'
+        self.project_id = f'proj-{_short_id()}'
+        self._cache_keys_to_clean: list[str] = []
+
+    # NOTE: cache cleanup is performed inside each test (while the
+    # ``TestClient`` lifespan is active) — ``valkey.get_client()`` is
+    # only valid between lifespan startup and shutdown. Unique
+    # ``plugin_id`` / ``project_id`` per test keep us hermetic anyway.
+
+    def _track_cache_key(self, key: str) -> None:
+        self._cache_keys_to_clean.append(key)
+
+    def _list_cache_key(
+        self,
+        source: str | None = None,
+        environment: str | None = None,
+    ) -> str:
+        src = source or '_'
+        env = environment or '_'
+        key = (
+            f'imbi:plugin-cache:{self.plugin_id}:{self.project_id}'
+            f':{src}:{env}:list'
+        )
+        self._track_cache_key(key)
+        return key
+
+    # ``imbi_common.valkey.get_client()`` returns a singleton bound to
+    # the lifespan's event loop, which is unusable from our own
+    # ``asyncio.run`` (the connection pool's futures live on a different
+    # loop). Open a fresh short-lived client for each cache touch
+    # instead — pointed at the same Valkey instance by reading the URL
+    # from the same settings the app uses.
+    async def _read_cache(self, key: str) -> str | None:
+        client = valkey_asyncio.Valkey.from_url(
+            str(imbi_settings.Valkey().url)
+        )
+        try:
+            value = await client.get(key)
+        finally:
+            await client.aclose()
+        if isinstance(value, bytes):
+            return value.decode('utf-8')
+        return value
+
+    async def _seed_cache(self, key: str, payload: object) -> None:
+        client = valkey_asyncio.Valkey.from_url(
+            str(imbi_settings.Valkey().url)
+        )
+        try:
+            await client.setex(key, 60, json.dumps(payload))
+        finally:
+            await client.aclose()
+
+    async def _query_audit(
+        self,
+        project_id: str,
+        recorded_after: datetime.datetime,
+    ) -> list[dict[str, typing.Any]]:
+        # Same loop-binding caveat as the cache helpers: spin up a
+        # dedicated ClickHouse client for the test's loop instead of
+        # reusing the singleton from the lifespan.
+        ch = imbi_clickhouse.client.Clickhouse()
+        await ch.initialize()
+        try:
+            rows: list[dict[str, typing.Any]] = await ch.query(
+                'SELECT id, project_id, project_slug, environment_slug,'
+                ' entry_type, description, recorded_by'
+                ' FROM operations_log FINAL'
+                ' WHERE project_id = {pid:String}'
+                '   AND recorded_at >= {after:DateTime64(3)}'
+                ' ORDER BY recorded_at',
+                {'pid': project_id, 'after': recorded_after},
+            )
+        finally:
+            await ch.aclose()
+        return rows
+
+    # ----- list / cache behaviour ------------------------------------
 
     def test_get_configuration_credentials_missing(self) -> None:
         with testclient.TestClient(self.test_app) as client:
             with (
                 mock.patch(
                     'imbi_api.endpoints.project_configuration.resolve_plugin',
-                    return_value=_resolved(),
+                    return_value=_resolved(self.plugin_id),
                 ),
                 mock.patch(
                     'imbi_api.endpoints.project_configuration'
@@ -144,107 +243,126 @@ class ProjectConfigurationEndpointTestCase(unittest.TestCase):
                 ),
             ):
                 response = client.get(
-                    '/organizations/myorg/projects/proj1/configuration/'
+                    f'/organizations/myorg/projects/{self.project_id}'
+                    '/configuration/'
                 )
         self.assertEqual(response.status_code, 503)
 
     def test_get_configuration_cache_miss_writes(self) -> None:
-        valkey_client = mock.AsyncMock()
-        valkey_client.get.return_value = None
+        cache_key = self._list_cache_key()
         with testclient.TestClient(self.test_app) as client:
             with (
                 mock.patch(
                     'imbi_api.endpoints.project_configuration.resolve_plugin',
-                    return_value=_resolved(),
+                    return_value=_resolved(self.plugin_id),
                 ),
                 mock.patch(
                     'imbi_api.endpoints.project_configuration'
                     '.get_plugin_credentials',
                     return_value={},
                 ),
-                mock.patch(
-                    'imbi_api.endpoints.project_configuration'
-                    '.valkey.get_client',
-                    return_value=valkey_client,
-                ),
             ):
                 response = client.get(
-                    '/organizations/myorg/projects/proj1/configuration/'
+                    f'/organizations/myorg/projects/{self.project_id}'
+                    '/configuration/'
                 )
+            # Read the cache while the lifespan is still active —
+            # ``valkey.get_client()`` raises after the context exits.
+            cached = asyncio.run(self._read_cache(cache_key))
         self.assertEqual(response.status_code, 200)
         data = response.json()
         self.assertEqual(len(data), 1)
         self.assertEqual(data[0]['key'], '/foo')
-        valkey_client.setex.assert_awaited_once()
+        self.assertIsNotNone(cached)
+        cached_payload = json.loads(typing.cast(str, cached))
+        self.assertEqual(cached_payload[0]['key'], '/foo')
 
     def test_get_configuration_cache_hit(self) -> None:
-        cached = json.dumps(
-            [
-                {
-                    'key': '/cached',
-                    'data_type': 'string',
-                    'last_modified': None,
-                    'secret': False,
-                }
-            ]
-        )
-        valkey_client = mock.AsyncMock()
-        valkey_client.get.return_value = cached
+        cache_key = self._list_cache_key()
         with testclient.TestClient(self.test_app) as client:
+            asyncio.run(
+                self._seed_cache(
+                    cache_key,
+                    [
+                        {
+                            'key': '/cached',
+                            'data_type': 'string',
+                            'last_modified': None,
+                            'secret': False,
+                        }
+                    ],
+                )
+            )
             with (
                 mock.patch(
                     'imbi_api.endpoints.project_configuration.resolve_plugin',
-                    return_value=_resolved(),
+                    return_value=_resolved(self.plugin_id),
                 ),
                 mock.patch(
                     'imbi_api.endpoints.project_configuration'
                     '.get_plugin_credentials',
                     return_value={},
                 ),
-                mock.patch(
-                    'imbi_api.endpoints.project_configuration'
-                    '.valkey.get_client',
-                    return_value=valkey_client,
-                ),
             ):
                 response = client.get(
-                    '/organizations/myorg/projects/proj1/configuration/'
+                    f'/organizations/myorg/projects/{self.project_id}'
+                    '/configuration/'
                 )
         self.assertEqual(response.status_code, 200)
         data = response.json()
         self.assertEqual(data[0]['key'], '/cached')
-        valkey_client.setex.assert_not_called()
 
-    def test_get_configuration_no_valkey(self) -> None:
+    def test_cache_key_scoped_by_source_and_environment(self) -> None:
+        # The default-context cache must NOT serve a request that
+        # specifies a different ``source``/``environment``.
+        default_key = self._list_cache_key()
+        scoped_key = self._list_cache_key(
+            source='other-plugin', environment='prod'
+        )
         with testclient.TestClient(self.test_app) as client:
+            asyncio.run(
+                self._seed_cache(
+                    default_key,
+                    [
+                        {
+                            'key': '/from-default',
+                            'data_type': 'string',
+                            'last_modified': None,
+                            'secret': False,
+                        }
+                    ],
+                )
+            )
             with (
                 mock.patch(
                     'imbi_api.endpoints.project_configuration.resolve_plugin',
-                    return_value=_resolved(),
+                    return_value=_resolved(self.plugin_id),
                 ),
                 mock.patch(
                     'imbi_api.endpoints.project_configuration'
                     '.get_plugin_credentials',
                     return_value={},
                 ),
-                mock.patch(
-                    'imbi_api.endpoints.project_configuration'
-                    '.valkey.get_client',
-                    side_effect=RuntimeError('no valkey'),
-                ),
             ):
                 response = client.get(
-                    '/organizations/myorg/projects/proj1/configuration/'
+                    f'/organizations/myorg/projects/{self.project_id}'
+                    '/configuration/?source=other-plugin&environment=prod'
                 )
+            scoped_cached = asyncio.run(self._read_cache(scoped_key))
+        # Should hit the plugin (not the cached /from-default entry).
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.json()), 1)
+        self.assertEqual(response.json()[0]['key'], '/foo')
+        # And it must have populated the scoped key.
+        self.assertIsNotNone(scoped_cached)
+
+    # ----- value fetch ------------------------------------------------
 
     def test_fetch_values(self) -> None:
         with testclient.TestClient(self.test_app) as client:
             with (
                 mock.patch(
                     'imbi_api.endpoints.project_configuration.resolve_plugin',
-                    return_value=_resolved(),
+                    return_value=_resolved(self.plugin_id),
                 ),
                 mock.patch(
                     'imbi_api.endpoints.project_configuration'
@@ -253,8 +371,8 @@ class ProjectConfigurationEndpointTestCase(unittest.TestCase):
                 ),
             ):
                 response = client.post(
-                    '/organizations/myorg/projects/proj1/'
-                    'configuration/values:fetch',
+                    f'/organizations/myorg/projects/{self.project_id}'
+                    '/configuration/values:fetch',
                     json={'keys': ['/foo']},
                 )
         self.assertEqual(response.status_code, 200)
@@ -266,7 +384,7 @@ class ProjectConfigurationEndpointTestCase(unittest.TestCase):
             with (
                 mock.patch(
                     'imbi_api.endpoints.project_configuration.resolve_plugin',
-                    return_value=_resolved(),
+                    return_value=_resolved(self.plugin_id),
                 ),
                 mock.patch(
                     'imbi_api.endpoints.project_configuration'
@@ -275,28 +393,37 @@ class ProjectConfigurationEndpointTestCase(unittest.TestCase):
                 ),
             ):
                 response = client.post(
-                    '/organizations/myorg/projects/proj1/'
-                    'configuration/values:fetch',
+                    f'/organizations/myorg/projects/{self.project_id}'
+                    '/configuration/values:fetch',
                     json={'keys': ['/foo']},
                 )
         self.assertEqual(response.status_code, 503)
 
+    # ----- set / delete + audit + cache invalidation -----------------
+
     def test_set_configuration_value(self) -> None:
-        # NOTE: ``_write_audit`` writes to ClickHouse with an ad-hoc column
-        # set ([project_id, action, actor, metadata]) that does NOT match
-        # the canonical operations_log schema. The function swallows any
-        # exception, so a failed audit insert won't break the response.
-        # The simplify pass already flagged this; this test does not assert
-        # on the column shape — only that the audit attempt is made and the
-        # response succeeds.
-        ch = mock.MagicMock()
-        ch.insert = mock.AsyncMock()
-        valkey_client = mock.AsyncMock()
+        # Seed both default and scoped cache entries — the write must
+        # invalidate every (source, environment) variant.
+        default_key = self._list_cache_key()
+        scoped_key = self._list_cache_key(source='alt', environment='staging')
+
+        # Stub project-slug lookup so the audit row carries a real slug.
+        self.mock_db.execute.return_value = [{'slug': 'fake-slug'}]
+        before = datetime.datetime.now(datetime.UTC) - datetime.timedelta(
+            seconds=5
+        )
+
         with testclient.TestClient(self.test_app) as client:
+            asyncio.run(
+                self._seed_cache(default_key, [{'key': '/old', 'sentinel': 1}])
+            )
+            asyncio.run(
+                self._seed_cache(scoped_key, [{'key': '/old', 'sentinel': 2}])
+            )
             with (
                 mock.patch(
                     'imbi_api.endpoints.project_configuration.resolve_plugin',
-                    return_value=_resolved(),
+                    return_value=_resolved(self.plugin_id),
                 ),
                 mock.patch(
                     'imbi_api.endpoints.project_configuration'
@@ -304,35 +431,49 @@ class ProjectConfigurationEndpointTestCase(unittest.TestCase):
                     return_value={},
                 ),
                 mock.patch(
-                    'imbi_api.endpoints.project_configuration'
-                    '.valkey.get_client',
-                    return_value=valkey_client,
-                ),
-                mock.patch(
-                    'imbi_api.endpoints.project_configuration'
-                    '.ch_client.Clickhouse.get_instance',
-                    return_value=ch,
+                    'imbi_api.endpoints.project_configuration.graph'
+                    '.parse_agtype',
+                    return_value='fake-slug',
                 ),
             ):
                 response = client.put(
-                    '/organizations/myorg/projects/proj1/configuration/foo',
+                    f'/organizations/myorg/projects/{self.project_id}'
+                    '/configuration/foo?environment=production',
                     json={
                         'data_type': 'string',
                         'value': 'bar',
                         'secret': False,
                     },
                 )
+            cache_after_default = asyncio.run(self._read_cache(default_key))
+            cache_after_scoped = asyncio.run(self._read_cache(scoped_key))
+            rows = asyncio.run(self._query_audit(self.project_id, before))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()['key'], 'foo')
-        valkey_client.delete.assert_awaited_once()
-        ch.insert.assert_awaited_once()
+        # Both cache variants must have been wiped.
+        self.assertIsNone(cache_after_default)
+        self.assertIsNone(cache_after_scoped)
+        # Real audit row must exist with the canonical schema.
+        self.assertEqual(len(rows), 1)
+        row = rows[0]
+        self.assertEqual(row['project_id'], self.project_id)
+        self.assertEqual(row['project_slug'], 'fake-slug')
+        self.assertEqual(row['environment_slug'], 'production')
+        self.assertEqual(row['entry_type'], 'Configured')
+        self.assertEqual(row['recorded_by'], 'admin@example.com')
+        description = json.loads(row['description'])
+        self.assertEqual(description['action'], 'set_value')
+        self.assertEqual(description['plugin_slug'], 'ssm')
+        self.assertEqual(description['key'], 'foo')
+        self.assertEqual(description['data_type'], 'string')
+        self.assertFalse(description['secret'])
 
     def test_set_configuration_value_credentials_missing(self) -> None:
         with testclient.TestClient(self.test_app) as client:
             with (
                 mock.patch(
                     'imbi_api.endpoints.project_configuration.resolve_plugin',
-                    return_value=_resolved(),
+                    return_value=_resolved(self.plugin_id),
                 ),
                 mock.patch(
                     'imbi_api.endpoints.project_configuration'
@@ -341,7 +482,8 @@ class ProjectConfigurationEndpointTestCase(unittest.TestCase):
                 ),
             ):
                 response = client.put(
-                    '/organizations/myorg/projects/proj1/configuration/foo',
+                    f'/organizations/myorg/projects/{self.project_id}'
+                    '/configuration/foo',
                     json={
                         'data_type': 'string',
                         'value': 'bar',
@@ -350,15 +492,18 @@ class ProjectConfigurationEndpointTestCase(unittest.TestCase):
                 )
         self.assertEqual(response.status_code, 503)
 
-    def test_set_configuration_value_audit_failure_swallowed(self) -> None:
-        ch = mock.MagicMock()
-        ch.insert = mock.AsyncMock(side_effect=RuntimeError('CH down'))
-        valkey_client = mock.AsyncMock()
-        with testclient.TestClient(self.test_app) as client:
+    def test_set_configuration_value_audit_failure_propagates(self) -> None:
+        # Audit failures must NOT be swallowed: a successful plugin
+        # write that fails to be recorded leaves operations_log silently
+        # inconsistent. ``raise_server_exceptions=False`` lets the
+        # TestClient surface the resulting 500 instead of re-raising.
+        with testclient.TestClient(
+            self.test_app, raise_server_exceptions=False
+        ) as client:
             with (
                 mock.patch(
                     'imbi_api.endpoints.project_configuration.resolve_plugin',
-                    return_value=_resolved(),
+                    return_value=_resolved(self.plugin_id),
                 ),
                 mock.patch(
                     'imbi_api.endpoints.project_configuration'
@@ -366,35 +511,34 @@ class ProjectConfigurationEndpointTestCase(unittest.TestCase):
                     return_value={},
                 ),
                 mock.patch(
-                    'imbi_api.endpoints.project_configuration'
-                    '.valkey.get_client',
-                    return_value=valkey_client,
-                ),
-                mock.patch(
-                    'imbi_api.endpoints.project_configuration'
-                    '.ch_client.Clickhouse.get_instance',
-                    return_value=ch,
+                    'imbi_api.endpoints.project_configuration.clickhouse'
+                    '.client.Clickhouse.get_instance',
+                    side_effect=RuntimeError('CH down'),
                 ),
             ):
                 response = client.put(
-                    '/organizations/myorg/projects/proj1/configuration/foo',
+                    f'/organizations/myorg/projects/{self.project_id}'
+                    '/configuration/foo',
                     json={
                         'data_type': 'string',
                         'value': 'bar',
                         'secret': True,
                     },
                 )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 500)
 
     def test_delete_configuration_key(self) -> None:
-        ch = mock.MagicMock()
-        ch.insert = mock.AsyncMock()
-        valkey_client = mock.AsyncMock()
+        cache_key = self._list_cache_key()
+        before = datetime.datetime.now(datetime.UTC) - datetime.timedelta(
+            seconds=5
+        )
+
         with testclient.TestClient(self.test_app) as client:
+            asyncio.run(self._seed_cache(cache_key, [{'sentinel': True}]))
             with (
                 mock.patch(
                     'imbi_api.endpoints.project_configuration.resolve_plugin',
-                    return_value=_resolved(),
+                    return_value=_resolved(self.plugin_id),
                 ),
                 mock.patch(
                     'imbi_api.endpoints.project_configuration'
@@ -402,28 +546,32 @@ class ProjectConfigurationEndpointTestCase(unittest.TestCase):
                     return_value={},
                 ),
                 mock.patch(
-                    'imbi_api.endpoints.project_configuration'
-                    '.valkey.get_client',
-                    return_value=valkey_client,
-                ),
-                mock.patch(
-                    'imbi_api.endpoints.project_configuration'
-                    '.ch_client.Clickhouse.get_instance',
-                    return_value=ch,
+                    'imbi_api.endpoints.project_configuration.graph'
+                    '.parse_agtype',
+                    return_value='',
                 ),
             ):
                 response = client.delete(
-                    '/organizations/myorg/projects/proj1/configuration/foo'
+                    f'/organizations/myorg/projects/{self.project_id}'
+                    '/configuration/foo'
                 )
+            cache_after = asyncio.run(self._read_cache(cache_key))
+            rows = asyncio.run(self._query_audit(self.project_id, before))
         self.assertEqual(response.status_code, 204)
-        valkey_client.delete.assert_awaited_once()
+        # Cache invalidated.
+        self.assertIsNone(cache_after)
+        # Audit row landed with action=delete_key.
+        self.assertEqual(len(rows), 1)
+        description = json.loads(rows[0]['description'])
+        self.assertEqual(description['action'], 'delete_key')
+        self.assertEqual(rows[0]['entry_type'], 'Configured')
 
     def test_delete_configuration_key_credentials_missing(self) -> None:
         with testclient.TestClient(self.test_app) as client:
             with (
                 mock.patch(
                     'imbi_api.endpoints.project_configuration.resolve_plugin',
-                    return_value=_resolved(),
+                    return_value=_resolved(self.plugin_id),
                 ),
                 mock.patch(
                     'imbi_api.endpoints.project_configuration'
@@ -432,7 +580,8 @@ class ProjectConfigurationEndpointTestCase(unittest.TestCase):
                 ),
             ):
                 response = client.delete(
-                    '/organizations/myorg/projects/proj1/configuration/foo'
+                    f'/organizations/myorg/projects/{self.project_id}'
+                    '/configuration/foo'
                 )
         self.assertEqual(response.status_code, 503)
 
@@ -446,18 +595,22 @@ class ProjectConfigurationEndpointTestCase(unittest.TestCase):
                 'imbi_api.endpoints.project_configuration.valkey.get_client',
                 side_effect=RuntimeError('no valkey'),
             ):
-                await _invalidate_cache('p1', 'proj1')
+                # Should not raise.
+                await _invalidate_cache(self.plugin_id, self.project_id)
 
         asyncio.run(_run())
 
     def test_get_configuration_cache_read_error_swallowed(self) -> None:
-        valkey_client = mock.AsyncMock()
-        valkey_client.get.side_effect = RuntimeError('bad cache')
+        # Replace ``valkey.get_client`` returns a broken client whose
+        # ``get`` blows up. The endpoint must ignore the failure and
+        # proceed to the plugin.
+        broken = mock.AsyncMock()
+        broken.get.side_effect = RuntimeError('bad cache')
         with testclient.TestClient(self.test_app) as client:
             with (
                 mock.patch(
                     'imbi_api.endpoints.project_configuration.resolve_plugin',
-                    return_value=_resolved(),
+                    return_value=_resolved(self.plugin_id),
                 ),
                 mock.patch(
                     'imbi_api.endpoints.project_configuration'
@@ -467,36 +620,11 @@ class ProjectConfigurationEndpointTestCase(unittest.TestCase):
                 mock.patch(
                     'imbi_api.endpoints.project_configuration'
                     '.valkey.get_client',
-                    return_value=valkey_client,
+                    return_value=broken,
                 ),
             ):
                 response = client.get(
-                    '/organizations/myorg/projects/proj1/configuration/'
-                )
-        self.assertEqual(response.status_code, 200)
-
-    def test_get_configuration_cache_write_error_swallowed(self) -> None:
-        valkey_client = mock.AsyncMock()
-        valkey_client.get.return_value = None
-        valkey_client.setex.side_effect = RuntimeError('full disk')
-        with testclient.TestClient(self.test_app) as client:
-            with (
-                mock.patch(
-                    'imbi_api.endpoints.project_configuration.resolve_plugin',
-                    return_value=_resolved(),
-                ),
-                mock.patch(
-                    'imbi_api.endpoints.project_configuration'
-                    '.get_plugin_credentials',
-                    return_value={},
-                ),
-                mock.patch(
-                    'imbi_api.endpoints.project_configuration'
-                    '.valkey.get_client',
-                    return_value=valkey_client,
-                ),
-            ):
-                response = client.get(
-                    '/organizations/myorg/projects/proj1/configuration/'
+                    f'/organizations/myorg/projects/{self.project_id}'
+                    '/configuration/'
                 )
         self.assertEqual(response.status_code, 200)

--- a/tests/endpoints/test_project_configuration.py
+++ b/tests/endpoints/test_project_configuration.py
@@ -115,6 +115,22 @@ class ProjectConfigurationEndpointTestCase(unittest.TestCase):
     causing pytest to hang indefinitely.
     """
 
+    @classmethod
+    def setUpClass(cls) -> None:
+        # Ensure ClickHouse has the ``operations_log`` table for the
+        # audit-write assertions. Locally the table is left over from
+        # ``imbi-api setup``; in CI the fresh container needs an
+        # explicit schema bootstrap.
+        async def _ensure_schema() -> None:
+            ch = imbi_clickhouse.client.Clickhouse()
+            await ch.initialize()
+            try:
+                await ch.setup_schema()
+            finally:
+                await ch.aclose()
+
+        asyncio.run(_ensure_schema())
+
     def setUp(self) -> None:
         self.test_app = app.create_app()
         self.test_user = models.User(

--- a/tests/endpoints/test_project_logs.py
+++ b/tests/endpoints/test_project_logs.py
@@ -1,0 +1,285 @@
+"""Tests for the project logs plugin endpoints."""
+
+import datetime
+import json
+import unittest
+from unittest import mock
+
+from fastapi import testclient
+from imbi_common import graph
+from imbi_common.plugins.base import (
+    LogEntry,
+    LogResult,
+    LogsPlugin,
+    PluginManifest,
+)
+from imbi_common.plugins.errors import (
+    CursorExpiredError,
+)
+from imbi_common.plugins.registry import RegistryEntry
+
+from imbi_api import app, models
+from imbi_api.auth import password, permissions
+from imbi_api.plugins.resolution import ResolvedPlugin
+
+
+class _FakeLogsPlugin(LogsPlugin):
+    manifest = PluginManifest(
+        slug='logzio',
+        name='Logz.io',
+        plugin_type='logs',
+    )
+
+    async def search(self, ctx, credentials, query):  # type: ignore[override]
+        return LogResult(
+            entries=[
+                LogEntry(
+                    timestamp=datetime.datetime(
+                        2026, 1, 1, tzinfo=datetime.UTC
+                    ),
+                    message='hello',
+                    level='INFO',
+                    raw={'k': 'v'},
+                )
+            ],
+            next_cursor=None,
+            total=1,
+        )
+
+    async def schema(self, ctx, credentials):  # type: ignore[override]
+        return [{'name': 'level', 'type': 'string'}]
+
+
+def _entry() -> RegistryEntry:
+    return RegistryEntry(
+        handler_cls=_FakeLogsPlugin,
+        manifest=_FakeLogsPlugin.manifest,
+        package_name='imbi-plugin-logzio',
+        package_version='1.0.0',
+    )
+
+
+class ProjectLogsEndpointTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.test_app = app.create_app()
+        self.test_user = models.User(
+            email='admin@example.com',
+            display_name='Admin User',
+            is_active=True,
+            is_admin=True,
+            password_hash=password.hash_password('testpassword123'),
+            created_at=datetime.datetime.now(datetime.UTC),
+        )
+        self.auth_context = permissions.AuthContext(
+            user=self.test_user,
+            session_id='test-session',
+            auth_method='jwt',
+            permissions={'project:logs:read'},
+        )
+
+        async def mock_get_current_user() -> permissions.AuthContext:
+            return self.auth_context
+
+        self.test_app.dependency_overrides[permissions.get_current_user] = (
+            mock_get_current_user
+        )
+        self.mock_db = mock.AsyncMock(spec=graph.Graph)
+        self.test_app.dependency_overrides[graph._inject_graph] = (
+            lambda: self.mock_db
+        )
+
+    def _resolved(self) -> ResolvedPlugin:
+        return ResolvedPlugin(
+            plugin_id='p1',
+            plugin_slug='logzio',
+            entry=_entry(),
+            options={},
+        )
+
+    def test_search_logs_happy_path(self) -> None:
+        with (
+            mock.patch(
+                'imbi_api.endpoints.project_logs.resolve_plugin',
+                return_value=self._resolved(),
+            ),
+            mock.patch(
+                'imbi_api.endpoints.project_logs.get_plugin_credentials',
+                return_value={},
+            ),
+        ):
+            with testclient.TestClient(self.test_app) as client:
+                response = client.get(
+                    '/organizations/myorg/projects/proj1/logs/'
+                )
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(len(data['entries']), 1)
+        self.assertEqual(data['entries'][0]['message'], 'hello')
+
+    def test_search_logs_invalid_datetime_returns_400(self) -> None:
+        with mock.patch(
+            'imbi_api.endpoints.project_logs.resolve_plugin',
+            return_value=self._resolved(),
+        ):
+            with testclient.TestClient(self.test_app) as client:
+                response = client.get(
+                    '/organizations/myorg/projects/proj1/logs/'
+                    '?start_time=not-a-date'
+                )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('datetime', response.json()['detail'])
+
+    def test_search_logs_invalid_filter_returns_400(self) -> None:
+        with mock.patch(
+            'imbi_api.endpoints.project_logs.resolve_plugin',
+            return_value=self._resolved(),
+        ):
+            with testclient.TestClient(self.test_app) as client:
+                response = client.get(
+                    '/organizations/myorg/projects/proj1/logs/?filter=oops'
+                )
+        self.assertEqual(response.status_code, 400)
+
+    def test_search_logs_unknown_filter_op(self) -> None:
+        with mock.patch(
+            'imbi_api.endpoints.project_logs.resolve_plugin',
+            return_value=self._resolved(),
+        ):
+            with testclient.TestClient(self.test_app) as client:
+                response = client.get(
+                    '/organizations/myorg/projects/proj1/logs/'
+                    '?filter=field:lt:1'
+                )
+        self.assertEqual(response.status_code, 400)
+
+    def test_search_logs_credentials_missing_returns_503(self) -> None:
+        from imbi_common.plugins.errors import PluginCredentialsMissing
+
+        with (
+            mock.patch(
+                'imbi_api.endpoints.project_logs.resolve_plugin',
+                return_value=self._resolved(),
+            ),
+            mock.patch(
+                'imbi_api.endpoints.project_logs.get_plugin_credentials',
+                side_effect=PluginCredentialsMissing('missing token'),
+            ),
+        ):
+            with testclient.TestClient(self.test_app) as client:
+                response = client.get(
+                    '/organizations/myorg/projects/proj1/logs/'
+                )
+        self.assertEqual(response.status_code, 503)
+
+    def test_search_logs_cursor_expired_returns_409(self) -> None:
+        class _Expiring(_FakeLogsPlugin):
+            async def search(self, ctx, credentials, query):  # type: ignore[override]
+                raise CursorExpiredError('cursor too old')
+
+        entry = RegistryEntry(
+            handler_cls=_Expiring,
+            manifest=_Expiring.manifest,
+            package_name='imbi-plugin-logzio',
+            package_version='1.0.0',
+        )
+        resolved = ResolvedPlugin(
+            plugin_id='p1',
+            plugin_slug='logzio',
+            entry=entry,
+            options={},
+        )
+        with (
+            mock.patch(
+                'imbi_api.endpoints.project_logs.resolve_plugin',
+                return_value=resolved,
+            ),
+            mock.patch(
+                'imbi_api.endpoints.project_logs.get_plugin_credentials',
+                return_value={},
+            ),
+        ):
+            with testclient.TestClient(self.test_app) as client:
+                response = client.get(
+                    '/organizations/myorg/projects/proj1/logs/?cursor=abc'
+                )
+        self.assertEqual(response.status_code, 409)
+        self.assertEqual(response.json()['detail']['error'], 'cursor_expired')
+
+    def test_get_log_schema(self) -> None:
+        with (
+            mock.patch(
+                'imbi_api.endpoints.project_logs.resolve_plugin',
+                return_value=self._resolved(),
+            ),
+            mock.patch(
+                'imbi_api.endpoints.project_logs.get_plugin_credentials',
+                return_value={},
+            ),
+        ):
+            with testclient.TestClient(self.test_app) as client:
+                response = client.get(
+                    '/organizations/myorg/projects/proj1/logs/schema'
+                )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json(), [{'name': 'level', 'type': 'string'}]
+        )
+
+    def test_get_log_schema_credentials_missing(self) -> None:
+        from imbi_common.plugins.errors import PluginCredentialsMissing
+
+        with (
+            mock.patch(
+                'imbi_api.endpoints.project_logs.resolve_plugin',
+                return_value=self._resolved(),
+            ),
+            mock.patch(
+                'imbi_api.endpoints.project_logs.get_plugin_credentials',
+                side_effect=PluginCredentialsMissing('no token'),
+            ),
+        ):
+            with testclient.TestClient(self.test_app) as client:
+                response = client.get(
+                    '/organizations/myorg/projects/proj1/logs/schema'
+                )
+        self.assertEqual(response.status_code, 503)
+
+    def test_search_logs_with_valid_datetime_and_filter(self) -> None:
+        with (
+            mock.patch(
+                'imbi_api.endpoints.project_logs.resolve_plugin',
+                return_value=self._resolved(),
+            ),
+            mock.patch(
+                'imbi_api.endpoints.project_logs.get_plugin_credentials',
+                return_value={},
+            ),
+        ):
+            with testclient.TestClient(self.test_app) as client:
+                response = client.get(
+                    '/organizations/myorg/projects/proj1/logs/'
+                    '?start_time=2026-01-01T00:00:00%2B00:00'
+                    '&end_time=2026-01-02T00:00:00%2B00:00'
+                    '&filter=level:eq:INFO'
+                )
+        self.assertEqual(response.status_code, 200)
+
+
+class ParseFiltersTestCase(unittest.TestCase):
+    def test_filter_parses_with_value_containing_colon(self) -> None:
+        from imbi_api.endpoints.project_logs import _parse_filters
+
+        # `split(':', 2)` should keep ``key:value`` intact in value.
+        result = _parse_filters(['url:eq:https://example.com'])
+        self.assertEqual(result[0].field, 'url')
+        self.assertEqual(result[0].op, 'eq')
+        self.assertEqual(result[0].value, 'https://example.com')
+
+    def test_audit_log_payload_for_logs(self) -> None:
+        # Sanity check: importing the module should succeed and expose router
+        from imbi_api.endpoints import project_logs
+
+        self.assertTrue(hasattr(project_logs, 'project_logs_router'))
+        # Use json import so the module-level json import is exercised
+        # (also catches accidental import removal).
+        self.assertEqual(json.loads('{"a": 1}'), {'a': 1})

--- a/tests/endpoints/test_project_plugins.py
+++ b/tests/endpoints/test_project_plugins.py
@@ -153,8 +153,9 @@ class ProjectPluginsEndpointTestCase(unittest.TestCase):
             'options': '{}',
             'api_version': 1,
         }
-        # delete + create + final read
+        # validate plugin_ids + delete + create + final read
         self.mock_db.execute.side_effect = [
+            [{'found': '1'}],  # validate
             [{'deleted': '0'}],  # delete
             [],  # create
             [

--- a/tests/endpoints/test_project_plugins.py
+++ b/tests/endpoints/test_project_plugins.py
@@ -1,0 +1,194 @@
+"""Tests for project plugin assignment endpoints."""
+
+import datetime
+import json
+import unittest
+from unittest import mock
+
+from fastapi import testclient
+from imbi_common import graph
+
+from imbi_api import app, models
+from imbi_api.auth import password, permissions
+
+
+class ProjectPluginsEndpointTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.test_app = app.create_app()
+        self.test_user = models.User(
+            email='admin@example.com',
+            display_name='Admin User',
+            is_active=True,
+            is_admin=True,
+            password_hash=password.hash_password('testpassword123'),
+            created_at=datetime.datetime.now(datetime.UTC),
+        )
+        self.auth_context = permissions.AuthContext(
+            user=self.test_user,
+            session_id='test-session',
+            auth_method='jwt',
+            permissions={'project:read', 'project:write'},
+        )
+
+        async def mock_get_current_user() -> permissions.AuthContext:
+            return self.auth_context
+
+        self.test_app.dependency_overrides[permissions.get_current_user] = (
+            mock_get_current_user
+        )
+        self.mock_db = mock.AsyncMock(spec=graph.Graph)
+        self.test_app.dependency_overrides[graph._inject_graph] = (
+            lambda: self.mock_db
+        )
+
+    def test_get_project_plugins_not_found(self) -> None:
+        self.mock_db.execute.return_value = []
+        with testclient.TestClient(self.test_app) as client:
+            response = client.get(
+                '/organizations/myorg/projects/proj1/plugins/'
+            )
+        self.assertEqual(response.status_code, 404)
+
+    def test_get_project_plugins_merged_view(self) -> None:
+        plugin_a = {
+            'id': 'pa',
+            'plugin_slug': 'ssm',
+            'label': 'PT default',
+            'options': '{}',
+            'api_version': 1,
+        }
+        plugin_b = {
+            'id': 'pb',
+            'plugin_slug': 'logzio',
+            'label': 'Project log override',
+            'options': '{}',
+            'api_version': 1,
+        }
+        self.mock_db.execute.return_value = [
+            {
+                'pt_rows': json.dumps(
+                    [
+                        {
+                            'plugin': plugin_a,
+                            'edge': {
+                                'tab': 'configuration',
+                                'default': True,
+                                'options': '{}',
+                            },
+                            'src': 'project_type',
+                        }
+                    ]
+                ),
+                'proj_rows': json.dumps(
+                    [
+                        {
+                            'plugin': plugin_b,
+                            'edge': {
+                                'tab': 'logs',
+                                'default': True,
+                                'options': '{}',
+                            },
+                            'src': 'project',
+                        }
+                    ]
+                ),
+            }
+        ]
+        with testclient.TestClient(self.test_app) as client:
+            response = client.get(
+                '/organizations/myorg/projects/proj1/plugins/'
+            )
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        ids = {r['plugin_id']: r for r in data}
+        self.assertEqual(ids['pa']['source'], 'project_type')
+        self.assertEqual(ids['pb']['source'], 'project')
+
+    def test_replace_project_plugins_validation_error(self) -> None:
+        with testclient.TestClient(self.test_app) as client:
+            response = client.put(
+                '/organizations/myorg/projects/proj1/plugins/',
+                json=[
+                    {
+                        'plugin_id': 'p1',
+                        'tab': 'configuration',
+                        'default': True,
+                        'options': {},
+                    },
+                    {
+                        'plugin_id': 'p2',
+                        'tab': 'configuration',
+                        'default': True,
+                        'options': {},
+                    },
+                ],
+            )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('default', response.json()['detail'])
+
+    def test_replace_project_plugins_empty_list_ok(self) -> None:
+        # No assignments == clear all. Skips validation, runs delete only.
+        self.mock_db.execute.side_effect = [
+            [{'deleted': '0'}],  # delete query
+            [
+                {  # the post-mutation get_project_plugins read
+                    'pt_rows': '[]',
+                    'proj_rows': '[]',
+                }
+            ],
+        ]
+        with testclient.TestClient(self.test_app) as client:
+            response = client.put(
+                '/organizations/myorg/projects/proj1/plugins/',
+                json=[],
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), [])
+
+    def test_replace_project_plugins_creates_each(self) -> None:
+        plugin_raw = {
+            'id': 'p1',
+            'plugin_slug': 'ssm',
+            'label': 'SSM',
+            'options': '{}',
+            'api_version': 1,
+        }
+        # delete + create + final read
+        self.mock_db.execute.side_effect = [
+            [{'deleted': '0'}],  # delete
+            [],  # create
+            [
+                {
+                    'pt_rows': '[]',
+                    'proj_rows': json.dumps(
+                        [
+                            {
+                                'plugin': plugin_raw,
+                                'edge': {
+                                    'tab': 'configuration',
+                                    'default': True,
+                                    'options': '{}',
+                                },
+                                'src': 'project',
+                            }
+                        ]
+                    ),
+                }
+            ],
+        ]
+        with testclient.TestClient(self.test_app) as client:
+            response = client.put(
+                '/organizations/myorg/projects/proj1/plugins/',
+                json=[
+                    {
+                        'plugin_id': 'p1',
+                        'tab': 'configuration',
+                        'default': True,
+                        'options': {},
+                    }
+                ],
+            )
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]['plugin_id'], 'p1')

--- a/tests/endpoints/test_project_type_plugins.py
+++ b/tests/endpoints/test_project_type_plugins.py
@@ -108,6 +108,7 @@ class ProjectTypePluginsEndpointTestCase(unittest.TestCase):
             },
         }
         self.mock_db.execute.side_effect = [
+            [{'found': '1'}],  # validate plugin_ids
             [{'deleted': '0'}],  # delete
             [],  # create edge
             [plugin_record],  # final list call

--- a/tests/endpoints/test_project_type_plugins.py
+++ b/tests/endpoints/test_project_type_plugins.py
@@ -1,0 +1,152 @@
+"""Tests for project-type plugin assignment endpoints."""
+
+import datetime
+import json
+import unittest
+from unittest import mock
+
+from fastapi import testclient
+from imbi_common import graph
+
+from imbi_api import app, models
+from imbi_api.auth import password, permissions
+
+
+class ProjectTypePluginsEndpointTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.test_app = app.create_app()
+        self.test_user = models.User(
+            email='admin@example.com',
+            display_name='Admin User',
+            is_active=True,
+            is_admin=True,
+            password_hash=password.hash_password('testpassword123'),
+            created_at=datetime.datetime.now(datetime.UTC),
+        )
+        self.auth_context = permissions.AuthContext(
+            user=self.test_user,
+            session_id='test-session',
+            auth_method='jwt',
+            permissions={'project_type:read', 'project_type:update'},
+        )
+
+        async def mock_get_current_user() -> permissions.AuthContext:
+            return self.auth_context
+
+        self.test_app.dependency_overrides[permissions.get_current_user] = (
+            mock_get_current_user
+        )
+        self.mock_db = mock.AsyncMock(spec=graph.Graph)
+        self.test_app.dependency_overrides[graph._inject_graph] = (
+            lambda: self.mock_db
+        )
+
+    def test_list_empty(self) -> None:
+        self.mock_db.execute.return_value = []
+        with testclient.TestClient(self.test_app) as client:
+            response = client.get(
+                '/organizations/myorg/project-types/web/plugins/'
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), [])
+
+    def test_list_with_results(self) -> None:
+        self.mock_db.execute.return_value = [
+            {
+                'plugin': {
+                    'id': 'p1',
+                    'plugin_slug': 'ssm',
+                    'label': 'SSM',
+                    'options': '{}',
+                    'api_version': 1,
+                },
+                'edge': {
+                    'tab': 'configuration',
+                    'default': True,
+                    'options': '{}',
+                },
+            }
+        ]
+        with testclient.TestClient(self.test_app) as client:
+            response = client.get(
+                '/organizations/myorg/project-types/web/plugins/'
+            )
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data[0]['plugin_id'], 'p1')
+        self.assertEqual(data[0]['source'], 'project_type')
+
+    def test_replace_validation_error(self) -> None:
+        with testclient.TestClient(self.test_app) as client:
+            response = client.put(
+                '/organizations/myorg/project-types/web/plugins/',
+                json=[
+                    {
+                        'plugin_id': 'p1',
+                        'tab': 'configuration',
+                        'default': False,
+                        'options': {},
+                    }
+                ],
+            )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('default', response.json()['detail'])
+
+    def test_replace_creates_assignments(self) -> None:
+        plugin_record = {
+            'plugin': {
+                'id': 'p1',
+                'plugin_slug': 'ssm',
+                'label': 'SSM',
+                'options': '{}',
+                'api_version': 1,
+            },
+            'edge': {
+                'tab': 'configuration',
+                'default': True,
+                'options': '{}',
+            },
+        }
+        self.mock_db.execute.side_effect = [
+            [{'deleted': '0'}],  # delete
+            [],  # create edge
+            [plugin_record],  # final list call
+        ]
+        with testclient.TestClient(self.test_app) as client:
+            response = client.put(
+                '/organizations/myorg/project-types/web/plugins/',
+                json=[
+                    {
+                        'plugin_id': 'p1',
+                        'tab': 'configuration',
+                        'default': True,
+                        'options': {},
+                    }
+                ],
+            )
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data[0]['plugin_id'], 'p1')
+
+    def test_from_record_with_string_edge(self) -> None:
+        # Covers the parse_agtype path for an edge that is a JSON string.
+        from imbi_api.endpoints.project_type_plugins import _from_record
+
+        rec = {
+            'plugin': json.dumps(
+                {
+                    'id': 'p1',
+                    'plugin_slug': 'ssm',
+                    'label': 'SSM',
+                }
+            ),
+            'edge': json.dumps(
+                {
+                    'tab': 'configuration',
+                    'default': True,
+                    'options': '{}',
+                }
+            ),
+        }
+        resp = _from_record(rec, 'project_type')
+        self.assertEqual(resp.plugin_id, 'p1')

--- a/tests/endpoints/test_service_plugins.py
+++ b/tests/endpoints/test_service_plugins.py
@@ -1,0 +1,136 @@
+"""Tests for service plugin CRUD endpoints."""
+
+import datetime
+import json
+import unittest
+from unittest import mock
+
+from fastapi import testclient
+from imbi_common import graph
+
+from imbi_api import app, models
+from imbi_api.auth import password, permissions
+
+
+class ServicePluginsEndpointTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.test_app = app.create_app()
+        self.test_user = models.User(
+            email='admin@example.com',
+            display_name='Admin User',
+            is_active=True,
+            is_admin=True,
+            password_hash=password.hash_password('testpassword123'),
+            created_at=datetime.datetime.now(datetime.UTC),
+        )
+        self.auth_context = permissions.AuthContext(
+            user=self.test_user,
+            session_id='test-session',
+            auth_method='jwt',
+            permissions={
+                'third_party_service:read',
+                'third_party_service:update',
+            },
+        )
+
+        async def mock_get_current_user() -> permissions.AuthContext:
+            return self.auth_context
+
+        self.test_app.dependency_overrides[permissions.get_current_user] = (
+            mock_get_current_user
+        )
+        self.mock_db = mock.AsyncMock(spec=graph.Graph)
+
+        self.test_app.dependency_overrides[graph._inject_graph] = (
+            lambda: self.mock_db
+        )
+
+    def test_list_plugins_empty(self) -> None:
+        self.mock_db.execute.return_value = []
+        with mock.patch(
+            'imbi_api.endpoints.service_plugins.list_plugins',
+            return_value=[],
+        ):
+            with testclient.TestClient(self.test_app) as client:
+                response = client.get(
+                    '/organizations/myorg/third-party-services/github/plugins/'
+                )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), [])
+
+    def test_list_plugins_with_results(self) -> None:
+        plugin_raw = json.dumps(
+            {
+                'id': 'abc123',
+                'plugin_slug': 'ssm',
+                'label': 'SSM Config',
+                'options': '{}',
+                'api_version': 1,
+            }
+        )
+        svc_raw = json.dumps({'slug': 'github'})
+        self.mock_db.execute.return_value = [
+            {
+                'plugin': plugin_raw,
+                'svc': svc_raw,
+            }
+        ]
+        with mock.patch(
+            'imbi_api.endpoints.service_plugins.list_plugins',
+            return_value=[],
+        ):
+            with testclient.TestClient(self.test_app) as client:
+                response = client.get(
+                    '/organizations/myorg/third-party-services/github/plugins/'
+                )
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]['plugin_slug'], 'ssm')
+        self.assertEqual(data[0]['status'], 'unavailable')
+
+    def test_create_plugin_slug_not_installed(self) -> None:
+        from imbi_common.plugins.errors import PluginNotFoundError
+
+        self.mock_db.execute.return_value = []
+        with mock.patch(
+            'imbi_api.endpoints.service_plugins.get_plugin',
+            side_effect=PluginNotFoundError('ssm'),
+        ):
+            with testclient.TestClient(self.test_app) as client:
+                response = client.post(
+                    '/organizations/myorg/'
+                    'third-party-services/github/plugins/',
+                    json={
+                        'plugin_slug': 'ssm',
+                        'label': 'My SSM',
+                        'options': {},
+                    },
+                )
+        self.assertEqual(response.status_code, 400)
+
+    def test_delete_plugin_conflict(self) -> None:
+        self.mock_db.execute.return_value = [{'cnt': '2'}]
+        with testclient.TestClient(self.test_app) as client:
+            response = client.delete(
+                '/organizations/myorg/'
+                'third-party-services/github/plugins/abc123'
+            )
+        self.assertEqual(response.status_code, 409)
+
+    def test_delete_plugin_not_found(self) -> None:
+        self.mock_db.execute.return_value = [{'cnt': '0'}]
+
+        def _side_effect(*args: object, **kwargs: object) -> list[dict]:
+            call_count = self.mock_db.execute.call_count
+            if call_count == 1:
+                return [{'cnt': '0'}]
+            return [{'deleted': '0'}]
+
+        self.mock_db.execute.side_effect = _side_effect
+        with testclient.TestClient(self.test_app) as client:
+            response = client.delete(
+                '/organizations/myorg/'
+                'third-party-services/github/plugins/abc123'
+            )
+        self.assertEqual(response.status_code, 404)

--- a/tests/endpoints/test_service_plugins.py
+++ b/tests/endpoints/test_service_plugins.py
@@ -372,8 +372,11 @@ class ServicePluginsEndpointTestCase(unittest.TestCase):
             }
         )
         svc_raw = json.dumps({'slug': 'github'})
-        self.mock_db.execute.return_value = [
-            {'plugin': plugin_raw, 'svc': svc_raw}
+        # PUT now runs a duplicate-label check before the update; supply
+        # a zero count for the check, then the updated row.
+        self.mock_db.execute.side_effect = [
+            [{'cnt': '0'}],  # dup-label check
+            [{'plugin': plugin_raw, 'svc': svc_raw}],  # update
         ]
         with mock.patch(
             'imbi_api.endpoints.service_plugins.list_plugins',
@@ -389,7 +392,8 @@ class ServicePluginsEndpointTestCase(unittest.TestCase):
         self.assertEqual(response.json()['label'], 'New Label')
 
     def test_update_plugin_not_found(self) -> None:
-        self.mock_db.execute.return_value = []
+        # dup-label check returns 0, then update returns empty.
+        self.mock_db.execute.side_effect = [[{'cnt': '0'}], []]
         with testclient.TestClient(self.test_app) as client:
             response = client.put(
                 '/organizations/myorg/'

--- a/tests/endpoints/test_service_plugins.py
+++ b/tests/endpoints/test_service_plugins.py
@@ -134,3 +134,293 @@ class ServicePluginsEndpointTestCase(unittest.TestCase):
                 'third-party-services/github/plugins/abc123'
             )
         self.assertEqual(response.status_code, 404)
+
+    def test_list_plugins_active_status(self) -> None:
+        from imbi_common.plugins.base import (
+            ConfigurationPlugin,
+            PluginManifest,
+        )
+        from imbi_common.plugins.registry import RegistryEntry
+
+        class _Fake(ConfigurationPlugin):
+            manifest = PluginManifest(
+                slug='ssm', name='SSM', plugin_type='configuration'
+            )
+
+            async def list_keys(self, ctx, credentials):  # type: ignore[override]
+                return []
+
+            async def get_values(self, ctx, credentials, keys=None):  # type: ignore[override]
+                return []
+
+            async def set_value(self, ctx, credentials, key, value):  # type: ignore[override]
+                raise NotImplementedError
+
+            async def delete_key(self, ctx, credentials, key):  # type: ignore[override]
+                return None
+
+        entry = RegistryEntry(
+            handler_cls=_Fake,
+            manifest=_Fake.manifest,
+            package_name='imbi-plugin-ssm',
+            package_version='1.0.0',
+        )
+        plugin_raw = json.dumps(
+            {
+                'id': 'abc123',
+                'plugin_slug': 'ssm',
+                'label': 'SSM',
+                'options': '{}',
+                'api_version': 1,
+            }
+        )
+        svc_raw = json.dumps({'slug': 'github'})
+        self.mock_db.execute.return_value = [
+            {'plugin': plugin_raw, 'svc': svc_raw}
+        ]
+        with mock.patch(
+            'imbi_api.endpoints.service_plugins.list_plugins',
+            return_value=[entry],
+        ):
+            with testclient.TestClient(self.test_app) as client:
+                response = client.get(
+                    '/organizations/myorg/third-party-services/github/plugins/'
+                )
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data[0]['status'], 'active')
+
+    def test_create_plugin_duplicate_label_returns_409(self) -> None:
+        from imbi_common.plugins.base import (
+            ConfigurationPlugin,
+            PluginManifest,
+        )
+        from imbi_common.plugins.registry import RegistryEntry
+
+        class _Fake(ConfigurationPlugin):
+            manifest = PluginManifest(
+                slug='ssm', name='SSM', plugin_type='configuration'
+            )
+
+            async def list_keys(self, ctx, credentials):  # type: ignore[override]
+                return []
+
+            async def get_values(self, ctx, credentials, keys=None):  # type: ignore[override]
+                return []
+
+            async def set_value(self, ctx, credentials, key, value):  # type: ignore[override]
+                raise NotImplementedError
+
+            async def delete_key(self, ctx, credentials, key):  # type: ignore[override]
+                return None
+
+        entry = RegistryEntry(
+            handler_cls=_Fake,
+            manifest=_Fake.manifest,
+            package_name='imbi-plugin-ssm',
+            package_version='1.0.0',
+        )
+        self.mock_db.execute.return_value = [{'cnt': '1'}]
+        with mock.patch(
+            'imbi_api.endpoints.service_plugins.get_plugin',
+            return_value=entry,
+        ):
+            with testclient.TestClient(self.test_app) as client:
+                response = client.post(
+                    '/organizations/myorg/'
+                    'third-party-services/github/plugins/',
+                    json={
+                        'plugin_slug': 'ssm',
+                        'label': 'My SSM',
+                        'options': {},
+                    },
+                )
+        self.assertEqual(response.status_code, 409)
+
+    def test_create_plugin_success(self) -> None:
+        from imbi_common.plugins.base import (
+            ConfigurationPlugin,
+            PluginManifest,
+        )
+        from imbi_common.plugins.registry import RegistryEntry
+
+        class _Fake(ConfigurationPlugin):
+            manifest = PluginManifest(
+                slug='ssm', name='SSM', plugin_type='configuration'
+            )
+
+            async def list_keys(self, ctx, credentials):  # type: ignore[override]
+                return []
+
+            async def get_values(self, ctx, credentials, keys=None):  # type: ignore[override]
+                return []
+
+            async def set_value(self, ctx, credentials, key, value):  # type: ignore[override]
+                raise NotImplementedError
+
+            async def delete_key(self, ctx, credentials, key):  # type: ignore[override]
+                return None
+
+        entry = RegistryEntry(
+            handler_cls=_Fake,
+            manifest=_Fake.manifest,
+            package_name='imbi-plugin-ssm',
+            package_version='1.0.0',
+        )
+        plugin_raw = json.dumps(
+            {
+                'id': 'newid',
+                'plugin_slug': 'ssm',
+                'label': 'My SSM',
+                'options': '{}',
+                'api_version': 1,
+            }
+        )
+        svc_raw = json.dumps({'slug': 'github'})
+        responses = [
+            [{'cnt': '0'}],
+            [{'plugin': plugin_raw, 'svc': svc_raw}],
+        ]
+
+        def _exec(*_a: object, **_k: object) -> list[dict]:
+            return responses.pop(0)
+
+        self.mock_db.execute.side_effect = _exec
+        with (
+            mock.patch(
+                'imbi_api.endpoints.service_plugins.get_plugin',
+                return_value=entry,
+            ),
+            mock.patch(
+                'imbi_api.endpoints.service_plugins.list_plugins',
+                return_value=[entry],
+            ),
+        ):
+            with testclient.TestClient(self.test_app) as client:
+                response = client.post(
+                    '/organizations/myorg/'
+                    'third-party-services/github/plugins/',
+                    json={
+                        'plugin_slug': 'ssm',
+                        'label': 'My SSM',
+                        'options': {},
+                    },
+                )
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.json()['id'], 'newid')
+
+    def test_create_plugin_service_not_found(self) -> None:
+        from imbi_common.plugins.base import (
+            ConfigurationPlugin,
+            PluginManifest,
+        )
+        from imbi_common.plugins.registry import RegistryEntry
+
+        class _Fake(ConfigurationPlugin):
+            manifest = PluginManifest(
+                slug='ssm', name='SSM', plugin_type='configuration'
+            )
+
+            async def list_keys(self, ctx, credentials):  # type: ignore[override]
+                return []
+
+            async def get_values(self, ctx, credentials, keys=None):  # type: ignore[override]
+                return []
+
+            async def set_value(self, ctx, credentials, key, value):  # type: ignore[override]
+                raise NotImplementedError
+
+            async def delete_key(self, ctx, credentials, key):  # type: ignore[override]
+                return None
+
+        entry = RegistryEntry(
+            handler_cls=_Fake,
+            manifest=_Fake.manifest,
+            package_name='imbi-plugin-ssm',
+            package_version='1.0.0',
+        )
+        responses = [[{'cnt': '0'}], []]
+
+        def _exec(*_a: object, **_k: object) -> list[dict]:
+            return responses.pop(0)
+
+        self.mock_db.execute.side_effect = _exec
+        with mock.patch(
+            'imbi_api.endpoints.service_plugins.get_plugin',
+            return_value=entry,
+        ):
+            with testclient.TestClient(self.test_app) as client:
+                response = client.post(
+                    '/organizations/myorg/'
+                    'third-party-services/github/plugins/',
+                    json={
+                        'plugin_slug': 'ssm',
+                        'label': 'My SSM',
+                        'options': {},
+                    },
+                )
+        self.assertEqual(response.status_code, 404)
+
+    def test_update_plugin_success(self) -> None:
+        plugin_raw = json.dumps(
+            {
+                'id': 'abc123',
+                'plugin_slug': 'ssm',
+                'label': 'New Label',
+                'options': '{}',
+                'api_version': 1,
+            }
+        )
+        svc_raw = json.dumps({'slug': 'github'})
+        self.mock_db.execute.return_value = [
+            {'plugin': plugin_raw, 'svc': svc_raw}
+        ]
+        with mock.patch(
+            'imbi_api.endpoints.service_plugins.list_plugins',
+            return_value=[],
+        ):
+            with testclient.TestClient(self.test_app) as client:
+                response = client.put(
+                    '/organizations/myorg/'
+                    'third-party-services/github/plugins/abc123',
+                    json={'label': 'New Label', 'options': {}},
+                )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()['label'], 'New Label')
+
+    def test_update_plugin_not_found(self) -> None:
+        self.mock_db.execute.return_value = []
+        with testclient.TestClient(self.test_app) as client:
+            response = client.put(
+                '/organizations/myorg/'
+                'third-party-services/github/plugins/abc123',
+                json={'label': 'New Label', 'options': {}},
+            )
+        self.assertEqual(response.status_code, 404)
+
+    def test_delete_plugin_force_skips_ref_check(self) -> None:
+        # When force=true, only the delete query runs (no ref check).
+        self.mock_db.execute.return_value = [{'deleted': '1'}]
+        with testclient.TestClient(self.test_app) as client:
+            response = client.delete(
+                '/organizations/myorg/'
+                'third-party-services/github/plugins/abc123?force=true'
+            )
+        self.assertEqual(response.status_code, 204)
+
+    def test_delete_plugin_success(self) -> None:
+        responses = [
+            [{'cnt': '0'}],
+            [{'deleted': '1'}],
+        ]
+
+        def _exec(*_a: object, **_k: object) -> list[dict]:
+            return responses.pop(0)
+
+        self.mock_db.execute.side_effect = _exec
+        with testclient.TestClient(self.test_app) as client:
+            response = client.delete(
+                '/organizations/myorg/'
+                'third-party-services/github/plugins/abc123'
+            )
+        self.assertEqual(response.status_code, 204)

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,0 +1,229 @@
+"""Tests for the plugin infrastructure modules."""
+
+import asyncio
+import unittest
+from unittest import mock
+
+
+class CatalogTestCase(unittest.TestCase):
+    def test_catalog_loads(self) -> None:
+        from imbi_api.plugins.catalog import list_catalog_entries
+
+        with mock.patch(
+            'imbi_api.plugins.catalog.list_plugins',
+            return_value=[],
+        ):
+            entries = list_catalog_entries()
+        self.assertIsInstance(entries, list)
+        self.assertTrue(len(entries) > 0)
+        self.assertEqual(entries[0]['package'], 'imbi-plugin-ssm')
+        self.assertEqual(entries[0]['status'], 'not_installed')
+
+    def test_catalog_installed_status(self) -> None:
+        from imbi_common.plugins.base import (
+            ConfigurationPlugin,
+            PluginManifest,
+        )
+        from imbi_common.plugins.registry import RegistryEntry
+
+        from imbi_api.plugins.catalog import list_catalog_entries
+
+        class _FakePlugin(ConfigurationPlugin):
+            manifest = PluginManifest(
+                slug='ssm',
+                name='SSM',
+                plugin_type='configuration',
+            )
+
+            async def list_keys(self, ctx, credentials):  # type: ignore[override]
+                return []
+
+            async def get_values(self, ctx, credentials, keys=None):  # type: ignore[override]
+                return []
+
+            async def set_value(self, ctx, credentials, key, value):  # type: ignore[override]
+                raise NotImplementedError
+
+            async def delete_key(self, ctx, credentials, key):  # type: ignore[override]
+                pass
+
+        entry = RegistryEntry(
+            handler_cls=_FakePlugin,
+            manifest=_FakePlugin.manifest,
+            package_name='imbi-plugin-ssm',
+            package_version='1.0.0',
+        )
+        with mock.patch(
+            'imbi_api.plugins.catalog.list_plugins',
+            return_value=[entry],
+        ):
+            entries = list_catalog_entries()
+        ssm = next(e for e in entries if e['package'] == 'imbi-plugin-ssm')
+        self.assertEqual(ssm['status'], 'installed')
+
+
+class AssignmentsTestCase(unittest.TestCase):
+    def test_validate_one_default_per_tab_ok(self) -> None:
+        from imbi_api.plugins.assignments import (
+            PluginAssignmentRow,
+            validate_one_default_per_tab,
+        )
+
+        rows: list[PluginAssignmentRow] = [
+            PluginAssignmentRow(
+                plugin_id='p1',
+                tab='configuration',
+                default=True,
+                options={},
+            ),
+            PluginAssignmentRow(
+                plugin_id='p2',
+                tab='logs',
+                default=True,
+                options={},
+            ),
+        ]
+        validate_one_default_per_tab(rows)
+
+    def test_validate_two_defaults_same_tab_raises(self) -> None:
+        from imbi_api.plugins.assignments import (
+            PluginAssignmentRow,
+            validate_one_default_per_tab,
+        )
+
+        rows: list[PluginAssignmentRow] = [
+            PluginAssignmentRow(
+                plugin_id='p1',
+                tab='configuration',
+                default=True,
+                options={},
+            ),
+            PluginAssignmentRow(
+                plugin_id='p2',
+                tab='configuration',
+                default=True,
+                options={},
+            ),
+        ]
+        with self.assertRaises(ValueError):
+            validate_one_default_per_tab(rows)
+
+    def test_validate_no_default_raises(self) -> None:
+        from imbi_api.plugins.assignments import (
+            PluginAssignmentRow,
+            validate_one_default_per_tab,
+        )
+
+        rows: list[PluginAssignmentRow] = [
+            PluginAssignmentRow(
+                plugin_id='p1',
+                tab='configuration',
+                default=False,
+                options={},
+            ),
+        ]
+        with self.assertRaises(ValueError):
+            validate_one_default_per_tab(rows)
+
+
+class LifecycleTestCase(unittest.TestCase):
+    def test_get_unavailable_slugs_empty(self) -> None:
+        from imbi_api.plugins.lifecycle import get_unavailable_slugs
+
+        result = get_unavailable_slugs()
+        self.assertIsInstance(result, list)
+
+    def test_startup_load_plugins_logs(self) -> None:
+        from imbi_common.plugins.registry import LoadResult
+
+        from imbi_api.plugins import lifecycle
+
+        mock_db = mock.AsyncMock()
+        mock_db.execute.return_value = []
+
+        with (
+            mock.patch(
+                'imbi_api.plugins.lifecycle.load_plugins',
+                return_value=LoadResult(
+                    loaded=['ssm'],
+                    errors={},
+                    skipped=[],
+                ),
+            ),
+            mock.patch(
+                'imbi_api.plugins.lifecycle.list_plugins',
+                return_value=[],
+            ),
+        ):
+            asyncio.run(lifecycle.startup_load_plugins(mock_db))
+
+    def test_audit_unavailable_handles_error(self) -> None:
+        from imbi_api.plugins import lifecycle
+
+        mock_db = mock.AsyncMock()
+        mock_db.execute.side_effect = RuntimeError('db error')
+
+        with mock.patch(
+            'imbi_api.plugins.lifecycle.list_plugins',
+            return_value=[],
+        ):
+            asyncio.run(lifecycle._audit_unavailable(mock_db))
+
+
+class ReloadHookTestCase(unittest.TestCase):
+    def test_plugin_reload_hook_no_valkey(self) -> None:
+        from imbi_api.plugins.reload import plugin_reload_hook
+
+        async def _run() -> None:
+            with mock.patch(
+                'imbi_api.plugins.reload.valkey.get_client',
+                side_effect=RuntimeError('no valkey'),
+            ):
+                async with plugin_reload_hook(db=None):
+                    pass
+
+        asyncio.run(_run())
+
+    def test_plugin_reload_hook_no_db(self) -> None:
+        from imbi_api.plugins.reload import plugin_reload_hook
+
+        mock_client = mock.MagicMock()
+
+        async def _run() -> None:
+            with mock.patch(
+                'imbi_api.plugins.reload.valkey.get_client',
+                return_value=mock_client,
+            ):
+                async with plugin_reload_hook(db=None):
+                    pass
+
+        asyncio.run(_run())
+
+    def test_publish_reload(self) -> None:
+        from imbi_api.plugins.reload import publish_reload
+
+        mock_client = mock.AsyncMock()
+
+        asyncio.run(publish_reload(mock_client))
+        mock_client.publish.assert_called_once_with(
+            'imbi:plugins:reload', 'reload'
+        )
+
+
+class InstallerTestCase(unittest.TestCase):
+    def test_install_disabled_raises(self) -> None:
+        from imbi_api.plugins import installer
+        from imbi_api.plugins.installer import InstallError
+
+        with mock.patch.object(installer, '_INSTALL_ENABLED', False):
+            with self.assertRaises(InstallError) as ctx:
+                asyncio.run(installer.install_package('imbi-plugin-ssm'))
+        self.assertIn('disabled', str(ctx.exception))
+
+    def test_install_not_in_catalog_raises(self) -> None:
+        from imbi_api.plugins import installer
+        from imbi_api.plugins.installer import InstallError
+
+        with self.assertRaises(InstallError) as ctx:
+            asyncio.run(installer.install_package('not-in-catalog-pkg'))
+        self.assertIn('not in the plugin catalog', str(ctx.exception))

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -287,6 +287,9 @@ class InstallerTestCase(unittest.TestCase):
         mock_proc = mock.MagicMock()
         mock_proc.communicate = mock.AsyncMock(side_effect=TimeoutError())
         mock_proc.kill = mock.MagicMock()
+        # ``installer`` drains the child via ``await proc.wait()`` after
+        # killing it on timeout to avoid leaking fds.
+        mock_proc.wait = mock.AsyncMock(return_value=-9)
 
         async def _exec(*_a: object, **_k: object) -> mock.MagicMock:
             return mock_proc
@@ -298,6 +301,7 @@ class InstallerTestCase(unittest.TestCase):
                 asyncio.run(installer.install_package('imbi-plugin-ssm'))
         self.assertIn('timed out', str(ctx.exception))
         mock_proc.kill.assert_called_once()
+        mock_proc.wait.assert_awaited_once()
 
     def test_uninstall_success(self) -> None:
         from imbi_common.plugins.registry import LoadResult
@@ -358,6 +362,7 @@ class InstallerTestCase(unittest.TestCase):
         mock_proc = mock.MagicMock()
         mock_proc.communicate = mock.AsyncMock(side_effect=TimeoutError())
         mock_proc.kill = mock.MagicMock()
+        mock_proc.wait = mock.AsyncMock(return_value=-9)
 
         async def _exec(*_a: object, **_k: object) -> mock.MagicMock:
             return mock_proc
@@ -368,6 +373,8 @@ class InstallerTestCase(unittest.TestCase):
             with self.assertRaises(InstallError) as ctx:
                 asyncio.run(installer.uninstall_package('imbi-plugin-ssm'))
         self.assertIn('timed out', str(ctx.exception))
+        mock_proc.kill.assert_called_once()
+        mock_proc.wait.assert_awaited_once()
 
 
 def _make_registry_entry(

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,8 +1,15 @@
 """Tests for the plugin infrastructure modules."""
 
+from __future__ import annotations
+
 import asyncio
+import json
+import typing
 import unittest
 from unittest import mock
+
+if typing.TYPE_CHECKING:
+    from imbi_common.plugins.registry import RegistryEntry
 
 
 class CatalogTestCase(unittest.TestCase):
@@ -227,3 +234,639 @@ class InstallerTestCase(unittest.TestCase):
         with self.assertRaises(InstallError) as ctx:
             asyncio.run(installer.install_package('not-in-catalog-pkg'))
         self.assertIn('not in the plugin catalog', str(ctx.exception))
+
+    def test_install_success(self) -> None:
+        from imbi_common.plugins.registry import LoadResult
+
+        from imbi_api.plugins import installer
+
+        mock_proc = mock.MagicMock()
+        mock_proc.communicate = mock.AsyncMock(return_value=(b'ok', b''))
+        mock_proc.returncode = 0
+
+        async def _exec(*_a: object, **_k: object) -> mock.MagicMock:
+            return mock_proc
+
+        with (
+            mock.patch.object(
+                installer.asyncio, 'create_subprocess_exec', _exec
+            ),
+            mock.patch.object(
+                installer,
+                'reload_plugins',
+                return_value=LoadResult(loaded=['ssm'], errors={}, skipped=[]),
+            ),
+        ):
+            result = asyncio.run(
+                installer.install_package('imbi-plugin-ssm', '1.2.3')
+            )
+        self.assertEqual(result.loaded, ['ssm'])
+
+    def test_install_nonzero_exit_raises(self) -> None:
+        from imbi_api.plugins import installer
+        from imbi_api.plugins.installer import InstallError
+
+        mock_proc = mock.MagicMock()
+        mock_proc.communicate = mock.AsyncMock(return_value=(b'', b'boom'))
+        mock_proc.returncode = 1
+
+        async def _exec(*_a: object, **_k: object) -> mock.MagicMock:
+            return mock_proc
+
+        with mock.patch.object(
+            installer.asyncio, 'create_subprocess_exec', _exec
+        ):
+            with self.assertRaises(InstallError) as ctx:
+                asyncio.run(installer.install_package('imbi-plugin-ssm'))
+        self.assertIn('failed', str(ctx.exception))
+
+    def test_install_timeout_raises(self) -> None:
+        from imbi_api.plugins import installer
+        from imbi_api.plugins.installer import InstallError
+
+        mock_proc = mock.MagicMock()
+        mock_proc.communicate = mock.AsyncMock(side_effect=TimeoutError())
+        mock_proc.kill = mock.MagicMock()
+
+        async def _exec(*_a: object, **_k: object) -> mock.MagicMock:
+            return mock_proc
+
+        with mock.patch.object(
+            installer.asyncio, 'create_subprocess_exec', _exec
+        ):
+            with self.assertRaises(InstallError) as ctx:
+                asyncio.run(installer.install_package('imbi-plugin-ssm'))
+        self.assertIn('timed out', str(ctx.exception))
+        mock_proc.kill.assert_called_once()
+
+    def test_uninstall_success(self) -> None:
+        from imbi_common.plugins.registry import LoadResult
+
+        from imbi_api.plugins import installer
+
+        mock_proc = mock.MagicMock()
+        mock_proc.communicate = mock.AsyncMock(return_value=(b'', b''))
+        mock_proc.returncode = 0
+
+        async def _exec(*_a: object, **_k: object) -> mock.MagicMock:
+            return mock_proc
+
+        with (
+            mock.patch.object(
+                installer.asyncio, 'create_subprocess_exec', _exec
+            ),
+            mock.patch.object(
+                installer,
+                'reload_plugins',
+                return_value=LoadResult(loaded=[], errors={}, skipped=[]),
+            ),
+        ):
+            result = asyncio.run(
+                installer.uninstall_package('imbi-plugin-ssm')
+            )
+        self.assertEqual(result.loaded, [])
+
+    def test_uninstall_disabled_raises(self) -> None:
+        from imbi_api.plugins import installer
+        from imbi_api.plugins.installer import InstallError
+
+        with mock.patch.object(installer, '_INSTALL_ENABLED', False):
+            with self.assertRaises(InstallError):
+                asyncio.run(installer.uninstall_package('imbi-plugin-ssm'))
+
+    def test_uninstall_nonzero_exit_raises(self) -> None:
+        from imbi_api.plugins import installer
+        from imbi_api.plugins.installer import InstallError
+
+        mock_proc = mock.MagicMock()
+        mock_proc.communicate = mock.AsyncMock(return_value=(b'', b'oops'))
+        mock_proc.returncode = 1
+
+        async def _exec(*_a: object, **_k: object) -> mock.MagicMock:
+            return mock_proc
+
+        with mock.patch.object(
+            installer.asyncio, 'create_subprocess_exec', _exec
+        ):
+            with self.assertRaises(InstallError):
+                asyncio.run(installer.uninstall_package('imbi-plugin-ssm'))
+
+    def test_uninstall_timeout_raises(self) -> None:
+        from imbi_api.plugins import installer
+        from imbi_api.plugins.installer import InstallError
+
+        mock_proc = mock.MagicMock()
+        mock_proc.communicate = mock.AsyncMock(side_effect=TimeoutError())
+        mock_proc.kill = mock.MagicMock()
+
+        async def _exec(*_a: object, **_k: object) -> mock.MagicMock:
+            return mock_proc
+
+        with mock.patch.object(
+            installer.asyncio, 'create_subprocess_exec', _exec
+        ):
+            with self.assertRaises(InstallError) as ctx:
+                asyncio.run(installer.uninstall_package('imbi-plugin-ssm'))
+        self.assertIn('timed out', str(ctx.exception))
+
+
+def _make_registry_entry(
+    slug: str = 'ssm',
+    required_creds: bool = False,
+) -> RegistryEntry:
+    """Build a RegistryEntry with a fake handler for resolution tests."""
+    from imbi_common.plugins.base import (
+        ConfigurationPlugin,
+        CredentialField,
+        PluginManifest,
+    )
+    from imbi_common.plugins.registry import RegistryEntry
+
+    class _Fake(ConfigurationPlugin):
+        manifest = PluginManifest(
+            slug=slug,
+            name=slug.upper(),
+            plugin_type='configuration',
+            credentials=(
+                [CredentialField(name='token', label='Token', required=True)]
+                if required_creds
+                else []
+            ),
+        )
+
+        async def list_keys(self, ctx, credentials):  # type: ignore[override]
+            return []
+
+        async def get_values(self, ctx, credentials, keys=None):  # type: ignore[override]
+            return []
+
+        async def set_value(self, ctx, credentials, key, value):  # type: ignore[override]
+            raise NotImplementedError
+
+        async def delete_key(self, ctx, credentials, key):  # type: ignore[override]
+            return None
+
+    return RegistryEntry(
+        handler_cls=_Fake,
+        manifest=_Fake.manifest,
+        package_name=f'imbi-plugin-{slug}',
+        package_version='1.0.0',
+    )
+
+
+class ResolutionTestCase(unittest.TestCase):
+    """Branch coverage for ``resolve_plugin``."""
+
+    def test_project_not_found_returns_404(self) -> None:
+        from fastapi import HTTPException
+
+        from imbi_api.plugins.resolution import resolve_plugin
+
+        mock_db = mock.AsyncMock()
+        mock_db.execute.return_value = []
+        with self.assertRaises(HTTPException) as ctx:
+            asyncio.run(resolve_plugin(mock_db, 'p1', 'configuration', None))
+        self.assertEqual(ctx.exception.status_code, 404)
+        self.assertIn('Project not found', ctx.exception.detail)
+
+    def test_no_plugins_assigned_returns_404(self) -> None:
+        from fastapi import HTTPException
+
+        from imbi_api.plugins.resolution import resolve_plugin
+
+        mock_db = mock.AsyncMock()
+        mock_db.execute.return_value = [
+            {'proj_plugins': '[]', 'pt_plugins': '[]'}
+        ]
+        with self.assertRaises(HTTPException) as ctx:
+            asyncio.run(resolve_plugin(mock_db, 'p1', 'configuration', None))
+        self.assertEqual(ctx.exception.status_code, 404)
+        self.assertIn('No plugin assigned', ctx.exception.detail)
+
+    def test_single_plugin_resolves(self) -> None:
+        from imbi_api.plugins.resolution import resolve_plugin
+
+        mock_db = mock.AsyncMock()
+        mock_db.execute.return_value = [
+            {
+                'proj_plugins': '[]',
+                'pt_plugins': json.dumps(
+                    [
+                        {
+                            'id': 'p1',
+                            'slug': 'ssm',
+                            'options': '{}',
+                            'default': True,
+                            'src': 'project_type',
+                        }
+                    ]
+                ),
+            }
+        ]
+        entry = _make_registry_entry('ssm')
+        with mock.patch(
+            'imbi_api.plugins.resolution.get_plugin', return_value=entry
+        ):
+            resolved = asyncio.run(
+                resolve_plugin(mock_db, 'proj1', 'configuration', None)
+            )
+        self.assertEqual(resolved.plugin_id, 'p1')
+        self.assertEqual(resolved.plugin_slug, 'ssm')
+        self.assertEqual(resolved.options, {})
+
+    def test_project_overrides_project_type_default(self) -> None:
+        from imbi_api.plugins.resolution import resolve_plugin
+
+        mock_db = mock.AsyncMock()
+        mock_db.execute.return_value = [
+            {
+                'pt_plugins': json.dumps(
+                    [
+                        {
+                            'id': 'p1',
+                            'slug': 'ssm',
+                            'options': '{}',
+                            'default': True,
+                            'src': 'project_type',
+                        }
+                    ]
+                ),
+                'proj_plugins': json.dumps(
+                    [
+                        {
+                            'id': 'p1',
+                            'slug': 'ssm',
+                            'options': '{"region": "us-east-1"}',
+                            'default': True,
+                            'src': 'project',
+                        }
+                    ]
+                ),
+            }
+        ]
+        with mock.patch(
+            'imbi_api.plugins.resolution.get_plugin',
+            return_value=_make_registry_entry('ssm'),
+        ):
+            resolved = asyncio.run(
+                resolve_plugin(mock_db, 'proj1', 'configuration', None)
+            )
+        self.assertEqual(resolved.options, {'region': 'us-east-1'})
+
+    def test_multi_plugin_no_default_returns_400(self) -> None:
+        from fastapi import HTTPException
+
+        from imbi_api.plugins.resolution import resolve_plugin
+
+        mock_db = mock.AsyncMock()
+        mock_db.execute.return_value = [
+            {
+                'pt_plugins': '[]',
+                'proj_plugins': json.dumps(
+                    [
+                        {
+                            'id': 'p1',
+                            'slug': 'ssm',
+                            'options': '{}',
+                            'default': False,
+                            'src': 'project',
+                        },
+                        {
+                            'id': 'p2',
+                            'slug': 'ssm',
+                            'options': '{}',
+                            'default': False,
+                            'src': 'project',
+                        },
+                    ]
+                ),
+            }
+        ]
+        with self.assertRaises(HTTPException) as ctx:
+            asyncio.run(
+                resolve_plugin(mock_db, 'proj1', 'configuration', None)
+            )
+        self.assertEqual(ctx.exception.status_code, 400)
+        self.assertIn('source', ctx.exception.detail)
+
+    def test_multi_plugin_picks_default(self) -> None:
+        from imbi_api.plugins.resolution import resolve_plugin
+
+        mock_db = mock.AsyncMock()
+        mock_db.execute.return_value = [
+            {
+                'pt_plugins': '[]',
+                'proj_plugins': json.dumps(
+                    [
+                        {
+                            'id': 'p1',
+                            'slug': 'ssm',
+                            'options': '{}',
+                            'default': False,
+                            'src': 'project',
+                        },
+                        {
+                            'id': 'p2',
+                            'slug': 'ssm',
+                            'options': '{}',
+                            'default': True,
+                            'src': 'project',
+                        },
+                    ]
+                ),
+            }
+        ]
+        with mock.patch(
+            'imbi_api.plugins.resolution.get_plugin',
+            return_value=_make_registry_entry('ssm'),
+        ):
+            resolved = asyncio.run(
+                resolve_plugin(mock_db, 'proj1', 'configuration', None)
+            )
+        self.assertEqual(resolved.plugin_id, 'p2')
+
+    def test_source_param_picks_specific_plugin(self) -> None:
+        from imbi_api.plugins.resolution import resolve_plugin
+
+        mock_db = mock.AsyncMock()
+        mock_db.execute.return_value = [
+            {
+                'pt_plugins': '[]',
+                'proj_plugins': json.dumps(
+                    [
+                        {
+                            'id': 'p1',
+                            'slug': 'ssm',
+                            'options': '{}',
+                            'default': True,
+                            'src': 'project',
+                        },
+                        {
+                            'id': 'p2',
+                            'slug': 'ssm',
+                            'options': '{}',
+                            'default': False,
+                            'src': 'project',
+                        },
+                    ]
+                ),
+            }
+        ]
+        with mock.patch(
+            'imbi_api.plugins.resolution.get_plugin',
+            return_value=_make_registry_entry('ssm'),
+        ):
+            resolved = asyncio.run(
+                resolve_plugin(mock_db, 'proj1', 'configuration', 'p2')
+            )
+        self.assertEqual(resolved.plugin_id, 'p2')
+
+    def test_unknown_source_returns_404(self) -> None:
+        from fastapi import HTTPException
+
+        from imbi_api.plugins.resolution import resolve_plugin
+
+        mock_db = mock.AsyncMock()
+        mock_db.execute.return_value = [
+            {
+                'pt_plugins': '[]',
+                'proj_plugins': json.dumps(
+                    [
+                        {
+                            'id': 'p1',
+                            'slug': 'ssm',
+                            'options': '{}',
+                            'default': True,
+                            'src': 'project',
+                        }
+                    ]
+                ),
+            }
+        ]
+        with self.assertRaises(HTTPException) as ctx:
+            asyncio.run(
+                resolve_plugin(mock_db, 'proj1', 'configuration', 'unknown')
+            )
+        self.assertEqual(ctx.exception.status_code, 404)
+
+    def test_plugin_slug_not_in_registry_raises_unavailable(self) -> None:
+        from imbi_common.plugins.errors import (
+            PluginNotFoundError,
+            PluginUnavailableError,
+        )
+
+        from imbi_api.plugins.resolution import resolve_plugin
+
+        mock_db = mock.AsyncMock()
+        mock_db.execute.return_value = [
+            {
+                'pt_plugins': '[]',
+                'proj_plugins': json.dumps(
+                    [
+                        {
+                            'id': 'p1',
+                            'slug': 'gone',
+                            'options': '{}',
+                            'default': True,
+                            'src': 'project',
+                        }
+                    ]
+                ),
+            }
+        ]
+        with mock.patch(
+            'imbi_api.plugins.resolution.get_plugin',
+            side_effect=PluginNotFoundError('gone'),
+        ):
+            with self.assertRaises(PluginUnavailableError):
+                asyncio.run(
+                    resolve_plugin(mock_db, 'proj1', 'configuration', None)
+                )
+
+
+class CredentialsTestCase(unittest.TestCase):
+    """Branch coverage for ``get_plugin_credentials``."""
+
+    def test_empty_no_required_returns_empty_dict(self) -> None:
+        from imbi_api.plugins.credentials import get_plugin_credentials
+
+        mock_db = mock.AsyncMock()
+        mock_db.execute.return_value = []
+        entry = _make_registry_entry('ssm', required_creds=False)
+        creds = asyncio.run(get_plugin_credentials(mock_db, 'p1', entry))
+        self.assertEqual(creds, {})
+
+    def test_missing_required_raises(self) -> None:
+        from imbi_common.plugins.errors import PluginCredentialsMissing
+
+        from imbi_api.plugins.credentials import get_plugin_credentials
+
+        mock_db = mock.AsyncMock()
+        mock_db.execute.return_value = [{'creds': None}]
+        entry = _make_registry_entry('ssm', required_creds=True)
+        with self.assertRaises(PluginCredentialsMissing) as ctx:
+            asyncio.run(get_plugin_credentials(mock_db, 'p1', entry))
+        self.assertIn('token', str(ctx.exception))
+
+    def test_decrypt_returns_dict(self) -> None:
+        from imbi_api.plugins.credentials import get_plugin_credentials
+
+        mock_db = mock.AsyncMock()
+        mock_db.execute.return_value = [{'creds': '"ENCRYPTED"'}]
+
+        encryptor = mock.MagicMock()
+        encryptor.decrypt.return_value = json.dumps({'token': 'abc'})
+        entry = _make_registry_entry('ssm', required_creds=True)
+        with mock.patch(
+            'imbi_api.plugins.credentials.TokenEncryption.get_instance',
+            return_value=encryptor,
+        ):
+            creds = asyncio.run(get_plugin_credentials(mock_db, 'p1', entry))
+        self.assertEqual(creds, {'token': 'abc'})
+
+    def test_decrypt_returns_empty_string_yields_no_creds(self) -> None:
+        from imbi_common.plugins.errors import PluginCredentialsMissing
+
+        from imbi_api.plugins.credentials import get_plugin_credentials
+
+        mock_db = mock.AsyncMock()
+        mock_db.execute.return_value = [{'creds': '"ENCRYPTED"'}]
+        encryptor = mock.MagicMock()
+        encryptor.decrypt.return_value = ''
+        entry = _make_registry_entry('ssm', required_creds=True)
+        with mock.patch(
+            'imbi_api.plugins.credentials.TokenEncryption.get_instance',
+            return_value=encryptor,
+        ):
+            with self.assertRaises(PluginCredentialsMissing):
+                asyncio.run(get_plugin_credentials(mock_db, 'p1', entry))
+
+
+class ReloadSubscriberTestCase(unittest.TestCase):
+    """Test the pubsub subscriber loop in plugins.reload."""
+
+    def test_subscribe_processes_message_and_reloads(self) -> None:
+        from imbi_api.plugins import reload as reload_mod
+
+        pubsub = mock.MagicMock()
+        pubsub.subscribe = mock.AsyncMock()
+        pubsub.unsubscribe = mock.AsyncMock()
+        client = mock.MagicMock()
+        client.pubsub = mock.MagicMock(return_value=pubsub)
+        mock_db = mock.AsyncMock()
+        mock_db.execute.return_value = []
+
+        async def _run() -> None:
+            stop = asyncio.Event()
+            calls: list[int] = []
+
+            async def _wait_for(*_a: object, **_k: object) -> object:
+                calls.append(1)
+                # First call delivers a message; second iteration we stop.
+                if len(calls) == 1:
+                    return {'type': 'message', 'data': b'reload'}
+                stop.set()
+                raise TimeoutError()
+
+            with (
+                mock.patch.object(
+                    reload_mod.asyncio, 'wait_for', side_effect=_wait_for
+                ),
+                mock.patch.object(reload_mod, 'reload_plugins') as reload_p,
+                mock.patch.object(
+                    reload_mod, '_audit_unavailable', mock.AsyncMock()
+                ) as audit,
+            ):
+                await reload_mod._subscribe_reload(client, mock_db, stop)
+
+            reload_p.assert_called_once()
+            audit.assert_awaited()
+            pubsub.unsubscribe.assert_awaited()
+
+        asyncio.run(_run())
+
+    def test_subscribe_handles_cancelled(self) -> None:
+        from imbi_api.plugins import reload as reload_mod
+
+        pubsub = mock.MagicMock()
+        pubsub.subscribe = mock.AsyncMock()
+        pubsub.unsubscribe = mock.AsyncMock()
+        client = mock.MagicMock()
+        client.pubsub = mock.MagicMock(return_value=pubsub)
+        mock_db = mock.AsyncMock()
+
+        async def _run() -> None:
+            stop = asyncio.Event()
+
+            async def _raise_cancel(*_a: object, **_k: object) -> object:
+                raise asyncio.CancelledError
+
+            with mock.patch.object(
+                reload_mod.asyncio, 'wait_for', side_effect=_raise_cancel
+            ):
+                await reload_mod._subscribe_reload(client, mock_db, stop)
+            pubsub.unsubscribe.assert_awaited()
+
+        asyncio.run(_run())
+
+    def test_subscribe_skips_none_message(self) -> None:
+        from imbi_api.plugins import reload as reload_mod
+
+        pubsub = mock.MagicMock()
+        pubsub.subscribe = mock.AsyncMock()
+        pubsub.unsubscribe = mock.AsyncMock()
+        client = mock.MagicMock()
+        client.pubsub = mock.MagicMock(return_value=pubsub)
+        mock_db = mock.AsyncMock()
+
+        async def _run() -> None:
+            stop = asyncio.Event()
+            calls: list[int] = []
+
+            async def _wait_for(*_a: object, **_k: object) -> object:
+                calls.append(1)
+                if len(calls) == 1:
+                    return None
+                stop.set()
+                raise TimeoutError()
+
+            with (
+                mock.patch.object(
+                    reload_mod.asyncio, 'wait_for', side_effect=_wait_for
+                ),
+                mock.patch.object(reload_mod, 'reload_plugins') as reload_p,
+            ):
+                await reload_mod._subscribe_reload(client, mock_db, stop)
+            reload_p.assert_not_called()
+
+        asyncio.run(_run())
+
+    def test_plugin_reload_hook_starts_and_stops_task(self) -> None:
+        from imbi_api.plugins import reload as reload_mod
+
+        client = mock.MagicMock()
+        pubsub = mock.MagicMock()
+        pubsub.subscribe = mock.AsyncMock()
+        pubsub.unsubscribe = mock.AsyncMock()
+        client.pubsub = mock.MagicMock(return_value=pubsub)
+        mock_db = mock.AsyncMock()
+
+        async def _fake_subscribe(
+            _client: object, _db: object, stop: asyncio.Event
+        ) -> None:
+            await stop.wait()
+
+        async def _run() -> None:
+            with (
+                mock.patch(
+                    'imbi_api.plugins.reload.valkey.get_client',
+                    return_value=client,
+                ),
+                mock.patch.object(
+                    reload_mod, '_subscribe_reload', _fake_subscribe
+                ),
+            ):
+                async with reload_mod.plugin_reload_hook(db=mock_db):
+                    pass
+
+        asyncio.run(_run())

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -23,8 +23,8 @@ class CatalogTestCase(unittest.TestCase):
             entries = list_catalog_entries()
         self.assertIsInstance(entries, list)
         self.assertTrue(len(entries) > 0)
-        self.assertEqual(entries[0]['package'], 'imbi-plugin-ssm')
-        self.assertEqual(entries[0]['status'], 'not_installed')
+        ssm = next(e for e in entries if e['package'] == 'imbi-plugin-ssm')
+        self.assertEqual(ssm['status'], 'not_installed')
 
     def test_catalog_installed_status(self) -> None:
         from imbi_common.plugins.base import (

--- a/uv.lock
+++ b/uv.lock
@@ -944,7 +944,7 @@ docs = [
 [[package]]
 name = "imbi-common"
 version = "0.1.0"
-source = { git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=main#1998b91c01f7164219c6fdaf86032362a63dc7bd" }
+source = { git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=main#73586077724dc7bd817659597808719792868db1" }
 dependencies = [
     { name = "cryptography" },
     { name = "jsonschema-models" },


### PR DESCRIPTION
## Summary

- Adds a runtime-extensible plugin system so operators can install configuration- and log-source plugins (SSM, Logz.io, etc.) and assign them to third-party services, project types, and projects.
- Wires plugin handlers into new project endpoints (`/configuration`, `/logs`) that resolve the assigned plugin, fetch credentials from the linked service application, and dispatch through a shared timeout helper.
- Adds admin endpoints to list / inspect / install / uninstall plugin packages from a curated catalog, plus a Valkey pub/sub channel that refreshes the in-process registry across pods.

## Changes

- **Endpoints**
  - `endpoints/service_plugins.py` — Plugin CRUD on third-party services
  - `endpoints/project_type_plugins.py`, `endpoints/project_plugins.py` — Plugin assignment with one-default-per-tab validation; project overrides project-type
  - `endpoints/project_configuration.py` — list keys / fetch values / set / delete via the assigned configuration plugin (Valkey-cached, audit-logged to ClickHouse)
  - `endpoints/project_logs.py` — search and schema endpoints via the assigned logs plugin
  - `endpoints/admin_plugins.py` — installed-plugin listing, catalog, install/uninstall
- **Plugin runtime** (`src/imbi_api/plugins/`)
  - `assignments.py` — `validate_one_default_per_tab` + shared response builder
  - `catalog.py` + `catalog.toml` — declared plugin packages and install status
  - `credentials.py` — fetches and decrypts `plugin_credentials` from the linked `ServiceApplication`
  - `installer.py` — `uv pip install/uninstall` against catalog packages, behind `IMBI_PLUGINS_INSTALL_ENABLED`
  - `lifecycle.py` — startup load + audit of graph Plugin nodes against the registry
  - `reload.py` — Valkey pub/sub subscriber for cross-pod registry reload
  - `resolution.py` — picks the right plugin for a (project, tab) with project/project-type merge
  - `__init__.py` — `parse_options` and `call_with_timeout` shared helpers
- **Auth** — new permissions: `admin:plugins:{read,manage}`, `project:configuration:{read,read_secrets,write}`, `project:logs:read`
- **Models** — pydantic request/response models for plugins, assignments, config keys, log entries; `plugin_credentials` added to `SECRET_FIELDS`
- **Lifespan** — startup hook now also runs `startup_load_plugins(db)` after the graph pool opens

## Notes

- Imports from `imbi_common.plugins` carry `# type: ignore[import-not-found]` until the corresponding imbi-common release is published.
- This branch was reviewed via `/simplify`; bug fix in the duplicate-label Cypher arrow, plus shared helpers (`parse_options`, `call_with_timeout`, `build_assignment_response`, `props_template`) extracted to remove duplication across the new endpoints.

## Test plan

- [ ] CI passes (lint + tests)
- [ ] Manual: install a plugin via `POST /plugins/install`, assign it to a project type, verify project inherits the assignment
- [ ] Manual: override at the project level via `PUT /organizations/{org}/projects/{id}/plugins/`
- [ ] Manual: list/fetch/set/delete configuration keys and confirm Valkey cache invalidates on writes
- [ ] Manual: search logs with cursor pagination; confirm 503 + Retry-After when the plugin times out
- [ ] Confirm `admin:plugins:read` vs `admin:plugins:manage` permission split