### PR TITLE
Wire identity plugins into the login provider list

### DIFF
--- a/src/imbi_api/auth/login_providers.py
+++ b/src/imbi_api/auth/login_providers.py
@@ -28,18 +28,35 @@ _list_cache: dict[bool, tuple[list[LoginApp], float]] = {}
 
 
 class LoginApp(pydantic.BaseModel):
-    """Flat view of a login-eligible ``ServiceApplication`` row.
+    """Flat view of a login-eligible row.
 
-    Combines the application row with the OAuth endpoints from the
-    parent ``ThirdPartyService`` so callers don't need to traverse the
-    graph again.
+    Combines the application or identity-plugin row with the OAuth
+    endpoints from the parent ``ThirdPartyService`` so callers don't
+    need to traverse the graph again.
+
+    Two sources feed this list:
+
+    * ``source='service_app'`` — legacy ``ServiceApplication`` rows
+      whose ``usage`` is ``'login'`` or ``'both'``. ``oauth_app_type``
+      is one of the hardcoded literals (``google``, ``github``,
+      ``oidc``).
+    * ``source='identity_plugin'`` — ``Plugin`` nodes whose manifest is
+      ``login_capable=true`` *and* whose row has ``used_as_login=true``.
+      ``oauth_app_type='identity_plugin'`` and ``plugin_id`` carries the
+      Plugin nano-ID so the auth router can route start/callback
+      through ``imbi_api.identity.flows``.
     """
 
     model_config = pydantic.ConfigDict(extra='ignore')
 
     slug: str
     name: str
-    oauth_app_type: typing.Literal['google', 'github', 'oidc']
+    oauth_app_type: typing.Literal[
+        'google', 'github', 'oidc', 'identity_plugin'
+    ]
+    source: typing.Literal['service_app', 'identity_plugin'] = 'service_app'
+    plugin_id: str | None = None
+    plugin_slug: str | None = None
     client_id: str | None = None
     client_secret_encrypted: str | None = None
     issuer_url: str | None = None
@@ -69,6 +86,13 @@ MATCH (a:ServiceApplication)-[:REGISTERED_IN]->(s:ThirdPartyService)
 WHERE a.usage IN ['login', 'both']
 RETURN a{{.*}} AS app, s{{.*}} AS service
 ORDER BY a.slug
+"""
+
+_IDENTITY_LOGIN_QUERY: typing.LiteralString = """
+MATCH (p:Plugin)
+WHERE p.login_capable = true AND p.used_as_login = true
+RETURN p{{.*}} AS plugin
+ORDER BY p.plugin_slug
 """
 
 
@@ -116,14 +140,39 @@ def _row_to_login_app(
     )
 
 
+def _plugin_row_to_login_app(plugin: dict[str, typing.Any]) -> LoginApp:
+    """Materialize a ``LoginApp`` from a Plugin node row.
+
+    Identity-plugin rows have no client_id/client_secret on the Plugin
+    node — those live on the parent ``ServiceApplication`` and are
+    looked up by the identity flow at start/callback time. The
+    ``LoginApp`` returned here only carries enough metadata for the UI
+    to render the row and for the auth router to dispatch.
+    """
+    return LoginApp(
+        slug=plugin['plugin_slug'],
+        name=plugin.get('label') or plugin['plugin_slug'],
+        oauth_app_type='identity_plugin',
+        source='identity_plugin',
+        plugin_id=plugin['id'],
+        plugin_slug=plugin['plugin_slug'],
+        status='active',
+        callback_url=settings.oauth_callback_url(plugin['plugin_slug']),
+    )
+
+
 async def list_login_apps(
     db: graph.Graph,
     *,
     enabled_only: bool = False,
 ) -> list[LoginApp]:
-    """Return every ``ServiceApplication`` flagged for login use.
+    """Return every login-eligible row, merged across both sources.
 
-    Cached per ``enabled_only`` for ``_CACHE_TTL_SECONDS``.
+    Cached per ``enabled_only`` for ``_CACHE_TTL_SECONDS``. The merge
+    rule is "identity-plugin row wins on slug collision" — operators
+    are expected to disable the legacy ``ServiceApplication.usage``
+    flag once the identity-plugin equivalent is in use, but if both
+    are flagged, the identity row is the canonical source.
     """
     cached = _list_cache.get(enabled_only)
     now = time.time()
@@ -131,7 +180,7 @@ async def list_login_apps(
         return list(cached[0])
 
     records = await db.execute(_LIST_QUERY, {}, ['app', 'service'])
-    apps: list[LoginApp] = []
+    apps: dict[str, LoginApp] = {}
     for record in records:
         app = graph.parse_agtype(record['app'])
         svc = graph.parse_agtype(record.get('service'))
@@ -140,9 +189,22 @@ async def list_login_apps(
         login_app = _row_to_login_app(app, svc)
         if enabled_only and login_app.status != 'active':
             continue
-        apps.append(login_app)
-    _list_cache[enabled_only] = (list(apps), now)
-    return apps
+        apps[login_app.slug] = login_app
+
+    plugin_records = await db.execute(_IDENTITY_LOGIN_QUERY, {}, ['plugin'])
+    for record in plugin_records:
+        plugin = graph.parse_agtype(record['plugin'])
+        if not plugin.get('plugin_slug') or not plugin.get('id'):
+            continue
+        login_app = _plugin_row_to_login_app(plugin)
+        # Identity-plugin row wins on slug collision (operators are
+        # expected to disable the legacy service-app flag once they
+        # promote the identity plugin to a login provider).
+        apps[login_app.slug] = login_app
+
+    merged = list(apps.values())
+    _list_cache[enabled_only] = (list(merged), now)
+    return merged
 
 
 _GET_QUERY: typing.LiteralString = """
