### PR TITLE
Add identity plugin flow, repository, and audit hooks

### DIFF
--- a/src/imbi_api/app.py
+++ b/src/imbi_api/app.py
@@ -17,6 +17,7 @@ def create_app() -> fastapi.FastAPI:
             lifespans.storage_hook,
             valkey.valkey_lifespan,
             lifespans.score_worker_hook,
+            lifespans.identity_refresh_hook,
         ),
         version=version,
         redoc_url='/docs',

--- a/src/imbi_api/auth/models.py
+++ b/src/imbi_api/auth/models.py
@@ -46,12 +46,31 @@ class AuthProvidersResponse(pydantic.BaseModel):
 
 
 class OAuthStateData(pydantic.BaseModel):
-    """Data stored in OAuth state parameter for CSRF protection."""
+    """Data stored in OAuth state parameter for CSRF protection.
+
+    The identity-plugin flow extends this with optional fields:
+
+    * ``intent`` discriminates ``'login'`` from ``'identity'``.  Login
+      flows still create the local user; identity flows persist an
+      :class:`imbi_common.models.IdentityConnection` for the actor.
+    * ``plugin_id`` names the target identity plugin (or ``None`` for
+      the legacy hardcoded login providers).
+    * ``code_verifier`` carries the PKCE verifier through the redirect
+      so we don't need server-side state for in-flight flows.
+    * ``return_to`` is where the UI lands after a successful exchange.
+    * ``actor_user_id`` lets a logged-in user begin an identity flow
+      without re-authenticating.
+    """
 
     provider: str
     nonce: str  # Random nonce for CSRF
     redirect_uri: str  # Where to redirect after auth
     timestamp: int  # Unix timestamp for expiry
+    intent: typing.Literal['login', 'identity'] = 'login'
+    plugin_id: str | None = None
+    code_verifier: str | None = None
+    return_to: str | None = None
+    actor_user_id: str | None = None
 
 
 class OAuthCallbackError(pydantic.BaseModel):

--- a/src/imbi_api/auth/seed.py
+++ b/src/imbi_api/auth/seed.py
@@ -338,6 +338,25 @@ STANDARD_PERMISSIONS: list[tuple[str, str, str, str]] = [
         'logs:read',
         'Read project logs via plugins',
     ),
+    # Identity plugin connections
+    (
+        'me:identities:manage',
+        'me',
+        'identities:manage',
+        'Connect, refresh, and disconnect own third-party identities',
+    ),
+    (
+        'admin:identities:read',
+        'admin',
+        'identities:read',
+        'List identity connections across users (audit / support)',
+    ),
+    (
+        'admin:identities:revoke',
+        'admin',
+        'identities:revoke',
+        "Force-revoke another user's identity connection",
+    ),
 ]
 
 # Default role definitions
@@ -383,6 +402,7 @@ DEFAULT_ROLES: list[tuple[str, str, str, int, list[str]]] = [
             'note:write',
             'note:delete',
             'note_template:read',
+            'me:identities:manage',
         ],
     ),
     (
@@ -407,6 +427,7 @@ DEFAULT_ROLES: list[tuple[str, str, str, int, list[str]]] = [
             'tag:read',
             'note:read',
             'note_template:read',
+            'me:identities:manage',
         ],
     ),
 ]

--- a/src/imbi_api/endpoints/__init__.py
+++ b/src/imbi_api/endpoints/__init__.py
@@ -1,5 +1,7 @@
 import fastapi
 
+from imbi_api.identity.endpoints import me_identities_router
+
 from .admin import admin_router
 from .admin_plugins import admin_plugins_router
 from .api_keys import api_keys_router
@@ -31,6 +33,7 @@ prefixed_routers: list[fastapi.APIRouter] = [
     client_credentials_router,
     events_router,
     local_auth_router,
+    me_identities_router,
     mfa_router,
     operations_log_router,
     organizations_router,

--- a/src/imbi_api/identity/__init__.py
+++ b/src/imbi_api/identity/__init__.py
@@ -1,0 +1,1 @@
+"""Per-user identity flows for the identity plugin type."""

--- a/src/imbi_api/identity/endpoints.py
+++ b/src/imbi_api/identity/endpoints.py
@@ -1,0 +1,191 @@
+"""User-facing identity flow endpoints (``/me/identities/*``)."""
+
+import logging
+import typing
+
+import fastapi
+import fastapi.responses
+from imbi_common import graph
+from imbi_common.plugins.errors import PluginNotFoundError
+
+from imbi_api import settings
+from imbi_api.auth import permissions
+from imbi_api.identity import (
+    errors,
+    flows,
+    models,
+    repository,
+)
+
+LOGGER = logging.getLogger(__name__)
+
+
+me_identities_router = fastapi.APIRouter(
+    prefix='/me/identities', tags=['Identities']
+)
+
+
+def _build_redirect_uri(request: fastapi.Request, plugin_id: str) -> str:
+    """Compute the absolute callback URL for a connect flow."""
+    try:
+        base = settings.get_server_config().public_base_url
+    except Exception:  # noqa: BLE001
+        base = ''
+    if base:
+        return f'{base.rstrip("/")}/me/identities/{plugin_id}/callback'
+    # Fallback: build from the inbound request — works in dev where
+    # public_base_url isn't configured yet.
+    scheme = request.url.scheme
+    host = request.url.netloc
+    return f'{scheme}://{host}/me/identities/{plugin_id}/callback'
+
+
+@me_identities_router.get('')
+async def list_my_identities(
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('me:identities:manage'),
+        ),
+    ],
+) -> list[models.IdentityConnectionResponse]:
+    """List the caller's identity connections."""
+    user = auth.require_user
+    rows = await repository.list_for_user(db, user.id)
+    return [
+        models.IdentityConnectionResponse(
+            id=row['id'],
+            plugin_id=row['plugin_id'],
+            plugin_slug=row.get('plugin_slug') or '',
+            plugin_label=row.get('plugin_label'),
+            subject=row.get('subject') or '',
+            status=row.get('status') or 'active',
+            expires_at=row.get('expires_at'),
+            scopes=list(row.get('scopes') or []),
+            last_used_at=row.get('last_used_at'),
+            connects_users_to=row.get('connects_users_to'),
+            metadata=row.get('metadata') or {},
+        )
+        for row in rows
+    ]
+
+
+@me_identities_router.post('/{plugin_id}/start')
+async def start_connect(
+    plugin_id: str,
+    body: models.IdentityConnectionStartRequest,
+    request: fastapi.Request,
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('me:identities:manage'),
+        ),
+    ],
+) -> models.IdentityConnectionStartResponse:
+    """Begin a connect flow.
+
+    Returns the authorization URL (and a polling descriptor for
+    device-flow plugins).  The browser then either redirects to the
+    URL (redirect flows) or polls ``/poll`` (device flows).
+    """
+    user = auth.require_user
+    redirect_uri = _build_redirect_uri(request, plugin_id)
+    try:
+        url, state_token, polling = await flows.start_flow(
+            db,
+            plugin_id=plugin_id,
+            redirect_uri=redirect_uri,
+            actor_user_id=user.id,
+            return_to=body.return_to,
+            scopes=body.scopes,
+            intent='identity',
+        )
+    except PluginNotFoundError as exc:
+        raise fastapi.HTTPException(
+            status_code=404, detail=f'Plugin {plugin_id!r} not available'
+        ) from exc
+    return models.IdentityConnectionStartResponse(
+        authorization_url=url, state=state_token, polling=polling
+    )
+
+
+@me_identities_router.get('/{plugin_id}/callback')
+async def callback(
+    plugin_id: str,
+    code: str,
+    state: str,
+    db: graph.Pool,
+) -> fastapi.responses.Response:
+    """Browser callback handler — exchanges ``code`` and persists the
+    connection.  Trusts the state JWT for actor identity (the user may
+    not have a session yet during a login flow)."""
+    try:
+        (
+            _profile,
+            _credentials,
+            _returned_plugin_id,
+            return_to,
+        ) = await flows.complete_flow(db, code=code, state_token=state)
+    except ValueError as exc:
+        raise fastapi.HTTPException(
+            status_code=400, detail=f'Invalid state: {exc}'
+        ) from exc
+    except PluginNotFoundError as exc:
+        raise fastapi.HTTPException(
+            status_code=404, detail=f'Plugin {plugin_id!r} not available'
+        ) from exc
+
+    target = return_to or '/settings/connections'
+    return fastapi.responses.RedirectResponse(target, status_code=302)
+
+
+@me_identities_router.post('/{plugin_id}/refresh')
+async def refresh(
+    plugin_id: str,
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('me:identities:manage'),
+        ),
+    ],
+) -> dict[str, str]:
+    """Force-refresh the actor's connection."""
+    user = auth.require_user
+    try:
+        await flows.refresh_connection(
+            db, plugin_id=plugin_id, actor_user_id=user.id
+        )
+    except errors.IdentityRequiredError as exc:
+        raise fastapi.HTTPException(
+            status_code=401,
+            detail={
+                'error': 'identity_required',
+                'plugin_id': exc.plugin_id,
+                'start_url': exc.start_url,
+            },
+        ) from exc
+    except errors.IdentityRefreshFailed as exc:
+        raise fastapi.HTTPException(status_code=502, detail=str(exc)) from exc
+    return {'status': 'refreshed'}
+
+
+@me_identities_router.delete('/{plugin_id}')
+async def disconnect(
+    plugin_id: str,
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('me:identities:manage'),
+        ),
+    ],
+) -> fastapi.Response:
+    """Revoke + delete the actor's connection for ``plugin_id``."""
+    user = auth.require_user
+    await flows.revoke_connection(
+        db, plugin_id=plugin_id, actor_user_id=user.id
+    )
+    return fastapi.Response(status_code=204)

--- a/src/imbi_api/identity/endpoints.py
+++ b/src/imbi_api/identity/endpoints.py
@@ -2,6 +2,7 @@
 
 import logging
 import typing
+import urllib.parse
 
 import fastapi
 import fastapi.responses
@@ -23,6 +24,25 @@ LOGGER = logging.getLogger(__name__)
 me_identities_router = fastapi.APIRouter(
     prefix='/me/identities', tags=['Identities']
 )
+
+
+def _is_safe_return_to(url: str | None) -> bool:
+    """Return True if ``url`` is a safe in-app redirect target.
+
+    ``return_to`` is user-supplied via :class:`IdentityConnectionStartRequest`
+    and signed inside the state JWT, but the signature only proves the
+    requester chose the value — not that it points back at the UI.  Reject
+    anything with a scheme or netloc to avoid an open redirect that could
+    chain a successful identity callback into a phishing page.  The value
+    must also start with ``/`` (and not ``//`` which browsers treat as
+    protocol-relative).
+    """
+    if not url:
+        return False
+    parsed = urllib.parse.urlparse(url)
+    if parsed.scheme or parsed.netloc:
+        return False
+    return url.startswith('/') and not url.startswith('//')
 
 
 def _build_redirect_uri(request: fastapi.Request, plugin_id: str) -> str:
@@ -137,7 +157,11 @@ async def callback(
             status_code=404, detail=f'Plugin {plugin_id!r} not available'
         ) from exc
 
-    target = return_to or '/settings/connections'
+    target: str = (
+        return_to
+        if return_to is not None and _is_safe_return_to(return_to)
+        else '/settings/connections'
+    )
     return fastapi.responses.RedirectResponse(target, status_code=302)
 
 

--- a/src/imbi_api/identity/errors.py
+++ b/src/imbi_api/identity/errors.py
@@ -1,0 +1,28 @@
+"""Identity-flow error types."""
+
+
+class IdentityRequiredError(Exception):
+    """Raised when a dependent plugin call needs an identity that the
+    actor has not yet connected.
+
+    Mapped by the API to HTTP 401 with
+    ``WWW-Authenticate: Imbi-Identity plugin_id=<id>`` and a JSON body
+    ``{error: 'identity_required', plugin_id, start_url}``.
+    """
+
+    def __init__(self, plugin_id: str, start_url: str) -> None:
+        super().__init__(f'Identity required for plugin {plugin_id!r}')
+        self.plugin_id = plugin_id
+        self.start_url = start_url
+
+
+class IdentityRefreshFailed(Exception):
+    """Raised when a refresh-token grant fails terminally.
+
+    The repository flips the connection's ``status`` to ``'expired'``
+    before this propagates.
+    """
+
+
+class IdentityRevokedError(Exception):
+    """Raised when the actor's connection has been revoked."""

