### PR TITLE
Multi-env log search + identity_plugin_id admin wiring

### DIFF
--- a/src/imbi_api/domain/models.py
+++ b/src/imbi_api/domain/models.py
@@ -841,6 +841,7 @@ class PluginAssignmentCreate(pydantic.BaseModel):
     tab: typing.Literal['configuration', 'logs']
     default: bool = False
     options: dict[str, typing.Any] = pydantic.Field(default_factory=dict)
+    identity_plugin_id: str | None = None
 
 
 class PluginAssignmentResponse(pydantic.BaseModel):
@@ -855,6 +856,7 @@ class PluginAssignmentResponse(pydantic.BaseModel):
     source: typing.Literal['project', 'project_type', 'merged'] = (
         'project_type'
     )
+    identity_plugin_id: str | None = None
 
 
 # -- Configuration / Logs response models ---------------------------------
@@ -900,6 +902,7 @@ class LogResultResponse(pydantic.BaseModel):
     entries: list[LogEntryResponse]
     next_cursor: str | None = None
     total: int | None = None
+    warnings: list[str] = []
 
 
 class OAuth2TokenResponse(pydantic.BaseModel):

--- a/src/imbi_api/endpoints/_helpers.py
+++ b/src/imbi_api/endpoints/_helpers.py
@@ -98,6 +98,40 @@ async def update_membership_role(
         )
 
 
+async def lookup_project_slugs(
+    db: graph.Graph,
+    project_id: str,
+) -> tuple[str, str | None]:
+    """Look up the project's slug and the slug of its owning team.
+
+    Returns ``('', None)`` on lookup failure or missing project — these
+    are template-only inputs (never authorization-relevant) and audit
+    writes also tolerate an empty slug.
+    """
+    query: typing.LiteralString = (
+        'MATCH (p:Project {{id: {project_id}}}) '
+        'OPTIONAL MATCH (p)-[:OWNED_BY]->(t:Team) '
+        'RETURN p.slug AS slug, t.slug AS team_slug'
+    )
+    try:
+        records = await db.execute(
+            query,
+            {'project_id': project_id},
+            ['slug', 'team_slug'],
+        )
+    except Exception:  # noqa: BLE001
+        LOGGER.debug('Project slug lookup failed', exc_info=True)
+        return '', None
+    if not records:
+        return '', None
+    slug_raw = graph.parse_agtype(records[0]['slug'])
+    team_raw = graph.parse_agtype(records[0].get('team_slug'))
+    return (
+        str(slug_raw) if slug_raw else '',
+        str(team_raw) if team_raw else None,
+    )
+
+
 def extract_role_slug(
     operations: list[json_patch.PatchOperation],
 ) -> str:

--- a/src/imbi_api/endpoints/identity_plugins.py
+++ b/src/imbi_api/endpoints/identity_plugins.py
@@ -1,0 +1,79 @@
+"""Org-scoped listing of identity plugin instances.
+
+Used by the admin UI to populate the "Identity Plugin" dropdown on
+plugin assignment rows (third-party-service / project-type / project
+levels) — only plugin instances whose registry entry is
+``plugin_type='identity'`` are eligible.
+"""
+
+from __future__ import annotations
+
+import typing
+
+import fastapi
+import pydantic
+from imbi_common import graph
+from imbi_common.plugins.errors import PluginNotFoundError
+from imbi_common.plugins.registry import get_plugin
+
+from imbi_api.auth import permissions
+
+identity_plugins_router = fastapi.APIRouter(tags=['Identity Plugins'])
+
+
+class IdentityPluginRef(pydantic.BaseModel):
+    plugin_id: str
+    plugin_slug: str
+    label: str
+
+
+@identity_plugins_router.get('/')
+async def list_identity_plugins(
+    org_slug: str,
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('third_party_service:read'),
+        ),
+    ],
+) -> list[IdentityPluginRef]:
+    """List all identity plugin instances visible in this org.
+
+    Walks ``ThirdPartyService -[:HAS_PLUGIN]-> Plugin`` for the org
+    and filters to entries whose registry record is
+    ``plugin_type='identity'`` (the registry is in-process, so the
+    filter is cheap).
+    """
+    _ = auth
+    query: typing.LiteralString = """
+    MATCH (s:ThirdPartyService)
+          -[:BELONGS_TO]->(:Organization {{slug: {org_slug}}})
+    MATCH (s)-[:HAS_PLUGIN]->(p:Plugin)
+    RETURN p.id AS id, p.plugin_slug AS slug, p.label AS label
+    ORDER BY p.label
+    """
+    records = await db.execute(
+        query, {'org_slug': org_slug}, ['id', 'slug', 'label']
+    )
+    out: list[IdentityPluginRef] = []
+    for row in records:
+        plugin_id = graph.parse_agtype(row['id'])
+        slug = graph.parse_agtype(row['slug'])
+        label = graph.parse_agtype(row.get('label'))
+        if not plugin_id or not slug:
+            continue
+        try:
+            entry = get_plugin(str(slug))
+        except PluginNotFoundError:
+            continue
+        if entry.manifest.plugin_type != 'identity':
+            continue
+        out.append(
+            IdentityPluginRef(
+                plugin_id=str(plugin_id),
+                plugin_slug=str(slug),
+                label=str(label) if label else str(slug),
+            )
+        )
+    return out

--- a/src/imbi_api/endpoints/organizations.py
+++ b/src/imbi_api/endpoints/organizations.py
@@ -15,6 +15,7 @@ from imbi_api.relationships import build_relationships
 
 from .environments import environments_router
 from .events import events_project_router
+from .identity_plugins import identity_plugins_router
 from .link_definitions import link_definitions_router
 from .note_templates import note_templates_router
 from .notes import notes_project_router, notes_router