@@ -152,13 +214,34 @@ WHERE a.usage IN ['login', 'both']
 RETURN a{{.*}} AS app, s{{.*}} AS service
 """
 
+_IDENTITY_LOGIN_GET_QUERY: typing.LiteralString = """
+MATCH (p:Plugin {{plugin_slug: {slug}}})
+WHERE p.login_capable = true AND p.used_as_login = true
+RETURN p{{.*}} AS plugin
+LIMIT 1
+"""
+
 
 async def get_login_app(db: graph.Graph, slug: str) -> LoginApp | None:
-    """Look up a single login app by slug."""
+    """Look up a single login app by slug.
+
+    Checks the identity-plugin source first so it wins on collision
+    (matching :func:`list_login_apps`).
+    """
     cached = _provider_cache.get(slug)
     now = time.time()
     if cached is not None and (now - cached[1]) < _CACHE_TTL_SECONDS:
         return cached[0]
+
+    plugin_records = await db.execute(
+        _IDENTITY_LOGIN_GET_QUERY, {'slug': slug}, ['plugin']
+    )
+    if plugin_records:
+        plugin = graph.parse_agtype(plugin_records[0]['plugin'])
+        if plugin.get('plugin_slug') and plugin.get('id'):
+            login_app = _plugin_row_to_login_app(plugin)
+            _provider_cache[slug] = (login_app, now)
+            return login_app
 
     records = await db.execute(_GET_QUERY, {'slug': slug}, ['app', 'service'])
     if not records:

--- a/src/imbi_api/domain/models.py
+++ b/src/imbi_api/domain/models.py
@@ -815,6 +815,8 @@ class PluginUpdate(pydantic.BaseModel):
 
     label: str = pydantic.Field(min_length=1, max_length=128)
     options: dict[str, typing.Any] = pydantic.Field(default_factory=dict)
+    used_as_login: bool | None = None
+    connects_users_to: str | None = None
 
 
 class PluginResponse(pydantic.BaseModel):
@@ -827,6 +829,9 @@ class PluginResponse(pydantic.BaseModel):
     api_version: int
     status: typing.Literal['active', 'unavailable'] = 'active'
     service_slug: str | None = None
+    login_capable: bool = False
+    used_as_login: bool = False
+    connects_users_to: str | None = None
 
 
 class PluginAssignmentCreate(pydantic.BaseModel):

--- a/src/imbi_api/endpoints/auth.py
+++ b/src/imbi_api/endpoints/auth.py
@@ -1084,11 +1084,16 @@ async def _identity_plugin_login_callback(
     user.last_login = meta['issued_at']
     await db.merge(user, match_on=['email'])
 
+    # Redirect to frontend with tokens in URL fragment so they are not
+    # forwarded to the server in subsequent requests, matching the
+    # legacy OAuth callback's behaviour.
     target = return_to or '/dashboard'
     redirect_url = (
-        f'/auth/callback?access_token={at}&refresh_token={rt}'
-        f'&redirect_uri={urlparse.quote(target, safe="")}'
-        f'&token_type=Bearer&expires_in='
+        f'{target}#'
+        f'access_token={at}&'
+        f'refresh_token={rt}&'
+        f'token_type=bearer&'
+        f'expires_in='
         f'{auth_settings.access_token_expire_seconds}'
     )
     return fastapi.responses.RedirectResponse(url=redirect_url)

--- a/src/imbi_api/endpoints/auth.py
+++ b/src/imbi_api/endpoints/auth.py
@@ -13,6 +13,7 @@ import pydantic
 import pyotp
 from imbi_common import graph
 from imbi_common.auth import core, encryption
+from imbi_common.plugins import errors as plugin_errors
 
 from imbi_api import models, settings
 from imbi_api.auth import (
@@ -24,6 +25,8 @@ from imbi_api.auth import (
 )
 from imbi_api.auth import models as auth_models
 from imbi_api.auth import password as password_auth
+from imbi_api.identity import flows as identity_flows
+from imbi_api.identity import repository as identity_repository
 from imbi_api.middleware import rate_limit
 
 LOGGER = logging.getLogger(__name__)
@@ -723,6 +726,38 @@ async def oauth_login(
             detail=f'Invalid provider: {provider}',
         )
 
+    # Identity-plugin login providers route through the registry's
+    # plugin handler — same redirect, but the URL builder + token
+    # exchange are owned by the plugin instead of the hardcoded
+    # branches below.
+    if app.oauth_app_type == 'identity_plugin':
+        if not app.plugin_id:
+            raise fastapi.HTTPException(
+                status_code=500,
+                detail=f'Identity plugin row {provider!r} missing plugin_id',
+            )
+        callback_url = settings.oauth_callback_url(provider)
+        try:
+            url, _state, _polling = await identity_flows.start_flow(
+                db,
+                plugin_id=app.plugin_id,
+                redirect_uri=callback_url,
+                actor_user_id=None,
+                return_to=redirect_uri,
+                intent='login',
+            )
+        except plugin_errors.PluginNotFoundError as exc:
+            raise fastapi.HTTPException(
+                status_code=503,
+                detail=f'Identity plugin {provider!r} not loaded',
+            ) from exc
+        LOGGER.info(
+            'Identity-plugin login initiated for slug %s (plugin_id=%s)',
+            provider,
+            app.plugin_id,
+        )
+        return fastapi.responses.RedirectResponse(url=url)
+
     state_token, _ = oauth.generate_oauth_state(
         provider, redirect_uri, auth_settings
     )
@@ -821,6 +856,25 @@ async def oauth_callback(
         # Validate required parameters
         if not code or not state:
             raise ValueError('Missing required parameters: code and state')
+
+        # Identity-plugin login providers use the registry's
+        # exchange_code instead of the legacy oauth.py paths. We
+        # detect this by re-resolving the slug — the LoginApp's
+        # source discriminator says which path to take.
+        login_app_for_callback = await login_providers.get_login_app(
+            db, provider
+        )
+        if (
+            login_app_for_callback is not None
+            and login_app_for_callback.oauth_app_type == 'identity_plugin'
+        ):
+            return await _identity_plugin_login_callback(
+                db,
+                provider,
+                code,
+                state,
+                auth_settings,
+            )
 
         # Verify state parameter
         state_data = oauth.verify_oauth_state(state, auth_settings)
@@ -932,6 +986,112 @@ async def oauth_callback(
         return fastapi.responses.RedirectResponse(
             url='/auth/callback?error=authentication_failed'
         )
+
+
+async def _identity_plugin_login_callback(
+    db: graph.Graph,
+    provider: str,
+    code: str,
+    state: str,
+    auth_settings: settings.Auth,
+) -> fastapi.responses.RedirectResponse:
+    """Complete a login-intent flow handled by an identity plugin.
+
+    Mirrors the OAuth callback's user-provisioning + JWT-issue path
+    but uses :func:`identity_flows.complete_login_flow` instead of the
+    hardcoded OAuth branches and persists an
+    :class:`imbi_common.models.IdentityConnection` instead of an
+    :class:`imbi_api.domain.models.OAuthIdentity`.
+    """
+    (
+        profile,
+        credentials,
+        plugin_id,
+        return_to,
+    ) = await identity_flows.complete_login_flow(
+        db, code=code, state_token=state
+    )
+    if not profile.email:
+        raise ValueError(
+            'Identity plugin returned no email; cannot establish a session'
+        )
+
+    user_results = await db.match(models.User, {'email': profile.email})
+    existing = user_results[0] if user_results else None
+
+    if existing is not None:
+        if not auth_settings.oauth_auto_link_by_email:
+            raise ValueError(
+                f'A user with email {profile.email} already exists. '
+                'OAuth auto-link by email is disabled.'
+            )
+        if not profile.email_verified:
+            raise ValueError(
+                'Refusing to auto-link identity-plugin login to existing '
+                f'user {profile.email}: provider did not assert '
+                'email_verified=true.'
+            )
+        user = existing
+        LOGGER.info(
+            'Linked identity-plugin %s to existing user %s',
+            provider,
+            user.email,
+        )
+    else:
+        if not auth_settings.oauth_auto_create_users:
+            raise ValueError('User auto-creation disabled')
+        user = models.User(
+            email=profile.email,
+            display_name=profile.name or profile.email,
+            password_hash=None,
+            is_active=True,
+            is_admin=False,
+            is_service_account=False,
+            created_at=datetime.datetime.now(datetime.UTC),
+            avatar_url=(
+                pydantic.HttpUrl(profile.avatar_url)
+                if profile.avatar_url
+                else None
+            ),
+        )
+        await db.merge(user, ['email'])
+        LOGGER.info(
+            'Created new user %s via identity-plugin %s',
+            user.email,
+            provider,
+        )
+
+    if user.is_service_account:
+        raise ValueError(
+            'Service accounts cannot use identity-plugin authentication'
+        )
+
+    # Persist the IdentityConnection now that we have a user_id.
+    await identity_repository.upsert_connection(
+        db,
+        plugin_id,
+        user.id,
+        profile,
+        credentials,
+    )
+
+    at, rt, meta = await tokens.issue_token_pair(
+        db,
+        principal_type='user',
+        principal_id=user.email,
+        auth_settings=auth_settings,
+    )
+    user.last_login = meta['issued_at']
+    await db.merge(user, match_on=['email'])
+
+    target = return_to or '/dashboard'
+    redirect_url = (
+        f'/auth/callback?access_token={at}&refresh_token={rt}'
+        f'&redirect_uri={urlparse.quote(target, safe="")}'
+        f'&token_type=Bearer&expires_in='
+        f'{auth_settings.access_token_expire_seconds}'
+    )
+    return fastapi.responses.RedirectResponse(url=redirect_url)
 
 
 async def find_or_create_oauth_identity(
@@ -1087,8 +1247,14 @@ async def find_or_create_oauth_identity(
 
     # Create OAuth identity (Phase 5: with encrypted tokens)
     now = datetime.datetime.now(datetime.UTC)
+    # ``oauth_app_type`` is one of the legacy literals here — the
+    # identity-plugin path branched out in ``oauth_callback`` before
+    # reaching ``find_or_create_oauth_identity``.
+    legacy_provider = typing.cast(
+        typing.Literal['google', 'github', 'oidc'], oauth_app_type
+    )
     identity = models.OAuthIdentity(
-        provider=oauth_app_type,
+        provider=legacy_provider,
         provider_user_id=profile['id'],
         email=profile['email'],
         display_name=profile['name'],

--- a/src/imbi_api/endpoints/service_plugins.py
+++ b/src/imbi_api/endpoints/service_plugins.py
@@ -15,7 +15,7 @@ from imbi_common.plugins.registry import (
     list_plugins,
 )
 
-from imbi_api.auth import permissions
+from imbi_api.auth import login_providers, permissions
 from imbi_api.domain import models
 from imbi_api.graph_sql import props_template, set_clause
 from imbi_api.plugins import parse_options as _parse_options
@@ -46,6 +46,9 @@ def _build_plugin_response(
         api_version=plugin.get('api_version', 1),
         status='active' if slug in registry_slugs else 'unavailable',
         service_slug=svc.get('slug') if svc else None,  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType]
+        login_capable=bool(plugin.get('login_capable', False)),
+        used_as_login=bool(plugin.get('used_as_login', False)),
+        connects_users_to=plugin.get('connects_users_to'),
     )
 
 
@@ -198,6 +201,40 @@ async def update_service_plugin(
         'label': data.label,
         'options': options_str,
     }
+    if data.connects_users_to is not None:
+        props['connects_users_to'] = data.connects_users_to
+    if data.used_as_login is not None:
+        # Toggling on requires the manifest to declare login_capable=true.
+        # Consult the registry — the Plugin node's snapshot may be stale
+        # if the plugin was upgraded.
+        if data.used_as_login:
+            slug_query: typing.LiteralString = (
+                'MATCH (p:Plugin {{id: {plugin_id}}}) '
+                'RETURN p.plugin_slug AS slug LIMIT 1'
+            )
+            slug_records = await db.execute(
+                slug_query, {'plugin_id': plugin_id}, ['slug']
+            )
+            plugin_slug = (
+                graph.parse_agtype(slug_records[0]['slug'])
+                if slug_records
+                else None
+            )
+            entry = None
+            if plugin_slug:
+                try:
+                    entry = get_plugin(plugin_slug)
+                except PluginNotFoundError:
+                    entry = None
+            if entry is None or not entry.manifest.login_capable:
+                raise fastapi.HTTPException(
+                    status_code=400,
+                    detail=(
+                        f'Plugin {plugin_slug!r} cannot be used as a login '
+                        'provider (manifest.login_capable=false)'
+                    ),
+                )
+        props['used_as_login'] = data.used_as_login
     set_stmt = set_clause('p', props)
 
     update_query: str = (
@@ -222,6 +259,10 @@ async def update_service_plugin(
             status_code=404,
             detail=f'Plugin {plugin_id!r} not found in service {slug!r}',
         )
+    # Bust the login-providers TTL cache when login flags changed so the
+    # next call to GET /auth/login-providers reflects the new state.
+    if data.used_as_login is not None or data.connects_users_to is not None:
+        login_providers.invalidate_cache()
     return _build_plugin_response(records[0], _registry_slugs())
 
 

--- a/src/imbi_api/endpoints/service_plugins.py
+++ b/src/imbi_api/endpoints/service_plugins.py
@@ -226,7 +226,15 @@ async def update_service_plugin(
                     entry = get_plugin(plugin_slug)
                 except PluginNotFoundError:
                     entry = None
-            if entry is None or not entry.manifest.login_capable:
+            if entry is None:
+                raise fastapi.HTTPException(
+                    status_code=400,
+                    detail=(
+                        f'Plugin {plugin_slug!r} cannot be used as a login '
+                        'provider (not loaded in the registry)'
+                    ),
+                )
+            if not entry.manifest.login_capable:
                 raise fastapi.HTTPException(
                     status_code=400,
                     detail=(

--- a/src/imbi_api/identity/flows.py
+++ b/src/imbi_api/identity/flows.py
@@ -135,6 +135,41 @@ async def complete_flow(
     return profile, credentials, plugin_id, state_data.return_to
 
 
+async def complete_login_flow(
+    db: graph.Graph,
+    *,
+    code: str,
+    state_token: str,
+) -> tuple[IdentityProfile, IdentityCredentials, str, str | None]:
+    """Exchange a code from an ``intent='login'`` flow.
+
+    Mirrors :func:`complete_flow` but accepts a state token whose
+    ``intent`` is ``'login'``.  Does *not* upsert an
+    :class:`IdentityConnection` — the caller must provision the local
+    user first and then call :func:`repository.upsert_connection` with
+    that user's id.
+    """
+    state_data = state.decode_login_state(state_token)
+    plugin_id = state_data.plugin_id
+    if not plugin_id:
+        raise ValueError('state token missing plugin_id')
+
+    _entry, handler, creds = await _load_plugin_handler(db, plugin_id)
+    ctx = PluginContext(
+        project_id='',
+        project_slug='',
+        org_slug='',
+    )
+    profile, credentials = await handler.exchange_code(
+        ctx,
+        creds,
+        code,
+        state_data.redirect_uri,
+        state_data.code_verifier,
+    )
+    return profile, credentials, plugin_id, state_data.return_to
+
+
 async def refresh_connection(
     db: graph.Graph,
     *,

--- a/src/imbi_api/identity/state.py
+++ b/src/imbi_api/identity/state.py
@@ -46,6 +46,41 @@ def encode_identity_state(
     )
 
 
+def _decode_state_for_intent(
+    state_token: str,
+    *,
+    expected_intent: str,
+    invalid_message: str,
+    intent_message: str,
+    expired_label: str,
+    auth_settings: settings.Auth | None = None,
+    max_age_seconds: int = 600,
+) -> models.OAuthStateData:
+    """Shared decode + verify for identity-flow state JWTs.
+
+    Both the ``identity`` and ``login`` intents use the same payload
+    shape and the same expiry / plugin_id assertions; only the error
+    messages differ. Centralizing the logic prevents the two flows from
+    drifting apart over time.
+    """
+    auth = auth_settings or settings.Auth()  # type: ignore[call-arg]
+    try:
+        payload = jwt.decode(
+            state_token,
+            auth.jwt_secret,
+            algorithms=[auth.jwt_algorithm],
+        )
+        state_data = models.OAuthStateData(**payload)
+    except jwt.InvalidTokenError as exc:
+        raise ValueError(f'{invalid_message}: {exc}') from exc
+    if state_data.intent != expected_intent or not state_data.plugin_id:
+        raise ValueError(intent_message)
+    age = int(time.time()) - state_data.timestamp
+    if age > max_age_seconds:
+        raise ValueError(f'{expired_label} state expired (age: {age}s)')
+    return state_data
+
+
 def decode_identity_state(
     state_token: str,
     *,
@@ -57,22 +92,15 @@ def decode_identity_state(
     Raises :class:`ValueError` for invalid signature or expiry — same
     semantics as the login-side ``verify_oauth_state``.
     """