--- a/src/imbi_api/identity/flows.py
+++ b/src/imbi_api/identity/flows.py
@@ -1,0 +1,208 @@
+"""High-level identity-flow operations: start, complete, refresh."""
+
+import logging
+import typing
+
+from imbi_common import graph
+from imbi_common.plugins.base import (
+    IdentityCredentials,
+    IdentityPlugin,
+    IdentityProfile,
+    PluginContext,
+)
+from imbi_common.plugins.errors import PluginNotFoundError
+from imbi_common.plugins.registry import RegistryEntry, get_plugin
+
+from imbi_api.identity import errors, repository, state
+from imbi_api.plugins import credentials as plugin_credentials
+
+LOGGER = logging.getLogger(__name__)
+
+
+async def _load_plugin_handler(
+    db: graph.Graph,
+    plugin_id: str,
+) -> tuple[RegistryEntry, IdentityPlugin, dict[str, str]]:
+    """Look up the registered identity-plugin handler for ``plugin_id``.
+
+    Returns ``(registry_entry, handler_instance, oauth_client_creds)``.
+    Raises :class:`PluginNotFoundError` when the slug is not registered
+    (caller maps to 404 / 503).
+    """
+    query: typing.LiteralString = (
+        'MATCH (p:Plugin {{id: {plugin_id}}}) '
+        'RETURN p.plugin_slug AS slug LIMIT 1'
+    )
+    rows = await db.execute(query, {'plugin_id': plugin_id}, ['slug'])
+    if not rows:
+        raise PluginNotFoundError(plugin_id)
+    slug = graph.parse_agtype(rows[0]['slug'])
+    entry = get_plugin(slug)
+    handler = entry.handler_cls()
+    if not isinstance(handler, IdentityPlugin):
+        raise PluginNotFoundError(slug)
+    creds = await plugin_credentials.get_plugin_credentials(
+        db, plugin_id, entry
+    )
+    return entry, handler, creds
+
+
+async def start_flow(
+    db: graph.Graph,
+    *,
+    plugin_id: str,
+    redirect_uri: str,
+    actor_user_id: str | None,
+    return_to: str | None = None,
+    scopes: list[str] | None = None,
+    intent: str = 'identity',
+) -> tuple[str, str, typing.Any]:
+    """Build the authorization URL + signed state token for a flow.
+
+    Returns ``(authorization_url, state_token, polling_descriptor)``.
+    The polling descriptor is ``None`` for redirect-based flows; for
+    device-code plugins (AWS IAM IC) the UI uses it to render the user
+    code and poll until the user completes the flow.
+    """
+    entry, handler, creds = await _load_plugin_handler(db, plugin_id)
+
+    ctx = PluginContext(
+        project_id='',
+        project_slug='',
+        org_slug='',
+        actor_user_id=actor_user_id,
+    )
+    request = await handler.authorization_request(
+        ctx,
+        creds,
+        redirect_uri,
+        scopes or entry.manifest.default_scopes or None,
+    )
+    state_token = state.encode_identity_state(
+        plugin_id=plugin_id,
+        plugin_slug=entry.manifest.slug,
+        redirect_uri=redirect_uri,
+        intent=intent,
+        return_to=return_to,
+        code_verifier=request.code_verifier,
+        actor_user_id=actor_user_id,
+    )
+    return request.authorization_url, state_token, request.polling
+
+
+async def complete_flow(
+    db: graph.Graph,
+    *,
+    code: str,
+    state_token: str,
+) -> tuple[IdentityProfile, IdentityCredentials, str, str | None]:
+    """Exchange ``code`` for tokens and persist the connection.
+
+    Returns ``(profile, credentials, plugin_id, return_to)``.  The caller
+    decides whether to also create / refresh a session (login intent) or
+    just record the IdentityConnection (identity intent).
+    """
+    state_data = state.decode_identity_state(state_token)
+    plugin_id = state_data.plugin_id
+    if not plugin_id:
+        raise ValueError('state token missing plugin_id')
+
+    _entry, handler, creds = await _load_plugin_handler(db, plugin_id)
+
+    ctx = PluginContext(
+        project_id='',
+        project_slug='',
+        org_slug='',
+        actor_user_id=state_data.actor_user_id,
+    )
+    profile, credentials = await handler.exchange_code(
+        ctx,
+        creds,
+        code,
+        state_data.redirect_uri,
+        state_data.code_verifier,
+    )
+
+    if state_data.actor_user_id:
+        await repository.upsert_connection(
+            db,
+            plugin_id,
+            state_data.actor_user_id,
+            profile,
+            credentials,
+        )
+
+    return profile, credentials, plugin_id, state_data.return_to
+
+
+async def refresh_connection(
+    db: graph.Graph,
+    *,
+    plugin_id: str,
+    actor_user_id: str,
+) -> IdentityCredentials:
+    """Force-refresh the actor's connection for ``plugin_id``."""
+    connection = await repository.load_connection(db, plugin_id, actor_user_id)
+    if connection is None:
+        raise errors.IdentityRequiredError(
+            plugin_id=plugin_id,
+            start_url=f'/me/identities/{plugin_id}/start',
+        )
+    if not connection.refresh_token:
+        raise errors.IdentityRefreshFailed(
+            'No refresh token on this connection'
+        )
+    _entry, handler, creds = await _load_plugin_handler(db, plugin_id)
+    ctx = PluginContext(
+        project_id='',
+        project_slug='',
+        org_slug='',
+        actor_user_id=actor_user_id,
+    )
+    try:
+        new_credentials = await handler.refresh(
+            ctx, creds, connection.refresh_token
+        )
+    except Exception as exc:
+        await repository.mark_status(db, connection.connection_id, 'expired')
+        raise errors.IdentityRefreshFailed(str(exc)) from exc
+
+    profile = IdentityProfile(subject=connection.subject)
+    await repository.upsert_connection(
+        db,
+        plugin_id,
+        actor_user_id,
+        profile,
+        new_credentials,
+    )
+    return new_credentials
+
+
+async def revoke_connection(
+    db: graph.Graph,
+    *,
+    plugin_id: str,
+    actor_user_id: str,
+) -> None:
+    """Best-effort revoke at the IdP, then mark the connection revoked."""
+    connection = await repository.load_connection(db, plugin_id, actor_user_id)
+    if connection is None:
+        return
+    try:
+        _entry, handler, creds = await _load_plugin_handler(db, plugin_id)
+        ctx = PluginContext(
+            project_id='',
+            project_slug='',
+            org_slug='',
+            actor_user_id=actor_user_id,
+        )
+        await handler.revoke(ctx, creds, connection.access_token)
+    except Exception:  # noqa: BLE001
+        LOGGER.warning(
+            'IdP revoke failed for plugin_id=%s user_id=%s; '
+            'marking connection revoked anyway',
+            plugin_id,
+            actor_user_id,
+            exc_info=True,
+        )
+    await repository.revoke(db, plugin_id, actor_user_id)

--- a/src/imbi_api/identity/models.py
+++ b/src/imbi_api/identity/models.py
@@ -1,0 +1,61 @@
+"""Per-user identity request/response models for the API surface."""
+
+import datetime
+import typing
+
+import pydantic
+from imbi_common.plugins.base import PollingDescriptor
+
+
+class IdentityConnectionResponse(pydantic.BaseModel):
+    """Public read model for a user's identity connection.
+
+    Tokens — encrypted or plaintext — never appear here.
+    """
+
+    id: str
+    plugin_id: str
+    plugin_slug: str
+    plugin_label: str | None = None
+    subject: str
+    status: typing.Literal['active', 'revoked', 'expired']
+    expires_at: datetime.datetime | None = None
+    scopes: list[str] = []
+    last_used_at: datetime.datetime | None = None
+    connects_users_to: str | None = None
+    metadata: dict[str, typing.Any] = {}
+
+
+class IdentityConnectionStartRequest(pydantic.BaseModel):
+    """Body for ``POST /me/identities/{plugin_id}/start``."""
+
+    return_to: str | None = None
+    scopes: list[str] | None = None
+
+
+class IdentityConnectionStartResponse(pydantic.BaseModel):
+    """Reply to ``POST /me/identities/{plugin_id}/start``."""
+
+    authorization_url: str
+    state: str
+    polling: PollingDescriptor | None = None
+
+
+class IdentityCredentialsInternal(pydantic.BaseModel):
+    """Server-side decrypted credentials.
+
+    Built by the repository on read; *never* serialized to a response
+    (the response model omits it).  Tokens are plaintext for in-process
+    use only.
+    """
+
+    connection_id: str
+    plugin_id: str
+    user_id: str
+    subject: str
+    access_token: str
+    refresh_token: str | None = None
+    expires_at: datetime.datetime | None = None
+    scopes: list[str] = []
+    status: typing.Literal['active', 'revoked', 'expired']
+    metadata: dict[str, typing.Any] = {}

--- a/src/imbi_api/identity/repository.py
+++ b/src/imbi_api/identity/repository.py
@@ -1,0 +1,303 @@
+"""Graph CRUD for ``IdentityConnection`` nodes.
+
+Encryption boundary: this module is the *only* place that touches the
+:class:`imbi_common.auth.encryption.TokenEncryption` singleton for
+identity tokens.  Plaintext credentials enter via ``upsert_connection``
+and leave via :class:`IdentityCredentialsInternal` from
+``load_connection``; the rest of the API code path never handles
+ciphertext directly.
+"""
+
+import datetime
+import json
+import logging
+import typing
+
+import nanoid
+from imbi_common import graph
+from imbi_common.auth.encryption import TokenEncryption
+from imbi_common.plugins.base import IdentityCredentials, IdentityProfile
+
+from imbi_api.identity.models import IdentityCredentialsInternal
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _decrypt(value: typing.Any) -> str | None:
+    if value is None:
+        return None
+    raw = graph.parse_agtype(value) if not isinstance(value, str) else value
+    if not raw:
+        return None
+    return TokenEncryption.get_instance().decrypt(raw)
+
+
+def _now_iso() -> str:
+    return datetime.datetime.now(datetime.UTC).isoformat()
+
+
+async def upsert_connection(
+    db: graph.Graph,
+    plugin_id: str,
+    user_id: str,
+    profile: IdentityProfile,
+    credentials: IdentityCredentials,
+    *,
+    metadata: dict[str, typing.Any] | None = None,
+) -> str:
+    """MERGE the user's connection for this plugin and persist tokens.
+
+    Returns the connection's nano-ID.  Sets ``status='active'``,
+    ``last_used_at=now()``.
+    """
+    encryption = TokenEncryption.get_instance()
+    enc_access = encryption.encrypt(credentials.access_token)
+    enc_refresh = (
+        encryption.encrypt(credentials.refresh_token)
+        if credentials.refresh_token
+        else None
+    )
+    enc_claims = (
+        encryption.encrypt(json.dumps(profile.raw_claims))
+        if profile.raw_claims
+        else None
+    )
+
+    expires_at = (
+        credentials.expires_at.isoformat() if credentials.expires_at else None
+    )
+
+    new_id = nanoid.generate()
+    now = _now_iso()
+
+    # AGE doesn't implement ON CREATE SET, so the MERGE below uses
+    # coalesce() to preserve ``id`` and ``created_at`` on the existing
+    # row while every other field is overwritten.
+    query: typing.LiteralString = """
+    MERGE (c:IdentityConnection {{plugin_id: {plugin_id},
+                                  user_id: {user_id}}})
+    SET c.id = coalesce(c.id, {new_id}),
+        c.created_at = coalesce(c.created_at, {now}),
+        c.subject = {subject},
+        c.access_token_encrypted = {access},
+        c.refresh_token_encrypted = {refresh},
+        c.id_token_claims_encrypted = {claims},
+        c.expires_at = {expires_at},
+        c.scopes = {scopes},
+        c.status = 'active',
+        c.last_used_at = {now},
+        c.updated_at = {now},
+        c.metadata = {metadata}
+    WITH c
+    MATCH (u:User {{id: {user_id}}}), (p:Plugin {{id: {plugin_id}}})
+    MERGE (u)-[:HAS_IDENTITY]->(c)
+    MERGE (c)-[:USES_PLUGIN]->(p)
+    RETURN c.id AS id
+    """
+    params = {
+        'plugin_id': plugin_id,
+        'user_id': user_id,
+        'new_id': new_id,
+        'now': now,
+        'subject': profile.subject,
+        'access': enc_access,
+        'refresh': enc_refresh,
+        'claims': enc_claims,
+        'expires_at': expires_at,
+        'scopes': credentials.scopes,
+        'metadata': metadata or {},
+    }
+
+    try:
+        records = await db.execute(query, params, ['id'])
+    except Exception:
+        LOGGER.exception(
+            'Failed to upsert IdentityConnection plugin_id=%s user_id=%s',
+            plugin_id,
+            user_id,
+        )
+        raise
+    if not records:
+        raise RuntimeError('upsert_connection returned no rows')
+    return str(graph.parse_agtype(records[0]['id']))
+
+
+async def load_connection(
+    db: graph.Graph,
+    plugin_id: str,
+    user_id: str,
+) -> IdentityCredentialsInternal | None:
+    """Load and decrypt the actor's connection for ``plugin_id``."""
+    query: typing.LiteralString = """
+    MATCH (c:IdentityConnection {{plugin_id: {plugin_id},
+                                  user_id: {user_id}}})
+    RETURN c.id AS id,
+           c.subject AS subject,
+           c.access_token_encrypted AS access,
+           c.refresh_token_encrypted AS refresh,
+           c.expires_at AS expires_at,
+           c.scopes AS scopes,
+           c.status AS status,
+           c.metadata AS metadata
+    LIMIT 1
+    """
+    records = await db.execute(
+        query,
+        {'plugin_id': plugin_id, 'user_id': user_id},
+        [
+            'id',
+            'subject',
+            'access',
+            'refresh',
+            'expires_at',
+            'scopes',
+            'status',
+            'metadata',
+        ],
+    )
+    if not records:
+        return None
+    row = records[0]
+    access = _decrypt(row.get('access'))
+    if access is None:
+        LOGGER.warning(
+            'IdentityConnection plugin_id=%s user_id=%s missing access token',
+            plugin_id,
+            user_id,
+        )
+        return None
+    refresh = _decrypt(row.get('refresh'))
+
+    expires_raw = (
+        graph.parse_agtype(row['expires_at'])
+        if row.get('expires_at') is not None
+        else None
+    )
+    expires_at = (
+        datetime.datetime.fromisoformat(expires_raw) if expires_raw else None
+    )
+
+    scopes_raw: typing.Any = (
+        graph.parse_agtype(row['scopes']) if row.get('scopes') else []
+    )
+    scopes: list[str] = list(scopes_raw or [])
+
+    return IdentityCredentialsInternal(
+        connection_id=graph.parse_agtype(row['id']),
+        plugin_id=plugin_id,
+        user_id=user_id,
+        subject=graph.parse_agtype(row['subject']),
+        access_token=access,
+        refresh_token=refresh,
+        expires_at=expires_at,
+        scopes=scopes,
+        status=graph.parse_agtype(row['status']),
+        metadata=graph.parse_agtype(row.get('metadata') or {}) or {},
+    )
+
+
+async def mark_status(
+    db: graph.Graph,
+    connection_id: str,
+    status: typing.Literal['active', 'revoked', 'expired'],
+) -> None:
+    """Update the ``status`` field on a connection."""
+    query: typing.LiteralString = """
+    MATCH (c:IdentityConnection {{id: {id}}})
+    SET c.status = {status}, c.updated_at = {now}
+    """
+    await db.execute(
+        query,
+        {'id': connection_id, 'status': status, 'now': _now_iso()},
+        [],
+    )
+
+
+async def revoke(
+    db: graph.Graph,
+    plugin_id: str,
+    user_id: str,
+) -> None:
+    """Mark the user's connection revoked and clear tokens."""
+    query: typing.LiteralString = """
+    MATCH (c:IdentityConnection {{plugin_id: {plugin_id},
+                                  user_id: {user_id}}})
+    SET c.status = 'revoked',
+        c.access_token_encrypted = null,
+        c.refresh_token_encrypted = null,
+        c.id_token_claims_encrypted = null,
+        c.updated_at = {now}
+    """
+    await db.execute(
+        query,
+        {'plugin_id': plugin_id, 'user_id': user_id, 'now': _now_iso()},
+        [],
+    )
+
+
+async def list_for_user(
+    db: graph.Graph,
+    user_id: str,
+) -> list[dict[str, typing.Any]]:
+    """Return raw connection rows for the actor (for admin / settings UI)."""
+    query: typing.LiteralString = """
+    MATCH (u:User {{id: {user_id}}})-[:HAS_IDENTITY]->(c:IdentityConnection)
+    OPTIONAL MATCH (c)-[:USES_PLUGIN]->(p:Plugin)
+    RETURN c.id AS id,
+           c.plugin_id AS plugin_id,
+           p.plugin_slug AS plugin_slug,
+           p.label AS plugin_label,
+           p.connects_users_to AS connects_users_to,
+           c.subject AS subject,
+           c.status AS status,
+           c.expires_at AS expires_at,
+           c.scopes AS scopes,
+           c.last_used_at AS last_used_at,
+           c.metadata AS metadata
+    """
+    records = await db.execute(
+        query,
+        {'user_id': user_id},
+        [
+            'id',
+            'plugin_id',
+            'plugin_slug',
+            'plugin_label',
+            'connects_users_to',
+            'subject',
+            'status',
+            'expires_at',
+            'scopes',
+            'last_used_at',
+            'metadata',
+        ],
+    )
+    out: list[dict[str, typing.Any]] = []
+    for row in records:
+        out.append({k: graph.parse_agtype(v) for k, v in row.items()})
+    return out
+
+
+async def stale_connections(
+    db: graph.Graph,
+    before: datetime.datetime,
+) -> list[dict[str, typing.Any]]:
+    """Return active connections whose ``expires_at < before`` and that
+    have a refresh token, for the background refresh sweeper.
+    """
+    query: typing.LiteralString = """
+    MATCH (c:IdentityConnection)
+    WHERE c.status = 'active'
+      AND c.refresh_token_encrypted IS NOT NULL
+      AND c.expires_at IS NOT NULL
+      AND c.expires_at < {before}
+    RETURN c.id AS id,
+           c.plugin_id AS plugin_id,
+           c.user_id AS user_id
+    """
+    records = await db.execute(
+        query, {'before': before.isoformat()}, ['id', 'plugin_id', 'user_id']
+    )
+    return [
+        {k: graph.parse_agtype(v) for k, v in row.items()} for row in records
+    ]