@@ -101,6 +102,10 @@ organizations_router.include_router(
 organizations_router.include_router(
     service_plugins_router,
     prefix='/{org_slug}/third-party-services/{slug}/plugins',
+)
+organizations_router.include_router(
+    identity_plugins_router,
+    prefix='/{org_slug}/identity-plugins',
 )
 organizations_router.include_router(
     project_type_plugins_router,

--- a/src/imbi_api/endpoints/project_configuration.py
+++ b/src/imbi_api/endpoints/project_configuration.py
@@ -21,6 +21,7 @@ from imbi_common.plugins.errors import (
 
 from imbi_api.auth import permissions
 from imbi_api.domain import models
+from imbi_api.endpoints._helpers import lookup_project_slugs
 from imbi_api.identity.host_integration import attach_identity
 from imbi_api.plugins import call_with_timeout
 from imbi_api.plugins.credentials import get_plugin_credentials
@@ -77,27 +78,9 @@ async def _lookup_project_slug(
     db: graph.Graph,
     project_id: str,
 ) -> str:
-    """Look up the project's slug for audit-log writes.
-
-    Returns an empty string if the project can't be matched — the audit
-    record still wins more value than failing the user's write.
-    """
-    query: typing.LiteralString = (
-        'MATCH (p:Project {{id: {project_id}}}) RETURN p.slug AS slug'
-    )
-    try:
-        records = await db.execute(
-            query,
-            {'project_id': project_id},
-            ['slug'],
-        )
-    except Exception:  # noqa: BLE001
-        LOGGER.debug('Project slug lookup failed', exc_info=True)
-        return ''
-    if not records:
-        return ''
-    parsed = graph.parse_agtype(records[0]['slug'])
-    return str(parsed) if parsed else ''
+    """Look up the project's slug for audit-log writes."""
+    slug, _ = await lookup_project_slugs(db, project_id)
+    return slug
 
 
 @project_configuration_router.get('/')
@@ -116,10 +99,12 @@ async def get_configuration(
 ) -> list[models.ConfigKeyResponse]:
     """List configuration keys for a project via the assigned plugin."""
     resolved = await resolve_plugin(db, project_id, 'configuration', source)
+    project_slug, team_slug = await lookup_project_slugs(db, project_id)
     ctx = PluginContext(
         project_id=project_id,
-        project_slug='',
+        project_slug=project_slug,
         org_slug=org_slug,
+        team_slug=team_slug,
         environment=environment,
         assignment_options=resolved.options,
     )
@@ -192,10 +177,12 @@ async def fetch_values(
 ) -> list[models.ConfigKeyValueResponse]:
     """Fetch values for specific configuration keys."""
     resolved = await resolve_plugin(db, project_id, 'configuration', source)
+    project_slug, team_slug = await lookup_project_slugs(db, project_id)
     ctx = PluginContext(
         project_id=project_id,
-        project_slug='',
+        project_slug=project_slug,
         org_slug=org_slug,
+        team_slug=team_slug,
         environment=environment,
         assignment_options=resolved.options,
     )
@@ -246,10 +233,12 @@ async def set_configuration_value(
 ) -> models.ConfigKeyResponse:
     """Set a configuration value via the assigned plugin."""
     resolved = await resolve_plugin(db, project_id, 'configuration', source)
+    project_slug, team_slug = await lookup_project_slugs(db, project_id)
     ctx = PluginContext(
         project_id=project_id,
-        project_slug='',
+        project_slug=project_slug,
         org_slug=org_slug,
+        team_slug=team_slug,
         environment=environment,
         assignment_options=resolved.options,
     )
@@ -307,10 +296,12 @@ async def delete_configuration_key(
 ) -> None:
     """Delete a configuration key via the assigned plugin."""
     resolved = await resolve_plugin(db, project_id, 'configuration', source)
+    project_slug, team_slug = await lookup_project_slugs(db, project_id)
     ctx = PluginContext(
         project_id=project_id,
-        project_slug='',
+        project_slug=project_slug,
         org_slug=org_slug,
+        team_slug=team_slug,
         environment=environment,
         assignment_options=resolved.options,
     )

--- a/src/imbi_api/endpoints/project_logs.py
+++ b/src/imbi_api/endpoints/project_logs.py
@@ -1,5 +1,6 @@
 """Project logs plugin endpoints."""
 
+import asyncio
 import datetime
 import logging
 import typing
@@ -8,7 +9,9 @@ import fastapi
 from imbi_common import graph
 from imbi_common.plugins.base import (
     LogFilter,
+    LogHistogramBucket,
     LogQuery,
+    LogResult,
     LogsPlugin,
     PluginContext,
 )
@@ -19,39 +22,18 @@ from imbi_common.plugins.errors import (
 
 from imbi_api.auth import permissions
 from imbi_api.domain import models
+from imbi_api.endpoints._helpers import lookup_project_slugs
+from imbi_api.identity import resolution as identity_resolution
 from imbi_api.identity.host_integration import attach_identity
 from imbi_api.plugins import call_with_timeout
 from imbi_api.plugins.credentials import get_plugin_credentials
-from imbi_api.plugins.resolution import resolve_plugin
+from imbi_api.plugins.resolution import ResolvedPlugin, resolve_plugin
 
 LOGGER = logging.getLogger(__name__)
 
 project_logs_router = fastapi.APIRouter(tags=['Project: Logs'])
 
 _VALID_FILTER_OPS = frozenset({'eq', 'ne', 'contains', 'starts_with', 'regex'})
-
-
-async def _lookup_project_slug(
-    db: graph.Graph,
-    project_id: str,
-) -> str:
-    """Look up the project's slug for plugin context expansion."""
-    query: typing.LiteralString = (
-        'MATCH (p:Project {{id: {project_id}}}) RETURN p.slug AS slug'
-    )
-    try:
-        records = await db.execute(
-            query,
-            {'project_id': project_id},
-            ['slug'],
-        )
-    except Exception:  # noqa: BLE001
-        LOGGER.debug('Project slug lookup failed', exc_info=True)
-        return ''
-    if not records:
-        return ''
-    parsed = graph.parse_agtype(records[0]['slug'])
-    return str(parsed) if parsed else ''
 
 
 def _parse_filters(raw: list[str]) -> list[LogFilter]:
@@ -79,6 +61,47 @@ def _parse_filters(raw: list[str]) -> list[LogFilter]:
     return filters
 
 
+async def _search_one_env(
+    *,
+    db: graph.Graph,
+    ctx_template: PluginContext,
+    resolved: ResolvedPlugin,
+    auth: permissions.AuthContext,
+    query: LogQuery,
+    environment: str | None,
+    identity_options: dict[str, typing.Any] | None,
+) -> LogResult:
+    """Run a single (env-scoped) plugin search.
+
+    ``identity_options`` is pre-loaded once by the caller and shared
+    across the fan-out so the identity plugin's ``Plugin.options``
+    aren't re-queried per env.
+    """
+    ctx = ctx_template.model_copy(update={'environment': environment})
+    ctx = await attach_identity(
+        db, ctx, resolved, auth, identity_options=identity_options
+    )
+    credentials = await get_plugin_credentials(
+        db, resolved.plugin_id, resolved.entry
+    )
+    handler = typing.cast(LogsPlugin, resolved.entry.handler_cls())
+    return await call_with_timeout(handler.search(ctx, credentials, query))
+
+
+def _to_response_entries(
+    entries: list[typing.Any],
+) -> list[models.LogEntryResponse]:
+    return [
+        models.LogEntryResponse(
+            timestamp=e.timestamp,
+            message=e.message,
+            level=e.level,
+            raw=e.raw,
+        )
+        for e in entries
+    ]
+
+
 @project_logs_router.get('/')
 async def search_logs(
     org_slug: str,
@@ -91,7 +114,9 @@ async def search_logs(
         ),
     ],
     source: str | None = fastapi.Query(default=None),
-    environment: str | None = fastapi.Query(default=None),
+    environment: list[str] = fastapi.Query(  # noqa: B008
+        default_factory=list,
+    ),
     start_time: str | None = fastapi.Query(default=None),
     end_time: str | None = fastapi.Query(default=None),
     cursor: str | None = fastapi.Query(default=None),
@@ -101,7 +126,16 @@ async def search_logs(
         alias='filter',
     ),
 ) -> models.LogResultResponse:
-    """Search project logs via the assigned logs plugin."""
+    """Search project logs via the assigned logs plugin.
+
+    ``environment`` is a repeated query param: ``?environment=production
+    &environment=staging``.  When two or more envs are passed, the
+    endpoint fans out one identity-scoped search per env in parallel,
+    merges entries by timestamp (desc), and returns the first ``limit``
+    entries.  Pagination via ``cursor`` is only supported for
+    single-env searches; multi-env returns ``next_cursor=None`` and
+    surfaces partial-failure / truncation notes via ``warnings``.
+    """
     resolved = await resolve_plugin(db, project_id, 'logs', source)
 
     now = datetime.datetime.now(datetime.UTC)
@@ -127,6 +161,14 @@ async def search_logs(
         end_dt = end_dt.replace(tzinfo=datetime.UTC)
 
     filters = _parse_filters(raw_filters)
+    if cursor and len(environment) > 1:
+        raise fastapi.HTTPException(
+            status_code=400,
+            detail=(
+                'Pagination is only supported for single-environment '
+                'searches; received multiple environments with a cursor'
+            ),
+        )
     query = LogQuery(
         start_time=start_dt,
         end_time=end_dt,
@@ -135,51 +177,123 @@ async def search_logs(
         cursor=cursor,
     )
 
-    project_slug = await _lookup_project_slug(db, project_id)
-    ctx = PluginContext(
+    project_slug, team_slug = await lookup_project_slugs(db, project_id)
+    ctx_template = PluginContext(
         project_id=project_id,
         project_slug=project_slug,
         org_slug=org_slug,
-        environment=environment,
+        team_slug=team_slug,
         assignment_options=resolved.options,
     )
-    ctx = await attach_identity(db, ctx, resolved, auth)
-    try:
-        credentials = await get_plugin_credentials(
-            db, resolved.plugin_id, resolved.entry
+    # Pre-load the identity plugin's options once so the multi-env
+    # fan-out shares the result (instead of re-querying per env).
+    identity_options = (
+        await identity_resolution.load_plugin_options(
+            db, resolved.identity_plugin_id
         )
-    except PluginCredentialsMissing as exc:
-        raise fastapi.HTTPException(
-            status_code=503,
-            detail=str(exc),
-        ) from exc
+        if resolved.identity_plugin_id
+        else None
+    )
 
-    handler = typing.cast(LogsPlugin, resolved.entry.handler_cls())
-    try:
-        result = await call_with_timeout(
-            handler.search(ctx, credentials, query)
-        )
-    except CursorExpiredError as exc:
-        raise fastapi.HTTPException(
-            status_code=409,
-            detail={
-                'error': 'cursor_expired',
-                'message': str(exc),
-            },
-        ) from exc
+    envs: list[str | None] = list(environment) if environment else [None]
 
-    return models.LogResultResponse(
-        entries=[
-            models.LogEntryResponse(
-                timestamp=e.timestamp,
-                message=e.message,
-                level=e.level,
-                raw=e.raw,
+    if len(envs) == 1:
+        try:
+            result = await _search_one_env(
+                db=db,
+                ctx_template=ctx_template,
+                resolved=resolved,
+                auth=auth,
+                query=query,
+                environment=envs[0],
+                identity_options=identity_options,
             )
-            for e in result.entries
-        ],
-        next_cursor=result.next_cursor,
-        total=result.total,
+        except CursorExpiredError as exc:
+            raise fastapi.HTTPException(
+                status_code=409,
+                detail={
+                    'error': 'cursor_expired',
+                    'message': str(exc),
+                },
+            ) from exc
+        except PluginCredentialsMissing as exc:
+            raise fastapi.HTTPException(
+                status_code=503,
+                detail=str(exc),
+            ) from exc
+        return models.LogResultResponse(
+            entries=_to_response_entries(result.entries),
+            next_cursor=result.next_cursor,
+            total=result.total,
+            warnings=result.warnings,
+        )
+
+    # Multi-env fan-out.  Each env gets its own identity hydration +
+    # plugin search; failures are surfaced as warnings rather than
+    # failing the whole request — partial results are still useful.
+    raw_results = await asyncio.gather(
+        *(
+            _search_one_env(
+                db=db,
+                ctx_template=ctx_template,
+                resolved=resolved,
+                auth=auth,
+                query=query,
+                environment=env,
+                identity_options=identity_options,
+            )
+            for env in envs
+        ),
+        return_exceptions=True,
+    )
+
+    merged_entries: list[typing.Any] = []
+    warnings: list[str] = []
+    total: int = 0
+    for env, result_or_exc in zip(envs, raw_results, strict=True):
+        if isinstance(result_or_exc, BaseException):
+            LOGGER.warning(
+                'Log search failed for env=%s: %s', env, result_or_exc
+            )
+            warnings.append(
+                f'Search for environment {env!r} failed: {result_or_exc}'
+            )
+            continue
+        merged_entries.extend(result_or_exc.entries)
+        warnings.extend(result_or_exc.warnings)
+        if result_or_exc.total is not None:
+            total += result_or_exc.total
+    merged_entries.sort(key=lambda e: e.timestamp, reverse=True)
+    truncated = merged_entries[:limit]
+    return models.LogResultResponse(
+        entries=_to_response_entries(truncated),
+        next_cursor=None,
+        total=total or None,
+        warnings=warnings,
+    )
+
+
+async def _histogram_one_env(
+    *,
+    db: graph.Graph,
+    ctx_template: PluginContext,
+    resolved: ResolvedPlugin,
+    auth: permissions.AuthContext,
+    query: LogQuery,
+    bucket_count: int,
+    environment: str | None,
+    identity_options: dict[str, typing.Any] | None,
+) -> list[LogHistogramBucket]:
+    ctx = ctx_template.model_copy(update={'environment': environment})
+    ctx = await attach_identity(
+        db, ctx, resolved, auth, identity_options=identity_options
+    )
+    credentials = await get_plugin_credentials(
+        db, resolved.plugin_id, resolved.entry
+    )
+    handler = typing.cast(LogsPlugin, resolved.entry.handler_cls())
+    return await call_with_timeout(
+        handler.histogram(ctx, credentials, query, bucket_count)
     )
 
 
@@ -195,7 +309,9 @@ async def get_log_histogram(
         ),
     ],
     source: str | None = fastapi.Query(default=None),
-    environment: str | None = fastapi.Query(default=None),
+    environment: list[str] = fastapi.Query(  # noqa: B008
+        default_factory=list,
+    ),
     start_time: str | None = fastapi.Query(default=None),
     end_time: str | None = fastapi.Query(default=None),
     bucket_count: int = fastapi.Query(default=60, ge=1, le=1440),
@@ -208,6 +324,9 @@ async def get_log_histogram(
 
     Returns an empty list when the assigned plugin does not support
     histograms (``PluginManifest.supports_histogram`` is ``False``).
+    Multi-env requests fan out one histogram per env and sum bucket
+    counts at matching timestamps; per-level counts are aggregated
+    across envs.
     """
     resolved = await resolve_plugin(db, project_id, 'logs', source)
     handler = typing.cast(LogsPlugin, resolved.entry.handler_cls())
@@ -240,35 +359,93 @@ async def get_log_histogram(
         filters=filters,
     )
 
-    project_slug = await _lookup_project_slug(db, project_id)
-    ctx = PluginContext(
+    project_slug, team_slug = await lookup_project_slugs(db, project_id)
+    ctx_template = PluginContext(
         project_id=project_id,
         project_slug=project_slug,
         org_slug=org_slug,
-        environment=environment,
+        team_slug=team_slug,
         assignment_options=resolved.options,
     )
-    ctx = await attach_identity(db, ctx, resolved, auth)
-    try:
-        credentials = await get_plugin_credentials(
-            db, resolved.plugin_id, resolved.entry
+    identity_options = (
+        await identity_resolution.load_plugin_options(
+            db, resolved.identity_plugin_id
         )
-    except PluginCredentialsMissing as exc:
-        raise fastapi.HTTPException(
-            status_code=503,
-            detail=str(exc),
-        ) from exc
-
-    buckets = await call_with_timeout(
-        handler.histogram(ctx, credentials, query, bucket_count)
+        if resolved.identity_plugin_id
+        else None
     )
+
+    envs: list[str | None] = list(environment) if environment else [None]
+
+    if len(envs) == 1:
+        try:
+            buckets = await _histogram_one_env(
+                db=db,
+                ctx_template=ctx_template,
+                resolved=resolved,
+                auth=auth,
+                query=query,
+                bucket_count=bucket_count,
+                environment=envs[0],
+                identity_options=identity_options,
+            )
+        except PluginCredentialsMissing as exc:
+            raise fastapi.HTTPException(
+                status_code=503,
+                detail=str(exc),
+            ) from exc
+        return [
+            models.LogHistogramBucketResponse(
+                timestamp=b.timestamp,
+                count=b.count,
+                levels=b.levels,
+            )
+            for b in buckets
+        ]
+
+    # Multi-env fan-out: sum bucket counts at matching timestamps,
+    # aggregate level breakdowns.  Failures from any env are logged
+    # and that env's contribution is dropped — the histogram is not
+    # the place to surface partial-failure warnings (the search
+    # endpoint already does).
+    raw_results = await asyncio.gather(
+        *(
+            _histogram_one_env(
+                db=db,
+                ctx_template=ctx_template,
+                resolved=resolved,
+                auth=auth,
+                query=query,
+                bucket_count=bucket_count,
+                environment=env,
+                identity_options=identity_options,
+            )
+            for env in envs
+        ),
+        return_exceptions=True,
+    )
+    summed: dict[datetime.datetime, dict[str, int | dict[str, int]]] = {}
+    for env, result_or_exc in zip(envs, raw_results, strict=True):
+        if isinstance(result_or_exc, BaseException):
+            LOGGER.warning(
+                'Histogram failed for env=%s: %s', env, result_or_exc
+            )
+            continue
+        for b in result_or_exc:
+            slot = summed.setdefault(
+                b.timestamp, {'count': 0, 'levels': {}}
+            )
+            slot['count'] = typing.cast(int, slot['count']) + b.count
+            levels_dict = typing.cast(dict[str, int], slot['levels'])
+            for lvl, n in (b.levels or {}).items():
+                levels_dict[lvl] = levels_dict.get(lvl, 0) + n
     return [
         models.LogHistogramBucketResponse(
-            timestamp=b.timestamp,
-            count=b.count,
-            levels=b.levels,
+            timestamp=ts,
+            count=typing.cast(int, slot['count']),
+            levels=typing.cast(dict[str, int], slot['levels']),
         )
-        for b in buckets
+        for ts, slot in sorted(summed.items())
     ]
 
 
@@ -288,11 +465,12 @@ async def get_log_schema(
 ) -> list[dict[str, typing.Any]]:
     """Get the log schema (available fields) for the assigned logs plugin."""
     resolved = await resolve_plugin(db, project_id, 'logs', source)
-    project_slug = await _lookup_project_slug(db, project_id)
+    project_slug, team_slug = await lookup_project_slugs(db, project_id)
     ctx = PluginContext(
         project_id=project_id,
         project_slug=project_slug,
         org_slug=org_slug,
+        team_slug=team_slug,
         environment=environment,
         assignment_options=resolved.options,
     )

--- a/src/imbi_api/endpoints/project_logs.py
+++ b/src/imbi_api/endpoints/project_logs.py
@@ -63,27 +63,21 @@ def _parse_filters(raw: list[str]) -> list[LogFilter]:
 
 async def _search_one_env(
     *,
-    db: graph.Graph,
     ctx_template: PluginContext,
     resolved: ResolvedPlugin,
-    auth: permissions.AuthContext,
+    credentials: dict[str, typing.Any],
     query: LogQuery,
     environment: str | None,
-    identity_options: dict[str, typing.Any] | None,
 ) -> LogResult:
     """Run a single (env-scoped) plugin search.
 
-    ``identity_options`` is pre-loaded once by the caller and shared
-    across the fan-out so the identity plugin's ``Plugin.options``
-    aren't re-queried per env.
+    The caller is responsible for hydrating identity and resolving
+    plugin credentials once — those operations don't vary by
+    environment, so doing them inside each fan-out task would
+    downgrade shared identity / credential failures into per-env
+    warnings.
     """
     ctx = ctx_template.model_copy(update={'environment': environment})
-    ctx = await attach_identity(
-        db, ctx, resolved, auth, identity_options=identity_options
-    )
-    credentials = await get_plugin_credentials(
-        db, resolved.plugin_id, resolved.entry
-    )
     handler = typing.cast(LogsPlugin, resolved.entry.handler_cls())
     return await call_with_timeout(handler.search(ctx, credentials, query))
 
@@ -185,8 +179,10 @@ async def search_logs(
         team_slug=team_slug,
         assignment_options=resolved.options,
     )
-    # Pre-load the identity plugin's options once so the multi-env
-    # fan-out shares the result (instead of re-querying per env).
+    # Hydrate identity and resolve plugin credentials once before
+    # fanning out — neither depends on ``ctx.environment`` and doing
+    # them per-task would downgrade shared identity / credential
+    # failures into per-env warnings on multi-env requests.
     identity_options = (
         await identity_resolution.load_plugin_options(
             db, resolved.identity_plugin_id
@@ -194,19 +190,29 @@ async def search_logs(
         if resolved.identity_plugin_id
         else None
     )
+    ctx_template = await attach_identity(
+        db, ctx_template, resolved, auth, identity_options=identity_options
+    )
+    try:
+        credentials = await get_plugin_credentials(
+            db, resolved.plugin_id, resolved.entry
+        )
+    except PluginCredentialsMissing as exc:
+        raise fastapi.HTTPException(
+            status_code=503,
+            detail=str(exc),
+        ) from exc
 
     envs: list[str | None] = list(environment) if environment else [None]
 
     if len(envs) == 1:
         try:
             result = await _search_one_env(
-                db=db,
                 ctx_template=ctx_template,
                 resolved=resolved,
-                auth=auth,
+                credentials=credentials,
                 query=query,
                 environment=envs[0],
-                identity_options=identity_options,
             )
         except CursorExpiredError as exc:
             raise fastapi.HTTPException(
@@ -216,11 +222,6 @@ async def search_logs(
                     'message': str(exc),
                 },
             ) from exc
-        except PluginCredentialsMissing as exc:
-            raise fastapi.HTTPException(
-                status_code=503,
-                detail=str(exc),
-            ) from exc
         return models.LogResultResponse(
             entries=_to_response_entries(result.entries),
             next_cursor=result.next_cursor,
@@ -228,19 +229,18 @@ async def search_logs(
             warnings=result.warnings,
         )
 
-    # Multi-env fan-out.  Each env gets its own identity hydration +
-    # plugin search; failures are surfaced as warnings rather than
-    # failing the whole request — partial results are still useful.
+    # Multi-env fan-out.  Identity / credentials are already resolved
+    # above; per-env failures from ``handler.search`` are surfaced as
+    # warnings rather than failing the whole request — partial
+    # results are still useful.
     raw_results = await asyncio.gather(
         *(
             _search_one_env(
-                db=db,
                 ctx_template=ctx_template,
                 resolved=resolved,
-                auth=auth,
+                credentials=credentials,
                 query=query,
                 environment=env,
-                identity_options=identity_options,
             )
             for env in envs
         ),
@@ -251,7 +251,7 @@ async def search_logs(
     warnings: list[str] = []
     total: int = 0
     for env, result_or_exc in zip(envs, raw_results, strict=True):
-        if isinstance(result_or_exc, BaseException):
+        if isinstance(result_or_exc, Exception):
             LOGGER.warning(
                 'Log search failed for env=%s: %s', env, result_or_exc
             )
@@ -259,6 +259,11 @@ async def search_logs(
                 f'Search for environment {env!r} failed: {result_or_exc}'
             )
             continue
+        if isinstance(result_or_exc, BaseException):
+            # CancelledError / KeyboardInterrupt / SystemExit must
+            # propagate — never downgrade them to a partial-failure
+            # warning.
+            raise result_or_exc
         merged_entries.extend(result_or_exc.entries)
         warnings.extend(result_or_exc.warnings)
         if result_or_exc.total is not None:
@@ -275,22 +280,14 @@ async def search_logs(
 
 async def _histogram_one_env(
     *,
-    db: graph.Graph,
     ctx_template: PluginContext,
     resolved: ResolvedPlugin,
-    auth: permissions.AuthContext,
+    credentials: dict[str, typing.Any],
     query: LogQuery,
     bucket_count: int,
     environment: str | None,
-    identity_options: dict[str, typing.Any] | None,
 ) -> list[LogHistogramBucket]:
     ctx = ctx_template.model_copy(update={'environment': environment})
-    ctx = await attach_identity(
-        db, ctx, resolved, auth, identity_options=identity_options
-    )
-    credentials = await get_plugin_credentials(
-        db, resolved.plugin_id, resolved.entry
-    )
     handler = typing.cast(LogsPlugin, resolved.entry.handler_cls())
     return await call_with_timeout(
         handler.histogram(ctx, credentials, query, bucket_count)
@@ -367,6 +364,8 @@ async def get_log_histogram(
         team_slug=team_slug,
         assignment_options=resolved.options,
     )
+    # Hydrate identity and resolve plugin credentials once before the
+    # fan-out — see the equivalent comment in ``search_logs``.
     identity_options = (
         await identity_resolution.load_plugin_options(
             db, resolved.identity_plugin_id
@@ -374,26 +373,30 @@ async def get_log_histogram(
         if resolved.identity_plugin_id
         else None
     )
+    ctx_template = await attach_identity(
+        db, ctx_template, resolved, auth, identity_options=identity_options
+    )
+    try:
+        credentials = await get_plugin_credentials(
+            db, resolved.plugin_id, resolved.entry
+        )
+    except PluginCredentialsMissing as exc:
+        raise fastapi.HTTPException(
+            status_code=503,
+            detail=str(exc),
+        ) from exc
 
     envs: list[str | None] = list(environment) if environment else [None]
 
     if len(envs) == 1:
-        try:
-            buckets = await _histogram_one_env(
-                db=db,
-                ctx_template=ctx_template,
-                resolved=resolved,
-                auth=auth,
-                query=query,
-                bucket_count=bucket_count,
-                environment=envs[0],
-                identity_options=identity_options,
-            )
-        except PluginCredentialsMissing as exc:
-            raise fastapi.HTTPException(
-                status_code=503,
-                detail=str(exc),
-            ) from exc
+        buckets = await _histogram_one_env(
+            ctx_template=ctx_template,
+            resolved=resolved,
+            credentials=credentials,
+            query=query,
+            bucket_count=bucket_count,
+            environment=envs[0],
+        )
         return [
             models.LogHistogramBucketResponse(
                 timestamp=b.timestamp,
@@ -411,14 +414,12 @@ async def get_log_histogram(
     raw_results = await asyncio.gather(
         *(
             _histogram_one_env(
-                db=db,
                 ctx_template=ctx_template,
                 resolved=resolved,
-                auth=auth,
+                credentials=credentials,
                 query=query,
                 bucket_count=bucket_count,
                 environment=env,
-                identity_options=identity_options,
             )
             for env in envs
         ),
@@ -426,11 +427,13 @@ async def get_log_histogram(
     )
     summed: dict[datetime.datetime, dict[str, int | dict[str, int]]] = {}
     for env, result_or_exc in zip(envs, raw_results, strict=True):
-        if isinstance(result_or_exc, BaseException):
+        if isinstance(result_or_exc, Exception):
             LOGGER.warning(
                 'Histogram failed for env=%s: %s', env, result_or_exc
             )
             continue
+        if isinstance(result_or_exc, BaseException):
+            raise result_or_exc
         for b in result_or_exc:
             slot = summed.setdefault(b.timestamp, {'count': 0, 'levels': {}})
             slot['count'] = typing.cast(int, slot['count']) + b.count

--- a/src/imbi_api/endpoints/project_logs.py
+++ b/src/imbi_api/endpoints/project_logs.py
@@ -432,9 +432,7 @@ async def get_log_histogram(
             )
             continue
         for b in result_or_exc:
-            slot = summed.setdefault(
-                b.timestamp, {'count': 0, 'levels': {}}
-            )
+            slot = summed.setdefault(b.timestamp, {'count': 0, 'levels': {}})
             slot['count'] = typing.cast(int, slot['count']) + b.count
             levels_dict = typing.cast(dict[str, int], slot['levels'])
             for lvl, n in (b.levels or {}).items():

--- a/src/imbi_api/endpoints/project_plugins.py
+++ b/src/imbi_api/endpoints/project_plugins.py
@@ -151,11 +151,7 @@ async def replace_project_plugins(
         await validate_identity_plugin_ids(
             db,
             sorted(
-                {
-                    iid
-                    for row in rows
-                    if (iid := row.get('identity_plugin_id'))
-                }
+                {iid for row in rows if (iid := row.get('identity_plugin_id'))}
             ),
         )
 

--- a/src/imbi_api/endpoints/project_plugins.py
+++ b/src/imbi_api/endpoints/project_plugins.py
@@ -150,6 +150,7 @@ async def replace_project_plugins(
 
         await validate_identity_plugin_ids(
             db,
+            org_slug,
             sorted(
                 {iid for row in rows if (iid := row.get('identity_plugin_id'))}
             ),

--- a/src/imbi_api/endpoints/project_plugins.py
+++ b/src/imbi_api/endpoints/project_plugins.py
@@ -12,6 +12,7 @@ from imbi_api.graph_sql import props_template
 from imbi_api.plugins.assignments import (
     PluginAssignmentRow,
     build_assignment_response,
+    validate_identity_plugin_ids,
     validate_one_default_per_tab,
 )
 
@@ -107,6 +108,7 @@ async def replace_project_plugins(
             tab=a.tab,
             default=a.default,
             options=a.options,
+            identity_plugin_id=a.identity_plugin_id,
         )
         for a in assignments
     ]
@@ -146,6 +148,17 @@ async def replace_project_plugins(
                 detail='One or more plugin IDs are invalid',
             )
 
+        await validate_identity_plugin_ids(
+            db,
+            sorted(
+                {
+                    iid
+                    for row in rows
+                    if (iid := row.get('identity_plugin_id'))
+                }
+            ),
+        )
+
     # Scope mutations to the org via the project's team→org chain so a
     # caller from another org can't modify edges by guessing project_id.
     delete_query: typing.LiteralString = """
@@ -163,11 +176,14 @@ async def replace_project_plugins(
     )
 
     for row in rows:
-        edge_props = {
+        edge_props: dict[str, typing.Any] = {
             'tab': row['tab'],
             'default': row['default'],
             'options': json.dumps(row['options']),
         }
+        identity_id = row.get('identity_plugin_id')
+        if identity_id:
+            edge_props['identity_plugin_id'] = identity_id
         create_query: str = (
             'MATCH (proj:Project {{id: {project_id}}})'
             ' -[:OWNED_BY]->(:Team)-[:BELONGS_TO]->'

--- a/src/imbi_api/endpoints/project_type_plugins.py
+++ b/src/imbi_api/endpoints/project_type_plugins.py
@@ -120,6 +120,7 @@ async def replace_project_type_plugins(
 
         await validate_identity_plugin_ids(
             db,
+            org_slug,
             sorted(
                 {iid for row in rows if (iid := row.get('identity_plugin_id'))}
             ),

--- a/src/imbi_api/endpoints/project_type_plugins.py
+++ b/src/imbi_api/endpoints/project_type_plugins.py
@@ -12,6 +12,7 @@ from imbi_api.graph_sql import props_template
 from imbi_api.plugins.assignments import (
     PluginAssignmentRow,
     build_assignment_response,
+    validate_identity_plugin_ids,
     validate_one_default_per_tab,
 )
 
@@ -77,6 +78,7 @@ async def replace_project_type_plugins(
             tab=a.tab,
             default=a.default,
             options=a.options,
+            identity_plugin_id=a.identity_plugin_id,
         )
         for a in assignments
     ]
@@ -116,6 +118,17 @@ async def replace_project_type_plugins(
                 detail='One or more plugin IDs are invalid',
             )
 
+        await validate_identity_plugin_ids(
+            db,
+            sorted(
+                {
+                    iid
+                    for row in rows
+                    if (iid := row.get('identity_plugin_id'))
+                }
+            ),
+        )
+
     delete_query: typing.LiteralString = """
     MATCH (pt:ProjectType {{slug: {pt_slug}}})
           -[:BELONGS_TO]->(o:Organization {{slug: {org_slug}}})
@@ -130,11 +143,14 @@ async def replace_project_type_plugins(
     )
 
     for row in rows:
-        edge_props = {
+        edge_props: dict[str, typing.Any] = {
             'tab': row['tab'],
             'default': row['default'],
             'options': json.dumps(row['options']),
         }
+        identity_id = row.get('identity_plugin_id')
+        if identity_id:
+            edge_props['identity_plugin_id'] = identity_id
         merge_query: str = (
             'MATCH (pt:ProjectType {{slug: {pt_slug}}})'
             ' -[:BELONGS_TO]->(o:Organization {{slug: {org_slug}}})'

--- a/src/imbi_api/endpoints/project_type_plugins.py
+++ b/src/imbi_api/endpoints/project_type_plugins.py
@@ -121,11 +121,7 @@ async def replace_project_type_plugins(
         await validate_identity_plugin_ids(
             db,
             sorted(
-                {
-                    iid
-                    for row in rows
-                    if (iid := row.get('identity_plugin_id'))
-                }
+                {iid for row in rows if (iid := row.get('identity_plugin_id'))}
             ),
         )
 

--- a/src/imbi_api/endpoints/service_plugins.py
+++ b/src/imbi_api/endpoints/service_plugins.py
@@ -638,6 +638,7 @@ async def replace_plugin_assignments(
 
         await validate_identity_plugin_ids(
             db,
+            org_slug,
             sorted(
                 {a.identity_plugin_id for a in body if a.identity_plugin_id}
             ),

--- a/src/imbi_api/endpoints/service_plugins.py
+++ b/src/imbi_api/endpoints/service_plugins.py
@@ -19,6 +19,7 @@ from imbi_api.auth import login_providers, permissions
 from imbi_api.domain import models
 from imbi_api.graph_sql import props_template, set_clause
 from imbi_api.plugins import parse_options as _parse_options
+from imbi_api.plugins.assignments import validate_identity_plugin_ids
 from imbi_api.plugins.credentials import (
     get_plugin_configuration_keys,
     patch_plugin_configuration,
@@ -484,6 +485,7 @@ class _AssignmentInput(pydantic.BaseModel):
     tab: typing.Literal['configuration', 'logs']
     default: bool = False
     options: dict[str, typing.Any] = {}
+    identity_plugin_id: str | None = None
 
 
 class _AssignmentRow(pydantic.BaseModel):
@@ -492,6 +494,7 @@ class _AssignmentRow(pydantic.BaseModel):
     tab: typing.Literal['configuration', 'logs']
     default: bool
     options: dict[str, typing.Any]
+    identity_plugin_id: str | None = None
 
 
 async def _list_assignments(
@@ -517,6 +520,12 @@ async def _list_assignments(
         edge: dict[str, typing.Any] = (  # pyright: ignore[reportUnknownVariableType,reportUnknownArgumentType]
             graph.parse_agtype(r.get('edge', '{}')) or {}
         )
+        raw_identity = edge.get('identity_plugin_id')
+        identity_plugin_id = (
+            str(raw_identity)
+            if isinstance(raw_identity, str) and raw_identity
+            else None
+        )
         rows.append(
             _AssignmentRow(
                 project_type_slug=pt.get('slug', ''),
@@ -524,6 +533,7 @@ async def _list_assignments(
                 tab=edge.get('tab', 'configuration'),
                 default=bool(edge.get('default', False)),
                 options=_parse_options(edge.get('options')),
+                identity_plugin_id=identity_plugin_id,
             )
         )
     return rows
@@ -626,6 +636,17 @@ async def replace_plugin_assignments(
                 detail='One or more project_type_slug values are invalid',
             )
 
+        await validate_identity_plugin_ids(
+            db,
+            sorted(
+                {
+                    a.identity_plugin_id
+                    for a in body
+                    if a.identity_plugin_id
+                }
+            ),
+        )
+
     delete_query: typing.LiteralString = """
     MATCH (pt:ProjectType)
           -[:BELONGS_TO]->(o:Organization {{slug: {org_slug}}})
@@ -647,11 +668,13 @@ async def replace_plugin_assignments(
     """
 
     for a in body:
-        edge_props = {
+        edge_props: dict[str, typing.Any] = {
             'tab': a.tab,
             'default': a.default,
             'options': json.dumps(a.options),
         }
+        if a.identity_plugin_id:
+            edge_props['identity_plugin_id'] = a.identity_plugin_id
         if a.default:
             await db.execute(
                 clear_default_query,

--- a/src/imbi_api/endpoints/service_plugins.py
+++ b/src/imbi_api/endpoints/service_plugins.py
@@ -639,11 +639,7 @@ async def replace_plugin_assignments(
         await validate_identity_plugin_ids(
             db,
             sorted(
-                {
-                    a.identity_plugin_id
-                    for a in body
-                    if a.identity_plugin_id
-                }
+                {a.identity_plugin_id for a in body if a.identity_plugin_id}
             ),
         )
 

--- a/src/imbi_api/identity/host_integration.py
+++ b/src/imbi_api/identity/host_integration.py
@@ -38,6 +38,8 @@ async def attach_identity(
     ctx: PluginContext,
     resolved: ResolvedPlugin,
     auth: permissions.AuthContext,
+    *,
+    identity_options: dict[str, typing.Any] | None = None,
 ) -> PluginContext:
     """Hydrate ``ctx.identity`` for a plugin call.
 
@@ -52,6 +54,10 @@ async def attach_identity(
     ``identity_required`` shape (401 +
     ``WWW-Authenticate: Imbi-Identity plugin_id=<id>``) when the actor
     has no active connection.
+
+    ``identity_options`` lets a multi-call host (e.g. multi-env log
+    fan-out) pre-load the identity plugin's ``Plugin.options`` once
+    and share them across N attaches instead of re-querying per call.
     """
     actor_user_id = auth.user.id if auth.user else None
     ctx = ctx.model_copy(update={'actor_user_id': actor_user_id})
@@ -59,7 +65,10 @@ async def attach_identity(
         return ctx
     try:
         return await identity_resolution.hydrate_identity(
-            db, ctx, resolved.identity_plugin_id
+            db,
+            ctx,
+            resolved.identity_plugin_id,
+            identity_options=identity_options,
         )
     except identity_errors.IdentityRequiredError as exc:
         raise _identity_required_response(exc) from exc

--- a/src/imbi_api/identity/resolution.py
+++ b/src/imbi_api/identity/resolution.py
@@ -15,6 +15,7 @@ from imbi_common.plugins.registry import get_plugin
 
 from imbi_api.identity import errors as identity_errors
 from imbi_api.identity import repository
+from imbi_api.plugins import parse_options
 
 LOGGER = logging.getLogger(__name__)
 
@@ -28,6 +29,8 @@ async def hydrate_identity(
     db: graph.Graph,
     ctx: PluginContext,
     identity_plugin_id: str,
+    *,
+    identity_options: dict[str, typing.Any] | None = None,
 ) -> PluginContext:
     """Load the actor's connection for ``identity_plugin_id`` and attach
     materialized credentials to ``ctx.identity``.
@@ -83,10 +86,15 @@ async def hydrate_identity(
         scopes=connection.scopes,
     )
 
+    if identity_options is None:
+        identity_options = await load_plugin_options(db, identity_plugin_id)
+
     materialized = await handler.materialize(
         ctx,
         {},
         base_credentials,
+        db=db,
+        identity_options=identity_options,
     )
 
     return ctx.model_copy(update={'identity': materialized})
@@ -102,6 +110,24 @@ async def _plugin_slug(db: graph.Graph, plugin_id: str) -> str | None:
         return None
     parsed = graph.parse_agtype(rows[0]['slug'])
     return str(parsed) if parsed is not None else None
+
+
+async def load_plugin_options(
+    db: graph.Graph, plugin_id: str
+) -> dict[str, typing.Any]:
+    """Return the identity plugin instance's ``Plugin.options`` dict.
+
+    Materialize implementations are expected to validate the keys they
+    need; an empty dict is returned when the blob is absent.
+    """
+    query: typing.LiteralString = (
+        'MATCH (p:Plugin {{id: {plugin_id}}}) '
+        'RETURN p.options AS options LIMIT 1'
+    )
+    rows = await db.execute(query, {'plugin_id': plugin_id}, ['options'])
+    if not rows:
+        return {}
+    return parse_options(graph.parse_agtype(rows[0]['options']))
 
 
 def is_active(connection_expires_at: datetime.datetime | None) -> bool:

--- a/src/imbi_api/plugins/assignments.py
+++ b/src/imbi_api/plugins/assignments.py
@@ -2,6 +2,11 @@
 
 import typing
 
+import fastapi
+from imbi_common import graph
+from imbi_common.plugins.errors import PluginNotFoundError
+from imbi_common.plugins.registry import get_plugin
+
 from imbi_api.domain import models
 from imbi_api.plugins import parse_options
 
@@ -11,6 +16,7 @@ class PluginAssignmentRow(typing.TypedDict):
     tab: typing.Literal['configuration', 'logs']
     default: bool
     options: dict[str, typing.Any]
+    identity_plugin_id: typing.NotRequired[str | None]
 
 
 def validate_one_default_per_tab(
@@ -36,12 +42,58 @@ def validate_one_default_per_tab(
             )
 
 
+async def validate_identity_plugin_ids(
+    db: graph.Graph, identity_plugin_ids: list[str]
+) -> None:
+    """Validate every supplied id is an identity-type plugin in registry.
+
+    Raises ``HTTPException(400)`` listing every invalid id.
+    """
+    if not identity_plugin_ids:
+        return
+    query: typing.LiteralString = (
+        'UNWIND {ids} AS pid '
+        'OPTIONAL MATCH (p:Plugin {{id: pid}}) '
+        'RETURN pid AS id, p.plugin_slug AS slug'
+    )
+    rows = await db.execute(
+        query, {'ids': identity_plugin_ids}, ['id', 'slug']
+    )
+    bad: list[str] = []
+    for row in rows:
+        pid = str(graph.parse_agtype(row['id']))
+        slug = graph.parse_agtype(row.get('slug'))
+        if not slug:
+            bad.append(f'{pid} (plugin not found)')
+            continue
+        try:
+            entry = get_plugin(str(slug))
+        except PluginNotFoundError:
+            bad.append(f'{pid} ({slug!r} not loaded)')
+            continue
+        if entry.manifest.plugin_type != 'identity':
+            bad.append(
+                f'{pid} ({slug!r} is plugin_type='
+                f'{entry.manifest.plugin_type!r}, expected identity)'
+            )
+    if bad:
+        raise fastapi.HTTPException(
+            status_code=400,
+            detail='Invalid identity_plugin_id values: ' + ', '.join(bad),
+        )
+
+
 def build_assignment_response(
     plugin: dict[str, typing.Any],
     edge: dict[str, typing.Any],
     source: typing.Literal['project', 'project_type', 'merged'],
 ) -> models.PluginAssignmentResponse:
     """Build a PluginAssignmentResponse from parsed plugin/edge dicts."""
+    raw_identity = edge.get('identity_plugin_id')
+    identity_plugin_id = (
+        str(raw_identity) if isinstance(raw_identity, str) and raw_identity
+        else None
+    )
     return models.PluginAssignmentResponse(
         plugin_id=plugin['id'],
         plugin_slug=plugin['plugin_slug'],
@@ -50,4 +102,5 @@ def build_assignment_response(
         default=bool(edge.get('default', False)),
         options=parse_options(edge.get('options')),
         source=source,
+        identity_plugin_id=identity_plugin_id,
     )

--- a/src/imbi_api/plugins/assignments.py
+++ b/src/imbi_api/plugins/assignments.py
@@ -43,21 +43,30 @@ def validate_one_default_per_tab(
 
 
 async def validate_identity_plugin_ids(
-    db: graph.Graph, identity_plugin_ids: list[str]
+    db: graph.Graph,
+    org_slug: str,
+    identity_plugin_ids: list[str],
 ) -> None:
     """Validate every supplied id is an identity-type plugin in registry.
 
-    Raises ``HTTPException(400)`` listing every invalid id.
+    The lookup is scoped to ``org_slug`` so an admin in one org can't
+    bind an assignment to an identity plugin owned by another org by
+    guessing its id.  Raises ``HTTPException(400)`` listing every
+    invalid id (not found, not loaded, wrong type, or out-of-org).
     """
     if not identity_plugin_ids:
         return
     query: typing.LiteralString = (
         'UNWIND {ids} AS pid '
-        'OPTIONAL MATCH (p:Plugin {{id: pid}}) '
+        'OPTIONAL MATCH (p:Plugin {{id: pid}})'
+        '<-[:HAS_PLUGIN]-(:ThirdPartyService)'
+        '-[:BELONGS_TO]->(:Organization {{slug: {org_slug}}}) '
         'RETURN pid AS id, p.plugin_slug AS slug'
     )
     rows = await db.execute(
-        query, {'ids': identity_plugin_ids}, ['id', 'slug']
+        query,
+        {'ids': identity_plugin_ids, 'org_slug': org_slug},
+        ['id', 'slug'],
     )
     bad: list[str] = []
     for row in rows:

--- a/src/imbi_api/plugins/assignments.py
+++ b/src/imbi_api/plugins/assignments.py
@@ -91,7 +91,8 @@ def build_assignment_response(
     """Build a PluginAssignmentResponse from parsed plugin/edge dicts."""
     raw_identity = edge.get('identity_plugin_id')
     identity_plugin_id = (
-        str(raw_identity) if isinstance(raw_identity, str) and raw_identity
+        str(raw_identity)
+        if isinstance(raw_identity, str) and raw_identity
         else None
     )
     return models.PluginAssignmentResponse(

--- a/tests/identity/test_resolution.py
+++ b/tests/identity/test_resolution.py
@@ -185,6 +185,11 @@ class HydrateIdentityTestCase(unittest.IsolatedAsyncioTestCase):
             ),
             mock.patch.object(
                 resolution,
+                'load_plugin_options',
+                new=mock.AsyncMock(return_value={'k': 'v'}),
+            ),
+            mock.patch.object(
+                resolution,
                 'get_plugin',
                 return_value=entry,
             ),
@@ -196,6 +201,10 @@ class HydrateIdentityTestCase(unittest.IsolatedAsyncioTestCase):
         # ctx.model_copy is patched to capture the update kwargs.
         self.assertEqual(result, ('ctx-with', {'identity': materialized}))
         handler.materialize.assert_awaited_once()
+        # The new identity_options + db kwargs are forwarded.
+        _args, kwargs = handler.materialize.call_args
+        self.assertEqual(kwargs.get('identity_options'), {'k': 'v'})
+        self.assertIs(kwargs.get('db'), self.db)
 
 
 class PluginSlugHelperTestCase(unittest.IsolatedAsyncioTestCase):

--- a/uv.lock
+++ b/uv.lock
@@ -1002,8 +1002,8 @@ plugins = [
 
 [[package]]
 name = "imbi-common"
-version = "0.3.0"
-source = { git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=main#ce12bdc3cb324de065ebd99bf4f3349f43d1415e" }
+version = "0.4.0"
+source = { git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=main#cd2ef6b50dad61ae2925c70a1569d9b12275da38" }
 dependencies = [
   { name = "cryptography" },
   { name = "jsonschema-models" },


### PR DESCRIPTION
## Summary

Plugin assignment edges now persist \`identity_plugin_id\` end-to-end. The resolution layer already read \`pe.identity_plugin_id\` / \`pte.identity_plugin_id\` off the \`USES_PLUGIN\` edge, but the admin write paths silently dropped it because their request models + \`edge_props\` builders only knew about \`(tab, default, options)\`. Saves of any other field clobbered the identity binding.

Also: multi-environment log search via repeated \`environment\` query params with parallel per-env identity hydration.

## Changes

- \`PluginAssignmentCreate\` / \`PluginAssignmentResponse\` + \`PluginAssignmentRow\` gain \`identity_plugin_id\`.
- All three PUT handlers (\`service_plugins\`, \`project_type_plugins\`, \`project_plugins\`) persist it via \`edge_props\` and validate it via a new shared \`validate_identity_plugin_ids\` helper that cross-references the registry to require \`plugin_type='identity'\`.
- New \`GET /organizations/{org_slug}/identity-plugins/\` endpoint returns the org's identity-type plugin instances.
- \`search_logs\` and \`get_log_histogram\` accept \`environment\` as a repeated query param. With ≥2 envs, asyncio.gather fans out one identity-scoped search per env, merges entries by timestamp desc, slices to limit, and aggregates histogram bucket counts. Per-env failures surface as \`LogResultResponse.warnings\` instead of failing the whole request. Multi-env + cursor returns 400 (per-env cursor format is a follow-up).
- Identity plugin's \`Plugin.options\` is pre-loaded once and threaded through the fan-out via \`attach_identity(identity_options=...)\` so the per-env hydrate path doesn't re-query it.
- New \`endpoints/_helpers.lookup_project_slugs\` (consolidates duplicated copies); \`PluginContext.team_slug\` populated by walking \`Project-OWNED_BY->Team\`.
- \`LogResultResponse\` adds \`warnings\` to surface plugin-side notices (cloudwatch truncation, multi-env partial failures).

## Why

See companion docs in the orchestrator:
- \`docs/identity-plugin-assignment-binding-plan.md\` — admin gap.
- \`docs/identity-per-environment-credentials-plan.md\` — why \`materialize\` needs db + per-env account resolution.

## Depends on

- imbi-common: AWeber-Imbi/imbi-common#77.

## Test plan

- [x] \`just test tests/identity/ tests/endpoints/test_project_logs.py tests/endpoints/test_project_plugins.py tests/endpoints/test_project_type_plugins.py tests/endpoints/test_service_plugins.py\` — 136 passing.
- [x] \`just lint\` (pre-existing FURB110 errors in unrelated files).
- [ ] Manual: round-trip identity_plugin_id via admin PUT/GET; multi-env log search returns merged entries.