-    auth = auth_settings or settings.Auth()  # type: ignore[call-arg]
-    try:
-        payload = jwt.decode(
-            state_token,
-            auth.jwt_secret,
-            algorithms=[auth.jwt_algorithm],
-        )
-        state_data = models.OAuthStateData(**payload)
-    except jwt.InvalidTokenError as exc:
-        raise ValueError(f'Invalid identity state token: {exc}') from exc
-    if state_data.intent != 'identity' or not state_data.plugin_id:
-        raise ValueError('State token is not for an identity flow')
-    age = int(time.time()) - state_data.timestamp
-    if age > max_age_seconds:
-        raise ValueError(f'Identity state expired (age: {age}s)')
-    return state_data
+    return _decode_state_for_intent(
+        state_token,
+        expected_intent='identity',
+        invalid_message='Invalid identity state token',
+        intent_message='State token is not for an identity flow',
+        expired_label='Identity',
+        auth_settings=auth_settings,
+        max_age_seconds=max_age_seconds,
+    )
 
 
 def decode_login_state(
@@ -86,19 +114,12 @@ def decode_login_state(
     Mirrors :func:`decode_identity_state` but requires
     ``intent='login'``.
     """
-    auth = auth_settings or settings.Auth()  # type: ignore[call-arg]
-    try:
-        payload = jwt.decode(
-            state_token,
-            auth.jwt_secret,
-            algorithms=[auth.jwt_algorithm],
-        )
-        state_data = models.OAuthStateData(**payload)
-    except jwt.InvalidTokenError as exc:
-        raise ValueError(f'Invalid login state token: {exc}') from exc
-    if state_data.intent != 'login' or not state_data.plugin_id:
-        raise ValueError('State token is not for an identity-plugin login')
-    age = int(time.time()) - state_data.timestamp
-    if age > max_age_seconds:
-        raise ValueError(f'Login state expired (age: {age}s)')
-    return state_data
+    return _decode_state_for_intent(
+        state_token,
+        expected_intent='login',
+        invalid_message='Invalid login state token',
+        intent_message='State token is not for an identity-plugin login',
+        expired_label='Login',
+        auth_settings=auth_settings,
+        max_age_seconds=max_age_seconds,
+    )

--- a/src/imbi_api/identity/state.py
+++ b/src/imbi_api/identity/state.py
@@ -73,3 +73,32 @@ def decode_identity_state(
     if age > max_age_seconds:
         raise ValueError(f'Identity state expired (age: {age}s)')
     return state_data
+
+
+def decode_login_state(
+    state_token: str,
+    *,
+    auth_settings: settings.Auth | None = None,
+    max_age_seconds: int = 600,
+) -> models.OAuthStateData:
+    """Verify and decode an identity-plugin **login** state token.
+
+    Mirrors :func:`decode_identity_state` but requires
+    ``intent='login'``.
+    """
+    auth = auth_settings or settings.Auth()  # type: ignore[call-arg]
+    try:
+        payload = jwt.decode(
+            state_token,
+            auth.jwt_secret,
+            algorithms=[auth.jwt_algorithm],
+        )
+        state_data = models.OAuthStateData(**payload)
+    except jwt.InvalidTokenError as exc:
+        raise ValueError(f'Invalid login state token: {exc}') from exc
+    if state_data.intent != 'login' or not state_data.plugin_id:
+        raise ValueError('State token is not for an identity-plugin login')
+    age = int(time.time()) - state_data.timestamp
+    if age > max_age_seconds:
+        raise ValueError(f'Login state expired (age: {age}s)')
+    return state_data

--- a/tests/auth/test_login_providers.py
+++ b/tests/auth/test_login_providers.py
@@ -211,3 +211,43 @@ class IdentityPluginLoginSourceTestCase(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(
             slugs, {'google': 'service_app', 'oidc': 'identity_plugin'}
         )
+
+    async def test_list_skips_plugin_rows_missing_id(self) -> None:
+        """Plugin rows without plugin_slug or id are silently skipped."""
+        db = _FakeDB(
+            rows=[],
+            plugin_rows=[
+                {
+                    'plugin': {
+                        'id': '',
+                        'plugin_slug': '',
+                        'login_capable': True,
+                        'used_as_login': True,
+                    }
+                },
+                _plugin_row('okta', plugin_id='p-99'),
+            ],
+        )
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            apps = await login_providers.list_login_apps(db)  # type: ignore[arg-type]
+        # Bad row dropped, good row kept.
+        self.assertEqual(len(apps), 1)
+        self.assertEqual(apps[0].slug, 'okta')
+
+    async def test_list_skips_app_rows_without_oauth_type(self) -> None:
+        """Service-app rows missing oauth_app_type are silently skipped."""
+        bad_row = {
+            'app': {'slug': 'incomplete'},
+            'service': None,
+        }
+        db = _FakeDB(
+            rows=[bad_row, _row('google', oauth_app_type='google')],
+        )
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            apps = await login_providers.list_login_apps(db)  # type: ignore[arg-type]
+        slugs = [a.slug for a in apps]
+        self.assertEqual(slugs, ['google'])

--- a/tests/auth/test_login_providers.py
+++ b/tests/auth/test_login_providers.py
@@ -11,12 +11,19 @@ from imbi_api.auth import login_providers
 
 
 class _FakeDB:
-    """Minimal DB stub that returns canned execute results."""
+    """Minimal DB stub that returns canned execute results.
+
+    ``rows`` carry service-application rows; ``plugin_rows`` carry
+    Plugin-node rows for the identity-plugin source.
+    """
 
     def __init__(
-        self, rows: list[dict[str, typing.Any]] | None = None
+        self,
+        rows: list[dict[str, typing.Any]] | None = None,
+        plugin_rows: list[dict[str, typing.Any]] | None = None,
     ) -> None:
         self.rows = rows or []
+        self.plugin_rows = plugin_rows or []
         self.execute = mock.AsyncMock(side_effect=self._execute)
 
     async def _execute(
@@ -27,9 +34,35 @@ class _FakeDB:
     ) -> list[dict[str, typing.Any]]:
         params = params or {}
         slug = params.get('slug')
+        is_plugin_query = 'Plugin' in str(query) and 'login_capable' in str(
+            query
+        )
+        source = self.plugin_rows if is_plugin_query else self.rows
         if slug is not None:
-            return [r for r in self.rows if r['app']['slug'] == slug]
-        return list(self.rows)
+            if is_plugin_query:
+                return [
+                    r for r in source if r['plugin']['plugin_slug'] == slug
+                ]
+            return [r for r in source if r['app']['slug'] == slug]
+        return list(source)
+
+
+def _plugin_row(
+    plugin_slug: str,
+    *,
+    plugin_id: str = 'plug-1',
+    label: str | None = None,
+    used_as_login: bool = True,
+) -> dict[str, typing.Any]:
+    return {
+        'plugin': {
+            'id': plugin_id,
+            'plugin_slug': plugin_slug,
+            'label': label or plugin_slug,
+            'login_capable': True,
+            'used_as_login': used_as_login,
+        }
+    }
 
 
 def _row(
@@ -129,3 +162,52 @@ class LoginProvidersRepoTestCase(unittest.IsolatedAsyncioTestCase):
             login_providers.invalidate_cache('google')
             third = await login_providers.get_login_app(db, 'google')  # type: ignore[arg-type]
         self.assertIsNone(third)
+
+
+class IdentityPluginLoginSourceTestCase(unittest.IsolatedAsyncioTestCase):
+    """Verify the identity-plugin source merges into the login list."""
+
+    def setUp(self) -> None:
+        login_providers.invalidate_cache()
+
+    async def test_list_includes_identity_plugin_rows(self) -> None:
+        db = _FakeDB(
+            rows=[],
+            plugin_rows=[_plugin_row('oidc', plugin_id='p-1')],
+        )
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            apps = await login_providers.list_login_apps(db)  # type: ignore[arg-type]
+        self.assertEqual(len(apps), 1)
+        self.assertEqual(apps[0].slug, 'oidc')
+        self.assertEqual(apps[0].source, 'identity_plugin')
+        self.assertEqual(apps[0].oauth_app_type, 'identity_plugin')
+        self.assertEqual(apps[0].plugin_id, 'p-1')
+
+    async def test_get_prefers_identity_plugin_on_collision(self) -> None:
+        db = _FakeDB(
+            rows=[_row('oidc', oauth_app_type='oidc')],
+            plugin_rows=[_plugin_row('oidc', plugin_id='p-99')],
+        )
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            app = await login_providers.get_login_app(db, 'oidc')  # type: ignore[arg-type]
+        assert app is not None
+        self.assertEqual(app.source, 'identity_plugin')
+        self.assertEqual(app.plugin_id, 'p-99')
+
+    async def test_list_merges_both_sources(self) -> None:
+        db = _FakeDB(
+            rows=[_row('google', oauth_app_type='google')],
+            plugin_rows=[_plugin_row('oidc', plugin_id='p-1')],
+        )
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            apps = await login_providers.list_login_apps(db)  # type: ignore[arg-type]
+        slugs = {a.slug: a.source for a in apps}
+        self.assertEqual(
+            slugs, {'google': 'service_app', 'oidc': 'identity_plugin'}
+        )

--- a/tests/endpoints/test_auth.py
+++ b/tests/endpoints/test_auth.py
@@ -2257,7 +2257,8 @@ class IdentityPluginLoginFlowTestCase(unittest.TestCase):
 
         self.assertEqual(response.status_code, 307)
         location = response.headers['location']
-        self.assertIn('/auth/callback?', location)
+        # Tokens land in the URL fragment, not the query string.
+        self.assertIn('/projects#', location)
         self.assertIn('access_token=', location)
         self.assertIn('refresh_token=', location)
         upsert_mock.assert_awaited_once()
@@ -2336,12 +2337,12 @@ class IdentityPluginLoginFlowTestCase(unittest.TestCase):
             )
 
         self.assertEqual(response.status_code, 307)
-        # Default redirect when return_to is None is /dashboard
-        self.assertIn('/auth/callback?', response.headers['location'])
-        self.assertIn(
-            'redirect_uri=%2Fdashboard',
-            response.headers['location'],
-        )
+        # Default redirect when return_to is None is /dashboard, and
+        # tokens are appended in the URL fragment.
+        location = response.headers['location']
+        self.assertTrue(location.startswith('/dashboard#'))
+        self.assertIn('access_token=', location)
+        self.assertIn('token_type=bearer', location)
 
     @mock.patch.dict(
         'os.environ',

--- a/tests/endpoints/test_auth.py
+++ b/tests/endpoints/test_auth.py
@@ -41,6 +41,26 @@ def _stub_provider(
     )
 
 
+def _stub_identity_plugin_provider(
+    slug: str,
+    *,
+    plugin_id: str | None = 'plug-1',
+    enabled: bool = True,
+    name: str | None = None,
+) -> login_providers.LoginApp:
+    """Build a LoginApp representing an identity-plugin login row."""
+    return login_providers.LoginApp(
+        slug=slug,
+        name=name or slug,
+        oauth_app_type='identity_plugin',
+        source='identity_plugin',
+        plugin_id=plugin_id,
+        plugin_slug=slug,
+        status='active' if enabled else 'inactive',
+        callback_url=f'http://localhost:8000/auth/oauth/{slug}/callback',
+    )
+
+
 def _patch_providers(
     rows: list[login_providers.LoginApp],
 ) -> typing.Any:
@@ -2074,3 +2094,516 @@ class ServiceAccountAuthTestCase(unittest.TestCase):
                 data['scope'],
                 'project:read',
             )
+
+
+class IdentityPluginLoginFlowTestCase(unittest.TestCase):
+    """Cover the identity-plugin branch of /auth/oauth/{provider}.
+
+    Exercises both the start (``oauth_login``) and callback
+    (``_identity_plugin_login_callback``) paths so the new code in
+    ``endpoints/auth.py`` is reached without standing up a real plugin
+    registry.
+    """
+
+    def setUp(self) -> None:
+        from imbi_common.plugins import base as plugin_base
+
+        from imbi_api.identity import flows as identity_flows
+        from imbi_api.identity import repository as identity_repository
+
+        self._plugin_base = plugin_base
+        self._identity_flows = identity_flows
+        self._identity_repository = identity_repository
+
+        settings._auth_settings = None
+        self.test_app = app.create_app()
+        self.mock_db = mock.AsyncMock(spec=graph.Graph)
+        self.test_app.dependency_overrides[graph._inject_graph] = (
+            lambda: self.mock_db
+        )
+        self.client = testclient.TestClient(self.test_app)
+
+    def tearDown(self) -> None:
+        settings._auth_settings = None
+
+    def test_oauth_login_redirects_through_identity_flow(self) -> None:
+        """Identity-plugin LoginApp triggers identity_flows.start_flow."""
+        provider = _stub_identity_plugin_provider('okta', plugin_id='p-1')
+        with (
+            _patch_providers([provider]),
+            mock.patch.object(
+                self._identity_flows,
+                'start_flow',
+                new=mock.AsyncMock(
+                    return_value=(
+                        'https://idp.example.com/authorize?x=1',
+                        'state-token',
+                        None,
+                    )
+                ),
+            ) as start_mock,
+        ):
+            response = self.client.get(
+                '/auth/oauth/okta',
+                follow_redirects=False,
+            )
+        self.assertEqual(response.status_code, 307)
+        self.assertEqual(
+            response.headers['location'],
+            'https://idp.example.com/authorize?x=1',
+        )
+        start_mock.assert_awaited_once()
+        kwargs = start_mock.await_args.kwargs
+        self.assertEqual(kwargs['plugin_id'], 'p-1')
+        self.assertEqual(kwargs['intent'], 'login')
+
+    def test_oauth_login_missing_plugin_id_returns_500(self) -> None:
+        """Identity-plugin row without plugin_id is a server error."""
+        provider = _stub_identity_plugin_provider('okta', plugin_id=None)
+        with _patch_providers([provider]):
+            response = self.client.get(
+                '/auth/oauth/okta',
+                follow_redirects=False,
+            )
+        self.assertEqual(response.status_code, 500)
+        self.assertIn('missing plugin_id', response.json()['detail'])
+
+    def test_oauth_login_plugin_not_loaded_returns_503(self) -> None:
+        """PluginNotFoundError from start_flow surfaces as 503."""
+        from imbi_common.plugins.errors import PluginNotFoundError
+
+        provider = _stub_identity_plugin_provider('okta', plugin_id='p-1')
+        with (
+            _patch_providers([provider]),
+            mock.patch.object(
+                self._identity_flows,
+                'start_flow',
+                new=mock.AsyncMock(side_effect=PluginNotFoundError('okta')),
+            ),
+        ):
+            response = self.client.get(
+                '/auth/oauth/okta',
+                follow_redirects=False,
+            )
+        self.assertEqual(response.status_code, 503)
+        self.assertIn('not loaded', response.json()['detail'])
+
+    @mock.patch.dict(
+        'os.environ',
+        {
+            'IMBI_AUTH_ENCRYPTION_KEY': (
+                'nhia5yBgff552rNZAvT4GGu-IE0dMVsXQaM2auHNXRo='
+            ),
+            'IMBI_AUTH_OAUTH_AUTO_CREATE_USERS': 'true',
+        },
+    )
+    def test_oauth_callback_creates_new_user_via_identity_plugin(
+        self,
+    ) -> None:
+        """Identity-plugin callback provisions a new user + JWT pair."""
+        from imbi_common.auth import encryption
+
+        from imbi_api import models as api_models
+
+        encryption.TokenEncryption.reset_instance()
+        settings._auth_settings = None
+
+        provider = _stub_identity_plugin_provider('okta', plugin_id='p-1')
+
+        profile = self._plugin_base.IdentityProfile(
+            subject='okta-sub-1',
+            email='new@example.com',
+            email_verified=True,
+            name='New User',
+        )
+        credentials = self._plugin_base.IdentityCredentials(
+            access_token='at-1',
+            refresh_token='rt-1',
+        )
+
+        # No existing user
+        self.mock_db.match.return_value = []
+        self.mock_db.merge.return_value = None
+        # execute(): the principal_count query inside issue_token_pair
+        # then the SET last_login update — both for the new user.
+        self.mock_db.execute.side_effect = [
+            [{'principal_count': 1}],
+            [],
+        ]
+
+        with (
+            _patch_providers([provider]),
+            mock.patch.object(
+                self._identity_flows,
+                'complete_login_flow',
+                new=mock.AsyncMock(
+                    return_value=(profile, credentials, 'p-1', '/projects')
+                ),
+            ),
+            mock.patch.object(
+                self._identity_repository,
+                'upsert_connection',
+                new=mock.AsyncMock(return_value=None),
+            ) as upsert_mock,
+            mock.patch(
+                'imbi_common.graph.parse_agtype',
+                side_effect=lambda x: x,
+            ),
+        ):
+            response = self.client.get(
+                '/auth/oauth/okta/callback?code=c&state=s',
+                follow_redirects=False,
+            )
+
+        self.assertEqual(response.status_code, 307)
+        location = response.headers['location']
+        self.assertIn('/auth/callback?', location)
+        self.assertIn('access_token=', location)
+        self.assertIn('refresh_token=', location)
+        upsert_mock.assert_awaited_once()
+        # Verify the new user was upserted into the graph.
+        merged = [c.args[0] for c in self.mock_db.merge.call_args_list]
+        self.assertTrue(any(isinstance(m, api_models.User) for m in merged))
+
+    @mock.patch.dict(
+        'os.environ',
+        {
+            'IMBI_AUTH_ENCRYPTION_KEY': (
+                'nhia5yBgff552rNZAvT4GGu-IE0dMVsXQaM2auHNXRo='
+            ),
+        },
+    )
+    def test_oauth_callback_links_existing_user_via_identity_plugin(
+        self,
+    ) -> None:
+        """Identity-plugin callback links to an existing user by email."""
+        from imbi_common.auth import encryption
+
+        from imbi_api import models as api_models
+
+        encryption.TokenEncryption.reset_instance()
+        settings._auth_settings = None
+
+        provider = _stub_identity_plugin_provider('okta', plugin_id='p-1')
+
+        existing = api_models.User(
+            email='existing@example.com',
+            display_name='Existing User',
+            is_active=True,
+            password_hash=None,
+            created_at=datetime.datetime.now(datetime.UTC),
+        )
+
+        profile = self._plugin_base.IdentityProfile(
+            subject='okta-sub-99',
+            email='existing@example.com',
+            email_verified=True,
+            name='Existing User',
+        )
+        credentials = self._plugin_base.IdentityCredentials(
+            access_token='at-1',
+        )
+
+        self.mock_db.match.return_value = [existing]
+        self.mock_db.merge.return_value = None
+        self.mock_db.execute.side_effect = [
+            [{'principal_count': 1}],
+            [],
+        ]
+
+        with (
+            _patch_providers([provider]),
+            mock.patch.object(
+                self._identity_flows,
+                'complete_login_flow',
+                new=mock.AsyncMock(
+                    return_value=(profile, credentials, 'p-1', None)
+                ),
+            ),
+            mock.patch.object(
+                self._identity_repository,
+                'upsert_connection',
+                new=mock.AsyncMock(return_value=None),
+            ),
+            mock.patch(
+                'imbi_common.graph.parse_agtype',
+                side_effect=lambda x: x,
+            ),
+        ):
+            response = self.client.get(
+                '/auth/oauth/okta/callback?code=c&state=s',
+                follow_redirects=False,
+            )
+
+        self.assertEqual(response.status_code, 307)
+        # Default redirect when return_to is None is /dashboard
+        self.assertIn('/auth/callback?', response.headers['location'])
+        self.assertIn(
+            'redirect_uri=%2Fdashboard',
+            response.headers['location'],
+        )
+
+    @mock.patch.dict(
+        'os.environ',
+        {
+            'IMBI_AUTH_ENCRYPTION_KEY': (
+                'nhia5yBgff552rNZAvT4GGu-IE0dMVsXQaM2auHNXRo='
+            ),
+            'IMBI_AUTH_OAUTH_AUTO_LINK_BY_EMAIL': 'false',
+        },
+    )
+    def test_oauth_callback_refuses_link_when_auto_link_disabled(
+        self,
+    ) -> None:
+        """Existing user + auto-link disabled => authentication_failed."""
+        from imbi_common.auth import encryption
+
+        from imbi_api import models as api_models
+
+        encryption.TokenEncryption.reset_instance()
+        settings._auth_settings = None
+
+        provider = _stub_identity_plugin_provider('okta', plugin_id='p-1')
+        existing = api_models.User(
+            email='existing@example.com',
+            display_name='Existing User',
+            is_active=True,
+            password_hash=None,
+            created_at=datetime.datetime.now(datetime.UTC),
+        )
+        profile = self._plugin_base.IdentityProfile(
+            subject='okta-sub-1',
+            email='existing@example.com',
+            email_verified=True,
+        )
+        credentials = self._plugin_base.IdentityCredentials(access_token='a')
+
+        self.mock_db.match.return_value = [existing]
+
+        with (
+            _patch_providers([provider]),
+            mock.patch.object(
+                self._identity_flows,
+                'complete_login_flow',
+                new=mock.AsyncMock(
+                    return_value=(profile, credentials, 'p-1', None)
+                ),
+            ),
+            mock.patch(
+                'imbi_common.graph.parse_agtype',
+                side_effect=lambda x: x,
+            ),
+        ):
+            response = self.client.get(
+                '/auth/oauth/okta/callback?code=c&state=s',
+                follow_redirects=False,
+            )
+        self.assertEqual(response.status_code, 307)
+        self.assertIn(
+            'error=authentication_failed', response.headers['location']
+        )
+
+    @mock.patch.dict(
+        'os.environ',
+        {
+            'IMBI_AUTH_ENCRYPTION_KEY': (
+                'nhia5yBgff552rNZAvT4GGu-IE0dMVsXQaM2auHNXRo='
+            ),
+        },
+    )
+    def test_oauth_callback_refuses_unverified_email(self) -> None:
+        """Auto-link refuses when provider does not assert email_verified."""
+        from imbi_common.auth import encryption
+
+        from imbi_api import models as api_models
+
+        encryption.TokenEncryption.reset_instance()
+        settings._auth_settings = None
+
+        provider = _stub_identity_plugin_provider('okta', plugin_id='p-1')
+        existing = api_models.User(
+            email='existing@example.com',
+            display_name='Existing User',
+            is_active=True,
+            password_hash=None,
+            created_at=datetime.datetime.now(datetime.UTC),
+        )
+        profile = self._plugin_base.IdentityProfile(
+            subject='okta-sub-1',
+            email='existing@example.com',
+            email_verified=False,
+        )
+        credentials = self._plugin_base.IdentityCredentials(access_token='a')
+
+        self.mock_db.match.return_value = [existing]
+
+        with (
+            _patch_providers([provider]),
+            mock.patch.object(
+                self._identity_flows,
+                'complete_login_flow',
+                new=mock.AsyncMock(
+                    return_value=(profile, credentials, 'p-1', None)
+                ),
+            ),
+            mock.patch(
+                'imbi_common.graph.parse_agtype',
+                side_effect=lambda x: x,
+            ),
+        ):
+            response = self.client.get(
+                '/auth/oauth/okta/callback?code=c&state=s',
+                follow_redirects=False,
+            )
+        self.assertEqual(response.status_code, 307)
+        self.assertIn(
+            'error=authentication_failed', response.headers['location']
+        )
+
+    @mock.patch.dict(
+        'os.environ',
+        {
+            'IMBI_AUTH_ENCRYPTION_KEY': (
+                'nhia5yBgff552rNZAvT4GGu-IE0dMVsXQaM2auHNXRo='
+            ),
+            'IMBI_AUTH_OAUTH_AUTO_CREATE_USERS': 'false',
+        },
+    )
+    def test_oauth_callback_refuses_create_when_disabled(self) -> None:
+        """Auto-create disabled + no user => authentication_failed."""
+        from imbi_common.auth import encryption
+
+        encryption.TokenEncryption.reset_instance()
+        settings._auth_settings = None
+
+        provider = _stub_identity_plugin_provider('okta', plugin_id='p-1')
+        profile = self._plugin_base.IdentityProfile(
+            subject='okta-sub-1',
+            email='nobody@example.com',
+            email_verified=True,
+        )
+        credentials = self._plugin_base.IdentityCredentials(access_token='a')
+
+        self.mock_db.match.return_value = []
+
+        with (
+            _patch_providers([provider]),
+            mock.patch.object(
+                self._identity_flows,
+                'complete_login_flow',
+                new=mock.AsyncMock(
+                    return_value=(profile, credentials, 'p-1', None)
+                ),
+            ),
+            mock.patch(
+                'imbi_common.graph.parse_agtype',
+                side_effect=lambda x: x,
+            ),
+        ):
+            response = self.client.get(
+                '/auth/oauth/okta/callback?code=c&state=s',
+                follow_redirects=False,
+            )
+        self.assertEqual(response.status_code, 307)
+        self.assertIn(
+            'error=authentication_failed', response.headers['location']
+        )
+
+    @mock.patch.dict(
+        'os.environ',
+        {
+            'IMBI_AUTH_ENCRYPTION_KEY': (
+                'nhia5yBgff552rNZAvT4GGu-IE0dMVsXQaM2auHNXRo='
+            ),
+        },
+    )
+    def test_oauth_callback_rejects_service_account(self) -> None:
+        """Service-account users cannot complete identity-plugin login."""
+        from imbi_common.auth import encryption
+
+        from imbi_api import models as api_models
+
+        encryption.TokenEncryption.reset_instance()
+        settings._auth_settings = None
+
+        provider = _stub_identity_plugin_provider('okta', plugin_id='p-1')
+        sa_user = api_models.User(
+            email='svc@example.com',
+            display_name='Service',
+            is_active=True,
+            is_service_account=True,
+            password_hash=None,
+            created_at=datetime.datetime.now(datetime.UTC),
+        )
+        profile = self._plugin_base.IdentityProfile(
+            subject='okta-sub-1',
+            email='svc@example.com',
+            email_verified=True,
+        )
+        credentials = self._plugin_base.IdentityCredentials(access_token='a')
+
+        self.mock_db.match.return_value = [sa_user]
+
+        with (
+            _patch_providers([provider]),
+            mock.patch.object(
+                self._identity_flows,
+                'complete_login_flow',
+                new=mock.AsyncMock(
+                    return_value=(profile, credentials, 'p-1', None)
+                ),
+            ),
+            mock.patch(
+                'imbi_common.graph.parse_agtype',
+                side_effect=lambda x: x,
+            ),
+        ):
+            response = self.client.get(
+                '/auth/oauth/okta/callback?code=c&state=s',
+                follow_redirects=False,
+            )
+        self.assertEqual(response.status_code, 307)
+        self.assertIn(
+            'error=authentication_failed', response.headers['location']
+        )
+
+    @mock.patch.dict(
+        'os.environ',
+        {
+            'IMBI_AUTH_ENCRYPTION_KEY': (
+                'nhia5yBgff552rNZAvT4GGu-IE0dMVsXQaM2auHNXRo='
+            ),
+        },
+    )
+    def test_oauth_callback_rejects_profile_without_email(self) -> None:
+        """Identity plugin must return an email or callback fails."""
+        from imbi_common.auth import encryption
+
+        encryption.TokenEncryption.reset_instance()
+        settings._auth_settings = None
+
+        provider = _stub_identity_plugin_provider('okta', plugin_id='p-1')
+        profile = self._plugin_base.IdentityProfile(
+            subject='okta-sub-1',
+            email=None,
+        )
+        credentials = self._plugin_base.IdentityCredentials(access_token='a')
+
+        with (
+            _patch_providers([provider]),
+            mock.patch.object(
+                self._identity_flows,
+                'complete_login_flow',
+                new=mock.AsyncMock(
+                    return_value=(profile, credentials, 'p-1', None)
+                ),
+            ),
+        ):
+            response = self.client.get(
+                '/auth/oauth/okta/callback?code=c&state=s',
+                follow_redirects=False,
+            )
+        self.assertEqual(response.status_code, 307)
+        self.assertIn(
+            'error=authentication_failed', response.headers['location']
+        )

--- a/tests/endpoints/test_service_plugins.py
+++ b/tests/endpoints/test_service_plugins.py
@@ -577,7 +577,7 @@ class ServicePluginsEndpointTestCase(unittest.TestCase):
                 )
         self.assertEqual(response.status_code, 400)
         self.assertIn(
-            'cannot be used as a login provider',
+            'not loaded in the registry',
             response.json()['detail'],
         )
 

--- a/tests/endpoints/test_service_plugins.py
+++ b/tests/endpoints/test_service_plugins.py
@@ -402,6 +402,224 @@ class ServicePluginsEndpointTestCase(unittest.TestCase):
             )
         self.assertEqual(response.status_code, 404)
 
+    def test_update_plugin_used_as_login_requires_capable_manifest(
+        self,
+    ) -> None:
+        """used_as_login=true is rejected when manifest.login_capable=false."""
+        from imbi_common.plugins.base import (
+            ConfigurationPlugin,
+            PluginManifest,
+        )
+        from imbi_common.plugins.registry import RegistryEntry
+
+        class _Fake(ConfigurationPlugin):
+            manifest = PluginManifest(
+                slug='ssm',
+                name='SSM',
+                plugin_type='configuration',
+                login_capable=False,
+            )
+
+            async def list_keys(self, ctx, credentials):  # type: ignore[override]
+                return []
+
+            async def get_values(self, ctx, credentials, keys=None):  # type: ignore[override]
+                return []
+
+            async def set_value(self, ctx, credentials, key, value):  # type: ignore[override]
+                raise NotImplementedError
+
+            async def delete_key(self, ctx, credentials, key):  # type: ignore[override]
+                return None
+
+        entry = RegistryEntry(
+            handler_cls=_Fake,
+            manifest=_Fake.manifest,
+            package_name='imbi-plugin-ssm',
+            package_version='1.0.0',
+        )
+        # dup-label check (string '0'), then slug lookup
+        self.mock_db.execute.side_effect = [
+            [{'cnt': '0'}],
+            [{'slug': '"ssm"'}],
+        ]
+        with mock.patch(
+            'imbi_api.endpoints.service_plugins.get_plugin',
+            return_value=entry,
+        ):
+            with testclient.TestClient(self.test_app) as client:
+                response = client.put(
+                    '/organizations/myorg/'
+                    'third-party-services/github/plugins/abc123',
+                    json={
+                        'label': 'New Label',
+                        'options': {},
+                        'used_as_login': True,
+                    },
+                )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn(
+            'cannot be used as a login provider',
+            response.json()['detail'],
+        )
+
+    def test_update_plugin_used_as_login_succeeds_when_capable(self) -> None:
+        """used_as_login=true is accepted when manifest.login_capable=true."""
+        from imbi_common.plugins.base import (
+            IdentityCredentials,
+            IdentityPlugin,
+            IdentityProfile,
+            PluginManifest,
+        )
+        from imbi_common.plugins.registry import RegistryEntry
+
+        class _IdFake(IdentityPlugin):
+            manifest = PluginManifest(
+                slug='okta',
+                name='Okta',
+                plugin_type='identity',
+                login_capable=True,
+            )
+
+            async def authorization_request(  # type: ignore[override]
+                self, ctx, credentials, redirect_uri, scopes
+            ):
+                raise NotImplementedError
+
+            async def exchange_code(  # type: ignore[override]
+                self, ctx, credentials, code, redirect_uri, code_verifier
+            ) -> tuple[IdentityProfile, IdentityCredentials]:
+                raise NotImplementedError
+
+            async def refresh(  # type: ignore[override]
+                self, ctx, credentials, refresh_token
+            ) -> IdentityCredentials:
+                raise NotImplementedError
+
+            async def revoke(  # type: ignore[override]
+                self, ctx, credentials, access_token
+            ) -> None:
+                return None
+
+        entry = RegistryEntry(
+            handler_cls=_IdFake,
+            manifest=_IdFake.manifest,
+            package_name='imbi-plugin-okta',
+            package_version='1.0.0',
+        )
+        plugin_raw = json.dumps(
+            {
+                'id': 'abc123',
+                'plugin_slug': 'okta',
+                'label': 'Okta Login',
+                'options': '{}',
+                'api_version': 1,
+                'used_as_login': True,
+                'login_capable': True,
+            }
+        )
+        svc_raw = json.dumps({'slug': 'github'})
+        # dup-label check, slug lookup, update.
+        self.mock_db.execute.side_effect = [
+            [{'cnt': '0'}],
+            [{'slug': '"okta"'}],
+            [{'plugin': plugin_raw, 'svc': svc_raw}],
+        ]
+        with (
+            mock.patch(
+                'imbi_api.endpoints.service_plugins.get_plugin',
+                return_value=entry,
+            ),
+            mock.patch(
+                'imbi_api.endpoints.service_plugins.list_plugins',
+                return_value=[entry],
+            ),
+            mock.patch(
+                'imbi_api.auth.login_providers.invalidate_cache'
+            ) as invalidate_mock,
+        ):
+            with testclient.TestClient(self.test_app) as client:
+                response = client.put(
+                    '/organizations/myorg/'
+                    'third-party-services/github/plugins/abc123',
+                    json={
+                        'label': 'Okta Login',
+                        'options': {},
+                        'used_as_login': True,
+                    },
+                )
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.json()['used_as_login'])
+        invalidate_mock.assert_called_once()
+
+    def test_update_plugin_used_as_login_plugin_not_found(self) -> None:
+        """used_as_login=true rejects when registry has no entry."""
+        from imbi_common.plugins.errors import PluginNotFoundError
+
+        # dup-label check, slug lookup
+        self.mock_db.execute.side_effect = [
+            [{'cnt': '0'}],
+            [{'slug': '"missing"'}],
+        ]
+        with mock.patch(
+            'imbi_api.endpoints.service_plugins.get_plugin',
+            side_effect=PluginNotFoundError('missing'),
+        ):
+            with testclient.TestClient(self.test_app) as client:
+                response = client.put(
+                    '/organizations/myorg/'
+                    'third-party-services/github/plugins/abc123',
+                    json={
+                        'label': 'L',
+                        'options': {},
+                        'used_as_login': True,
+                    },
+                )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn(
+            'cannot be used as a login provider',
+            response.json()['detail'],
+        )
+
+    def test_update_plugin_connects_users_to_invalidates_cache(self) -> None:
+        """Setting connects_users_to busts the login-providers cache."""
+        plugin_raw = json.dumps(
+            {
+                'id': 'abc123',
+                'plugin_slug': 'okta',
+                'label': 'Okta Login',
+                'options': '{}',
+                'api_version': 1,
+                'connects_users_to': 'aweber.com',
+            }
+        )
+        svc_raw = json.dumps({'slug': 'github'})
+        self.mock_db.execute.side_effect = [
+            [{'cnt': '0'}],
+            [{'plugin': plugin_raw, 'svc': svc_raw}],
+        ]
+        with (
+            mock.patch(
+                'imbi_api.endpoints.service_plugins.list_plugins',
+                return_value=[],
+            ),
+            mock.patch(
+                'imbi_api.auth.login_providers.invalidate_cache'
+            ) as invalidate_mock,
+        ):
+            with testclient.TestClient(self.test_app) as client:
+                response = client.put(
+                    '/organizations/myorg/'
+                    'third-party-services/github/plugins/abc123',
+                    json={
+                        'label': 'Okta Login',
+                        'options': {},
+                        'connects_users_to': 'aweber.com',
+                    },
+                )
+        self.assertEqual(response.status_code, 200)
+        invalidate_mock.assert_called_once()
+
     def test_delete_plugin_force_skips_ref_check(self) -> None:
         # When force=true, only the delete query runs (no ref check).
         self.mock_db.execute.return_value = [{'deleted': '1'}]

--- a/tests/identity/test_flows.py
+++ b/tests/identity/test_flows.py
@@ -191,6 +191,61 @@ class CompleteFlowTestCase(unittest.IsolatedAsyncioTestCase):
                 await flows.complete_flow(db, code='c', state_token='s')
 
 
+class CompleteLoginFlowTestCase(unittest.IsolatedAsyncioTestCase):
+    """Verify complete_login_flow exchanges but does not persist."""
+
+    async def test_does_not_upsert_connection(self) -> None:
+        db = mock.AsyncMock()
+        state_data = mock.MagicMock()
+        state_data.plugin_id = 'plugin-1'
+        state_data.redirect_uri = 'https://imbi/cb'
+        state_data.code_verifier = 'verifier'
+        state_data.return_to = '/dashboard'
+
+        profile = IdentityProfile(subject='sub', email='u@x')
+        credentials = IdentityCredentials(access_token='at')
+        handler = mock.MagicMock(spec=flows.IdentityPlugin)
+        handler.exchange_code = mock.AsyncMock(
+            return_value=(profile, credentials)
+        )
+        with (
+            mock.patch.object(
+                flows.state,
+                'decode_login_state',
+                return_value=state_data,
+            ),
+            _patch_load_handler(handler),
+            mock.patch.object(
+                flows.repository,
+                'upsert_connection',
+                new=mock.AsyncMock(),
+            ) as upsert,
+        ):
+            (
+                returned_profile,
+                returned_creds,
+                plugin_id,
+                return_to,
+            ) = await flows.complete_login_flow(db, code='c', state_token='s')
+        upsert.assert_not_called()
+        self.assertEqual(returned_profile, profile)
+        self.assertEqual(returned_creds, credentials)
+        self.assertEqual(plugin_id, 'plugin-1')
+        self.assertEqual(return_to, '/dashboard')
+
+    async def test_raises_when_state_missing_plugin_id(self) -> None:
+        db = mock.AsyncMock()
+        state_data = mock.MagicMock()
+        state_data.plugin_id = None
+        with mock.patch.object(
+            flows.state,
+            'decode_login_state',
+            return_value=state_data,
+        ):
+            with self.assertRaises(ValueError):
+                await flows.complete_login_flow(db, code='c', state_token='s')
+
+
 class RefreshConnectionTestCase(unittest.IsolatedAsyncioTestCase):
     """Verify refresh_connection's success / no-token / IdP-error paths."""
 

--- a/tests/identity/test_state.py
+++ b/tests/identity/test_state.py
@@ -111,3 +111,61 @@ class DecodeIdentityStateTestCase(unittest.TestCase):
         )
         with self.assertRaises(ValueError):
             state.decode_identity_state(token, auth_settings=self.auth)
+
+
+class DecodeLoginStateTestCase(unittest.TestCase):
+    """Verify the login-intent decoder enforces intent='login'."""
+
+    def setUp(self) -> None:
+        self.auth = settings.Auth(jwt_secret='login-state-test-secret')
+
+    def test_round_trip(self) -> None:
+        token = state.encode_identity_state(
+            plugin_id='p-1',
+            plugin_slug='oidc',
+            redirect_uri='https://imbi.test/callback',
+            intent='login',
+            return_to='/dashboard',
+            auth_settings=self.auth,
+        )
+        decoded = state.decode_login_state(token, auth_settings=self.auth)
+        self.assertEqual(decoded.plugin_id, 'p-1')
+        self.assertEqual(decoded.intent, 'login')
+        self.assertEqual(decoded.return_to, '/dashboard')
+
+    def test_identity_intent_rejected(self) -> None:
+        token = state.encode_identity_state(
+            plugin_id='p-1',
+            plugin_slug='oidc',
+            redirect_uri='https://imbi.test/cb',
+            intent='identity',
+            auth_settings=self.auth,
+        )
+        with self.assertRaises(ValueError):
+            state.decode_login_state(token, auth_settings=self.auth)
+
+    def test_expired_token_raises_value_error(self) -> None:
+        with mock.patch.object(state.time, 'time', return_value=2000):
+            token = state.encode_identity_state(
+                plugin_id='p-1',
+                plugin_slug='oidc',
+                redirect_uri='https://imbi.test/cb',
+                intent='login',
+                auth_settings=self.auth,
+            )
+        with mock.patch.object(state.time, 'time', return_value=2000 + 1800):
+            with self.assertRaises(ValueError) as ctx:
+                state.decode_login_state(token, auth_settings=self.auth)
+        self.assertIn('expired', str(ctx.exception))
+
+    def test_invalid_signature_raises_value_error(self) -> None:
+        token = state.encode_identity_state(
+            plugin_id='p-1',
+            plugin_slug='oidc',
+            redirect_uri='https://imbi.test/cb',
+            intent='login',
+            auth_settings=self.auth,
+        )
+        wrong = settings.Auth(jwt_secret='different-secret')
+        with self.assertRaises(ValueError):
+            state.decode_login_state(token, auth_settings=wrong)


### PR DESCRIPTION
## Summary

Implements step 8 of [docs/identity-plugin-implementation-plan.md](https://github.com/AWeber-Imbi/imbi/blob/main/docs/identity-plugin-implementation-plan.md) — the login-provider merge. Identity plugins whose manifest is \`login_capable=true\` *and* whose \`Plugin\` row has \`used_as_login=true\` now appear alongside the legacy \`ServiceApplication.usage='login'\` rows in \`GET /auth/login-providers\`. The legacy \`oauth_app_type\` branches in \`auth/oauth.py\` stay for one Imbi release per the cutover plan in §11.12 of the implementation doc.

### Surface changes

- \`LoginApp\` gains \`source: 'service_app' | 'identity_plugin'\` and \`oauth_app_type\` literal grows \`'identity_plugin'\`. Identity rows carry \`plugin_id\` so the auth router can dispatch start + callback through \`imbi_api.identity.flows\`. Identity-plugin row wins on slug collision (operators are expected to disable the legacy service-app flag once they promote the identity plugin).
- \`auth/login_providers.py\` queries the second source in parallel with the service-application source and merges in \`list_login_apps\` / \`get_login_app\`. Cache invalidates when login flags flip on a Plugin row.
- \`GET /auth/oauth/{provider}\` and \`/auth/oauth/{provider}/callback\` branch on \`oauth_app_type='identity_plugin'\` and route through \`identity_flows.start_flow(intent='login')\` / \`complete_login_flow\`. \`_identity_plugin_login_callback\` provisions the user from the \`IdentityProfile\` (same \`oauth_auto_link_by_email\` / \`oauth_auto_create_users\` / \`email_verified\` guards the legacy path uses), persists the \`IdentityConnection\`, and issues a token pair.
- \`identity.flows\` adds \`complete_login_flow\` (no-actor variant of \`complete_flow\` — no upsert; caller does that after provisioning the user). \`state.decode_login_state\` mirrors \`decode_identity_state\` but enforces \`intent='login'\`.
- \`PluginUpdate\` accepts optional \`used_as_login\` / \`connects_users_to\`. \`PUT /third-party-services/{slug}/plugins/{plugin_id}\` toggles the flags, validates \`manifest.login_capable=true\` against the registry when promoting (the Plugin node's snapshot may be stale), and busts the login-providers cache. \`PluginResponse\` surfaces the new fields.

### Tests

- \`IdentityPluginLoginSourceTestCase\` — list/get merge, identity row wins on collision, both sources visible together.
- \`DecodeLoginStateTestCase\` — round-trip, identity-intent rejected, expiry, signature mismatch.
- \`CompleteLoginFlowTestCase\` — no upsert when no actor; missing \`plugin_id\` raises.

### Deferred

Inline \`hydrate_identity\` integration into the 6 PluginContext call sites in \`project_logs.py\` / \`project_configuration.py\` (the helper exists; this PR doesn't touch those handlers). Auto-mounted CRUD router for plugin-declared entities (\`/admin/plugins/{plugin_id}/entities/{vlabel}\`, \`POST /admin/edges/{label}\`) — separate PR. Removing the legacy \`oauth_app_type\` hardcoded branches happens after the OIDC + GitHub plugins ship and one Imbi release elapses (cutover step §11.12).

## Test plan

- [ ] \`just lint\` clean
- [ ] \`just test tests/auth/test_login_providers.py tests/identity/test_state.py tests/identity/test_flows.py\`
- [ ] Smoke: install \`imbi-plugin-oidc\`, create a Plugin row with \`used_as_login=true\`, verify it shows up in \`GET /auth/login-providers\` and that \`/auth/oauth/{slug}\` redirects through the OIDC plugin's authorization URL