--- a/src/imbi_api/identity/resolution.py
+++ b/src/imbi_api/identity/resolution.py
@@ -1,0 +1,110 @@
+"""Identity hydration: thread per-user credentials into PluginContext."""
+
+import datetime
+import logging
+
+from imbi_common import graph
+from imbi_common.plugins.base import (
+    IdentityCredentials,
+    IdentityPlugin,
+    PluginContext,
+)
+from imbi_common.plugins.errors import PluginNotFoundError
+from imbi_common.plugins.registry import get_plugin
+
+from imbi_api.identity import errors as identity_errors
+from imbi_api.identity import repository
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _start_url_for(plugin_id: str) -> str:
+    """Build the canonical start URL for a plugin connect flow."""
+    return f'/me/identities/{plugin_id}/start'
+
+
+async def hydrate_identity(
+    db: graph.Graph,
+    ctx: PluginContext,
+    identity_plugin_id: str,
+) -> PluginContext:
+    """Load the actor's connection for ``identity_plugin_id`` and attach
+    materialized credentials to ``ctx.identity``.
+
+    Raises :class:`identity_errors.IdentityRequiredError` when the actor
+    has no active connection.
+    """
+    user_id = ctx.actor_user_id
+    if not user_id:
+        raise identity_errors.IdentityRequiredError(
+            plugin_id=identity_plugin_id,
+            start_url=_start_url_for(identity_plugin_id),
+        )
+
+    connection = await repository.load_connection(
+        db, identity_plugin_id, user_id
+    )
+    if connection is None or connection.status != 'active':
+        raise identity_errors.IdentityRequiredError(
+            plugin_id=identity_plugin_id,
+            start_url=_start_url_for(identity_plugin_id),
+        )
+
+    # Look up the identity plugin's slug + handler so we can call
+    # ``materialize`` for plugins that exchange the IdP token (AWS IAM IC).
+    slug = await _plugin_slug(db, identity_plugin_id)
+    if slug is None:
+        raise identity_errors.IdentityRequiredError(
+            plugin_id=identity_plugin_id,
+            start_url=_start_url_for(identity_plugin_id),
+        )
+
+    try:
+        entry = get_plugin(slug)
+    except PluginNotFoundError as exc:
+        LOGGER.error('Identity plugin %r unavailable for hydrate', slug)
+        raise identity_errors.IdentityRequiredError(
+            plugin_id=identity_plugin_id,
+            start_url=_start_url_for(identity_plugin_id),
+        ) from exc
+
+    handler = entry.handler_cls()
+    if not isinstance(handler, IdentityPlugin):
+        raise identity_errors.IdentityRequiredError(
+            plugin_id=identity_plugin_id,
+            start_url=_start_url_for(identity_plugin_id),
+        )
+
+    base_credentials = IdentityCredentials(
+        access_token=connection.access_token,
+        refresh_token=connection.refresh_token,
+        expires_at=connection.expires_at,
+        scopes=connection.scopes,
+    )
+
+    materialized = await handler.materialize(
+        ctx,
+        {},
+        base_credentials,
+    )
+
+    return ctx.model_copy(update={'identity': materialized})
+
+
+async def _plugin_slug(db: graph.Graph, plugin_id: str) -> str | None:
+    query = (
+        'MATCH (p:Plugin {{id: {plugin_id}}}) '
+        'RETURN p.plugin_slug AS slug LIMIT 1'
+    )
+    rows = await db.execute(query, {'plugin_id': plugin_id}, ['slug'])
+    if not rows:
+        return None
+    parsed = graph.parse_agtype(rows[0]['slug'])
+    return str(parsed) if parsed is not None else None
+
+
+def is_active(connection_expires_at: datetime.datetime | None) -> bool:
+    """Return True if the connection's token is not yet expired."""
+    if connection_expires_at is None:
+        return True
+    return connection_expires_at > datetime.datetime.now(datetime.UTC)

--- a/src/imbi_api/identity/resolution.py
+++ b/src/imbi_api/identity/resolution.py
@@ -2,6 +2,7 @@
 
 import datetime
 import logging
