### PR TITLE
Add bulk plugin-edges endpoint scoped by org

### DIFF
--- a/src/imbi_api/endpoints/admin_plugins.py
+++ b/src/imbi_api/endpoints/admin_plugins.py
@@ -18,6 +18,7 @@ from imbi_common.plugins.registry import (
 )
 
 from imbi_api.auth import permissions
+from imbi_api.endpoints import plugin_edges as _plugin_edges
 from imbi_api.plugins.lifecycle import (
     get_enabled_map,
     set_plugin_enabled,
@@ -381,6 +382,39 @@ async def _set_vertex_label_overrides(
             'REMOVE r.vertex_label_overrides'
         )
         await db.execute(query, {'slug': slug}, [])
+
+
+@admin_plugins_router.get('/plugins/{slug}/edges')
+async def list_plugin_edges(
+    slug: str,
+    rel_type: str,
+    org_slug: str,
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('admin:plugins:read'),
+        ),
+    ],
+) -> dict[str, list[_plugin_edges.EdgeResponse]]:
+    """Bulk-fetch every Environment-anchored edge of ``rel_type`` for an org.
+
+    Returns ``{env_slug: [edges]}`` for every environment in ``org_slug``,
+    including environments with no outgoing edge (empty list).  Used by
+    the plugin admin UI to render the per-org edge mapping table without
+    one HTTP request per environment.
+    """
+    _ = auth
+    try:
+        get_plugin(slug)
+    except PluginNotFoundError as exc:
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail=f'Plugin {slug!r} is not installed',
+        ) from exc
+    return await _plugin_edges.list_org_environment_edges(
+        db=db, rel_type=rel_type, org_slug=org_slug
+    )
 
 
 @admin_plugins_router.patch('/plugins/{slug}')

