### PR TITLE
Add global score history endpoints and service account avatar support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,5 +32,6 @@ repos:
         entry: uv
         args:
           - run
+          - --no-sync
           - mypy
           - src

--- a/src/imbi_api/domain/models.py
+++ b/src/imbi_api/domain/models.py
@@ -453,6 +453,7 @@ class ServiceAccount(models.GraphModel):
     description: str | None = None
     is_active: bool = True
     last_authenticated: datetime.datetime | None = None
+    avatar_url: str | None = None
 
     organizations: typing.Annotated[
         list[OrganizationEdge],
@@ -487,6 +488,7 @@ class ServiceAccountResponse(pydantic.BaseModel):
     is_active: bool
     created_at: datetime.datetime
     last_authenticated: datetime.datetime | None = None
+    avatar_url: str | None = None
     organizations: list[OrgMembership] = []
 
 

--- a/src/imbi_api/domain/scoring.py
+++ b/src/imbi_api/domain/scoring.py
@@ -15,17 +15,21 @@ from imbi_common.scoring import (
 __all__ = [
     'AttributeContribution',
     'AttributePolicy',
+    'GlobalScoreEvent',
     'MonthlyImprovementRow',
     'PolicyCreate',
     'PolicyUpdate',
     'RescoreRequest',
     'RescoreResponse',
     'ScoreBreakdown',
+    'ScoreHistoryByTeamResponse',
     'ScoreHistoryPoint',
     'ScoreHistoryResponse',
     'ScoreRollupRow',
     'ScoreTrend',
     'ScoringPolicy',
+    'TeamScoreHistoryPoint',
+    'TeamScoreSeries',
 ]
 
 
@@ -101,6 +105,31 @@ class ScoreRollupRow(pydantic.BaseModel):
     latest_score: float
     avg_score: float
     last_updated: str | None = None
+
+
+class GlobalScoreEvent(pydantic.BaseModel):
+    timestamp: str
+    project_id: str
+    project_name: str
+    team_key: str
+    score: float
+    previous_score: float | None = None
+    change_reason: str | None = None
+
+
+class TeamScoreHistoryPoint(pydantic.BaseModel):
+    timestamp: str
+    score: float
+
+
+class TeamScoreSeries(pydantic.BaseModel):
+    key: str
+    points: list[TeamScoreHistoryPoint]
+
+
+class ScoreHistoryByTeamResponse(pydantic.BaseModel):
+    granularity: typing.Literal['hour', 'day']
+    teams: list[TeamScoreSeries]
 
 
 class MonthlyImprovementRow(pydantic.BaseModel):

--- a/src/imbi_api/endpoints/scoring.py
+++ b/src/imbi_api/endpoints/scoring.py
@@ -355,6 +355,153 @@ async def score_monthly_improvement(
     return out
 
 
+@scoring_router.get('/scores/history-by-team')
+async def score_history_by_team(
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(permissions.require_permission('project:read')),
+    ],
+    granularity: typing.Literal['hour', 'day'] = 'day',
+    from_: typing.Annotated[
+        datetime.datetime | None, fastapi.Query(alias='from')
+    ] = None,
+    to: datetime.datetime | None = None,
+) -> scoring_models.ScoreHistoryByTeamResponse:
+    """Return avg score history per team, bucketed by granularity."""
+    dim_records = await db.execute(
+        _DIMENSION_QUERY['team'], {}, ['project_id', 'dim_key']
+    )
+    project_team: dict[str, str] = {}
+    for rec in dim_records:
+        pid = graph.parse_agtype(rec['project_id'])
+        key = graph.parse_agtype(rec['dim_key'])
+        if pid and key:
+            project_team[str(pid)] = str(key)
+    if not project_team:
+        return scoring_models.ScoreHistoryByTeamResponse(
+            granularity=granularity, teams=[]
+        )
+    bucket = _GRANULARITY_EXPR[granularity]
+    where: list[str] = ['project_id IN {project_ids:Array(String)}']
+    params: dict[str, typing.Any] = {'project_ids': list(project_team)}
+    if from_ is not None:
+        where.append('timestamp >= {from_ts:DateTime64(3)}')
+        params['from_ts'] = from_
+    if to is not None:
+        where.append('timestamp <= {to_ts:DateTime64(3)}')
+        params['to_ts'] = to
+    where_sql = ' AND '.join(where)
+    sql = (
+        f'SELECT {bucket} AS ts, project_id,'  # noqa: S608
+        ' argMax(score, timestamp) AS score'
+        ' FROM score_history WHERE '
+        + where_sql
+        + ' GROUP BY ts, project_id ORDER BY ts'
+    )
+    rows = await clickhouse.query(sql, params)
+    team_ts_scores: dict[str, dict[str, list[float]]] = {}
+    for row in rows:
+        pid = str(row['project_id'])
+        team = project_team.get(pid)
+        if not team:
+            continue
+        ts = str(row['ts'])
+        score = float(row['score'])
+        team_ts_scores.setdefault(team, {}).setdefault(ts, []).append(score)
+    teams: list[scoring_models.TeamScoreSeries] = []
+    for team_key in sorted(team_ts_scores):
+        ts_scores = team_ts_scores[team_key]
+        points = [
+            scoring_models.TeamScoreHistoryPoint(
+                timestamp=ts,
+                score=round(sum(scores) / len(scores), 4),
+            )
+            for ts, scores in sorted(ts_scores.items())
+        ]
+        teams.append(
+            scoring_models.TeamScoreSeries(key=team_key, points=points)
+        )
+    return scoring_models.ScoreHistoryByTeamResponse(
+        granularity=granularity, teams=teams
+    )
+
+
+@scoring_router.get('/scores/history-feed')
+async def score_history_feed(
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(permissions.require_permission('project:read')),
+    ],
+    from_: typing.Annotated[
+        datetime.datetime | None, fastapi.Query(alias='from')
+    ] = None,
+    to: datetime.datetime | None = None,
+    limit: typing.Annotated[int, fastapi.Query(ge=1, le=500)] = 200,
+) -> list[scoring_models.GlobalScoreEvent]:
+    """Return recent raw score change events across all projects."""
+    project_records = await db.execute(
+        'MATCH (p:Project)-[:OWNED_BY]->(t:Team)'
+        ' RETURN p.id AS project_id, p.name AS project_name,'
+        ' t.slug AS team_slug',
+        {},
+        ['project_id', 'project_name', 'team_slug'],
+    )
+    project_info: dict[str, tuple[str, str]] = {}
+    for rec in project_records:
+        pid = graph.parse_agtype(rec['project_id'])
+        name = graph.parse_agtype(rec['project_name'])
+        team = graph.parse_agtype(rec['team_slug'])
+        if pid and name and team:
+            project_info[str(pid)] = (str(name), str(team))
+    if not project_info:
+        return []
+    where: list[str] = [
+        'project_id IN {project_ids:Array(String)}',
+        "change_reason != ''",
+    ]
+    params: dict[str, typing.Any] = {'project_ids': list(project_info)}
+    if from_ is not None:
+        where.append('timestamp >= {from_ts:DateTime64(3)}')
+        params['from_ts'] = from_
+    if to is not None:
+        where.append('timestamp <= {to_ts:DateTime64(3)}')
+        params['to_ts'] = to
+    params['limit'] = limit
+    where_sql = ' AND '.join(where)
+    sql = (
+        'SELECT timestamp, project_id, score, previous_score, change_reason'  # noqa: S608
+        ' FROM score_history WHERE '
+        + where_sql
+        + ' ORDER BY timestamp DESC LIMIT {limit:UInt32}'
+    )
+    rows = await clickhouse.query(sql, params)
+    out: list[scoring_models.GlobalScoreEvent] = []
+    for row in rows:
+        pid = str(row['project_id'])
+        info = project_info.get(pid)
+        if not info:
+            continue
+        project_name, team_key = info
+        out.append(
+            scoring_models.GlobalScoreEvent(
+                timestamp=str(row['timestamp']),
+                project_id=pid,
+                project_name=project_name,
+                team_key=team_key,
+                score=float(row['score']),
+                previous_score=(
+                    float(row['previous_score'])
+                    if row.get('previous_score') is not None
+                    else None
+                ),
+                change_reason=str(row.get('change_reason') or '') or None,
+            )
+        )
+    return out
+
+
 @scoring_router.post('/scoring/rescore')
 async def rescore(
     db: graph.Pool,

--- a/src/imbi_api/endpoints/service_accounts.py
+++ b/src/imbi_api/endpoints/service_accounts.py
@@ -269,7 +269,11 @@ async def patch_service_account(
             display_name=patched.get('display_name', existing.display_name),
             description=patched.get('description', existing.description),
             is_active=patched.get('is_active', existing.is_active),
-            avatar_url=patched.get('avatar_url', existing.avatar_url),
+            avatar_url=(
+                patched['avatar_url']
+                if 'avatar_url' in patched
+                else existing.avatar_url
+            ),
             created_at=existing.created_at,
             last_authenticated=existing.last_authenticated,
         )

--- a/src/imbi_api/endpoints/service_accounts.py
+++ b/src/imbi_api/endpoints/service_accounts.py
@@ -146,6 +146,7 @@ async def list_service_accounts(
                 is_active=sa.is_active,
                 created_at=sa.created_at,
                 last_authenticated=sa.last_authenticated,
+                avatar_url=sa.avatar_url,
             )
         )
     return accounts

--- a/src/imbi_api/endpoints/service_accounts.py
+++ b/src/imbi_api/endpoints/service_accounts.py
@@ -107,6 +107,7 @@ async def create_service_account(
         description=sa.description,
         is_active=sa.is_active,
         created_at=sa.created_at,
+        avatar_url=sa.avatar_url,
         organizations=organizations,
     )
 
@@ -203,6 +204,7 @@ async def get_service_account(
         is_active=sa.is_active,
         created_at=sa.created_at,
         last_authenticated=sa.last_authenticated,
+        avatar_url=sa.avatar_url,
         organizations=organizations,
     )
 
@@ -249,6 +251,7 @@ async def patch_service_account(
         'display_name': existing.display_name,
         'description': existing.description,
         'is_active': existing.is_active,
+        'avatar_url': existing.avatar_url,
     }
 
     patched = json_patch.apply_patch(current, operations)
@@ -265,6 +268,7 @@ async def patch_service_account(
             display_name=patched.get('display_name', existing.display_name),
             description=patched.get('description', existing.description),
             is_active=patched.get('is_active', existing.is_active),
+            avatar_url=patched.get('avatar_url', existing.avatar_url),
             created_at=existing.created_at,
             last_authenticated=existing.last_authenticated,
         )
@@ -281,6 +285,7 @@ async def patch_service_account(
         display_name=updated.display_name,
         description=updated.description,
         is_active=updated.is_active,
+        avatar_url=updated.avatar_url,
         created_at=updated.created_at,
         last_authenticated=updated.last_authenticated,
     )

--- a/tests/endpoints/test_scoring.py
+++ b/tests/endpoints/test_scoring.py
@@ -373,3 +373,196 @@ class ScoringEndpointsTestCase(unittest.TestCase):
         )
         self.assertEqual(response.status_code, 200, response.text)
         self.assertEqual(response.json(), [])
