### PR TITLE
Add identity plugins to the plugins dependency group

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -212,7 +212,10 @@ docs = [
   "mkdocstrings[python]"
 ]
 plugins = [
+  "imbi-plugin-aws",
+  "imbi-plugin-github",
   "imbi-plugin-logzio",
+  "imbi-plugin-oidc",
 ]
 
 [[tool.uv.index]]
@@ -221,4 +224,7 @@ default = true
 
 [tool.uv.sources]
 imbi-common = { git = "https://github.com/AWeber-Imbi/imbi-common.git", rev = "main" }
+imbi-plugin-aws = { path = "../imbi-plugin-aws", editable = true }
+imbi-plugin-github = { path = "../imbi-plugin-github", editable = true }
 imbi-plugin-logzio = { path = "../imbi-plugin-logzio", editable = true }
+imbi-plugin-oidc = { path = "../imbi-plugin-oidc", editable = true }

--- a/uv.lock
+++ b/uv.lock
@@ -888,7 +888,10 @@ docs = [
     { name = "mkdocstrings-python-xref" },
 ]
 plugins = [
+    { name = "imbi-plugin-aws" },
+    { name = "imbi-plugin-github" },
     { name = "imbi-plugin-logzio" },
+    { name = "imbi-plugin-oidc" },
 ]
 
 [package.metadata]
@@ -943,7 +946,12 @@ docs = [
     { name = "mkdocstrings", extras = ["python"] },
     { name = "mkdocstrings-python-xref", specifier = ">=1.6,<2" },
 ]
-plugins = [{ name = "imbi-plugin-logzio", editable = "../imbi-plugin-logzio" }]
+plugins = [
+    { name = "imbi-plugin-aws", editable = "../imbi-plugin-aws" },
+    { name = "imbi-plugin-github", editable = "../imbi-plugin-github" },
+    { name = "imbi-plugin-logzio", editable = "../imbi-plugin-logzio" },
+    { name = "imbi-plugin-oidc", editable = "../imbi-plugin-oidc" },
+]
 
 [[package]]
 name = "imbi-common"
@@ -976,9 +984,111 @@ server = [
 ]
 
 [[package]]
+name = "imbi-plugin-aws"
+version = "0.1.0"
+source = { editable = "../imbi-plugin-aws" }
+dependencies = [
+    { name = "httpx" },
+    { name = "imbi-common" },
+    { name = "pydantic" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "httpx", specifier = ">=0.27" },
+    { name = "imbi-common", git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=main" },
+    { name = "pydantic", specifier = ">=2" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "basedpyright" },
+    { name = "coverage", extras = ["toml"] },
+    { name = "imbi-common", extras = ["server", "databases"], git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=main" },
+    { name = "pre-commit" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "respx" },
+    { name = "ruff", specifier = "~=0.14.6" },
+]
+dist = [
+    { name = "build" },
+    { name = "twine" },
+    { name = "wheel" },
+]
+
+[[package]]
+name = "imbi-plugin-github"
+version = "0.1.0"
+source = { editable = "../imbi-plugin-github" }
+dependencies = [
+    { name = "httpx" },
+    { name = "imbi-common" },
+    { name = "pydantic" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "httpx", specifier = ">=0.27" },
+    { name = "imbi-common", git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=main" },
+    { name = "pydantic", specifier = ">=2" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "basedpyright" },
+    { name = "coverage", extras = ["toml"] },
+    { name = "imbi-common", extras = ["server", "databases"], git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=main" },
+    { name = "pre-commit" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "respx" },
+    { name = "ruff", specifier = "~=0.14.6" },
+]
+dist = [
+    { name = "build" },
+    { name = "twine" },
+    { name = "wheel" },
+]
+
+[[package]]
 name = "imbi-plugin-logzio"
 version = "0.1.0"
 source = { editable = "../imbi-plugin-logzio" }
+dependencies = [
+    { name = "httpx" },
+    { name = "imbi-common" },
+    { name = "pydantic" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "httpx", specifier = ">=0.27" },
+    { name = "imbi-common", git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=main" },
+    { name = "pydantic", specifier = ">=2" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "basedpyright" },
+    { name = "coverage", extras = ["toml"] },
+    { name = "imbi-common", extras = ["server", "databases"], git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=main" },
+    { name = "pre-commit" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "respx" },
+    { name = "ruff", specifier = "~=0.14.6" },
+]
+dist = [
+    { name = "build" },
+    { name = "twine" },
+    { name = "wheel" },
+]
+
+[[package]]
+name = "imbi-plugin-oidc"
+version = "0.1.0"
+source = { editable = "../imbi-plugin-oidc" }
 dependencies = [
     { name = "httpx" },
     { name = "imbi-common" },


### PR DESCRIPTION
## Summary

Bakes the three Phase-1 identity plugins into the imbi-api image build alongside the existing \`imbi-plugin-logzio\`:

- \`imbi-plugin-aws\` (aws-iam-ic identity)
- \`imbi-plugin-github\` (github / GHEC / GHES)
- \`imbi-plugin-oidc\` (generic OIDC)

Sources match the existing convention — editable path siblings, the same shape \`imbi-plugin-logzio\` already uses. The orchestrator's \`Dockerfile.python\` COPYs the sibling directories at build time so the editable installs resolve.

## Why this is opt-in for CI

The \`[dependency-groups.plugins]\` group is gated. \`just setup\` syncs \`--group dev --group docs\` only, so imbi-api standalone CI continues to skip the plugin tree (no sibling clones required). The image build pulls \`--group plugins\` to bake them in.

## Lock regeneration note

uv refuses to compose imbi-api's git-pinned \`imbi-common\` source with the plugins' path-pinned \`imbi-common\` source in a single resolution. Same root cause the imbi-api #265 lock-bump hit. Worked around the same way: temporarily aligned each plugin's \`[tool.uv.sources] imbi-common\` to the git URL while running \`uv lock\`, then reverted the plugin pyprojects. The plugin repos themselves are untouched on disk.

## Test plan

- [ ] \`uv sync --group dev --group docs --all-extras --frozen\` succeeds (mirrors CI; should not require sibling plugin clones).
- [ ] \`uv sync --group plugins --all-extras --frozen\` succeeds when the plugin siblings are present (mirrors the image build).
- [ ] Smoke import: \`from imbi_plugin_{oidc,github,aws} import *\`.