--- a/src/imbi_api/endpoints/admin_plugins.py
+++ b/src/imbi_api/endpoints/admin_plugins.py
@@ -406,12 +406,24 @@ async def list_plugin_edges(
     """
     _ = auth
     try:
-        get_plugin(slug)
+        entry = get_plugin(slug)
     except PluginNotFoundError as exc:
         raise fastapi.HTTPException(
             status_code=404,
             detail=f'Plugin {slug!r} is not installed',
         ) from exc
+    declares = any(
+        edge.name == rel_type and 'Environment' in edge.from_labels
+        for edge in entry.manifest.edge_labels
+    )
+    if not declares:
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail=(
+                f'Plugin {slug!r} does not declare Environment edge '
+                f'{rel_type!r}'
+            ),
+        )
     return await _plugin_edges.list_org_environment_edges(
         db=db, rel_type=rel_type, org_slug=org_slug
     )

--- a/src/imbi_api/endpoints/plugin_edges.py
+++ b/src/imbi_api/endpoints/plugin_edges.py
@@ -164,6 +164,37 @@ def _parse_edge_props(raw: typing.Any) -> dict[str, typing.Any]:
     return out
 
 
+def _row_to_edge(
+    row: dict[str, typing.Any],
+    rel_type: str,
+    edge: PluginEdgeLabel,
+) -> EdgeResponse | None:
+    if row.get('t') is None:
+        return None
+    target: typing.Any = graph.parse_agtype(row['t'])
+    labels_raw: typing.Any = graph.parse_agtype(row['target_labels'])
+    labels: list[str] = (
+        [str(lbl) for lbl in labels_raw]  # pyright: ignore[reportUnknownVariableType,reportUnknownArgumentType]
+        if isinstance(labels_raw, list)
+        else []
+    )
+    target_label = next(
+        (lbl for lbl in labels if lbl in edge.to_labels),
+        edge.to_labels[0],
+    )
+    target_dict: dict[str, typing.Any] = (
+        {str(k): v for k, v in target.items()}  # pyright: ignore[reportUnknownVariableType,reportUnknownArgumentType,reportUnknownMemberType]
+        if isinstance(target, dict)
+        else {}
+    )
+    return EdgeResponse(
+        rel_type=rel_type,
+        target_label=target_label,
+        target=target_dict,
+        properties=_parse_edge_props(row.get('r')),
+    )
+
+
 async def list_anchor_edges(
     *,
     db: graph.Graph,
@@ -184,32 +215,54 @@ async def list_anchor_edges(
     rows = await db.execute(query, anchor_params, ['r', 't', 'target_labels'])
     out: list[EdgeResponse] = []
     for row in rows:
-        if row.get('t') is None:
+        parsed = _row_to_edge(row, rel_type, edge)
+        if parsed is not None:
+            out.append(parsed)
+    return out
+
+
+async def list_org_environment_edges(
+    *,
+    db: graph.Graph,
+    rel_type: str,
+    org_slug: str,
+) -> dict[str, list[EdgeResponse]]:
+    """Return ``{env_slug: [edges]}`` for every environment in ``org_slug``.
+
+    Resolves the edge from the plugin manifest (anchor=``Environment``)
+    and walks all environments under the organization in a single query,
+    so a card mounting N environment rows costs one HTTP round-trip
+    instead of N.
+
+    Environments without an outgoing edge of ``rel_type`` are present in
+    the result with an empty list — callers can render an empty row
+    without an extra "exists?" check.
+    """
+    edge = resolve_edge_for('Environment', rel_type)
+    target_label_expr = '|'.join(edge.to_labels)
+    query = (
+        'MATCH (a:Environment)-[:BELONGS_TO]->'
+        '(:Organization {{slug: {org_slug}}}) '
+        f'OPTIONAL MATCH (a)-[r:{rel_type}]->(t:{target_label_expr}) '
+        'RETURN a.slug AS anchor_slug, r, t, labels(t) AS target_labels'
+    )
+    rows = await db.execute(
+        query,
+        {'org_slug': org_slug},
+        ['anchor_slug', 'r', 't', 'target_labels'],
+    )
+    out: dict[str, list[EdgeResponse]] = {}
+    for row in rows:
+        anchor_raw = row.get('anchor_slug')
+        if anchor_raw is None:
             continue
-        target: typing.Any = graph.parse_agtype(row['t'])
-        labels_raw: typing.Any = graph.parse_agtype(row['target_labels'])
-        labels: list[str] = (
-            [str(lbl) for lbl in labels_raw]  # pyright: ignore[reportUnknownVariableType,reportUnknownArgumentType]
-            if isinstance(labels_raw, list)
-            else []
-        )
-        target_label = next(
-            (lbl for lbl in labels if lbl in edge.to_labels),
-            edge.to_labels[0],
-        )
-        target_dict: dict[str, typing.Any] = (
-            {str(k): v for k, v in target.items()}  # pyright: ignore[reportUnknownVariableType,reportUnknownArgumentType,reportUnknownMemberType]
-            if isinstance(target, dict)
-            else {}
-        )
-        out.append(
-            EdgeResponse(
-                rel_type=rel_type,
-                target_label=target_label,
-                target=target_dict,
-                properties=_parse_edge_props(row.get('r')),
-            )
-        )
+        anchor_slug = graph.parse_agtype(anchor_raw)
+        if not isinstance(anchor_slug, str):
+            continue
+        bucket = out.setdefault(anchor_slug, [])
+        parsed = _row_to_edge(row, rel_type, edge)
+        if parsed is not None:
+            bucket.append(parsed)
     return out
 
 
@@ -310,6 +363,7 @@ __all__ = [
     'EdgeResponse',
     'delete_anchor_edge',
     'list_anchor_edges',
+    'list_org_environment_edges',
     'put_anchor_edge',
     'resolve_edge_for',
 ]

--- a/tests/endpoints/test_admin_plugins.py
+++ b/tests/endpoints/test_admin_plugins.py
@@ -77,13 +77,23 @@ class AdminPluginsEndpointTestCase(unittest.TestCase):
     def _make_entry(self) -> object:
         from imbi_common.plugins.base import (
             ConfigurationPlugin,
+            PluginEdgeLabel,
             PluginManifest,
         )
         from imbi_common.plugins.registry import RegistryEntry
 
         class _Fake(ConfigurationPlugin):
             manifest = PluginManifest(
-                slug='ssm', name='SSM', plugin_type='configuration'
+                slug='ssm',
+                name='SSM',
+                plugin_type='configuration',
+                edge_labels=[
+                    PluginEdgeLabel(
+                        name='MAPS_TO',
+                        from_labels=['Environment'],
+                        to_labels=['AwsAccount'],
+                    )
+                ],
             )
 
             async def list_keys(self, ctx, credentials):  # type: ignore[override]
@@ -215,3 +225,17 @@ class AdminPluginsEndpointTestCase(unittest.TestCase):
         self.assertEqual(
             data['prod'][0]['target']['account_id'], '111122223333'
         )
+
+    def test_list_plugin_edges_rejects_foreign_rel_type(self) -> None:
+        entry = self._make_entry()
+        with mock.patch(
+            'imbi_api.endpoints.admin_plugins.get_plugin',
+            return_value=entry,
+        ):
+            with testclient.TestClient(self.test_app) as client:
+                response = client.get(
+                    '/admin/plugins/ssm/edges',
+                    params={'rel_type': 'OTHER', 'org_slug': 'acme'},
+                )
+        self.assertEqual(response.status_code, 404)
+        self.assertIn('OTHER', response.json()['detail'])

--- a/tests/endpoints/test_admin_plugins.py
+++ b/tests/endpoints/test_admin_plugins.py
@@ -9,6 +9,7 @@ from imbi_common import graph
 
 from imbi_api import app, models
 from imbi_api.auth import password, permissions
+from imbi_api.endpoints import plugin_edges as _plugin_edges
 
 
 class AdminPluginsEndpointTestCase(unittest.TestCase):
@@ -39,8 +40,8 @@ class AdminPluginsEndpointTestCase(unittest.TestCase):
         )
         self.mock_db = mock.AsyncMock(spec=graph.Graph)
         self.mock_db.execute.return_value = []
-        self.test_app.dependency_overrides[graph._inject_graph] = (
-            lambda: self.mock_db
+        self.test_app.dependency_overrides[graph._inject_graph] = lambda: (
+            self.mock_db
         )
 
     def test_list_installed_plugins_empty(self) -> None:
@@ -161,3 +162,56 @@ class AdminPluginsEndpointTestCase(unittest.TestCase):
                     '/admin/plugins/no-such', json={'enabled': True}
                 )
         self.assertEqual(response.status_code, 404)
+
+    def test_list_plugin_edges_not_found(self) -> None:
+        from imbi_common.plugins.errors import PluginNotFoundError
+
+        with mock.patch(
+            'imbi_api.endpoints.admin_plugins.get_plugin',
+            side_effect=PluginNotFoundError('no-such-plugin'),
+        ):
+            with testclient.TestClient(self.test_app) as client:
+                response = client.get(
+                    '/admin/plugins/no-such/edges',
+                    params={'rel_type': 'MAPS_TO', 'org_slug': 'acme'},
+                )
+        self.assertEqual(response.status_code, 404)
+
+    def test_list_plugin_edges_returns_grouping(self) -> None:
+        entry = self._make_entry()
+        edges_by_anchor = {
+            'prod': [
+                _plugin_edges.EdgeResponse(
+                    rel_type='MAPS_TO',
+                    target_label='AwsAccount',
+                    target={'id': 't-1', 'account_id': '111122223333'},
+                    properties={},
+                )
+            ],
+            'dev': [],
+        }
+        with (
+            mock.patch(
+                'imbi_api.endpoints.admin_plugins.get_plugin',
+                return_value=entry,
+            ),
+            mock.patch(
+                'imbi_api.endpoints.admin_plugins'
+                '._plugin_edges.list_org_environment_edges',
+                new_callable=mock.AsyncMock,
+                return_value=edges_by_anchor,
+            ),
+        ):
+            with testclient.TestClient(self.test_app) as client:
+                response = client.get(
+                    '/admin/plugins/ssm/edges',
+                    params={'rel_type': 'MAPS_TO', 'org_slug': 'acme'},
+                )
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(set(data.keys()), {'prod', 'dev'})
+        self.assertEqual(data['dev'], [])
+        self.assertEqual(len(data['prod']), 1)
+        self.assertEqual(
+            data['prod'][0]['target']['account_id'], '111122223333'
+        )


### PR DESCRIPTION
## Summary

Adds `GET /admin/plugins/{slug}/edges?rel_type=&org_slug=` returning `{env_slug: [edges]}` for every Environment under the given organization, so the third-party-services admin card no longer fans out one HTTP request per environment when it mounts.

Closes follow-up §1 from `docs/plugin-abstraction-followups.md`.

### What changes

- `endpoints/plugin_edges.py` — extract a shared `_row_to_edge` helper, add `list_org_environment_edges` that walks every Environment in the org plus its outgoing edge of `rel_type` in a single Cypher query. Returns environments without an edge as empty lists so callers can render a row without an extra "exists?" check.
- `endpoints/admin_plugins.py` — new route handler with `admin:plugins:read` permission and 404 on unknown plugin.
- `tests/endpoints/test_admin_plugins.py` — smoke tests for not-found and the grouping shape.

The edge resolution still goes through `resolve_edge_for('Environment', rel_type)` so the manifest contract is unchanged. Future anchor types (project / project-type) can extend the helper without breaking the path.

## Test plan

- [ ] `just lint` clean
- [ ] `just test tests/endpoints/test_admin_plugins.py`
- [ ] Smoke: from the UI, mount the third-party-services edge mappings card with N environments and verify a single HTTP request fires