### PR TITLE
Hydrate ctx.identity into project configuration / logs handlers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -224,7 +224,7 @@ default = true
 
 [tool.uv.sources]
 imbi-common = { git = "https://github.com/AWeber-Imbi/imbi-common.git", rev = "main" }
-imbi-plugin-aws = { path = "../imbi-plugin-aws", editable = true }
-imbi-plugin-github = { path = "../imbi-plugin-github", editable = true }
-imbi-plugin-logzio = { path = "../imbi-plugin-logzio", editable = true }
-imbi-plugin-oidc = { path = "../imbi-plugin-oidc", editable = true }
+imbi-plugin-aws = { git = "https://github.com/AWeber-Imbi/imbi-plugin-aws.git", rev = "main" }
+imbi-plugin-github = { git = "https://github.com/AWeber-Imbi/imbi-plugin-github.git", rev = "main" }
+imbi-plugin-logzio = { git = "https://github.com/AWeber-Imbi/imbi-plugin-logzio.git", rev = "main" }
+imbi-plugin-oidc = { git = "https://github.com/AWeber-Imbi/imbi-plugin-oidc.git", rev = "main" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -212,7 +212,10 @@ docs = [
   "mkdocstrings[python]"
 ]
 plugins = [
+  "imbi-plugin-aws",
+  "imbi-plugin-github",
   "imbi-plugin-logzio",
+  "imbi-plugin-oidc",
 ]
 
 [[tool.uv.index]]
@@ -221,4 +224,7 @@ default = true
 
 [tool.uv.sources]
 imbi-common = { git = "https://github.com/AWeber-Imbi/imbi-common.git", rev = "main" }
+imbi-plugin-aws = { path = "../imbi-plugin-aws", editable = true }
+imbi-plugin-github = { path = "../imbi-plugin-github", editable = true }
 imbi-plugin-logzio = { path = "../imbi-plugin-logzio", editable = true }
+imbi-plugin-oidc = { path = "../imbi-plugin-oidc", editable = true }

--- a/src/imbi_api/endpoints/project_configuration.py
+++ b/src/imbi_api/endpoints/project_configuration.py
@@ -21,6 +21,7 @@ from imbi_common.plugins.errors import (
 
 from imbi_api.auth import permissions
 from imbi_api.domain import models
+from imbi_api.identity.host_integration import attach_identity
 from imbi_api.plugins import call_with_timeout
 from imbi_api.plugins.credentials import get_plugin_credentials
 from imbi_api.plugins.resolution import resolve_plugin
@@ -122,6 +123,7 @@ async def get_configuration(
         environment=environment,
         assignment_options=resolved.options,
     )
+    ctx = await attach_identity(db, ctx, resolved, auth)
     try:
         credentials = await get_plugin_credentials(
             db, resolved.plugin_id, resolved.entry
@@ -197,6 +199,7 @@ async def fetch_values(
         environment=environment,
         assignment_options=resolved.options,
     )
+    ctx = await attach_identity(db, ctx, resolved, auth)
     try:
         credentials = await get_plugin_credentials(
             db, resolved.plugin_id, resolved.entry
@@ -250,6 +253,7 @@ async def set_configuration_value(
         environment=environment,
         assignment_options=resolved.options,
     )
+    ctx = await attach_identity(db, ctx, resolved, auth)
     try:
         credentials = await get_plugin_credentials(
             db, resolved.plugin_id, resolved.entry
@@ -310,6 +314,7 @@ async def delete_configuration_key(
         environment=environment,
         assignment_options=resolved.options,
     )
+    ctx = await attach_identity(db, ctx, resolved, auth)
     try:
         credentials = await get_plugin_credentials(
             db, resolved.plugin_id, resolved.entry

--- a/src/imbi_api/endpoints/project_logs.py
+++ b/src/imbi_api/endpoints/project_logs.py
@@ -19,6 +19,7 @@ from imbi_common.plugins.errors import (
 
 from imbi_api.auth import permissions
 from imbi_api.domain import models
+from imbi_api.identity.host_integration import attach_identity
 from imbi_api.plugins import call_with_timeout
 from imbi_api.plugins.credentials import get_plugin_credentials
 from imbi_api.plugins.resolution import resolve_plugin
@@ -142,6 +143,7 @@ async def search_logs(
         environment=environment,
         assignment_options=resolved.options,
     )
+    ctx = await attach_identity(db, ctx, resolved, auth)
     try:
         credentials = await get_plugin_credentials(
             db, resolved.plugin_id, resolved.entry
@@ -246,6 +248,7 @@ async def get_log_histogram(
         environment=environment,
         assignment_options=resolved.options,
     )
+    ctx = await attach_identity(db, ctx, resolved, auth)
     try:
         credentials = await get_plugin_credentials(
             db, resolved.plugin_id, resolved.entry
@@ -293,6 +296,7 @@ async def get_log_schema(
         environment=environment,
         assignment_options=resolved.options,
     )
+    ctx = await attach_identity(db, ctx, resolved, auth)
     try:
         credentials = await get_plugin_credentials(
             db, resolved.plugin_id, resolved.entry

--- a/src/imbi_api/identity/host_integration.py
+++ b/src/imbi_api/identity/host_integration.py
@@ -18,6 +18,7 @@ duplicating the try/except + actor stamping + 401 mapping seven times.
 
 from __future__ import annotations
 
+import logging
 import typing
 
 import fastapi
@@ -28,6 +29,8 @@ from imbi_api.auth import permissions
 from imbi_api.identity import errors as identity_errors
 from imbi_api.identity import resolution as identity_resolution
 from imbi_api.plugins.resolution import ResolvedPlugin
+
+LOGGER = logging.getLogger(__name__)
 
 
 async def attach_identity(

--- a/src/imbi_api/identity/host_integration.py
+++ b/src/imbi_api/identity/host_integration.py
@@ -1,0 +1,78 @@
+"""Helpers for the host-side wiring of plugin identity hydration.
+
+The ``configuration`` and ``logs`` endpoints construct a
+:class:`PluginContext` and then invoke a plugin handler.  When the
+plugin's :class:`USES_PLUGIN` edge carries an ``identity_plugin_id``,
+the API must:
+
+1. Stamp the actor's user id onto the context.
+2. Load the actor's identity connection for that plugin and attach
+   materialized credentials to ``ctx.identity``.
+3. Translate :class:`IdentityRequiredError` into the
+   ``401`` / ``WWW-Authenticate: Imbi-Identity`` response shape so the
+   UI knows which plugin to surface a Connect button for.
+
+This module exists so each call site is a single one-liner instead of
+duplicating the try/except + actor stamping + 401 mapping seven times.
+"""
+
+from __future__ import annotations
+
+import typing
+
+import fastapi
+from imbi_common import graph
+from imbi_common.plugins.base import PluginContext
+
+from imbi_api.auth import permissions
+from imbi_api.identity import errors as identity_errors
+from imbi_api.identity import resolution as identity_resolution
+from imbi_api.plugins.resolution import ResolvedPlugin
+
+
+async def attach_identity(
+    db: graph.Graph,
+    ctx: PluginContext,
+    resolved: ResolvedPlugin,
+    auth: permissions.AuthContext,
+) -> PluginContext:
+    """Hydrate ``ctx.identity`` for a plugin call.
+
+    Stamps ``actor_user_id`` regardless of whether an identity plugin
+    is named — downstream plugins may want to attribute calls to the
+    human even when no per-user IdP is involved.
+
+    When ``resolved.identity_plugin_id`` is set, looks up the actor's
+    :class:`IdentityConnection` and threads the materialized
+    credentials into ``ctx.identity``.  Raises
+    :class:`fastapi.HTTPException` with the
+    ``identity_required`` shape (401 +
+    ``WWW-Authenticate: Imbi-Identity plugin_id=<id>``) when the actor
+    has no active connection.
+    """
+    actor_user_id = auth.user.id if auth.user else None
+    ctx = ctx.model_copy(update={'actor_user_id': actor_user_id})
+    if not resolved.identity_plugin_id:
+        return ctx
+    try:
+        return await identity_resolution.hydrate_identity(
+            db, ctx, resolved.identity_plugin_id
+        )
+    except identity_errors.IdentityRequiredError as exc:
+        raise _identity_required_response(exc) from exc
+
+
+def _identity_required_response(
+    exc: identity_errors.IdentityRequiredError,
+) -> fastapi.HTTPException:
+    headers: dict[str, str] = {
+        'WWW-Authenticate': f'Imbi-Identity plugin_id={exc.plugin_id}',
+    }
+    detail: dict[str, typing.Any] = {
+        'error': 'identity_required',
+        'plugin_id': exc.plugin_id,
+        'start_url': exc.start_url,
+    }
+    return fastapi.HTTPException(
+        status_code=401, detail=detail, headers=headers
+    )

--- a/tests/identity/test_host_integration.py
+++ b/tests/identity/test_host_integration.py
@@ -1,5 +1,6 @@
 """Tests for the host-side identity hydration helper."""
 
+import typing
 import unittest
 from unittest import mock
 
@@ -101,8 +102,7 @@ class AttachIdentityTestCase(unittest.IsolatedAsyncioTestCase):
             {'WWW-Authenticate': 'Imbi-Identity plugin_id=plug-1'},
         )
         self.assertIsInstance(exc.detail, dict)
-        self.assertEqual(exc.detail['error'], 'identity_required')
-        self.assertEqual(exc.detail['plugin_id'], 'plug-1')
-        self.assertEqual(
-            exc.detail['start_url'], '/me/identities/plug-1/start'
-        )
+        detail = typing.cast('dict[str, typing.Any]', exc.detail)
+        self.assertEqual(detail['error'], 'identity_required')
+        self.assertEqual(detail['plugin_id'], 'plug-1')
+        self.assertEqual(detail['start_url'], '/me/identities/plug-1/start')

--- a/tests/identity/test_host_integration.py
+++ b/tests/identity/test_host_integration.py
@@ -1,0 +1,108 @@
+"""Tests for the host-side identity hydration helper."""
+
+import unittest
+from unittest import mock
+
+import fastapi
+from imbi_common.plugins.base import (
+    IdentityCredentials,
+    PluginContext,
+)
+
+from imbi_api.identity import errors as identity_errors
+from imbi_api.identity import host_integration
+
+
+def _ctx() -> PluginContext:
+    return PluginContext(
+        project_id='p-1',
+        project_slug='proj',
+        org_slug='org',
+        assignment_options={'k': 'v'},
+    )
+
+
+def _resolved(identity_plugin_id: str | None) -> mock.MagicMock:
+    resolved = mock.MagicMock()
+    resolved.identity_plugin_id = identity_plugin_id
+    return resolved
+
+
+def _auth(user_id: str | None) -> mock.MagicMock:
+    user = mock.MagicMock()
+    user.id = user_id
+    auth = mock.MagicMock()
+    auth.user = user if user_id else None
+    return auth
+
+
+class AttachIdentityTestCase(unittest.IsolatedAsyncioTestCase):
+    async def test_no_identity_plugin_only_stamps_actor(self) -> None:
+        db = mock.AsyncMock()
+        ctx = await host_integration.attach_identity(
+            db, _ctx(), _resolved(None), _auth('user-1')
+        )
+        self.assertEqual(ctx.actor_user_id, 'user-1')
+        self.assertIsNone(ctx.identity)
+
+    async def test_no_user_leaves_actor_none(self) -> None:
+        db = mock.AsyncMock()
+        ctx = await host_integration.attach_identity(
+            db, _ctx(), _resolved(None), _auth(None)
+        )
+        self.assertIsNone(ctx.actor_user_id)
+
+    async def test_hydrates_identity_when_plugin_id_set(self) -> None:
+        db = mock.AsyncMock()
+        hydrated = _ctx().model_copy(
+            update={
+                'actor_user_id': 'user-1',
+                'identity': IdentityCredentials(access_token='at'),
+            }
+        )
+        with mock.patch.object(
+            host_integration.identity_resolution,
+            'hydrate_identity',
+            new=mock.AsyncMock(return_value=hydrated),
+        ) as hydrate:
+            ctx = await host_integration.attach_identity(
+                db,
+                _ctx(),
+                _resolved('plug-1'),
+                _auth('user-1'),
+            )
+        hydrate.assert_awaited_once()
+        # Helper passes a stamped ctx, not the raw one.
+        passed_ctx = hydrate.await_args.args[1]
+        self.assertEqual(passed_ctx.actor_user_id, 'user-1')
+        self.assertEqual(ctx.identity.access_token, 'at')
+
+    async def test_identity_required_maps_to_401(self) -> None:
+        db = mock.AsyncMock()
+        with mock.patch.object(
+            host_integration.identity_resolution,
+            'hydrate_identity',
+            side_effect=identity_errors.IdentityRequiredError(
+                plugin_id='plug-1',
+                start_url='/me/identities/plug-1/start',
+            ),
+        ):
+            with self.assertRaises(fastapi.HTTPException) as ctx_mgr:
+                await host_integration.attach_identity(
+                    db,
+                    _ctx(),
+                    _resolved('plug-1'),
+                    _auth('user-1'),
+                )
+        exc = ctx_mgr.exception
+        self.assertEqual(exc.status_code, 401)
+        self.assertEqual(
+            exc.headers,
+            {'WWW-Authenticate': 'Imbi-Identity plugin_id=plug-1'},
+        )
+        self.assertIsInstance(exc.detail, dict)
+        self.assertEqual(exc.detail['error'], 'identity_required')
+        self.assertEqual(exc.detail['plugin_id'], 'plug-1')
+        self.assertEqual(
+            exc.detail['start_url'], '/me/identities/plug-1/start'
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -947,10 +947,10 @@ docs = [
     { name = "mkdocstrings-python-xref", specifier = ">=1.6,<2" },
 ]
 plugins = [
-    { name = "imbi-plugin-aws", editable = "../imbi-plugin-aws" },
-    { name = "imbi-plugin-github", editable = "../imbi-plugin-github" },
-    { name = "imbi-plugin-logzio", editable = "../imbi-plugin-logzio" },
-    { name = "imbi-plugin-oidc", editable = "../imbi-plugin-oidc" },
+    { name = "imbi-plugin-aws", git = "https://github.com/AWeber-Imbi/imbi-plugin-aws.git?rev=main" },
+    { name = "imbi-plugin-github", git = "https://github.com/AWeber-Imbi/imbi-plugin-github.git?rev=main" },
+    { name = "imbi-plugin-logzio", git = "https://github.com/AWeber-Imbi/imbi-plugin-logzio.git?rev=main" },
+    { name = "imbi-plugin-oidc", git = "https://github.com/AWeber-Imbi/imbi-plugin-oidc.git?rev=main" },
 ]
 
 [[package]]
@@ -986,137 +986,41 @@ server = [
 [[package]]
 name = "imbi-plugin-aws"
 version = "0.1.0"
-source = { editable = "../imbi-plugin-aws" }
+source = { git = "https://github.com/AWeber-Imbi/imbi-plugin-aws.git?rev=main#1aa3707b0692a8efadceb49e7fc546ca48389ef2" }
 dependencies = [
     { name = "httpx" },
     { name = "imbi-common" },
     { name = "pydantic" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "httpx", specifier = ">=0.27" },
-    { name = "imbi-common", git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=main" },
-    { name = "pydantic", specifier = ">=2" },
-]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "basedpyright" },
-    { name = "coverage", extras = ["toml"] },
-    { name = "imbi-common", extras = ["server", "databases"], git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=main" },
-    { name = "pre-commit" },
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
-    { name = "respx" },
-    { name = "ruff", specifier = "~=0.14.6" },
-]
-dist = [
-    { name = "build" },
-    { name = "twine" },
-    { name = "wheel" },
 ]
 
 [[package]]
 name = "imbi-plugin-github"
 version = "0.1.0"
-source = { editable = "../imbi-plugin-github" }
+source = { git = "https://github.com/AWeber-Imbi/imbi-plugin-github.git?rev=main#e7046d0dc8d7463aa7d58af97fa10831370b5d44" }
 dependencies = [
     { name = "httpx" },
     { name = "imbi-common" },
     { name = "pydantic" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "httpx", specifier = ">=0.27" },
-    { name = "imbi-common", git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=main" },
-    { name = "pydantic", specifier = ">=2" },
-]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "basedpyright" },
-    { name = "coverage", extras = ["toml"] },
-    { name = "imbi-common", extras = ["server", "databases"], git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=main" },
-    { name = "pre-commit" },
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
-    { name = "respx" },
-    { name = "ruff", specifier = "~=0.14.6" },
-]
-dist = [
-    { name = "build" },
-    { name = "twine" },
-    { name = "wheel" },
 ]
 
 [[package]]
 name = "imbi-plugin-logzio"
 version = "0.1.0"
-source = { editable = "../imbi-plugin-logzio" }
+source = { git = "https://github.com/AWeber-Imbi/imbi-plugin-logzio.git?rev=main#e6e9911c5d666cf3e1196a5442aabfedd069305c" }
 dependencies = [
     { name = "httpx" },
     { name = "imbi-common" },
     { name = "pydantic" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "httpx", specifier = ">=0.27" },
-    { name = "imbi-common", git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=main" },
-    { name = "pydantic", specifier = ">=2" },
-]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "basedpyright" },
-    { name = "coverage", extras = ["toml"] },
-    { name = "imbi-common", extras = ["server", "databases"], git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=main" },
-    { name = "pre-commit" },
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
-    { name = "respx" },
-    { name = "ruff", specifier = "~=0.14.6" },
-]
-dist = [
-    { name = "build" },
-    { name = "twine" },
-    { name = "wheel" },
 ]
 
 [[package]]
 name = "imbi-plugin-oidc"
 version = "0.1.0"
-source = { editable = "../imbi-plugin-oidc" }
+source = { git = "https://github.com/AWeber-Imbi/imbi-plugin-oidc.git?rev=main#35b4dd6198e4e1e3a819ec683b3490d4deabc16b" }
 dependencies = [
     { name = "httpx" },
     { name = "imbi-common" },
     { name = "pydantic" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "httpx", specifier = ">=0.27" },
-    { name = "imbi-common", git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=main" },
-    { name = "pydantic", specifier = ">=2" },
-]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "basedpyright" },
-    { name = "coverage", extras = ["toml"] },
-    { name = "imbi-common", extras = ["server", "databases"], git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=main" },
-    { name = "pre-commit" },
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
-    { name = "respx" },
-    { name = "ruff", specifier = "~=0.14.6" },
-]
-dist = [
-    { name = "build" },
-    { name = "twine" },
-    { name = "wheel" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -888,7 +888,10 @@ docs = [
     { name = "mkdocstrings-python-xref" },
 ]
 plugins = [
+    { name = "imbi-plugin-aws" },
+    { name = "imbi-plugin-github" },
     { name = "imbi-plugin-logzio" },
+    { name = "imbi-plugin-oidc" },
 ]
 
 [package.metadata]
@@ -943,7 +946,12 @@ docs = [
     { name = "mkdocstrings", extras = ["python"] },
     { name = "mkdocstrings-python-xref", specifier = ">=1.6,<2" },
 ]
-plugins = [{ name = "imbi-plugin-logzio", editable = "../imbi-plugin-logzio" }]
+plugins = [
+    { name = "imbi-plugin-aws", editable = "../imbi-plugin-aws" },
+    { name = "imbi-plugin-github", editable = "../imbi-plugin-github" },
+    { name = "imbi-plugin-logzio", editable = "../imbi-plugin-logzio" },
+    { name = "imbi-plugin-oidc", editable = "../imbi-plugin-oidc" },
+]
 
 [[package]]
 name = "imbi-common"
@@ -976,9 +984,111 @@ server = [
 ]
 
 [[package]]
+name = "imbi-plugin-aws"
+version = "0.1.0"
+source = { editable = "../imbi-plugin-aws" }
+dependencies = [
+    { name = "httpx" },
+    { name = "imbi-common" },
+    { name = "pydantic" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "httpx", specifier = ">=0.27" },
+    { name = "imbi-common", git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=main" },
+    { name = "pydantic", specifier = ">=2" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "basedpyright" },
+    { name = "coverage", extras = ["toml"] },
+    { name = "imbi-common", extras = ["server", "databases"], git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=main" },
+    { name = "pre-commit" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "respx" },
+    { name = "ruff", specifier = "~=0.14.6" },
+]
+dist = [
+    { name = "build" },
+    { name = "twine" },
+    { name = "wheel" },
+]
+
+[[package]]
+name = "imbi-plugin-github"
+version = "0.1.0"
+source = { editable = "../imbi-plugin-github" }
+dependencies = [
+    { name = "httpx" },
+    { name = "imbi-common" },
+    { name = "pydantic" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "httpx", specifier = ">=0.27" },
+    { name = "imbi-common", git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=main" },
+    { name = "pydantic", specifier = ">=2" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "basedpyright" },
+    { name = "coverage", extras = ["toml"] },
+    { name = "imbi-common", extras = ["server", "databases"], git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=main" },
+    { name = "pre-commit" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "respx" },
+    { name = "ruff", specifier = "~=0.14.6" },
+]
+dist = [
+    { name = "build" },
+    { name = "twine" },
+    { name = "wheel" },
+]
+
+[[package]]
 name = "imbi-plugin-logzio"
 version = "0.1.0"
 source = { editable = "../imbi-plugin-logzio" }
+dependencies = [
+    { name = "httpx" },
+    { name = "imbi-common" },
+    { name = "pydantic" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "httpx", specifier = ">=0.27" },
+    { name = "imbi-common", git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=main" },
+    { name = "pydantic", specifier = ">=2" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "basedpyright" },
+    { name = "coverage", extras = ["toml"] },
+    { name = "imbi-common", extras = ["server", "databases"], git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=main" },
+    { name = "pre-commit" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "respx" },
+    { name = "ruff", specifier = "~=0.14.6" },
+]
+dist = [
+    { name = "build" },
+    { name = "twine" },
+    { name = "wheel" },
+]
+
+[[package]]
+name = "imbi-plugin-oidc"
+version = "0.1.0"
+source = { editable = "../imbi-plugin-oidc" }
 dependencies = [
     { name = "httpx" },
     { name = "imbi-common" },


### PR DESCRIPTION
## Summary

Closes the deferred host-side wiring noted in AWeber-Imbi/imbi-api#265 and #266 — completes step 10 of [docs/identity-plugin-implementation-plan.md](https://github.com/AWeber-Imbi/imbi/blob/main/docs/identity-plugin-implementation-plan.md). The \`/configuration\` and \`/logs\` endpoints now thread per-user identity credentials into \`PluginContext\` when the assignment edge carries an \`identity_plugin_id\`.

### What changes

- New \`imbi_api.identity.host_integration.attach_identity\` helper. One-liner per call site:
  - Always stamps \`ctx.actor_user_id\` from \`auth.user.id\`.
  - When \`resolved.identity_plugin_id\` is set, calls \`hydrate_identity\` to materialize the actor's \`IdentityConnection\` into \`ctx.identity\`.
  - Maps \`IdentityRequiredError\` → HTTP 401 with \`WWW-Authenticate: Imbi-Identity plugin_id=<id>\` and JSON body \`{error: 'identity_required', plugin_id, start_url}\` per the design plan §"API Endpoints".
- Wired into all 4 \`PluginContext\` construction sites in \`project_configuration.py\` (get/fetch/set/delete) and all 3 in \`project_logs.py\` (search/histogram/schema).

### Test coverage

\`tests/identity/test_host_integration.py\` covers:
- No-identity-plugin path (just stamps actor, leaves \`ctx.identity\` None).
- No-user path (actor stays None).
- Happy hydration (actor stamped + materialized credentials attached).
- \`IdentityRequiredError\` → 401 with the expected \`WWW-Authenticate\` header and detail body.

### Companion docs

Documentation half of step 10 lands separately in [imbi-plugin-aws PR](https://github.com/AWeber-Imbi/imbi-plugin-aws) (the README contract for the future \`aws-ssm\` / \`aws-cloudwatch-logs\` data plugins).

## Test plan

- [ ] \`just lint\` clean
- [ ] \`just test tests/identity/test_host_integration.py\`
- [ ] Existing project_configuration / project_logs tests still pass (no behavior change when \`identity_plugin_id\` is unset)
- [ ] Smoke: with \`imbi-plugin-oidc\` enabled and a Project's USES_PLUGIN edge carrying an \`identity_plugin_id\`, hit \`GET /orgs/{o}/projects/{p}/configuration\` without a connection → expect 401 \`identity_required\`; connect via \`/me/identities/{id}/start\`; retry → expect 200.