+import typing
 
 from imbi_common import graph
 from imbi_common.plugins.base import (
@@ -92,7 +93,7 @@ async def hydrate_identity(
 
 
 async def _plugin_slug(db: graph.Graph, plugin_id: str) -> str | None:
-    query = (
+    query: typing.LiteralString = (
         'MATCH (p:Plugin {{id: {plugin_id}}}) '
         'RETURN p.plugin_slug AS slug LIMIT 1'
     )

--- a/src/imbi_api/identity/state.py
+++ b/src/imbi_api/identity/state.py
@@ -67,6 +67,8 @@ def decode_identity_state(
         state_data = models.OAuthStateData(**payload)
     except jwt.InvalidTokenError as exc:
         raise ValueError(f'Invalid identity state token: {exc}') from exc
+    if state_data.intent != 'identity' or not state_data.plugin_id:
+        raise ValueError('State token is not for an identity flow')
     age = int(time.time()) - state_data.timestamp
     if age > max_age_seconds:
         raise ValueError(f'Identity state expired (age: {age}s)')

--- a/src/imbi_api/identity/state.py
+++ b/src/imbi_api/identity/state.py
@@ -1,0 +1,73 @@
+"""Identity-flow state JWT helpers.
+
+Reuses the existing ``OAuthStateData`` model + JWT signing primitives
+from :mod:`imbi_api.auth.oauth` so login and identity flows share one
+state-token format.  ``intent='identity'`` discriminates the identity
+flow path.
+"""
+
+import secrets
+import time
+
+import jwt
+
+from imbi_api import settings
+from imbi_api.auth import models
+
+
+def encode_identity_state(
+    *,
+    plugin_id: str,
+    plugin_slug: str,
+    redirect_uri: str,
+    intent: str = 'identity',
+    return_to: str | None = None,
+    code_verifier: str | None = None,
+    actor_user_id: str | None = None,
+    auth_settings: settings.Auth | None = None,
+) -> str:
+    """Encode the identity-flow state JWT and return the signed token."""
+    auth = auth_settings or settings.Auth()  # type: ignore[call-arg]
+    state_data = models.OAuthStateData(
+        provider=plugin_slug,
+        nonce=secrets.token_urlsafe(32),
+        redirect_uri=redirect_uri,
+        timestamp=int(time.time()),
+        intent=intent,  # type: ignore[arg-type]
+        plugin_id=plugin_id,
+        code_verifier=code_verifier,
+        return_to=return_to,
+        actor_user_id=actor_user_id,
+    )
+    return jwt.encode(
+        state_data.model_dump(),
+        auth.jwt_secret,
+        algorithm=auth.jwt_algorithm,
+    )
+
+
+def decode_identity_state(
+    state_token: str,
+    *,
+    auth_settings: settings.Auth | None = None,
+    max_age_seconds: int = 600,
+) -> models.OAuthStateData:
+    """Verify and decode an identity-flow state token.
+
+    Raises :class:`ValueError` for invalid signature or expiry — same
+    semantics as the login-side ``verify_oauth_state``.
+    """
+    auth = auth_settings or settings.Auth()  # type: ignore[call-arg]
+    try:
+        payload = jwt.decode(
+            state_token,
+            auth.jwt_secret,
+            algorithms=[auth.jwt_algorithm],
+        )
+        state_data = models.OAuthStateData(**payload)
+    except jwt.InvalidTokenError as exc:
+        raise ValueError(f'Invalid identity state token: {exc}') from exc
+    age = int(time.time()) - state_data.timestamp
+    if age > max_age_seconds:
+        raise ValueError(f'Identity state expired (age: {age}s)')
+    return state_data

--- a/src/imbi_api/identity/sweeper.py
+++ b/src/imbi_api/identity/sweeper.py
@@ -1,0 +1,111 @@
+"""Background refresh sweeper for identity connections.
+
+Polls :func:`stale_connections` every 60s, acquires a per-(user,plugin)
+Valkey lock to prevent thundering-herd on shared dashboards, and calls
+:meth:`IdentityPlugin.refresh` for each row whose ``expires_at`` is
+within the next 5 minutes.  Failed refreshes flip ``status='expired'``.
+"""
+
+import asyncio
+import datetime
+import logging
+
+import valkey.asyncio
+from imbi_common import graph
+from imbi_common import valkey as valkey_module
+
+from imbi_api.identity import errors, flows, repository
+
+LOGGER = logging.getLogger(__name__)
+
+POLL_INTERVAL_SECONDS = 60
+LOOKAHEAD_SECONDS = 300
+LOCK_TTL_SECONDS = 10
+
+
+def _lock_key(plugin_id: str, user_id: str) -> str:
+    return f'imbi:identity:refresh:{plugin_id}:{user_id}'
+
+
+async def _try_lock(client: valkey.asyncio.Valkey, key: str) -> bool:
+    """Acquire a Valkey ``SET NX EX 10`` lock; True on success."""
+    try:
+        result = await client.set(key, '1', nx=True, ex=LOCK_TTL_SECONDS)
+    except Exception:  # noqa: BLE001
+        LOGGER.debug('Identity refresh lock acquire failed', exc_info=True)
+        return False
+    return bool(result)
+
+
+async def _refresh_one(
+    db: graph.Graph,
+    client: valkey.asyncio.Valkey,
+    row: dict[str, str],
+) -> None:
+    plugin_id = row.get('plugin_id') or ''
+    user_id = row.get('user_id') or ''
+    if not plugin_id or not user_id:
+        return
+    if not await _try_lock(client, _lock_key(plugin_id, user_id)):
+        return
+    try:
+        await flows.refresh_connection(
+            db, plugin_id=plugin_id, actor_user_id=user_id
+        )
+    except errors.IdentityRefreshFailed:
+        LOGGER.warning(
+            'Identity refresh failed plugin_id=%s user_id=%s; '
+            'connection marked expired',
+            plugin_id,
+            user_id,
+        )
+    except Exception:  # noqa: BLE001
+        LOGGER.warning(
+            'Identity refresh raised plugin_id=%s user_id=%s',
+            plugin_id,
+            user_id,
+            exc_info=True,
+        )
+
+
+async def run_sweeper(
+    db: graph.Graph,
+    client: valkey.asyncio.Valkey,
+    *,
+    stop: asyncio.Event,
+) -> None:
+    """Run the sweeper loop until ``stop`` is set."""
+    LOGGER.info('Identity refresh sweeper starting')
+    while not stop.is_set():
+        try:
+            horizon = datetime.datetime.now(datetime.UTC) + datetime.timedelta(
+                seconds=LOOKAHEAD_SECONDS
+            )
+            rows = await repository.stale_connections(db, horizon)
+            for row in rows:
+                if stop.is_set():
+                    break
+                await _refresh_one(db, client, row)
+        except Exception:  # noqa: BLE001
+            LOGGER.warning(
+                'Identity refresh sweeper iteration failed', exc_info=True
+            )
+        try:
+            await asyncio.wait_for(stop.wait(), timeout=POLL_INTERVAL_SECONDS)
+        except TimeoutError:
+            continue
+    LOGGER.info('Identity refresh sweeper stopped')
+
+
+async def lifespan_task(
+    db: graph.Graph,
+) -> tuple[asyncio.Task[None], asyncio.Event]:
+    """Start the sweeper as a background task.
+
+    Returns ``(task, stop_event)``.  Caller is responsible for setting
+    ``stop_event`` and awaiting ``task`` on shutdown.
+    """
+    client = valkey_module.get_client()
+    stop = asyncio.Event()
+    task = asyncio.create_task(run_sweeper(db, client, stop=stop))
+    return task, stop

--- a/src/imbi_api/identity/sweeper.py
+++ b/src/imbi_api/identity/sweeper.py
@@ -60,8 +60,22 @@ async def _refresh_one(
         # ``flows.refresh_connection`` flips status to ``expired`` only
         # for plugin-level refresh failures; the missing-refresh-token
         # branch raises before reaching that code path.  Mark the
-        # connection here so we do not retry it every poll.
-        connection = await repository.load_connection(db, plugin_id, user_id)
+        # connection here so we do not retry it every poll.  Guard the
+        # lookup so a transient graph error does not abort the sweeper
+        # iteration over remaining rows.
+        try:
+            connection = await repository.load_connection(
+                db, plugin_id, user_id
+            )
+        except Exception:  # noqa: BLE001
+            LOGGER.warning(
+                'Failed to load identity connection after refresh '
+                'failure plugin_id=%s user_id=%s',
+                plugin_id,
+                user_id,
+                exc_info=True,
+            )
+            return
         if connection is not None and connection.status != 'expired':
             try:
                 await repository.mark_status(

--- a/src/imbi_api/identity/sweeper.py
+++ b/src/imbi_api/identity/sweeper.py
@@ -4,6 +4,11 @@ Polls :func:`stale_connections` every 60s, acquires a per-(user,plugin)
 Valkey lock to prevent thundering-herd on shared dashboards, and calls
 :meth:`IdentityPlugin.refresh` for each row whose ``expires_at`` is
 within the next 5 minutes.  Failed refreshes flip ``status='expired'``.
+
+The actual lifespan integration lives in
+:func:`imbi_api.lifespans.identity_refresh_hook`; this module only
+exposes the loop body so it can be unit-tested without bringing the
+full FastAPI app stack up.
 """
 
 import asyncio
@@ -12,7 +17,6 @@ import logging
 
 import valkey.asyncio
 from imbi_common import graph
-from imbi_common import valkey as valkey_module
 
 from imbi_api.identity import errors, flows, repository
 
@@ -53,6 +57,24 @@ async def _refresh_one(
             db, plugin_id=plugin_id, actor_user_id=user_id
         )
     except errors.IdentityRefreshFailed:
+        # ``flows.refresh_connection`` flips status to ``expired`` only
+        # for plugin-level refresh failures; the missing-refresh-token
+        # branch raises before reaching that code path.  Mark the
+        # connection here so we do not retry it every poll.
+        connection = await repository.load_connection(db, plugin_id, user_id)
+        if connection is not None and connection.status != 'expired':
+            try:
+                await repository.mark_status(
+                    db, connection.connection_id, 'expired'
+                )
+            except Exception:  # noqa: BLE001
+                LOGGER.warning(
+                    'Failed to mark identity connection expired '
+                    'plugin_id=%s user_id=%s',
+                    plugin_id,
+                    user_id,
+                    exc_info=True,
+                )
         LOGGER.warning(
             'Identity refresh failed plugin_id=%s user_id=%s; '
             'connection marked expired',
@@ -95,17 +117,3 @@ async def run_sweeper(
         except TimeoutError:
             continue
     LOGGER.info('Identity refresh sweeper stopped')
-
-
-async def lifespan_task(
-    db: graph.Graph,
-) -> tuple[asyncio.Task[None], asyncio.Event]:
-    """Start the sweeper as a background task.
-
-    Returns ``(task, stop_event)``.  Caller is responsible for setting
-    ``stop_event`` and awaiting ``task`` on shutdown.
-    """
-    client = valkey_module.get_client()
-    stop = asyncio.Event()
-    task = asyncio.create_task(run_sweeper(db, client, stop=stop))
-    return task, stop

--- a/src/imbi_api/lifespans.py
+++ b/src/imbi_api/lifespans.py
@@ -15,6 +15,7 @@ from imbi_common import clickhouse, graph, valkey
 from imbi_api import openapi
 from imbi_api.email.client import EmailClient
 from imbi_api.email.templates import TemplateManager
+from imbi_api.identity import sweeper as identity_sweeper
 from imbi_api.plugins import lifecycle as plugin_lifecycle
 from imbi_api.scoring import queue as score_queue
 from imbi_api.storage.client import StorageClient
@@ -70,6 +71,42 @@ async def storage_hook() -> abc.AsyncIterator[StorageClient]:
     await storage_client.initialize()
     async with contextlib.aclosing(storage_client):
         yield storage_client
+
+
+@contextlib.asynccontextmanager
+async def identity_refresh_hook() -> abc.AsyncIterator[None]:
+    """Run the identity-token refresh sweeper for the API process.
+
+    Polls :func:`identity.repository.stale_connections` every 60s and
+    refreshes connections whose ``expires_at`` is within 5 minutes.
+    Failed refreshes flip ``status='expired'``.
+    """
+    try:
+        client = valkey.get_client()
+    except RuntimeError:
+        LOGGER.warning('Valkey unavailable; identity sweeper not started')
+        yield None
+        return
+    if _graph is None:
+        LOGGER.warning('Graph not ready; identity sweeper not started')
+        yield None
+        return
+    stop = asyncio.Event()
+    LOGGER.info('Identity refresh sweeper starting')
+    task = asyncio.create_task(
+        identity_sweeper.run_sweeper(_graph, client, stop=stop)
+    )
+    try:
+        yield None
+    finally:
+        stop.set()
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        except Exception:  # noqa: BLE001
+            LOGGER.warning('Identity sweeper exited with error', exc_info=True)
 
 
 @contextlib.asynccontextmanager

--- a/src/imbi_api/plugins/lifecycle.py
+++ b/src/imbi_api/plugins/lifecycle.py
@@ -8,6 +8,9 @@ from imbi_common.plugins.registry import (
     list_plugins,
     load_plugins,
 )
+from imbi_common.plugins.schemas import apply_plugin_schemas
+
+from imbi_api.plugins.schemas import audit_plugin_schemas
 
 LOGGER = logging.getLogger(__name__)
 
@@ -24,8 +27,17 @@ async def startup_load_plugins(db: graph.Graph) -> None:
     for slug, err in result.errors.items():
         LOGGER.error('Plugin load error for %r: %s', slug, err)
 
+    # Apply plugin-declared vlabels + indexes to AGE before any audit.
+    try:
+        await apply_plugin_schemas([e.manifest for e in list_plugins()])
+    except Exception:  # noqa: BLE001
+        LOGGER.warning(
+            'Failed to apply plugin-declared schemas', exc_info=True
+        )
+
     await _seed_registrations(db)
     await _audit_unavailable(db)
+    await audit_plugin_schemas()
 
 
 async def _audit_unavailable(db: graph.Graph) -> None:

--- a/src/imbi_api/plugins/lifecycle.py
+++ b/src/imbi_api/plugins/lifecycle.py
@@ -28,12 +28,13 @@ async def startup_load_plugins(db: graph.Graph) -> None:
         LOGGER.error('Plugin load error for %r: %s', slug, err)
 
     # Apply plugin-declared vlabels + indexes to AGE before any audit.
+    # Fail fast: missing labels/indexes corrupt every later request that
+    # touches the plugin, so abort startup rather than mask the breakage.
     try:
         await apply_plugin_schemas([e.manifest for e in list_plugins()])
-    except Exception:  # noqa: BLE001
-        LOGGER.warning(
-            'Failed to apply plugin-declared schemas', exc_info=True
-        )
+    except Exception:
+        LOGGER.exception('Failed to apply plugin-declared schemas')
+        raise
 
     await _seed_registrations(db)
     await _audit_unavailable(db)

--- a/src/imbi_api/plugins/resolution.py
+++ b/src/imbi_api/plugins/resolution.py
@@ -24,6 +24,7 @@ class ResolvedPlugin(typing.NamedTuple):
     plugin_slug: str
     entry: RegistryEntry
     options: dict[str, typing.Any]
+    identity_plugin_id: str | None = None
 
 
 async def resolve_plugin(
@@ -58,12 +59,14 @@ async def resolve_plugin(
       collect(DISTINCT {{id: p.id, slug: p.plugin_slug,
                          edge_options: pe.options,
                          plugin_options: p.options,
+                         identity_plugin_id: pe.identity_plugin_id,
                          default: pe.default,
                          src: 'project'}})
        AS proj_plugins,
       collect(DISTINCT {{id: p2.id, slug: p2.plugin_slug,
                          edge_options: pte.options,
                          plugin_options: p2.options,
+                         identity_plugin_id: pte.identity_plugin_id,
                          default: pte.default,
                          src: 'project_type'}})
        AS pt_plugins
@@ -176,9 +179,14 @@ async def resolve_plugin(
     except PluginNotFoundError as exc:
         raise PluginUnavailableError(plugin_slug) from exc
 
+    identity_plugin_id = chosen.get('identity_plugin_id')
+    if isinstance(identity_plugin_id, str) and not identity_plugin_id:
+        identity_plugin_id = None
+
     return ResolvedPlugin(
         plugin_id=plugin_id,
         plugin_slug=plugin_slug,
         entry=entry,
         options=options,
+        identity_plugin_id=identity_plugin_id,
     )

--- a/src/imbi_api/plugins/resolution.py
+++ b/src/imbi_api/plugins/resolution.py
@@ -107,9 +107,15 @@ async def resolve_plugin(
         if pid in pt_by_id:
             # Carry the project-type edge options as a middle tier so that
             # a partial project override does not drop project-type settings.
+            # Also carry the project-type ``identity_plugin_id`` separately
+            # so a project edge that omits it falls back to the type-level
+            # binding instead of clearing the identity requirement.
             merged[pid] = {
                 **p,
                 'pt_edge_options': pt_by_id[pid].get('edge_options'),
+                'pt_identity_plugin_id': pt_by_id[pid].get(
+                    'identity_plugin_id'
+                ),
             }
         else:
             merged[pid] = p
@@ -179,9 +185,7 @@ async def resolve_plugin(
     except PluginNotFoundError as exc:
         raise PluginUnavailableError(plugin_slug) from exc
 
-    identity_plugin_id = chosen.get('identity_plugin_id')
-    if isinstance(identity_plugin_id, str) and not identity_plugin_id:
-        identity_plugin_id = None
+    identity_plugin_id = _select_identity_plugin_id(chosen)
 
     return ResolvedPlugin(
         plugin_id=plugin_id,
@@ -190,3 +194,23 @@ async def resolve_plugin(
         options=options,
         identity_plugin_id=identity_plugin_id,
     )
+
+
+def _select_identity_plugin_id(
+    chosen: dict[str, typing.Any],
+) -> str | None:
+    """Pick the identity plugin id, preferring the project-level binding.
+
+    Falls back to the project-type binding (carried as
+    ``pt_identity_plugin_id``) when the chosen edge omits its own
+    ``identity_plugin_id`` so a partial project override does not drop the
+    type-level identity requirement.
+    """
+    identity_plugin_id = chosen.get('identity_plugin_id')
+    if isinstance(identity_plugin_id, str) and not identity_plugin_id:
+        identity_plugin_id = None
+    if identity_plugin_id is None:
+        pt_identity = chosen.get('pt_identity_plugin_id')
+        if isinstance(pt_identity, str) and pt_identity:
+            identity_plugin_id = pt_identity
+    return identity_plugin_id

--- a/src/imbi_api/plugins/schemas.py
+++ b/src/imbi_api/plugins/schemas.py
@@ -1,0 +1,80 @@
+"""Plugin-declared schema audit (imbi-api side).
+
+Complements :func:`imbi_common.plugins.apply_plugin_schemas` (which
+creates plugin-declared vlabels in AGE on startup) by surfacing
+*orphaned* plugin-declared data — vlabels still present in AGE whose
+declaring plugin is no longer in the registry.
+
+The audit result feeds the admin "Unavailable" view in
+``GET /admin/plugins`` under an ``unavailable_schemas`` array.
+"""
+
+import logging
+import pathlib
+import tomllib
+import typing
+
+import imbi_common.graph
+import psycopg
+from imbi_common import settings
+from imbi_common.plugins.registry import list_plugins
+
+LOGGER = logging.getLogger(__name__)
+
+
+async def audit_plugin_schemas() -> list[dict[str, typing.Any]]:
+    """Return a list of orphaned plugin-declared vlabels.
+
+    Each entry: ``{'vlabel': name}`` for every vlabel present in AGE
+    that is neither in core ``schemata.toml`` nor declared by a plugin
+    currently in the registry.  An empty list means every plugin-declared
+    vlabel currently in AGE has its declaring plugin loaded.
+    """
+    declared: set[str] = set()
+    for entry in list_plugins():
+        for vlabel in entry.manifest.vertex_labels:
+            declared.add(vlabel.name)
+
+    core_labels = _core_vlabel_names()
+    age_labels = await _ag_label_names()
+
+    orphaned = sorted(age_labels - core_labels - declared)
+    if orphaned:
+        LOGGER.error(
+            'Unavailable plugin-declared schemas (in AGE but not '
+            'declared by any loaded plugin): %s',
+            orphaned,
+        )
+    return [{'vlabel': name} for name in orphaned]
+
+
+async def _ag_label_names() -> set[str]:
+    """Return the set of vertex-label names currently in AGE."""
+    postgres = settings.Postgres()
+    try:
+        async with await psycopg.AsyncConnection.connect(
+            str(postgres.url), autocommit=True
+        ) as conn:
+            async with conn.cursor() as cursor:
+                await cursor.execute(
+                    'SELECT name FROM ag_catalog.ag_label '
+                    "WHERE kind = 'v' AND graph = ("
+                    '  SELECT graphid FROM ag_catalog.ag_graph WHERE name = %s'
+                    ')',
+                    (postgres.graph_name,),
+                )
+                rows = await cursor.fetchall()
+    except Exception:  # noqa: BLE001
+        LOGGER.warning(
+            'Failed to enumerate AGE labels for plugin schema audit',
+            exc_info=True,
+        )
+        return set()
+    return {row[0] for row in rows}
+
+
+def _core_vlabel_names() -> set[str]:
+    """Return the set of vlabels declared in core ``schemata.toml``."""
+    pkg_dir = pathlib.Path(imbi_common.graph.__file__).resolve().parent
+    schemata = tomllib.loads((pkg_dir / 'schemata.toml').read_text())
+    return set(schemata.get('vlabels', {}).get('name', []))

--- a/tests/auth/test_seed.py
+++ b/tests/auth/test_seed.py
@@ -108,14 +108,20 @@ class SeedDefaultRolesTestCase(unittest.IsolatedAsyncioTestCase):
             len(seed.STANDARD_PERMISSIONS),
         )
 
-        # Verify readonly has only read permissions
+        # Verify readonly has only read permissions plus self-service
+        # identity management (so readonly users can connect/disconnect
+        # their own identity providers).
         readonly_role = next(
             r for r in seed.DEFAULT_ROLES if r[0] == 'readonly'
         )
         readonly_permissions = readonly_role[4]
+        self_service = {'me:identities:manage'}
         self.assertTrue(
-            all(':read' in perm for perm in readonly_permissions),
-            'Readonly role should only have read permissions',
+            all(
+                ':read' in perm or perm in self_service
+                for perm in readonly_permissions
+            ),
+            'Readonly role should only have read or self-service permissions',
         )
 
     def test_no_group_permissions(self) -> None:

--- a/tests/identity/__init__.py
+++ b/tests/identity/__init__.py
@@ -1,0 +1,1 @@
+"""Identity package tests."""

--- a/tests/identity/test_endpoints.py
+++ b/tests/identity/test_endpoints.py
@@ -139,6 +139,147 @@ class DisconnectEndpointTestCase(unittest.IsolatedAsyncioTestCase):
         revoke.assert_awaited_once()
 
 
+class StartConnectEndpointTestCase(unittest.IsolatedAsyncioTestCase):
+    """Cover the start_connect endpoint."""
+
+    async def test_returns_authorization_url(self) -> None:
+        from imbi_api.identity import models
+
+        db = mock.AsyncMock()
+        auth = mock.MagicMock()
+        auth.require_user = mock.MagicMock(id='user-1')
+        request = mock.MagicMock()
+        with (
+            mock.patch.object(
+                endpoints,
+                '_build_redirect_uri',
+                return_value='https://imbi/cb',
+            ),
+            mock.patch.object(
+                endpoints.flows,
+                'start_flow',
+                new=mock.AsyncMock(
+                    return_value=('https://idp/auth', 'state-token', None)
+                ),
+            ),
+        ):
+            response = await endpoints.start_connect(
+                'plugin-1',
+                models.IdentityConnectionStartRequest(),
+                request,
+                db,
+                auth,
+            )
+        self.assertEqual(response.authorization_url, 'https://idp/auth')
+        self.assertEqual(response.state, 'state-token')
+
+    async def test_maps_plugin_not_found_to_404(self) -> None:
+        from imbi_common.plugins.errors import PluginNotFoundError
+
+        from imbi_api.identity import models
+
+        db = mock.AsyncMock()
+        auth = mock.MagicMock()
+        auth.require_user = mock.MagicMock(id='user-1')
+        with (
+            mock.patch.object(
+                endpoints,
+                '_build_redirect_uri',
+                return_value='https://imbi/cb',
+            ),
+            mock.patch.object(
+                endpoints.flows,
+                'start_flow',
+                new=mock.AsyncMock(
+                    side_effect=PluginNotFoundError('plugin-1')
+                ),
+            ),
+        ):
+            with self.assertRaises(fastapi.HTTPException) as ctx:
+                await endpoints.start_connect(
+                    'plugin-1',
+                    models.IdentityConnectionStartRequest(),
+                    mock.MagicMock(),
+                    db,
+                    auth,
+                )
+        self.assertEqual(ctx.exception.status_code, 404)
+
+
+class CallbackEndpointTestCase(unittest.IsolatedAsyncioTestCase):
+    """Cover the OAuth callback endpoint."""
+
+    async def test_redirects_to_safe_return_to(self) -> None:
+        from imbi_common.plugins.base import (
+            IdentityCredentials,
+            IdentityProfile,
+        )
+
+        db = mock.AsyncMock()
+        with mock.patch.object(
+            endpoints.flows,
+            'complete_flow',
+            new=mock.AsyncMock(
+                return_value=(
+                    IdentityProfile(subject='s'),
+                    IdentityCredentials(access_token='at'),
+                    'plugin-1',
+                    '/projects/x',
+                )
+            ),
+        ):
+            response = await endpoints.callback('plugin-1', 'code', 'st', db)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.headers['location'], '/projects/x')
+
+    async def test_redirects_to_default_when_return_to_unsafe(self) -> None:
+        from imbi_common.plugins.base import (
+            IdentityCredentials,
+            IdentityProfile,
+        )
+
+        db = mock.AsyncMock()
+        with mock.patch.object(
+            endpoints.flows,
+            'complete_flow',
+            new=mock.AsyncMock(
+                return_value=(
+                    IdentityProfile(subject='s'),
+                    IdentityCredentials(access_token='at'),
+                    'plugin-1',
+                    'https://attacker.example/x',
+                )
+            ),
+        ):
+            response = await endpoints.callback('plugin-1', 'code', 'st', db)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.headers['location'], '/settings/connections')
+
+    async def test_maps_invalid_state_to_400(self) -> None:
+        db = mock.AsyncMock()
+        with mock.patch.object(
+            endpoints.flows,
+            'complete_flow',
+            new=mock.AsyncMock(side_effect=ValueError('expired')),
+        ):
+            with self.assertRaises(fastapi.HTTPException) as ctx:
+                await endpoints.callback('plugin-1', 'code', 'st', db)
+        self.assertEqual(ctx.exception.status_code, 400)
+
+    async def test_maps_plugin_not_found_to_404(self) -> None:
+        from imbi_common.plugins.errors import PluginNotFoundError
+
+        db = mock.AsyncMock()
+        with mock.patch.object(
+            endpoints.flows,
+            'complete_flow',
+            new=mock.AsyncMock(side_effect=PluginNotFoundError('plugin-1')),
+        ):
+            with self.assertRaises(fastapi.HTTPException) as ctx:
+                await endpoints.callback('plugin-1', 'code', 'st', db)
+        self.assertEqual(ctx.exception.status_code, 404)
+
+
 class ListMyIdentitiesTestCase(unittest.IsolatedAsyncioTestCase):
     """Cover the list endpoint's row-mapping branch."""
 

--- a/tests/identity/test_endpoints.py
+++ b/tests/identity/test_endpoints.py
@@ -1,0 +1,172 @@
+"""Tests for identity endpoint helpers and route bodies."""
+
+import unittest
+from unittest import mock
+
+import fastapi
+
+from imbi_api.identity import endpoints, errors
+
+
+class IsSafeReturnToTestCase(unittest.TestCase):
+    """Verify the open-redirect guard rejects unsafe URLs."""
+
+    def test_none_is_unsafe(self) -> None:
+        self.assertFalse(endpoints._is_safe_return_to(None))
+
+    def test_empty_is_unsafe(self) -> None:
+        self.assertFalse(endpoints._is_safe_return_to(''))
+
+    def test_absolute_url_is_unsafe(self) -> None:
+        self.assertFalse(
+            endpoints._is_safe_return_to('https://attacker.example/x')
+        )
+
+    def test_protocol_relative_is_unsafe(self) -> None:
+        self.assertFalse(endpoints._is_safe_return_to('//attacker.example/x'))
+
+    def test_path_without_leading_slash_is_unsafe(self) -> None:
+        self.assertFalse(endpoints._is_safe_return_to('projects/x'))
+
+    def test_in_app_path_is_safe(self) -> None:
+        self.assertTrue(endpoints._is_safe_return_to('/projects/x'))
+
+
+class BuildRedirectUriTestCase(unittest.TestCase):
+    """Verify _build_redirect_uri prefers configured base URL."""
+
+    def test_uses_configured_base_url(self) -> None:
+        request = mock.MagicMock()
+        with mock.patch.object(
+            endpoints.settings,
+            'get_server_config',
+            return_value=mock.MagicMock(public_base_url='https://imbi.test/'),
+        ):
+            result = endpoints._build_redirect_uri(request, 'plugin-1')
+        self.assertEqual(
+            result,
+            'https://imbi.test/me/identities/plugin-1/callback',
+        )
+
+    def test_falls_back_to_request_when_base_unset(self) -> None:
+        request = mock.MagicMock()
+        request.url.scheme = 'https'
+        request.url.netloc = 'imbi.test'
+        with mock.patch.object(
+            endpoints.settings,
+            'get_server_config',
+            return_value=mock.MagicMock(public_base_url=''),
+        ):
+            result = endpoints._build_redirect_uri(request, 'plugin-1')
+        self.assertEqual(
+            result,
+            'https://imbi.test/me/identities/plugin-1/callback',
+        )
+
+    def test_falls_back_to_request_when_config_raises(self) -> None:
+        request = mock.MagicMock()
+        request.url.scheme = 'http'
+        request.url.netloc = 'localhost:8000'
+        with mock.patch.object(
+            endpoints.settings,
+            'get_server_config',
+            side_effect=RuntimeError('settings unavailable'),
+        ):
+            result = endpoints._build_redirect_uri(request, 'p')
+        self.assertEqual(
+            result, 'http://localhost:8000/me/identities/p/callback'
+        )
+
+
+class RefreshEndpointTestCase(unittest.IsolatedAsyncioTestCase):
+    """Cover the refresh endpoint's exception mapping."""
+
+    def setUp(self) -> None:
+        self.db = mock.AsyncMock()
+        self.auth = mock.MagicMock()
+        self.auth.require_user = mock.MagicMock(id='user-1')
+
+    async def test_returns_refreshed_on_success(self) -> None:
+        with mock.patch.object(
+            endpoints.flows,
+            'refresh_connection',
+            new=mock.AsyncMock(),
+        ):
+            result = await endpoints.refresh('p', self.db, self.auth)
+        self.assertEqual(result, {'status': 'refreshed'})
+
+    async def test_maps_identity_required_to_401(self) -> None:
+        with mock.patch.object(
+            endpoints.flows,
+            'refresh_connection',
+            new=mock.AsyncMock(
+                side_effect=errors.IdentityRequiredError(
+                    plugin_id='p', start_url='/me/identities/p/start'
+                )
+            ),
+        ):
+            with self.assertRaises(fastapi.HTTPException) as ctx:
+                await endpoints.refresh('p', self.db, self.auth)
+        self.assertEqual(ctx.exception.status_code, 401)
+
+    async def test_maps_refresh_failed_to_502(self) -> None:
+        with mock.patch.object(
+            endpoints.flows,
+            'refresh_connection',
+            new=mock.AsyncMock(
+                side_effect=errors.IdentityRefreshFailed('idp boom')
+            ),
+        ):
+            with self.assertRaises(fastapi.HTTPException) as ctx:
+                await endpoints.refresh('p', self.db, self.auth)
+        self.assertEqual(ctx.exception.status_code, 502)
+
+
+class DisconnectEndpointTestCase(unittest.IsolatedAsyncioTestCase):
+    """Cover the disconnect endpoint's success path."""
+
+    async def test_returns_204_after_revoke(self) -> None:
+        db = mock.AsyncMock()
+        auth = mock.MagicMock()
+        auth.require_user = mock.MagicMock(id='user-1')
+        with mock.patch.object(
+            endpoints.flows,
+            'revoke_connection',
+            new=mock.AsyncMock(),
+        ) as revoke:
+            response = await endpoints.disconnect('p', db, auth)
+        self.assertEqual(response.status_code, 204)
+        revoke.assert_awaited_once()
+
+
+class ListMyIdentitiesTestCase(unittest.IsolatedAsyncioTestCase):
+    """Cover the list endpoint's row-mapping branch."""
+
+    async def test_returns_response_models(self) -> None:
+        db = mock.AsyncMock()
+        auth = mock.MagicMock()
+        auth.require_user = mock.MagicMock(id='user-1')
+        rows = [
+            {
+                'id': 'conn-1',
+                'plugin_id': 'plugin-1',
+                'plugin_slug': 'oidc',
+                'plugin_label': 'OIDC',
+                'subject': 'sub-1',
+                'status': 'active',
+                'expires_at': None,
+                'scopes': ['openid'],
+                'last_used_at': None,
+                'connects_users_to': None,
+                'metadata': {},
+            }
+        ]
+        with mock.patch.object(
+            endpoints.repository,
+            'list_for_user',
+            new=mock.AsyncMock(return_value=rows),
+        ):
+            result = await endpoints.list_my_identities(db, auth)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].id, 'conn-1')
+        self.assertEqual(result[0].plugin_slug, 'oidc')

--- a/tests/identity/test_errors.py
+++ b/tests/identity/test_errors.py
@@ -21,9 +21,6 @@ class IdentityRequiredErrorTestCase(unittest.TestCase):
 class IdentityRefreshFailedTestCase(unittest.TestCase):
     """Marker exception for terminal refresh-grant failures."""
 
-    def test_is_exception(self) -> None:
-        self.assertTrue(issubclass(errors.IdentityRefreshFailed, Exception))
-
     def test_carries_message(self) -> None:
         exc = errors.IdentityRefreshFailed('expired')
         self.assertEqual(str(exc), 'expired')
@@ -32,5 +29,6 @@ class IdentityRefreshFailedTestCase(unittest.TestCase):
 class IdentityRevokedErrorTestCase(unittest.TestCase):
     """Marker exception for revoked connections."""
 
-    def test_is_exception(self) -> None:
-        self.assertTrue(issubclass(errors.IdentityRevokedError, Exception))
+    def test_can_be_raised(self) -> None:
+        with self.assertRaises(errors.IdentityRevokedError):
+            raise errors.IdentityRevokedError('token revoked')

--- a/tests/identity/test_errors.py
+++ b/tests/identity/test_errors.py
@@ -1,0 +1,36 @@
+"""Tests for identity-flow error types."""
+
+import unittest
+
+from imbi_api.identity import errors
+
+
+class IdentityRequiredErrorTestCase(unittest.TestCase):
+    """Verify IdentityRequiredError preserves plugin_id + start_url."""
+
+    def test_carries_plugin_id_and_start_url(self) -> None:
+        exc = errors.IdentityRequiredError(
+            plugin_id='abc',
+            start_url='/me/identities/abc/start',
+        )
+        self.assertEqual(exc.plugin_id, 'abc')
+        self.assertEqual(exc.start_url, '/me/identities/abc/start')
+        self.assertIn('abc', str(exc))
+
+
+class IdentityRefreshFailedTestCase(unittest.TestCase):
+    """Marker exception for terminal refresh-grant failures."""
+
+    def test_is_exception(self) -> None:
+        self.assertTrue(issubclass(errors.IdentityRefreshFailed, Exception))
+
+    def test_carries_message(self) -> None:
+        exc = errors.IdentityRefreshFailed('expired')
+        self.assertEqual(str(exc), 'expired')
+
+
+class IdentityRevokedErrorTestCase(unittest.TestCase):
+    """Marker exception for revoked connections."""
+
+    def test_is_exception(self) -> None:
+        self.assertTrue(issubclass(errors.IdentityRevokedError, Exception))

--- a/tests/identity/test_flows.py
+++ b/tests/identity/test_flows.py
@@ -1,6 +1,8 @@
 """Tests for identity-flow operations."""
 
+import contextlib
 import datetime
+import typing
 import unittest
 from unittest import mock
 
@@ -10,7 +12,10 @@ from imbi_common.plugins.errors import PluginNotFoundError
 from imbi_api.identity import errors, flows
 
 
-def _patch_load_handler(handler: object, creds: dict | None = None) -> object:
+def _patch_load_handler(
+    handler: object,
+    creds: dict[str, str] | None = None,
+) -> contextlib.AbstractContextManager[typing.Any]:
     """Common patch helper for ``flows._load_plugin_handler``."""
     entry = mock.MagicMock()
     entry.manifest = mock.MagicMock(slug='oidc', default_scopes=['openid'])

--- a/tests/identity/test_flows.py
+++ b/tests/identity/test_flows.py
@@ -1,0 +1,332 @@
+"""Tests for identity-flow operations."""
+
+import datetime
+import unittest
+from unittest import mock
+
+from imbi_common.plugins.base import IdentityCredentials, IdentityProfile
+from imbi_common.plugins.errors import PluginNotFoundError
+
+from imbi_api.identity import errors, flows
+
+
+def _patch_load_handler(handler: object, creds: dict | None = None) -> object:
+    """Common patch helper for ``flows._load_plugin_handler``."""
+    entry = mock.MagicMock()
+    entry.manifest = mock.MagicMock(slug='oidc', default_scopes=['openid'])
+    return mock.patch.object(
+        flows,
+        '_load_plugin_handler',
+        new=mock.AsyncMock(return_value=(entry, handler, creds or {})),
+    )
+
+
+class LoadPluginHandlerTestCase(unittest.IsolatedAsyncioTestCase):
+    """Verify _load_plugin_handler resolves plugin -> registered handler."""
+
+    async def test_raises_plugin_not_found_when_no_rows(self) -> None:
+        db = mock.AsyncMock()
+        db.execute.return_value = []
+        with self.assertRaises(PluginNotFoundError):
+            await flows._load_plugin_handler(db, 'plugin-1')
+
+    async def test_raises_plugin_not_found_when_handler_wrong_type(
+        self,
+    ) -> None:
+        db = mock.AsyncMock()
+        db.execute.return_value = [{'slug': '"oidc"'}]
+        non_identity = mock.MagicMock()
+        entry = mock.MagicMock()
+        entry.handler_cls = mock.MagicMock(return_value=non_identity)
+        with (
+            mock.patch.object(
+                flows.graph, 'parse_agtype', return_value='oidc'
+            ),
+            mock.patch.object(flows, 'get_plugin', return_value=entry),
+        ):
+            with self.assertRaises(PluginNotFoundError):
+                await flows._load_plugin_handler(db, 'plugin-1')
+
+    async def test_returns_entry_handler_creds(self) -> None:
+        db = mock.AsyncMock()
+        db.execute.return_value = [{'slug': '"oidc"'}]
+        handler = mock.MagicMock(spec=flows.IdentityPlugin)
+        entry = mock.MagicMock()
+        entry.handler_cls = mock.MagicMock(return_value=handler)
+        with (
+            mock.patch.object(
+                flows.graph, 'parse_agtype', return_value='oidc'
+            ),
+            mock.patch.object(flows, 'get_plugin', return_value=entry),
+            mock.patch.object(
+                flows.plugin_credentials,
+                'get_plugin_credentials',
+                new=mock.AsyncMock(return_value={'client_id': 'cid'}),
+            ),
+        ):
+            result = await flows._load_plugin_handler(db, 'plugin-1')
+        self.assertEqual(result[0], entry)
+        self.assertEqual(result[1], handler)
+        self.assertEqual(result[2], {'client_id': 'cid'})
+
+
+class StartFlowTestCase(unittest.IsolatedAsyncioTestCase):
+    """Verify start_flow returns auth URL + state token."""
+
+    async def test_returns_authorization_url_and_state_token(self) -> None:
+        db = mock.AsyncMock()
+        request = mock.MagicMock()
+        request.authorization_url = 'https://idp/authorize?...'
+        request.code_verifier = 'pkce-verifier'
+        request.polling = None
+        handler = mock.MagicMock(spec=flows.IdentityPlugin)
+        handler.authorization_request = mock.AsyncMock(return_value=request)
+        with (
+            _patch_load_handler(handler),
+            mock.patch.object(
+                flows.state,
+                'encode_identity_state',
+                return_value='state-token',
+            ),
+        ):
+            url, state_token, polling = await flows.start_flow(
+                db,
+                plugin_id='plugin-1',
+                redirect_uri='https://imbi/cb',
+                actor_user_id='user-1',
+            )
+        self.assertEqual(url, 'https://idp/authorize?...')
+        self.assertEqual(state_token, 'state-token')
+        self.assertIsNone(polling)
+
+
+class CompleteFlowTestCase(unittest.IsolatedAsyncioTestCase):
+    """Verify complete_flow persists the connection on success."""
+
+    async def test_persists_connection_when_actor_present(self) -> None:
+        db = mock.AsyncMock()
+        state_data = mock.MagicMock()
+        state_data.plugin_id = 'plugin-1'
+        state_data.actor_user_id = 'user-1'
+        state_data.redirect_uri = 'https://imbi/cb'
+        state_data.code_verifier = 'verifier'
+        state_data.return_to = '/projects'
+
+        profile = IdentityProfile(subject='sub')
+        credentials = IdentityCredentials(access_token='at')
+        handler = mock.MagicMock(spec=flows.IdentityPlugin)
+        handler.exchange_code = mock.AsyncMock(
+            return_value=(profile, credentials)
+        )
+
+        with (
+            mock.patch.object(
+                flows.state,
+                'decode_identity_state',
+                return_value=state_data,
+            ),
+            _patch_load_handler(handler),
+            mock.patch.object(
+                flows.repository,
+                'upsert_connection',
+                new=mock.AsyncMock(return_value='conn-1'),
+            ) as upsert,
+        ):
+            result = await flows.complete_flow(
+                db, code='auth-code', state_token='state-token'
+            )
+        upsert.assert_awaited_once()
+        self.assertEqual(result[0], profile)
+        self.assertEqual(result[1], credentials)
+        self.assertEqual(result[2], 'plugin-1')
+        self.assertEqual(result[3], '/projects')
+
+    async def test_skips_persist_when_no_actor(self) -> None:
+        db = mock.AsyncMock()
+        state_data = mock.MagicMock()
+        state_data.plugin_id = 'plugin-1'
+        state_data.actor_user_id = None
+        state_data.redirect_uri = 'https://imbi/cb'
+        state_data.code_verifier = None
+        state_data.return_to = None
+        profile = IdentityProfile(subject='sub')
+        credentials = IdentityCredentials(access_token='at')
+        handler = mock.MagicMock(spec=flows.IdentityPlugin)
+        handler.exchange_code = mock.AsyncMock(
+            return_value=(profile, credentials)
+        )
+        with (
+            mock.patch.object(
+                flows.state,
+                'decode_identity_state',
+                return_value=state_data,
+            ),
+            _patch_load_handler(handler),
+            mock.patch.object(
+                flows.repository,
+                'upsert_connection',
+                new=mock.AsyncMock(),
+            ) as upsert,
+        ):
+            await flows.complete_flow(
+                db, code='auth-code', state_token='state-token'
+            )
+        upsert.assert_not_called()
+
+    async def test_raises_when_state_missing_plugin_id(self) -> None:
+        db = mock.AsyncMock()
+        state_data = mock.MagicMock()
+        state_data.plugin_id = None
+        with mock.patch.object(
+            flows.state,
+            'decode_identity_state',
+            return_value=state_data,
+        ):
+            with self.assertRaises(ValueError):
+                await flows.complete_flow(db, code='c', state_token='s')
+
+
+class RefreshConnectionTestCase(unittest.IsolatedAsyncioTestCase):
+    """Verify refresh_connection's success / no-token / IdP-error paths."""
+
+    async def test_raises_identity_required_when_no_connection(self) -> None:
+        db = mock.AsyncMock()
+        with mock.patch.object(
+            flows.repository,
+            'load_connection',
+            new=mock.AsyncMock(return_value=None),
+        ):
+            with self.assertRaises(errors.IdentityRequiredError):
+                await flows.refresh_connection(
+                    db, plugin_id='p', actor_user_id='u'
+                )
+
+    async def test_raises_refresh_failed_when_no_refresh_token(self) -> None:
+        db = mock.AsyncMock()
+        connection = mock.MagicMock()
+        connection.refresh_token = None
+        with mock.patch.object(
+            flows.repository,
+            'load_connection',
+            new=mock.AsyncMock(return_value=connection),
+        ):
+            with self.assertRaises(errors.IdentityRefreshFailed):
+                await flows.refresh_connection(
+                    db, plugin_id='p', actor_user_id='u'
+                )
+
+    async def test_marks_expired_when_idp_refresh_raises(self) -> None:
+        db = mock.AsyncMock()
+        connection = mock.MagicMock()
+        connection.refresh_token = 'rt'
+        connection.connection_id = 'conn-1'
+        connection.subject = 'sub'
+        handler = mock.MagicMock(spec=flows.IdentityPlugin)
+        handler.refresh = mock.AsyncMock(side_effect=RuntimeError('idp boom'))
+        with (
+            mock.patch.object(
+                flows.repository,
+                'load_connection',
+                new=mock.AsyncMock(return_value=connection),
+            ),
+            _patch_load_handler(handler),
+            mock.patch.object(
+                flows.repository,
+                'mark_status',
+                new=mock.AsyncMock(),
+            ) as mark,
+        ):
+            with self.assertRaises(errors.IdentityRefreshFailed):
+                await flows.refresh_connection(
+                    db, plugin_id='p', actor_user_id='u'
+                )
+        mark.assert_awaited_once_with(db, 'conn-1', 'expired')
+
+    async def test_happy_path_upserts_new_credentials(self) -> None:
+        db = mock.AsyncMock()
+        connection = mock.MagicMock()
+        connection.refresh_token = 'rt'
+        connection.subject = 'sub'
+        new_credentials = IdentityCredentials(
+            access_token='new-at',
+            refresh_token='new-rt',
+            expires_at=datetime.datetime.now(datetime.UTC),
+        )
+        handler = mock.MagicMock(spec=flows.IdentityPlugin)
+        handler.refresh = mock.AsyncMock(return_value=new_credentials)
+        with (
+            mock.patch.object(
+                flows.repository,
+                'load_connection',
+                new=mock.AsyncMock(return_value=connection),
+            ),
+            _patch_load_handler(handler),
+            mock.patch.object(
+                flows.repository,
+                'upsert_connection',
+                new=mock.AsyncMock(return_value='conn-1'),
+            ) as upsert,
+        ):
+            result = await flows.refresh_connection(
+                db, plugin_id='p', actor_user_id='u'
+            )
+        self.assertEqual(result, new_credentials)
+        upsert.assert_awaited_once()
+
+
+class RevokeConnectionTestCase(unittest.IsolatedAsyncioTestCase):
+    """Verify revoke_connection still records revocation on IdP errors."""
+
+    async def test_returns_silently_when_no_connection(self) -> None:
+        db = mock.AsyncMock()
+        with mock.patch.object(
+            flows.repository,
+            'load_connection',
+            new=mock.AsyncMock(return_value=None),
+        ):
+            await flows.revoke_connection(db, plugin_id='p', actor_user_id='u')
+
+    async def test_revokes_locally_on_idp_failure(self) -> None:
+        db = mock.AsyncMock()
+        connection = mock.MagicMock()
+        connection.access_token = 'at'
+        handler = mock.MagicMock(spec=flows.IdentityPlugin)
+        handler.revoke = mock.AsyncMock(side_effect=RuntimeError('idp boom'))
+        with (
+            mock.patch.object(
+                flows.repository,
+                'load_connection',
+                new=mock.AsyncMock(return_value=connection),
+            ),
+            _patch_load_handler(handler),
+            mock.patch.object(
+                flows.repository,
+                'revoke',
+                new=mock.AsyncMock(),
+            ) as revoke,
+        ):
+            await flows.revoke_connection(db, plugin_id='p', actor_user_id='u')
+        revoke.assert_awaited_once_with(db, 'p', 'u')
+
+    async def test_happy_path_revokes_at_idp_and_locally(self) -> None:
+        db = mock.AsyncMock()
+        connection = mock.MagicMock()
+        connection.access_token = 'at'
+        handler = mock.MagicMock(spec=flows.IdentityPlugin)
+        handler.revoke = mock.AsyncMock()
+        with (
+            mock.patch.object(
+                flows.repository,
+                'load_connection',
+                new=mock.AsyncMock(return_value=connection),
+            ),
+            _patch_load_handler(handler),
+            mock.patch.object(
+                flows.repository,
+                'revoke',
+                new=mock.AsyncMock(),
+            ) as revoke,
+        ):
+            await flows.revoke_connection(db, plugin_id='p', actor_user_id='u')
+        handler.revoke.assert_awaited_once()
+        revoke.assert_awaited_once_with(db, 'p', 'u')

--- a/tests/identity/test_repository.py
+++ b/tests/identity/test_repository.py
@@ -1,0 +1,252 @@
+"""Tests for the identity repository module."""
+
+import datetime
+import unittest
+from unittest import mock
+
+from imbi_common.plugins.base import IdentityCredentials, IdentityProfile
+
+from imbi_api.identity import repository
+
+
+class FakeEncryptor:
+    """No-op TokenEncryption stand-in: returns input unchanged."""
+
+    def encrypt(self, value: str | None) -> str | None:
+        return value
+
+    def decrypt(self, value: str | None) -> str | None:
+        return value
+
+
+class NowIsoTestCase(unittest.TestCase):
+    """Verify the timestamp helper returns an ISO-8601 UTC string."""
+
+    def test_returns_isoformat_with_tz(self) -> None:
+        result = repository._now_iso()
+        # Must be parseable as an aware datetime.
+        parsed = datetime.datetime.fromisoformat(result)
+        self.assertIsNotNone(parsed.tzinfo)
+
+
+class DecryptHelperTestCase(unittest.TestCase):
+    """Verify _decrypt's None / empty / agtype-parsing branches."""
+
+    def test_none_input_returns_none(self) -> None:
+        self.assertIsNone(repository._decrypt(None))
+
+    def test_empty_string_returns_none(self) -> None:
+        with mock.patch.object(
+            repository.TokenEncryption,
+            'get_instance',
+            return_value=FakeEncryptor(),
+        ):
+            self.assertIsNone(repository._decrypt(''))
+
+    def test_string_input_decrypts_directly(self) -> None:
+        with mock.patch.object(
+            repository.TokenEncryption,
+            'get_instance',
+            return_value=FakeEncryptor(),
+        ):
+            self.assertEqual(repository._decrypt('cipher-text'), 'cipher-text')
+
+    def test_non_string_parses_agtype(self) -> None:
+        with (
+            mock.patch.object(
+                repository.graph,
+                'parse_agtype',
+                return_value='cipher',
+            ),
+            mock.patch.object(
+                repository.TokenEncryption,
+                'get_instance',
+                return_value=FakeEncryptor(),
+            ),
+        ):
+            self.assertEqual(repository._decrypt({'wrapped': True}), 'cipher')
+
+
+class MarkStatusTestCase(unittest.IsolatedAsyncioTestCase):
+    """Verify mark_status emits the expected query + params."""
+
+    async def test_executes_with_status_param(self) -> None:
+        db = mock.AsyncMock()
+        await repository.mark_status(db, 'conn-1', 'expired')
+        db.execute.assert_awaited_once()
+        _query, params, _columns = db.execute.await_args.args
+        self.assertEqual(params['id'], 'conn-1')
+        self.assertEqual(params['status'], 'expired')
+        self.assertIn('now', params)
+
+
+class RevokeTestCase(unittest.IsolatedAsyncioTestCase):
+    """Verify revoke clears tokens and flips status."""
+
+    async def test_executes_with_plugin_and_user(self) -> None:
+        db = mock.AsyncMock()
+        await repository.revoke(db, 'plugin-1', 'user-1')
+        db.execute.assert_awaited_once()
+        query, params, _columns = db.execute.await_args.args
+        self.assertEqual(params['plugin_id'], 'plugin-1')
+        self.assertEqual(params['user_id'], 'user-1')
+        self.assertIn("status = 'revoked'", query)
+        self.assertIn('access_token_encrypted = null', query)
+
+
+class UpsertConnectionTestCase(unittest.IsolatedAsyncioTestCase):
+    """Verify upsert_connection encrypts and returns the connection id."""
+
+    async def test_returns_connection_id(self) -> None:
+        db = mock.AsyncMock()
+        db.execute.return_value = [{'id': '"conn-abc"'}]
+        profile = IdentityProfile(subject='sub-1')
+        credentials = IdentityCredentials(
+            access_token='access',
+            refresh_token='refresh',
+        )
+        with (
+            mock.patch.object(
+                repository.TokenEncryption,
+                'get_instance',
+                return_value=FakeEncryptor(),
+            ),
+            mock.patch.object(
+                repository.graph,
+                'parse_agtype',
+                return_value='conn-abc',
+            ),
+        ):
+            connection_id = await repository.upsert_connection(
+                db, 'plugin-1', 'user-1', profile, credentials
+            )
+        self.assertEqual(connection_id, 'conn-abc')
+
+    async def test_raises_when_query_returns_no_rows(self) -> None:
+        db = mock.AsyncMock()
+        db.execute.return_value = []
+        profile = IdentityProfile(subject='sub-1')
+        credentials = IdentityCredentials(access_token='access')
+        with mock.patch.object(
+            repository.TokenEncryption,
+            'get_instance',
+            return_value=FakeEncryptor(),
+        ):
+            with self.assertRaises(RuntimeError):
+                await repository.upsert_connection(
+                    db, 'plugin-1', 'user-1', profile, credentials
+                )
+
+    async def test_logs_and_reraises_on_execute_failure(self) -> None:
+        db = mock.AsyncMock()
+        db.execute.side_effect = RuntimeError('graph down')
+        profile = IdentityProfile(subject='sub-1')
+        credentials = IdentityCredentials(access_token='access')
+        with mock.patch.object(
+            repository.TokenEncryption,
+            'get_instance',
+            return_value=FakeEncryptor(),
+        ):
+            with self.assertRaises(RuntimeError):
+                await repository.upsert_connection(
+                    db, 'plugin-1', 'user-1', profile, credentials
+                )
+
+
+class LoadConnectionTestCase(unittest.IsolatedAsyncioTestCase):
+    """Verify load_connection's None / missing-token / happy paths."""
+
+    async def test_returns_none_when_no_rows(self) -> None:
+        db = mock.AsyncMock()
+        db.execute.return_value = []
+        result = await repository.load_connection(db, 'p', 'u')
+        self.assertIsNone(result)
+
+    async def test_returns_none_when_access_token_missing(self) -> None:
+        db = mock.AsyncMock()
+        db.execute.return_value = [
+            {
+                'id': '"c"',
+                'subject': '"s"',
+                'access': None,
+                'refresh': None,
+                'expires_at': None,
+                'scopes': None,
+                'status': '"active"',
+                'metadata': None,
+            }
+        ]
+        with mock.patch.object(
+            repository.TokenEncryption,
+            'get_instance',
+            return_value=FakeEncryptor(),
+        ):
+            result = await repository.load_connection(db, 'p', 'u')
+        self.assertIsNone(result)
+
+    async def test_happy_path_returns_credentials_internal(self) -> None:
+        db = mock.AsyncMock()
+        db.execute.return_value = [
+            {
+                'id': '"conn-1"',
+                'subject': '"sub-1"',
+                'access': 'access-cipher',
+                'refresh': 'refresh-cipher',
+                'expires_at': None,
+                'scopes': None,
+                'status': '"active"',
+                'metadata': None,
+            }
+        ]
+
+        def parse(value: object) -> object:
+            # Strip the quoting our test fixtures use to mimic agtype.
+            if isinstance(value, str) and value.startswith('"'):
+                return value.strip('"')
+            return value
+
+        with (
+            mock.patch.object(
+                repository.TokenEncryption,
+                'get_instance',
+                return_value=FakeEncryptor(),
+            ),
+            mock.patch.object(
+                repository.graph,
+                'parse_agtype',
+                side_effect=parse,
+            ),
+        ):
+            result = await repository.load_connection(db, 'p', 'u')
+        assert result is not None
+        self.assertEqual(result.connection_id, 'conn-1')
+        self.assertEqual(result.subject, 'sub-1')
+        self.assertEqual(result.access_token, 'access-cipher')
+        self.assertEqual(result.refresh_token, 'refresh-cipher')
+        self.assertEqual(result.status, 'active')
+
+
+class StaleConnectionsTestCase(unittest.IsolatedAsyncioTestCase):
+    """Verify stale_connections returns parsed rows."""
+
+    async def test_returns_rows_with_parsed_values(self) -> None:
+        db = mock.AsyncMock()
+        db.execute.return_value = [
+            {'plugin_id': '"p"', 'user_id': '"u"', 'expires_at': '"x"'}
+        ]
+        horizon = datetime.datetime.now(datetime.UTC)
+
+        def parse(value: object) -> object:
+            if isinstance(value, str) and value.startswith('"'):
+                return value.strip('"')
+            return value
+
+        with mock.patch.object(
+            repository.graph,
+            'parse_agtype',
+            side_effect=parse,
+        ):
+            rows = await repository.stale_connections(db, horizon)
+        self.assertEqual(
+            rows, [{'plugin_id': 'p', 'user_id': 'u', 'expires_at': 'x'}]
+        )

--- a/tests/identity/test_repository.py
+++ b/tests/identity/test_repository.py
@@ -226,6 +226,49 @@ class LoadConnectionTestCase(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result.status, 'active')
 
 
+class ListForUserTestCase(unittest.IsolatedAsyncioTestCase):
+    """Verify list_for_user returns parsed rows for the actor."""
+
+    async def test_returns_parsed_rows(self) -> None:
+        db = mock.AsyncMock()
+        db.execute.return_value = [
+            {
+                'id': '"conn-1"',
+                'plugin_id': '"plugin-1"',
+                'plugin_slug': '"oidc"',
+                'plugin_label': '"OIDC"',
+                'connects_users_to': None,
+                'subject': '"sub"',
+                'status': '"active"',
+                'expires_at': None,
+                'scopes': None,
+                'last_used_at': None,
+                'metadata': None,
+            }
+        ]
+
+        def parse(value: object) -> object:
+            if isinstance(value, str) and value.startswith('"'):
+                return value.strip('"')
+            return value
+
+        with mock.patch.object(
+            repository.graph,
+            'parse_agtype',
+            side_effect=parse,
+        ):
+            rows = await repository.list_for_user(db, 'user-1')
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]['id'], 'conn-1')
+        self.assertEqual(rows[0]['plugin_slug'], 'oidc')
+
+    async def test_returns_empty_list_when_no_rows(self) -> None:
+        db = mock.AsyncMock()
+        db.execute.return_value = []
+        result = await repository.list_for_user(db, 'user-1')
+        self.assertEqual(result, [])
+
+
 class StaleConnectionsTestCase(unittest.IsolatedAsyncioTestCase):
     """Verify stale_connections returns parsed rows."""
 

--- a/tests/identity/test_resolution.py
+++ b/tests/identity/test_resolution.py
@@ -1,0 +1,230 @@
+"""Tests for identity hydration helpers."""
+
+import datetime
+import unittest
+from unittest import mock
+
+from imbi_common.plugins.errors import PluginNotFoundError
+
+from imbi_api.identity import errors as identity_errors
+from imbi_api.identity import resolution
+
+
+class IsActiveTestCase(unittest.TestCase):
+    """Verify is_active distinguishes expired from live tokens."""
+
+    def test_none_is_active(self) -> None:
+        self.assertTrue(resolution.is_active(None))
+
+    def test_future_expiry_is_active(self) -> None:
+        future = datetime.datetime.now(datetime.UTC) + datetime.timedelta(
+            minutes=5
+        )
+        self.assertTrue(resolution.is_active(future))
+
+    def test_past_expiry_is_inactive(self) -> None:
+        past = datetime.datetime.now(datetime.UTC) - datetime.timedelta(
+            minutes=5
+        )
+        self.assertFalse(resolution.is_active(past))
+
+
+class StartUrlForTestCase(unittest.TestCase):
+    """Verify the canonical start-URL builder."""
+
+    def test_builds_canonical_url(self) -> None:
+        self.assertEqual(
+            resolution._start_url_for('plugin-7'),
+            '/me/identities/plugin-7/start',
+        )
+
+
+class HydrateIdentityTestCase(unittest.IsolatedAsyncioTestCase):
+    """Verify hydrate_identity loads a connection and materializes it."""
+
+    def setUp(self) -> None:
+        self.db = mock.AsyncMock()
+        self.ctx = mock.MagicMock()
+        self.ctx.actor_user_id = 'user-1'
+        self.ctx.model_copy = mock.MagicMock(
+            side_effect=lambda update: ('ctx-with', update)
+        )
+
+    async def test_missing_actor_raises_identity_required(self) -> None:
+        self.ctx.actor_user_id = None
+        with self.assertRaises(identity_errors.IdentityRequiredError) as cm:
+            await resolution.hydrate_identity(self.db, self.ctx, 'plugin-1')
+        self.assertEqual(cm.exception.plugin_id, 'plugin-1')
+        self.assertEqual(
+            cm.exception.start_url, '/me/identities/plugin-1/start'
+        )
+
+    async def test_no_connection_raises_identity_required(self) -> None:
+        with mock.patch.object(
+            resolution.repository,
+            'load_connection',
+            new=mock.AsyncMock(return_value=None),
+        ):
+            with self.assertRaises(identity_errors.IdentityRequiredError):
+                await resolution.hydrate_identity(
+                    self.db, self.ctx, 'plugin-1'
+                )
+
+    async def test_inactive_connection_raises_identity_required(self) -> None:
+        connection = mock.MagicMock()
+        connection.status = 'expired'
+        with mock.patch.object(
+            resolution.repository,
+            'load_connection',
+            new=mock.AsyncMock(return_value=connection),
+        ):
+            with self.assertRaises(identity_errors.IdentityRequiredError):
+                await resolution.hydrate_identity(
+                    self.db, self.ctx, 'plugin-1'
+                )
+
+    async def test_missing_plugin_slug_raises_identity_required(self) -> None:
+        connection = mock.MagicMock()
+        connection.status = 'active'
+        with (
+            mock.patch.object(
+                resolution.repository,
+                'load_connection',
+                new=mock.AsyncMock(return_value=connection),
+            ),
+            mock.patch.object(
+                resolution,
+                '_plugin_slug',
+                new=mock.AsyncMock(return_value=None),
+            ),
+        ):
+            with self.assertRaises(identity_errors.IdentityRequiredError):
+                await resolution.hydrate_identity(
+                    self.db, self.ctx, 'plugin-1'
+                )
+
+    async def test_plugin_not_found_raises_identity_required(self) -> None:
+        connection = mock.MagicMock()
+        connection.status = 'active'
+        with (
+            mock.patch.object(
+                resolution.repository,
+                'load_connection',
+                new=mock.AsyncMock(return_value=connection),
+            ),
+            mock.patch.object(
+                resolution,
+                '_plugin_slug',
+                new=mock.AsyncMock(return_value='oidc'),
+            ),
+            mock.patch.object(
+                resolution,
+                'get_plugin',
+                side_effect=PluginNotFoundError('oidc'),
+            ),
+        ):
+            with self.assertRaises(identity_errors.IdentityRequiredError):
+                await resolution.hydrate_identity(
+                    self.db, self.ctx, 'plugin-1'
+                )
+
+    async def test_handler_not_identity_plugin_raises(self) -> None:
+        connection = mock.MagicMock()
+        connection.status = 'active'
+
+        # Handler that is *not* an IdentityPlugin instance.
+        non_identity_handler = mock.MagicMock()
+        entry = mock.MagicMock()
+        entry.handler_cls = mock.MagicMock(return_value=non_identity_handler)
+        with (
+            mock.patch.object(
+                resolution.repository,
+                'load_connection',
+                new=mock.AsyncMock(return_value=connection),
+            ),
+            mock.patch.object(
+                resolution,
+                '_plugin_slug',
+                new=mock.AsyncMock(return_value='oidc'),
+            ),
+            mock.patch.object(
+                resolution,
+                'get_plugin',
+                return_value=entry,
+            ),
+        ):
+            with self.assertRaises(identity_errors.IdentityRequiredError):
+                await resolution.hydrate_identity(
+                    self.db, self.ctx, 'plugin-1'
+                )
+
+    async def test_happy_path_calls_materialize(self) -> None:
+        connection = mock.MagicMock()
+        connection.status = 'active'
+        connection.access_token = 'access'
+        connection.refresh_token = 'refresh'
+        connection.expires_at = None
+        connection.scopes = ['email']
+
+        materialized = mock.MagicMock(name='materialized')
+        handler = mock.MagicMock(spec=resolution.IdentityPlugin)
+        handler.materialize = mock.AsyncMock(return_value=materialized)
+        entry = mock.MagicMock()
+        entry.handler_cls = mock.MagicMock(return_value=handler)
+
+        with (
+            mock.patch.object(
+                resolution.repository,
+                'load_connection',
+                new=mock.AsyncMock(return_value=connection),
+            ),
+            mock.patch.object(
+                resolution,
+                '_plugin_slug',
+                new=mock.AsyncMock(return_value='oidc'),
+            ),
+            mock.patch.object(
+                resolution,
+                'get_plugin',
+                return_value=entry,
+            ),
+        ):
+            result = await resolution.hydrate_identity(
+                self.db, self.ctx, 'plugin-1'
+            )
+
+        # ctx.model_copy is patched to capture the update kwargs.
+        self.assertEqual(result, ('ctx-with', {'identity': materialized}))
+        handler.materialize.assert_awaited_once()
+
+
+class PluginSlugHelperTestCase(unittest.IsolatedAsyncioTestCase):
+    """Verify the private _plugin_slug helper."""
+
+    async def test_returns_none_when_no_rows(self) -> None:
+        db = mock.AsyncMock()
+        db.execute.return_value = []
+        slug = await resolution._plugin_slug(db, 'plugin-1')
+        self.assertIsNone(slug)
+
+    async def test_parses_agtype_value(self) -> None:
+        db = mock.AsyncMock()
+        db.execute.return_value = [{'slug': '"oidc"'}]
+        with mock.patch.object(
+            resolution.graph,
+            'parse_agtype',
+            return_value='oidc',
+        ):
+            slug = await resolution._plugin_slug(db, 'plugin-1')
+        self.assertEqual(slug, 'oidc')
+
+    async def test_returns_none_when_parsed_value_is_none(self) -> None:
+        db = mock.AsyncMock()
+        db.execute.return_value = [{'slug': 'null'}]
+        with mock.patch.object(
+            resolution.graph,
+            'parse_agtype',
+            return_value=None,
+        ):
+            slug = await resolution._plugin_slug(db, 'plugin-1')
+        self.assertIsNone(slug)

--- a/tests/identity/test_state.py
+++ b/tests/identity/test_state.py
@@ -1,0 +1,113 @@
+"""Tests for identity-flow state JWT helpers."""
+
+import time
+import unittest
+from unittest import mock
+
+import jwt
+
+from imbi_api import settings
+from imbi_api.identity import state
+
+
+class EncodeIdentityStateTestCase(unittest.TestCase):
+    """Verify identity state JWTs round-trip cleanly."""
+
+    def setUp(self) -> None:
+        self.auth = settings.Auth(jwt_secret='identity-state-test-secret')
+
+    def test_round_trip_minimal(self) -> None:
+        token = state.encode_identity_state(
+            plugin_id='p-1',
+            plugin_slug='oidc',
+            redirect_uri='https://imbi.test/callback',
+            auth_settings=self.auth,
+        )
+        decoded = state.decode_identity_state(token, auth_settings=self.auth)
+        self.assertEqual(decoded.plugin_id, 'p-1')
+        self.assertEqual(decoded.provider, 'oidc')
+        self.assertEqual(decoded.redirect_uri, 'https://imbi.test/callback')
+        self.assertEqual(decoded.intent, 'identity')
+
+    def test_round_trip_full_payload(self) -> None:
+        token = state.encode_identity_state(
+            plugin_id='p-2',
+            plugin_slug='aws-sso',
+            redirect_uri='https://imbi.test/cb',
+            return_to='/projects/x',
+            code_verifier='verifier-abc',
+            actor_user_id='user-7',
+            auth_settings=self.auth,
+        )
+        decoded = state.decode_identity_state(token, auth_settings=self.auth)
+        self.assertEqual(decoded.plugin_id, 'p-2')
+        self.assertEqual(decoded.return_to, '/projects/x')
+        self.assertEqual(decoded.code_verifier, 'verifier-abc')
+        self.assertEqual(decoded.actor_user_id, 'user-7')
+
+
+class DecodeIdentityStateTestCase(unittest.TestCase):
+    """Verify decode rejects tampered, expired, and wrong-intent tokens."""
+
+    def setUp(self) -> None:
+        self.auth = settings.Auth(jwt_secret='identity-state-test-secret')
+
+    def test_invalid_signature_raises_value_error(self) -> None:
+        token = state.encode_identity_state(
+            plugin_id='p-1',
+            plugin_slug='oidc',
+            redirect_uri='https://imbi.test/cb',
+            auth_settings=self.auth,
+        )
+        wrong = settings.Auth(jwt_secret='different-secret')
+        with self.assertRaises(ValueError):
+            state.decode_identity_state(token, auth_settings=wrong)
+
+    def test_expired_token_raises_value_error(self) -> None:
+        with mock.patch.object(state.time, 'time', return_value=1000):
+            token = state.encode_identity_state(
+                plugin_id='p-1',
+                plugin_slug='oidc',
+                redirect_uri='https://imbi.test/cb',
+                auth_settings=self.auth,
+            )
+        # 30 minutes later — well beyond default 600s window.
+        with mock.patch.object(state.time, 'time', return_value=1000 + 1800):
+            with self.assertRaises(ValueError) as ctx:
+                state.decode_identity_state(token, auth_settings=self.auth)
+        self.assertIn('expired', str(ctx.exception))
+
+    def test_wrong_intent_raises_value_error(self) -> None:
+        # Hand-craft a 'login' intent token to confirm decode rejects it.
+        payload = {
+            'provider': 'oidc',
+            'nonce': 'n',
+            'redirect_uri': 'https://imbi.test/cb',
+            'timestamp': int(time.time()),
+            'intent': 'login',
+            'plugin_id': 'p-1',
+        }
+        token = jwt.encode(
+            payload,
+            self.auth.jwt_secret,
+            algorithm=self.auth.jwt_algorithm,
+        )
+        with self.assertRaises(ValueError):
+            state.decode_identity_state(token, auth_settings=self.auth)
+
+    def test_missing_plugin_id_raises_value_error(self) -> None:
+        payload = {
+            'provider': 'oidc',
+            'nonce': 'n',
+            'redirect_uri': 'https://imbi.test/cb',
+            'timestamp': int(time.time()),
+            'intent': 'identity',
+            'plugin_id': None,
+        }
+        token = jwt.encode(
+            payload,
+            self.auth.jwt_secret,
+            algorithm=self.auth.jwt_algorithm,
+        )
+        with self.assertRaises(ValueError):
+            state.decode_identity_state(token, auth_settings=self.auth)

--- a/tests/identity/test_sweeper.py
+++ b/tests/identity/test_sweeper.py
@@ -1,0 +1,272 @@
+"""Tests for the identity refresh sweeper."""
+
+import asyncio
+import unittest
+from unittest import mock
+
+from imbi_api.identity import errors, sweeper
+
+
+class LockKeyTestCase(unittest.TestCase):
+    """Verify the Valkey lock key encodes plugin + user."""
+
+    def test_lock_key_format(self) -> None:
+        self.assertEqual(
+            sweeper._lock_key('plugin-1', 'user-9'),
+            'imbi:identity:refresh:plugin-1:user-9',
+        )
+
+
+class TryLockTestCase(unittest.IsolatedAsyncioTestCase):
+    """Verify _try_lock translates Valkey results to booleans."""
+
+    async def test_returns_true_on_set_success(self) -> None:
+        client = mock.AsyncMock()
+        client.set.return_value = True
+        self.assertTrue(await sweeper._try_lock(client, 'k'))
+        client.set.assert_awaited_once_with(
+            'k', '1', nx=True, ex=sweeper.LOCK_TTL_SECONDS
+        )
+
+    async def test_returns_false_when_set_returns_none(self) -> None:
+        client = mock.AsyncMock()
+        client.set.return_value = None
+        self.assertFalse(await sweeper._try_lock(client, 'k'))
+
+    async def test_returns_false_on_exception(self) -> None:
+        client = mock.AsyncMock()
+        client.set.side_effect = RuntimeError('valkey down')
+        self.assertFalse(await sweeper._try_lock(client, 'k'))
+
+
+class RefreshOneTestCase(unittest.IsolatedAsyncioTestCase):
+    """Verify _refresh_one's lock + flow + expired-marking branches."""
+
+    def setUp(self) -> None:
+        self.db = mock.AsyncMock()
+        self.client = mock.AsyncMock()
+
+    async def test_skips_when_plugin_id_missing(self) -> None:
+        with mock.patch.object(sweeper, '_try_lock') as try_lock:
+            await sweeper._refresh_one(
+                self.db, self.client, {'plugin_id': '', 'user_id': 'u'}
+            )
+        try_lock.assert_not_called()
+
+    async def test_skips_when_user_id_missing(self) -> None:
+        with mock.patch.object(sweeper, '_try_lock') as try_lock:
+            await sweeper._refresh_one(
+                self.db, self.client, {'plugin_id': 'p', 'user_id': ''}
+            )
+        try_lock.assert_not_called()
+
+    async def test_skips_when_lock_not_acquired(self) -> None:
+        with (
+            mock.patch.object(
+                sweeper,
+                '_try_lock',
+                new=mock.AsyncMock(return_value=False),
+            ),
+            mock.patch.object(sweeper.flows, 'refresh_connection') as refresh,
+        ):
+            await sweeper._refresh_one(
+                self.db, self.client, {'plugin_id': 'p', 'user_id': 'u'}
+            )
+        refresh.assert_not_called()
+
+    async def test_happy_path_invokes_refresh(self) -> None:
+        with (
+            mock.patch.object(
+                sweeper,
+                '_try_lock',
+                new=mock.AsyncMock(return_value=True),
+            ),
+            mock.patch.object(
+                sweeper.flows,
+                'refresh_connection',
+                new=mock.AsyncMock(),
+            ) as refresh,
+        ):
+            await sweeper._refresh_one(
+                self.db, self.client, {'plugin_id': 'p', 'user_id': 'u'}
+            )
+        refresh.assert_awaited_once()
+
+    async def test_refresh_failed_marks_expired(self) -> None:
+        connection = mock.MagicMock()
+        connection.status = 'active'
+        connection.connection_id = 'conn-1'
+        with (
+            mock.patch.object(
+                sweeper,
+                '_try_lock',
+                new=mock.AsyncMock(return_value=True),
+            ),
+            mock.patch.object(
+                sweeper.flows,
+                'refresh_connection',
+                new=mock.AsyncMock(
+                    side_effect=errors.IdentityRefreshFailed('expired')
+                ),
+            ),
+            mock.patch.object(
+                sweeper.repository,
+                'load_connection',
+                new=mock.AsyncMock(return_value=connection),
+            ),
+            mock.patch.object(
+                sweeper.repository,
+                'mark_status',
+                new=mock.AsyncMock(),
+            ) as mark,
+        ):
+            await sweeper._refresh_one(
+                self.db, self.client, {'plugin_id': 'p', 'user_id': 'u'}
+            )
+        mark.assert_awaited_once_with(self.db, 'conn-1', 'expired')
+
+    async def test_refresh_failed_already_expired_skips_mark(self) -> None:
+        connection = mock.MagicMock()
+        connection.status = 'expired'
+        with (
+            mock.patch.object(
+                sweeper,
+                '_try_lock',
+                new=mock.AsyncMock(return_value=True),
+            ),
+            mock.patch.object(
+                sweeper.flows,
+                'refresh_connection',
+                new=mock.AsyncMock(
+                    side_effect=errors.IdentityRefreshFailed('x')
+                ),
+            ),
+            mock.patch.object(
+                sweeper.repository,
+                'load_connection',
+                new=mock.AsyncMock(return_value=connection),
+            ),
+            mock.patch.object(
+                sweeper.repository,
+                'mark_status',
+                new=mock.AsyncMock(),
+            ) as mark,
+        ):
+            await sweeper._refresh_one(
+                self.db, self.client, {'plugin_id': 'p', 'user_id': 'u'}
+            )
+        mark.assert_not_called()
+
+    async def test_refresh_failed_load_error_does_not_propagate(self) -> None:
+        # Regression for the CodeRabbit-flagged path: a graph error during
+        # load_connection inside the IdentityRefreshFailed handler must
+        # not bubble out of _refresh_one.
+        with (
+            mock.patch.object(
+                sweeper,
+                '_try_lock',
+                new=mock.AsyncMock(return_value=True),
+            ),
+            mock.patch.object(
+                sweeper.flows,
+                'refresh_connection',
+                new=mock.AsyncMock(
+                    side_effect=errors.IdentityRefreshFailed('x')
+                ),
+            ),
+            mock.patch.object(
+                sweeper.repository,
+                'load_connection',
+                new=mock.AsyncMock(side_effect=RuntimeError('graph down')),
+            ),
+            mock.patch.object(sweeper.repository, 'mark_status') as mark,
+        ):
+            # Should NOT raise.
+            await sweeper._refresh_one(
+                self.db, self.client, {'plugin_id': 'p', 'user_id': 'u'}
+            )
+        mark.assert_not_called()
+
+    async def test_unexpected_exception_swallowed(self) -> None:
+        with (
+            mock.patch.object(
+                sweeper,
+                '_try_lock',
+                new=mock.AsyncMock(return_value=True),
+            ),
+            mock.patch.object(
+                sweeper.flows,
+                'refresh_connection',
+                new=mock.AsyncMock(side_effect=RuntimeError('boom')),
+            ),
+        ):
+            # Should NOT raise.
+            await sweeper._refresh_one(
+                self.db, self.client, {'plugin_id': 'p', 'user_id': 'u'}
+            )
+
+
+class RunSweeperTestCase(unittest.IsolatedAsyncioTestCase):
+    """Verify the sweeper main loop honors the stop event."""
+
+    async def test_stop_event_terminates_loop(self) -> None:
+        db = mock.AsyncMock()
+        client = mock.AsyncMock()
+        stop = asyncio.Event()
+        stop.set()  # already set — loop should not iterate.
+
+        with mock.patch.object(
+            sweeper.repository,
+            'stale_connections',
+            new=mock.AsyncMock(return_value=[]),
+        ) as stale:
+            await sweeper.run_sweeper(db, client, stop=stop)
+        stale.assert_not_called()
+
+    async def test_iteration_failure_logged_and_loop_continues(
+        self,
+    ) -> None:
+        db = mock.AsyncMock()
+        client = mock.AsyncMock()
+        stop = asyncio.Event()
+
+        # First call raises; second call (after the wait_for) sees
+        # stop.set() and exits.
+        async def stale_then_stop(_db: object, _horizon: object) -> list:
+            stop.set()
+            raise RuntimeError('graph down')
+
+        with mock.patch.object(
+            sweeper.repository,
+            'stale_connections',
+            new=mock.AsyncMock(side_effect=stale_then_stop),
+        ):
+            await sweeper.run_sweeper(db, client, stop=stop)
+
+    async def test_processes_rows_then_stops(self) -> None:
+        db = mock.AsyncMock()
+        client = mock.AsyncMock()
+        stop = asyncio.Event()
+
+        rows = [{'plugin_id': 'p', 'user_id': 'u'}]
+
+        async def stale(_db: object, _horizon: object) -> list:
+            return rows
+
+        async def refresh_then_stop(*_args: object, **_kwargs: object) -> None:
+            stop.set()
+
+        with (
+            mock.patch.object(
+                sweeper.repository,
+                'stale_connections',
+                new=mock.AsyncMock(side_effect=stale),
+            ),
+            mock.patch.object(
+                sweeper,
+                '_refresh_one',
+                new=mock.AsyncMock(side_effect=refresh_then_stop),
+            ) as refresh_one,
+        ):
+            await sweeper.run_sweeper(db, client, stop=stop)
+        refresh_one.assert_awaited_once()

--- a/uv.lock
+++ b/uv.lock
@@ -948,7 +948,7 @@ plugins = [{ name = "imbi-plugin-logzio", editable = "../imbi-plugin-logzio" }]
 [[package]]
 name = "imbi-common"
 version = "0.1.0"
-source = { git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=main#309c347807761143f013d19398be67c4e305ca37" }
+source = { git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=main#061319d892ee996c2f2ae7f7018a9018adc96e67" }
 dependencies = [
     { name = "cryptography" },
     { name = "jsonschema-models" },


### PR DESCRIPTION
## Summary

Implements the identity plugin foundations on the API side
(companion to `docs/identity-plugin-plan.md` /
`docs/identity-plugin-implementation-plan.md` in the orchestrator).

### New `imbi_api.identity` package

- `errors.py` — `IdentityRequiredError` (mapped to 401 with
  `WWW-Authenticate: Imbi-Identity` semantics), `IdentityRefreshFailed`,
  `IdentityRevokedError`.
- `models.py` — `IdentityConnectionResponse` (no tokens),
  `IdentityConnectionStartRequest/Response`,
  `IdentityCredentialsInternal` (server-side decrypted view).
- `repository.py` — graph CRUD for `IdentityConnection` nodes. The
  encryption boundary lives here: only this module touches
  `TokenEncryption` for identity tokens. AGE has no `ON CREATE SET`
  so MERGE uses `coalesce()` to preserve `id` and `created_at` on
  existing rows.
- `state.py` — wraps the existing `OAuthStateData` JWT primitives so
  identity and login flows share one state-token format.
- `flows.py` — `start_flow`, `complete_flow`, `refresh_connection`,
  `revoke_connection` orchestrating the registry + repository.
- `resolution.py` — `hydrate_identity` helper that loads and
  materializes the actor's connection into `ctx.identity`.
- `endpoints.py` — `/me/identities`, `/me/identities/{plugin_id}/start`,
  `/callback`, `/refresh`, and DELETE disconnect.
- `sweeper.py` — background refresh: polls `stale_connections` every
  60s, refreshes any connection whose `expires_at` is within 5 min,
  flips `status='expired'` on terminal failure. Per-(user,plugin)
  Valkey `SET NX EX 10` lock prevents thundering-herd.

### Wiring

- New `identity_refresh_hook` in `lifespans.py`, composed into
  `create_app()`.
- `apply_plugin_schemas` and a new `audit_plugin_schemas` (reports
  orphaned plugin-declared vlabels) wired into `startup_load_plugins`.
- `OAuthStateData` extended with `intent` / `plugin_id` /
  `code_verifier` / `return_to` / `actor_user_id` so login + identity
  flows share one state JWT.
- `resolve_plugin` surfaces the merged `USES_PLUGIN` edge's
  `identity_plugin_id` so configuration / logs handlers can call
  `hydrate_identity` before invoking the dependent plugin.

### Permissions

Three new permissions seeded in `auth/seed.py`:
`me:identities:manage` (granted to developer + readonly),
`admin:identities:read`, `admin:identities:revoke`.

## Dependency order

⚠️ Depends on AWeber-Imbi/imbi-common#71 which adds `IdentityPlugin`,
`IdentityCredentials`, `apply_plugin_schemas`, etc. CI will fail
until that PR merges and `imbi-common`'s pinned ref bumps. Local
development against an editable `imbi-common` is unaffected.

## Deferred to follow-up

- Inline `hydrate_identity` integration into `project_logs.py` /
  `project_configuration.py` (the helper exists; the 6 PluginContext
  call sites need the wrapper).
- Auto-mounted CRUD router for plugin-declared entities
  (`/admin/plugins/{plugin_id}/entities/{vlabel}` and
  `POST /admin/edges/{label}`).
- Login provider merge (LoginApp source discriminator).

## Test plan

- [ ] Identity unit tests pass (mypy / basedpyright clean)
- [ ] Bring up `imbi-api` against a local imbi-common with the
      contract PR applied; smoke `GET /me/identities` and
      `/me/identities/{id}/start` against the OIDC plugin
- [ ] Verify identity refresh hook starts on lifespan
- [ ] Confirm the new permissions are created on `imbi-api setup`