### PR TITLE
Add GET /scores/monthly-improvement endpoint

### DIFF
--- a/src/imbi_api/domain/scoring.py
+++ b/src/imbi_api/domain/scoring.py
@@ -15,6 +15,7 @@ from imbi_common.scoring import (
 __all__ = [
     'AttributeContribution',
     'AttributePolicy',
+    'MonthlyImprovementRow',
     'PolicyCreate',
     'PolicyUpdate',
     'RescoreRequest',
@@ -100,3 +101,12 @@ class ScoreRollupRow(pydantic.BaseModel):
     latest_score: float
     avg_score: float
     last_updated: str | None = None
+
+
+class MonthlyImprovementRow(pydantic.BaseModel):
+    dimension: str
+    key: str
+    current_avg_score: float | None
+    previous_avg_score: float | None
+    improvement: float | None
+    project_count: int

--- a/src/imbi_api/endpoints/scoring.py
+++ b/src/imbi_api/endpoints/scoring.py
@@ -248,6 +248,113 @@ async def score_rollup(
     return out
 
 
+@scoring_router.get('/scores/monthly-improvement')
+async def score_monthly_improvement(
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(permissions.require_permission('project:read')),
+    ],
+    year: int = fastapi.Query(ge=2020, le=2100),
+    month: int = fastapi.Query(ge=1, le=12),
+    dimension: typing.Literal['team', 'project_type', 'organization'] = 'team',
+) -> list[scoring_models.MonthlyImprovementRow]:
+    """Return avg-score and improvement per dimension group for a month.
+
+    Improvement = avg(last project score in *selected* month)
+                - avg(last project score in *previous* month).
+    Only projects scored in the selected month are counted.
+    """
+    cur_start = datetime.datetime(year, month, 1, tzinfo=datetime.UTC)
+    if month == 12:
+        nxt_start = datetime.datetime(year + 1, 1, 1, tzinfo=datetime.UTC)
+    else:
+        nxt_start = datetime.datetime(year, month + 1, 1, tzinfo=datetime.UTC)
+    if month == 1:
+        prev_start = datetime.datetime(year - 1, 12, 1, tzinfo=datetime.UTC)
+    else:
+        prev_start = datetime.datetime(year, month - 1, 1, tzinfo=datetime.UTC)
+
+    dim_records = await db.execute(
+        _DIMENSION_QUERY[dimension], {}, ['project_id', 'dim_key']
+    )
+    project_dim: dict[str, str] = {}
+    for rec in dim_records:
+        pid = graph.parse_agtype(rec['project_id'])
+        key = graph.parse_agtype(rec['dim_key'])
+        if pid and key:
+            project_dim[str(pid)] = str(key)
+
+    if not project_dim:
+        return []
+
+    pid_list = list(project_dim)
+
+    cur_rows, prev_rows = await asyncio.gather(
+        clickhouse.query(
+            'SELECT project_id, argMax(score, timestamp) AS score'
+            ' FROM score_history'
+            ' WHERE project_id IN {pids:Array(String)}'
+            ' AND timestamp >= {t0:DateTime64(3)}'
+            ' AND timestamp < {t1:DateTime64(3)}'
+            ' GROUP BY project_id',
+            {'pids': pid_list, 't0': cur_start, 't1': nxt_start},
+        ),
+        clickhouse.query(
+            'SELECT project_id, argMax(score, timestamp) AS score'
+            ' FROM score_history'
+            ' WHERE project_id IN {pids:Array(String)}'
+            ' AND timestamp >= {t0:DateTime64(3)}'
+            ' AND timestamp < {t1:DateTime64(3)}'
+            ' GROUP BY project_id',
+            {'pids': pid_list, 't0': prev_start, 't1': cur_start},
+        ),
+    )
+
+    cur_scores: dict[str, float] = {
+        str(r['project_id']): float(r['score']) for r in cur_rows
+    }
+    prev_scores: dict[str, float] = {
+        str(r['project_id']): float(r['score']) for r in prev_rows
+    }
+
+    cur_by_key: dict[str, list[float]] = {}
+    prev_by_key: dict[str, list[float]] = {}
+    for pid, dim_key in project_dim.items():
+        if pid in cur_scores:
+            cur_by_key.setdefault(dim_key, []).append(cur_scores[pid])
+        if pid in prev_scores:
+            prev_by_key.setdefault(dim_key, []).append(prev_scores[pid])
+
+    all_keys = sorted(set(cur_by_key) | set(prev_by_key))
+    out: list[scoring_models.MonthlyImprovementRow] = []
+    for key in all_keys:
+        cur_list = cur_by_key.get(key, [])
+        prev_list = prev_by_key.get(key, [])
+        cur_avg = sum(cur_list) / len(cur_list) if cur_list else None
+        prev_avg = sum(prev_list) / len(prev_list) if prev_list else None
+        improvement = (
+            round(cur_avg - prev_avg, 4)
+            if cur_avg is not None and prev_avg is not None
+            else None
+        )
+        out.append(
+            scoring_models.MonthlyImprovementRow(
+                dimension=dimension,
+                key=key,
+                current_avg_score=round(cur_avg, 4)
+                if cur_avg is not None
+                else None,
+                previous_avg_score=round(prev_avg, 4)
+                if prev_avg is not None
+                else None,
+                improvement=improvement,
+                project_count=len(cur_list),
+            )
+        )
+    return out
+
+
 @scoring_router.post('/scoring/rescore')
 async def rescore(
     db: graph.Pool,

--- a/src/imbi_api/endpoints/scoring.py
+++ b/src/imbi_api/endpoints/scoring.py
@@ -326,7 +326,7 @@ async def score_monthly_improvement(
         if pid in prev_scores:
             prev_by_key.setdefault(dim_key, []).append(prev_scores[pid])
 
-    all_keys = sorted(set(cur_by_key) | set(prev_by_key))
+    all_keys = sorted(cur_by_key)
     out: list[scoring_models.MonthlyImprovementRow] = []
     for key in all_keys:
         cur_list = cur_by_key.get(key, [])

--- a/tests/endpoints/test_scoring.py
+++ b/tests/endpoints/test_scoring.py
@@ -303,3 +303,73 @@ class ScoringEndpointsTestCase(unittest.TestCase):
             '/organizations/eng/projects/missing/score/trend',
         )
         self.assertEqual(response.status_code, 404)
+
+    def test_monthly_improvement_returns_current_month_rows(self) -> None:
+        # p1 and p2 are in "platform", p3 is in "data" (current month only)
+        # p4 is in "legacy" but only scored in the previous month
+        self.mock_db.execute = mock.AsyncMock(
+            return_value=[
+                {'project_id': 'p1', 'dim_key': 'platform'},
+                {'project_id': 'p2', 'dim_key': 'platform'},
+                {'project_id': 'p3', 'dim_key': 'data'},
+                {'project_id': 'p4', 'dim_key': 'legacy'},
+            ]
+        )
+        # asyncio.gather calls clickhouse.query twice: cur then prev
+        with (
+            mock.patch(
+                'imbi_api.endpoints.scoring.clickhouse.query',
+                mock.AsyncMock(
+                    side_effect=[
+                        # current-month scores: p1, p2, p3 scored; p4 not
+                        [
+                            {'project_id': 'p1', 'score': 80.0},
+                            {'project_id': 'p2', 'score': 60.0},
+                            {'project_id': 'p3', 'score': 90.0},
+                        ],
+                        # previous-month scores: p1, p2, p4 scored; p3 not
+                        [
+                            {'project_id': 'p1', 'score': 70.0},
+                            {'project_id': 'p2', 'score': 50.0},
+                            {'project_id': 'p4', 'score': 85.0},
+                        ],
+                    ]
+                ),
+            ),
+            mock.patch(
+                'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+            ),
+        ):
+            response = self.client.get(
+                '/scores/monthly-improvement',
+                params={'year': 2026, 'month': 4, 'dimension': 'team'},
+            )
+        self.assertEqual(response.status_code, 200, response.text)
+        body = response.json()
+        keys = {row['key'] for row in body}
+        # Only keys present in current month
+        self.assertIn('platform', keys)
+        self.assertIn('data', keys)
+        # "legacy" only existed in prev month; must NOT appear
+        self.assertNotIn('legacy', keys)
+
+        platform_row = next(r for r in body if r['key'] == 'platform')
+        self.assertAlmostEqual(platform_row['current_avg_score'], 70.0)
+        self.assertAlmostEqual(platform_row['previous_avg_score'], 60.0)
+        self.assertAlmostEqual(platform_row['improvement'], 10.0)
+        self.assertEqual(platform_row['project_count'], 2)
+
+        data_row = next(r for r in body if r['key'] == 'data')
+        self.assertAlmostEqual(data_row['current_avg_score'], 90.0)
+        self.assertIsNone(data_row['previous_avg_score'])
+        self.assertIsNone(data_row['improvement'])
+        self.assertEqual(data_row['project_count'], 1)
+
+    def test_monthly_improvement_empty_when_no_projects(self) -> None:
+        self.mock_db.execute = mock.AsyncMock(return_value=[])
+        response = self.client.get(
+            '/scores/monthly-improvement',
+            params={'year': 2026, 'month': 4, 'dimension': 'team'},
+        )
+        self.assertEqual(response.status_code, 200, response.text)
+        self.assertEqual(response.json(), [])


### PR DESCRIPTION
## Summary

New scoring endpoint that returns per-team (or per-project-type / per-org) score improvement for a calendar month, plus the current avg health score for that month.

## Problem

The Reports UI needs to display a monthly improvement leaderboard — each team's avg project score at the end of a selected month compared to the end of the prior month. The existing `/scores/rollup` only returns current scores with no historical context.

## Solution

`GET /scores/monthly-improvement?year=2026&month=4&dimension=team`

- Fetches the project→dimension-key mapping from AGE.
- Runs two parallel ClickHouse queries (`argMax(score, timestamp)`) — one for the selected month window, one for the prior month — to get each project's end-of-month score.
- Aggregates by dimension key: `current_avg_score`, `previous_avg_score`, `improvement = current - previous`, `project_count`.
- Returns `list[MonthlyImprovementRow]` sorted alphabetically by key.

New `MonthlyImprovementRow` Pydantic model added to `domain/scoring.py`.

## Impact

New read-only endpoint behind existing `project:read` permission. No schema migrations or ClickHouse table changes — reads from the existing `score_history` table. Compatible with all three dimension values (`team`, `project_type`, `organization`).