+
+    def test_history_by_team_empty_when_no_projects(self) -> None:
+        self.mock_db.execute = mock.AsyncMock(return_value=[])
+        response = self.client.get('/scores/history-by-team')
+        self.assertEqual(response.status_code, 200, response.text)
+        body = response.json()
+        self.assertEqual(body['granularity'], 'day')
+        self.assertEqual(body['teams'], [])
+
+    def test_history_by_team_returns_aggregated_series(self) -> None:
+        self.mock_db.execute = mock.AsyncMock(
+            return_value=[
+                {'project_id': 'p1', 'dim_key': 'platform'},
+                {'project_id': 'p2', 'dim_key': 'platform'},
+                {'project_id': 'p3', 'dim_key': 'data'},
+            ]
+        )
+        with (
+            mock.patch(
+                'imbi_api.endpoints.scoring.clickhouse.query',
+                mock.AsyncMock(
+                    return_value=[
+                        {
+                            'ts': '2026-04-01',
+                            'project_id': 'p1',
+                            'score': 80.0,
+                        },
+                        {
+                            'ts': '2026-04-01',
+                            'project_id': 'p2',
+                            'score': 60.0,
+                        },
+                        {
+                            'ts': '2026-04-01',
+                            'project_id': 'p3',
+                            'score': 90.0,
+                        },
+                    ]
+                ),
+            ),
+            mock.patch(
+                'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+            ),
+        ):
+            response = self.client.get('/scores/history-by-team')
+        self.assertEqual(response.status_code, 200, response.text)
+        body = response.json()
+        self.assertEqual(body['granularity'], 'day')
+        teams = {t['key']: t['points'] for t in body['teams']}
+        self.assertIn('platform', teams)
+        self.assertIn('data', teams)
+        platform_score = teams['platform'][0]['score']
+        self.assertAlmostEqual(platform_score, 70.0)
+        self.assertAlmostEqual(teams['data'][0]['score'], 90.0)
+
+    def test_history_by_team_hourly_with_date_filters(self) -> None:
+        self.mock_db.execute = mock.AsyncMock(
+            return_value=[{'project_id': 'p1', 'dim_key': 'eng'}]
+        )
+        with (
+            mock.patch(
+                'imbi_api.endpoints.scoring.clickhouse.query',
+                mock.AsyncMock(return_value=[]),
+            ),
+            mock.patch(
+                'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+            ),
+        ):
+            response = self.client.get(
+                '/scores/history-by-team',
+                params={
+                    'granularity': 'hour',
+                    'from': '2026-01-01T00:00:00',
+                    'to': '2026-04-01T00:00:00',
+                },
+            )
+        self.assertEqual(response.status_code, 200, response.text)
+        body = response.json()
+        self.assertEqual(body['granularity'], 'hour')
+        self.assertEqual(body['teams'], [])
+
+    def test_history_feed_empty_when_no_projects(self) -> None:
+        self.mock_db.execute = mock.AsyncMock(return_value=[])
+        response = self.client.get('/scores/history-feed')
+        self.assertEqual(response.status_code, 200, response.text)
+        self.assertEqual(response.json(), [])
+
+    def test_history_feed_returns_events(self) -> None:
+        self.mock_db.execute = mock.AsyncMock(
+            return_value=[
+                {
+                    'project_id': 'p1',
+                    'project_name': 'My Project',
+                    'team_slug': 'platform',
+                },
+            ]
+        )
+        with (
+            mock.patch(
+                'imbi_api.endpoints.scoring.clickhouse.query',
+                mock.AsyncMock(
+                    return_value=[
+                        {
+                            'timestamp': '2026-04-01T12:00:00',
+                            'project_id': 'p1',
+                            'score': 85.0,
+                            'previous_score': 75.0,
+                            'change_reason': 'attribute_change',
+                        }
+                    ]
+                ),
+            ),
+            mock.patch(
+                'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+            ),
+        ):
+            response = self.client.get('/scores/history-feed')
+        self.assertEqual(response.status_code, 200, response.text)
+        body = response.json()
+        self.assertEqual(len(body), 1)
+        event = body[0]
+        self.assertEqual(event['project_id'], 'p1')
+        self.assertEqual(event['project_name'], 'My Project')
+        self.assertEqual(event['team_key'], 'platform')
+        self.assertAlmostEqual(event['score'], 85.0)
+        self.assertAlmostEqual(event['previous_score'], 75.0)
+        self.assertEqual(event['change_reason'], 'attribute_change')
+
+    def test_history_feed_with_date_filters_and_limit(self) -> None:
+        self.mock_db.execute = mock.AsyncMock(
+            return_value=[
+                {
+                    'project_id': 'p1',
+                    'project_name': 'Proj',
+                    'team_slug': 'eng',
+                },
+            ]
+        )
+        with (
+            mock.patch(
+                'imbi_api.endpoints.scoring.clickhouse.query',
+                mock.AsyncMock(return_value=[]),
+            ),
+            mock.patch(
+                'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+            ),
+        ):
+            response = self.client.get(
+                '/scores/history-feed',
+                params={
+                    'from': '2026-01-01T00:00:00',
+                    'to': '2026-04-01T00:00:00',
+                    'limit': 50,
+                },
+            )
+        self.assertEqual(response.status_code, 200, response.text)
+        self.assertEqual(response.json(), [])
+
+    def test_history_feed_handles_null_previous_score(self) -> None:
+        self.mock_db.execute = mock.AsyncMock(
+            return_value=[
+                {
+                    'project_id': 'p1',
+                    'project_name': 'Proj',
+                    'team_slug': 'eng',
+                },
+            ]
+        )
+        with (
+            mock.patch(
+                'imbi_api.endpoints.scoring.clickhouse.query',
+                mock.AsyncMock(
+                    return_value=[
+                        {
+                            'timestamp': '2026-04-01T12:00:00',
+                            'project_id': 'p1',
+                            'score': 70.0,
+                            'previous_score': None,
+                            'change_reason': 'initial',
+                        }
+                    ]
+                ),
+            ),
+            mock.patch(
+                'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+            ),
+        ):
+            response = self.client.get('/scores/history-feed')
+        self.assertEqual(response.status_code, 200, response.text)
+        body = response.json()
+        self.assertEqual(len(body), 1)
+        self.assertIsNone(body[0]['previous_score'])
+        self.assertEqual(body[0]['change_reason'], 'initial')


### PR DESCRIPTION
## Summary

- Add `GET /scores/history-by-team`: aggregates per-project ClickHouse score history into per-team time series for the global score history chart
- Add `GET /scores/history-feed`: returns raw score change events with project name and team context for the global event feed
- Add `avatar_url` field to `ServiceAccount` and `ServiceAccountResponse` models; wire through PATCH and all response constructors
- Fix pre-commit mypy hook: add `--no-sync` to avoid uv dep resolution conflict when `imbi-plugin-logzio` is present as a local path dep

## Test plan

- [ ] `GET /scores/history-by-team?granularity=day` returns `teams` array with per-team time series
- [ ] `GET /scores/history-feed` returns recent score change events with `project_name` and `team_key`
- [ ] `PATCH /service-accounts/{slug}` with `avatar_url` op updates and returns the field
- [ ] Pre-commit mypy hook passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)