### PR TITLE
Resolve Imbi users from external identity subjects

### DIFF
--- a/src/imbi_api/domain/models.py
+++ b/src/imbi_api/domain/models.py
@@ -947,6 +947,21 @@ class WebhookCreate(pydantic.BaseModel):
         default=None,
         description='JSON Path expression to extract project identifier',
     )
+    user_subject_selector: str | None = pydantic.Field(
+        default=None,
+        description=(
+            'JSON Pointer that locates the external identity subject '
+            '(e.g. /deployment/creator/id) used to resolve the Imbi user.'
+        ),
+    )
+    identity_plugin_slug: str | None = pydantic.Field(
+        default=None,
+        description=(
+            'Optional override for the identity plugin slug used to resolve '
+            'the Imbi user; falls back to identity plugins attached to the '
+            'third-party service when unset.'
+        ),
+    )
     rules: list[WebhookRuleCreate] = pydantic.Field(
         default_factory=list,
     )
@@ -957,6 +972,14 @@ class WebhookCreate(pydantic.BaseModel):
         if self.identifier_selector and not self.third_party_service_slug:
             raise ValueError(
                 'identifier_selector requires third_party_service_slug'
+            )
+        if self.user_subject_selector and not self.third_party_service_slug:
+            raise ValueError(
+                'user_subject_selector requires third_party_service_slug'
+            )
+        if self.identity_plugin_slug and not self.third_party_service_slug:
+            raise ValueError(
+                'identity_plugin_slug requires third_party_service_slug'
             )
         return self
 
@@ -983,6 +1006,21 @@ class WebhookUpdate(pydantic.BaseModel):
         default=None,
         description='JSON Path expression to extract project identifier',
     )
+    user_subject_selector: str | None = pydantic.Field(
+        default=None,
+        description=(
+            'JSON Pointer that locates the external identity subject '
+            '(e.g. /deployment/creator/id) used to resolve the Imbi user.'
+        ),
+    )
+    identity_plugin_slug: str | None = pydantic.Field(
+        default=None,
+        description=(
+            'Optional override for the identity plugin slug used to resolve '
+            'the Imbi user; falls back to identity plugins attached to the '
+            'third-party service when unset.'
+        ),
+    )
     rules: list[WebhookRuleCreate] = pydantic.Field(
         default_factory=list,
     )
@@ -993,6 +1031,14 @@ class WebhookUpdate(pydantic.BaseModel):
         if self.identifier_selector and not self.third_party_service_slug:
             raise ValueError(
                 'identifier_selector requires third_party_service_slug'
+            )
+        if self.user_subject_selector and not self.third_party_service_slug:
+            raise ValueError(
+                'user_subject_selector requires third_party_service_slug'
+            )
+        if self.identity_plugin_slug and not self.third_party_service_slug:
+            raise ValueError(
+                'identity_plugin_slug requires third_party_service_slug'
             )
         return self
 
@@ -1020,6 +1066,8 @@ class WebhookResponse(pydantic.BaseModel):
     notification_path: str
     third_party_service: dict[str, typing.Any] | None = None
     identifier_selector: str | None = None
+    user_subject_selector: str | None = None
+    identity_plugin_slug: str | None = None
     rules: list[WebhookRuleResponse] = []
 
     @classmethod
@@ -1064,6 +1112,12 @@ class WebhookResponse(pydantic.BaseModel):
             third_party_service=tps,
             identifier_selector=graph.parse_agtype(
                 record.get('identifier_selector')
+            ),
+            user_subject_selector=graph.parse_agtype(
+                record.get('user_subject_selector')
+            ),
+            identity_plugin_slug=graph.parse_agtype(
+                record.get('identity_plugin_slug')
             ),
             rules=rules,
         )

--- a/src/imbi_api/endpoints/users.py
+++ b/src/imbi_api/endpoints/users.py
@@ -12,6 +12,7 @@ from imbi_api import models
 from imbi_api import patch as json_patch
 from imbi_api.auth import password, permissions
 from imbi_api.endpoints import _helpers
+from imbi_api.identity import repository as identity_repository
 
 LOGGER = logging.getLogger(__name__)
 
@@ -360,6 +361,66 @@ async def list_users(
             )
         )
     return users
+
+
+@users_router.get('/by-identity', response_model=models.UserResponse)
+async def get_user_by_identity(
+    plugin_slug: str,
+    subject: str,
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(permissions.require_permission('user:read')),
+    ],
+) -> models.UserResponse:
+    """Look up a user by an external identity-plugin subject.
+
+    Used by inbound webhook gateways to attribute external events
+    (e.g. a GitHub deployment) to the corresponding Imbi user.
+    Returns 404 when no active ``IdentityConnection`` matches.
+    """
+    del auth
+    user_id = await identity_repository.find_user_by_subject(
+        db, plugin_slug=plugin_slug, subject=subject
+    )
+    if user_id is None:
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail=(
+                f'No user matches plugin {plugin_slug!r} subject {subject!r}'
+            ),
+        )
+
+    results = await db.match(models.User, {'id': user_id})
+    if not results:
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail=f'User with id {user_id!r} not found',
+        )
+    user = results[0]
+
+    org_records = await _load_user_memberships(db, user.email)
+    organizations = [
+        models.OrgMembership(
+            organization_name=record['organization_name'],
+            organization_slug=record['organization_slug'],
+            role=record['role'],
+        )
+        for record in org_records
+    ]
+
+    return models.UserResponse(
+        email=user.email,
+        display_name=user.display_name,
+        is_active=user.is_active,
+        is_admin=user.is_admin,
+        is_service_account=user.is_service_account,
+        created_at=user.created_at,
+        last_login=user.last_login,
+        avatar_url=user.avatar_url,
+        email_notifications=user.email_notifications,
+        organizations=organizations,
+    )
 
 
 @users_router.get('/{email}', response_model=models.UserResponse)

--- a/src/imbi_api/endpoints/webhooks.py
+++ b/src/imbi_api/endpoints/webhooks.py
@@ -144,6 +144,8 @@ WITH w, tps, impl,
 RETURN w{{.*}} AS webhook,
        tps{{.*}} AS tps,
        impl.identifier_selector AS identifier_selector,
+       impl.user_subject_selector AS user_subject_selector,
+       impl.identity_plugin_slug AS identity_plugin_slug,
        [x IN all_rules
         | x {{.filter_expression, .handler,
               .handler_config}}]
@@ -161,6 +163,8 @@ _UPDATE_RETURN_TAIL_WITH_TPS: typing.LiteralString = (
     ' .handler_config, .ordinal}} END) AS all_rules'
     ' RETURN w{{.*}} AS webhook, tps{{.*}} AS tps,'
     ' impl.identifier_selector AS identifier_selector,'
+    ' impl.user_subject_selector AS user_subject_selector,'
+    ' impl.identity_plugin_slug AS identity_plugin_slug,'
     ' [x IN all_rules'
     ' | x {{.filter_expression, .handler,'
     ' .handler_config}}] AS rules'
@@ -177,6 +181,8 @@ _UPDATE_RETURN_TAIL_NO_TPS: typing.LiteralString = (
     ' .handler_config, .ordinal}} END) AS all_rules'
     ' RETURN w{{.*}} AS webhook, null AS tps,'
     ' null AS identifier_selector,'
+    ' null AS user_subject_selector,'
+    ' null AS identity_plugin_slug,'
     ' [x IN all_rules'
     ' | x {{.filter_expression, .handler,'
     ' .handler_config}}] AS rules'
@@ -263,15 +269,18 @@ async def create_webhook(
             ' -[:BELONGS_TO]->(o)'
             f' CREATE (w:Webhook {create_tpl})'
             ' CREATE (w)-[:BELONGS_TO]->(o)'
-            ' CREATE (w)-[:IMPLEMENTED_BY'
-            ' {{identifier_selector: {identifier_selector}}}]->(tps)'
-            + rule_clauses
-            + ' RETURN w.id AS id'
+            ' CREATE (w)-[:IMPLEMENTED_BY {{'
+            'identifier_selector: {identifier_selector},'
+            ' user_subject_selector: {user_subject_selector},'
+            ' identity_plugin_slug: {identity_plugin_slug}'
+            '}}]->(tps)' + rule_clauses + ' RETURN w.id AS id'
         )
         write_params: dict[str, typing.Any] = {
             **base_params,
             'tps_slug': data.third_party_service_slug,
             'identifier_selector': data.identifier_selector,
+            'user_subject_selector': data.user_subject_selector,
+            'identity_plugin_slug': data.identity_plugin_slug,
         }
     else:
         write_query = (
@@ -315,7 +324,14 @@ async def create_webhook(
     records = await db.execute(
         _FETCH_WEBHOOK_QUERY,
         {'identifier': webhook_id, 'org_slug': org_slug},
-        ['webhook', 'tps', 'identifier_selector', 'rules'],
+        [
+            'webhook',
+            'tps',
+            'identifier_selector',
+            'user_subject_selector',
+            'identity_plugin_slug',
+            'rules',
+        ],
     )
     return models.WebhookResponse.from_graph_record(records[0])
 
@@ -349,6 +365,8 @@ async def list_webhooks(
     RETURN w{{.*}} AS webhook,
            tps{{.*}} AS tps,
            impl.identifier_selector AS identifier_selector,
+           impl.user_subject_selector AS user_subject_selector,
+           impl.identity_plugin_slug AS identity_plugin_slug,
            [x IN all_rules
             | x {{.filter_expression, .handler,
                   .handler_config}}]
@@ -358,7 +376,14 @@ async def list_webhooks(
     records = await db.execute(
         query,
         {'org_slug': org_slug},
-        ['webhook', 'tps', 'identifier_selector', 'rules'],
+        [
+            'webhook',
+            'tps',
+            'identifier_selector',
+            'user_subject_selector',
+            'identity_plugin_slug',
+            'rules',
+        ],
     )
     return [models.WebhookResponse.from_graph_record(r) for r in records]
 
@@ -379,7 +404,14 @@ async def get_webhook(
     records = await db.execute(
         _FETCH_WEBHOOK_QUERY,
         {'identifier': webhook, 'org_slug': org_slug},
-        ['webhook', 'tps', 'identifier_selector', 'rules'],
+        [
+            'webhook',
+            'tps',
+            'identifier_selector',
+            'user_subject_selector',
+            'identity_plugin_slug',
+            'rules',
+        ],
     )
 
     if not records:
@@ -422,7 +454,14 @@ async def patch_webhook(
     existing = await db.execute(
         _FETCH_WEBHOOK_QUERY,
         {'identifier': webhook, 'org_slug': org_slug},
-        ['webhook', 'tps', 'identifier_selector', 'rules'],
+        [
+            'webhook',
+            'tps',
+            'identifier_selector',
+            'user_subject_selector',
+            'identity_plugin_slug',
+            'rules',
+        ],
     )
 
     if not existing:
@@ -450,6 +489,12 @@ async def patch_webhook(
         ),
         'identifier_selector': graph.parse_agtype(
             existing[0].get('identifier_selector')
+        ),
+        'user_subject_selector': graph.parse_agtype(
+            existing[0].get('user_subject_selector')
+        ),
+        'identity_plugin_slug': graph.parse_agtype(
+            existing[0].get('identity_plugin_slug')
         ),
         'rules': [
             {
@@ -547,7 +592,11 @@ async def patch_webhook(
             f' {set_stmt}'
             ' CREATE (w)-[impl:IMPLEMENTED_BY]->(tps)'
             ' SET impl.identifier_selector'
-            ' = {identifier_selector}' + rule_clauses + ' RETURN w.id AS id'
+            ' = {identifier_selector},'
+            ' impl.user_subject_selector = {user_subject_selector},'
+            ' impl.identity_plugin_slug = {identity_plugin_slug}'
+            + rule_clauses
+            + ' RETURN w.id AS id'
         )
         params: dict[str, typing.Any] = {
             'webhook_id': existing_webhook_id,
@@ -555,6 +604,8 @@ async def patch_webhook(
             'tps_slug': data.third_party_service_slug,
             **props,
             'identifier_selector': data.identifier_selector,
+            'user_subject_selector': data.user_subject_selector,
+            'identity_plugin_slug': data.identity_plugin_slug,
             **rules_params,
         }
     else:
@@ -600,7 +651,14 @@ async def patch_webhook(
     records = await db.execute(
         _FETCH_WEBHOOK_QUERY,
         {'identifier': existing_webhook_id, 'org_slug': org_slug},
-        ['webhook', 'tps', 'identifier_selector', 'rules'],
+        [
+            'webhook',
+            'tps',
+            'identifier_selector',
+            'user_subject_selector',
+            'identity_plugin_slug',
+            'rules',
+        ],
     )
     return models.WebhookResponse.from_graph_record(records[0])
 

--- a/src/imbi_api/identity/repository.py
+++ b/src/imbi_api/identity/repository.py
@@ -381,8 +381,8 @@ async def find_user_by_subject(
     )
     if not records:
         return None
-    user_ids = graph.parse_agtype(records[0]['user_ids']) or []
-    matches = [uid for uid in user_ids if uid]
+    raw: typing.Any = graph.parse_agtype(records[0]['user_ids']) or []
+    matches: list[str] = [str(uid) for uid in raw if uid]
     if len(matches) != 1:
         if len(matches) > 1:
             LOGGER.error(
@@ -393,7 +393,7 @@ async def find_user_by_subject(
                 sorted(matches),
             )
         return None
-    return str(matches[0])
+    return matches[0]
 
 
 async def stale_connections(

--- a/src/imbi_api/identity/repository.py
+++ b/src/imbi_api/identity/repository.py
@@ -381,8 +381,15 @@ async def find_user_by_subject(
     )
     if not records:
         return None
-    raw: typing.Any = graph.parse_agtype(records[0]['user_ids']) or []
-    matches: list[str] = [str(uid) for uid in raw if uid]
+    parsed = graph.parse_agtype(records[0]['user_ids'])
+    if not isinstance(parsed, list):
+        return None
+    # mypy already sees parsed as list[Any] after the isinstance narrow
+    # (so any extra cast is "redundant"); basedpyright's strict mode
+    # narrows to list[Unknown] and demands an annotation. Suppress the
+    # latter on this single statement rather than carry a runtime cast.
+    user_ids: list[typing.Any] = parsed  # pyright: ignore[reportUnknownVariableType]
+    matches: list[str] = [str(uid) for uid in user_ids if uid]
     if len(matches) != 1:
         if len(matches) > 1:
             LOGGER.error(

--- a/src/imbi_api/identity/repository.py
+++ b/src/imbi_api/identity/repository.py
@@ -42,7 +42,7 @@ def _parse_metadata(raw: typing.Any) -> dict[str, typing.Any]:
             return {}
         try:
             decoded = json.loads(parsed)
-        except json.JSONDecodeError, TypeError:
+        except (json.JSONDecodeError, TypeError):
             return {}
         if isinstance(decoded, dict):
             return typing.cast('dict[str, typing.Any]', decoded)

--- a/src/imbi_api/identity/repository.py
+++ b/src/imbi_api/identity/repository.py
@@ -349,6 +349,38 @@ async def list_for_user(
     return out
 
 
+async def find_user_by_subject(
+    db: graph.Graph,
+    plugin_slug: str,
+    subject: str,
+) -> str | None:
+    """Return the Imbi user_id whose active connection has this subject.
+
+    ``subject`` is the external provider's unique ID — for GitHub plugins
+    this is the numeric user ID as a string (e.g. ``"12345"``), which is
+    what :func:`imbi_plugin_github.plugin._build_userinfo` stores.
+
+    Returns ``None`` when no active connection matches.
+    """
+    query: typing.LiteralString = """
+    MATCH (c:IdentityConnection {{subject: {subject}}})
+          -[:USES_PLUGIN]->(p:Plugin {{plugin_slug: {plugin_slug}}})
+    WHERE c.status = 'active'
+    WITH c
+    MATCH (u:User)-[:HAS_IDENTITY]->(c)
+    RETURN u.id AS user_id
+    LIMIT 1
+    """
+    records = await db.execute(
+        query,
+        {'subject': subject, 'plugin_slug': plugin_slug},
+        ['user_id'],
+    )
+    if not records:
+        return None
+    return str(graph.parse_agtype(records[0]['user_id']))
+
+
 async def stale_connections(
     db: graph.Graph,
     before: datetime.datetime,

--- a/src/imbi_api/identity/repository.py
+++ b/src/imbi_api/identity/repository.py
@@ -42,7 +42,7 @@ def _parse_metadata(raw: typing.Any) -> dict[str, typing.Any]:
             return {}
         try:
             decoded = json.loads(parsed)
-        except (json.JSONDecodeError, TypeError):
+        except json.JSONDecodeError, TypeError:
             return {}
         if isinstance(decoded, dict):
             return typing.cast('dict[str, typing.Any]', decoded)
@@ -360,25 +360,40 @@ async def find_user_by_subject(
     this is the numeric user ID as a string (e.g. ``"12345"``), which is
     what :func:`imbi_plugin_github.plugin._build_userinfo` stores.
 
-    Returns ``None`` when no active connection matches.
+    Returns ``None`` when no active connection matches OR when more than
+    one distinct Imbi user is reachable from the (``plugin_slug``,
+    ``subject``) pair — that's a data bug we don't want to paper over by
+    silently picking one. Callers (the gateway in particular) treat
+    ``None`` as "do not attribute" rather than as "no such user".
     """
     query: typing.LiteralString = """
     MATCH (c:IdentityConnection {{subject: {subject}}})
           -[:USES_PLUGIN]->(p:Plugin {{plugin_slug: {plugin_slug}}})
     WHERE c.status = 'active'
-    WITH c
-    MATCH (u:User)-[:HAS_IDENTITY]->(c)
-    RETURN u.id AS user_id
-    LIMIT 1
+    OPTIONAL MATCH (u:User)-[:HAS_IDENTITY]->(c)
+    WITH collect(DISTINCT u.id) AS user_ids
+    RETURN user_ids
     """
     records = await db.execute(
         query,
         {'subject': subject, 'plugin_slug': plugin_slug},
-        ['user_id'],
+        ['user_ids'],
     )
     if not records:
         return None
-    return str(graph.parse_agtype(records[0]['user_id']))
+    user_ids = graph.parse_agtype(records[0]['user_ids']) or []
+    matches = [uid for uid in user_ids if uid]
+    if len(matches) != 1:
+        if len(matches) > 1:
+            LOGGER.error(
+                'plugin_slug=%r subject=%r resolved to multiple Imbi '
+                'users %r; refusing to guess',
+                plugin_slug,
+                subject,
+                sorted(matches),
+            )
+        return None
+    return str(matches[0])
 
 
 async def stale_connections(

--- a/tests/endpoints/test_users.py
+++ b/tests/endpoints/test_users.py
@@ -328,6 +328,71 @@ class UserEndpointsTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 404)
         self.assertIn('not found', response.json()['detail'])
 
+    def test_get_user_by_identity_success(self) -> None:
+        """Test resolving a user from a plugin subject."""
+        mock_user = models.User(
+            id='user-nano-id',
+            email='gh@example.com',
+            display_name='GH User',
+            is_active=True,
+            is_admin=False,
+            is_service_account=False,
+            created_at=datetime.datetime.now(datetime.UTC),
+        )
+        self.mock_db.match.return_value = [mock_user]
+        # find_user_by_subject + _load_user_memberships both call execute
+        self.mock_db.execute.side_effect = [
+            [{'user_id': 'user-nano-id'}],
+            [{'org_name': 'Default', 'org_slug': 'default', 'role': 'dev'}],
+        ]
+
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.get(
+                '/users/by-identity',
+                params={'plugin_slug': 'github', 'subject': '12345'},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data['email'], 'gh@example.com')
+        self.assertEqual(len(data['organizations']), 1)
+
+    def test_get_user_by_identity_not_found(self) -> None:
+        """Test 404 when no active IdentityConnection matches."""
+        self.mock_db.execute.return_value = []
+
+        response = self.client.get(
+            '/users/by-identity',
+            params={'plugin_slug': 'github', 'subject': '99999'},
+        )
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_get_user_by_identity_user_node_missing(self) -> None:
+        """find_user_by_subject hits but the User node was deleted."""
+        self.mock_db.execute.return_value = [{'user_id': 'orphan-id'}]
+        self.mock_db.match.return_value = []
+
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.get(
+                '/users/by-identity',
+                params={'plugin_slug': 'github', 'subject': '12345'},
+            )
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_get_user_by_identity_requires_query_params(self) -> None:
+        """Both plugin_slug and subject are required."""
+        response = self.client.get(
+            '/users/by-identity',
+            params={'plugin_slug': 'github'},
+        )
+        self.assertEqual(response.status_code, 422)
+
     def test_delete_user_success(self) -> None:
         """Test deleting a user."""
         self.mock_db.execute.return_value = [{'n': 'true'}]

--- a/tests/endpoints/test_users.py
+++ b/tests/endpoints/test_users.py
@@ -342,7 +342,7 @@ class UserEndpointsTestCase(unittest.TestCase):
         self.mock_db.match.return_value = [mock_user]
         # find_user_by_subject + _load_user_memberships both call execute
         self.mock_db.execute.side_effect = [
-            [{'user_id': 'user-nano-id'}],
+            [{'user_ids': ['user-nano-id']}],
             [{'org_name': 'Default', 'org_slug': 'default', 'role': 'dev'}],
         ]
 
@@ -372,7 +372,7 @@ class UserEndpointsTestCase(unittest.TestCase):
 
     def test_get_user_by_identity_user_node_missing(self) -> None:
         """find_user_by_subject hits but the User node was deleted."""
-        self.mock_db.execute.return_value = [{'user_id': 'orphan-id'}]
+        self.mock_db.execute.return_value = [{'user_ids': ['orphan-id']}]
         self.mock_db.match.return_value = []
 
         with mock.patch(

--- a/tests/endpoints/test_webhooks.py
+++ b/tests/endpoints/test_webhooks.py
@@ -819,6 +819,52 @@ class WebhookEndpointsTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 400)
         self.assertIn('third_party_service_slug', response.json()['detail'])
 
+    def test_patch_identity_plugin_slug_rejected_without_tps(self) -> None:
+        """Cover the second validator branch on PATCH.
+
+        ``test_patch_identity_fields_rejected_without_tps`` exercises the
+        ``user_subject_selector`` branch of ``WebhookUpdate``'s validator;
+        this sibling case locks down the same behavior for
+        ``identity_plugin_slug`` so a regression on either field would
+        fail. Suggested-by: coderabbitai
+        """
+        existing_record = {
+            'webhook': {
+                'id': 'abc123def4',
+                'name': 'Solo Hook',
+                'slug': 'solo-hook',
+                'description': None,
+                'notification_path': '/abc123def4',
+                'secret': None,
+            },
+            'tps': None,
+            'identifier_selector': None,
+            'user_subject_selector': None,
+            'identity_plugin_slug': None,
+            'rules': [],
+        }
+        self.mock_db.execute.side_effect = [[existing_record]]
+
+        with (
+            self._patch_encryption(),
+            mock.patch(
+                'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+            ),
+        ):
+            response = self.client.patch(
+                '/organizations/engineering/webhooks/solo-hook',
+                json=[
+                    {
+                        'op': 'replace',
+                        'path': '/identity_plugin_slug',
+                        'value': 'github',
+                    }
+                ],
+            )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('third_party_service_slug', response.json()['detail'])
+
     def test_patch_webhook_slug_collision_returns_409(self) -> None:
         existing_record = {
             'webhook': {

--- a/tests/endpoints/test_webhooks.py
+++ b/tests/endpoints/test_webhooks.py
@@ -34,6 +34,8 @@ class _WebhookRecord(typing.TypedDict):
     webhook: _WebhookDetails
     tps: typing.NotRequired[dict[str, str] | None]
     identifier_selector: typing.NotRequired[str | None]
+    user_subject_selector: typing.NotRequired[str | None]
+    identity_plugin_slug: typing.NotRequired[str | None]
     rules: list[_WebhookRule | None]
 
 
@@ -302,6 +304,62 @@ class WebhookEndpointsTestCase(unittest.TestCase):
             json={
                 'name': 'Test',
                 'identifier_selector': '$.foo',
+            },
+        )
+        self.assertEqual(response.status_code, 422)
+
+    def test_create_with_identity_fields(self) -> None:
+        """user_subject_selector and identity_plugin_slug round-trip."""
+        record = copy.deepcopy(self.webhook_record)
+        record['tps'] = {'name': 'GitHub', 'slug': 'github'}
+        record['identifier_selector'] = '/repository/full_name'
+        record['user_subject_selector'] = '/deployment/creator/id'
+        record['identity_plugin_slug'] = 'github'
+
+        self.mock_db.execute.return_value = [record]
+        with (
+            self._patch_encryption(),
+            mock.patch(
+                'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+            ),
+        ):
+            payload = {
+                'name': 'GitHub Events',
+                'third_party_service_slug': 'github',
+                'identifier_selector': '/repository/full_name',
+                'user_subject_selector': '/deployment/creator/id',
+                'identity_plugin_slug': 'github',
+            }
+            response = self.client.post(
+                '/organizations/engineering/webhooks/',
+                json=payload,
+            )
+
+        self.assertEqual(response.status_code, 201)
+        data = response.json()
+        self.assertEqual(
+            data['user_subject_selector'], '/deployment/creator/id'
+        )
+        self.assertEqual(data['identity_plugin_slug'], 'github')
+
+    def test_create_user_subject_selector_without_service(self) -> None:
+        """user_subject_selector requires a third-party service."""
+        response = self.client.post(
+            '/organizations/engineering/webhooks/',
+            json={
+                'name': 'Test',
+                'user_subject_selector': '/foo',
+            },
+        )
+        self.assertEqual(response.status_code, 422)
+
+    def test_create_identity_plugin_slug_without_service(self) -> None:
+        """identity_plugin_slug requires a third-party service."""
+        response = self.client.post(
+            '/organizations/engineering/webhooks/',
+            json={
+                'name': 'Test',
+                'identity_plugin_slug': 'github',
             },
         )
         self.assertEqual(response.status_code, 422)
@@ -657,6 +715,63 @@ class WebhookEndpointsTestCase(unittest.TestCase):
             )
 
         self.assertEqual(response.status_code, 200)
+
+    def test_patch_identity_fields(self) -> None:
+        """Patching identity-related selectors round-trips through the edge."""
+        existing_record = {
+            'webhook': {
+                'id': 'abc123def4',
+                'name': 'GitHub Hook',
+                'slug': 'github-hook',
+                'description': None,
+                'notification_path': '/abc123def4',
+                'secret': None,
+            },
+            'tps': {'slug': 'github', 'name': 'GitHub'},
+            'identifier_selector': '/repository/full_name',
+            'user_subject_selector': None,
+            'identity_plugin_slug': None,
+            'rules': [],
+        }
+        updated_record = copy.deepcopy(existing_record)
+        updated_record['user_subject_selector'] = '/deployment/creator/id'
+        updated_record['identity_plugin_slug'] = 'github'
+
+        self.mock_db.execute.side_effect = [
+            [existing_record],
+            [updated_record],
+            [updated_record],
+        ]
+
+        with (
+            self._patch_encryption(),
+            mock.patch(
+                'imbi_common.graph.parse_agtype',
+                side_effect=lambda x: x,
+            ),
+        ):
+            response = self.client.patch(
+                '/organizations/engineering/webhooks/github-hook',
+                json=[
+                    {
+                        'op': 'replace',
+                        'path': '/user_subject_selector',
+                        'value': '/deployment/creator/id',
+                    },
+                    {
+                        'op': 'replace',
+                        'path': '/identity_plugin_slug',
+                        'value': 'github',
+                    },
+                ],
+            )
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(
+            data['user_subject_selector'], '/deployment/creator/id'
+        )
+        self.assertEqual(data['identity_plugin_slug'], 'github')
 
     def test_patch_webhook_slug_collision_returns_409(self) -> None:
         existing_record = {

--- a/tests/endpoints/test_webhooks.py
+++ b/tests/endpoints/test_webhooks.py
@@ -77,8 +77,8 @@ class WebhookEndpointsTestCase(unittest.TestCase):
         )
 
         self.mock_db = mock.AsyncMock(spec=graph.Graph)
-        self.test_app.dependency_overrides[graph._inject_graph] = (
-            lambda: self.mock_db
+        self.test_app.dependency_overrides[graph._inject_graph] = lambda: (
+            self.mock_db
         )
 
         self.client = testclient.TestClient(self.test_app)
@@ -773,6 +773,52 @@ class WebhookEndpointsTestCase(unittest.TestCase):
         )
         self.assertEqual(data['identity_plugin_slug'], 'github')
 
+    def test_patch_identity_fields_rejected_without_tps(self) -> None:
+        """Setting identity selectors on a TPS-less webhook is a 400.
+
+        WebhookUpdate runs the model-level validator on the patched
+        document, so adding ``user_subject_selector`` /
+        ``identity_plugin_slug`` to a webhook that isn't linked to a
+        third-party service must be rejected, the same way the create
+        path rejects it. Suggested-by: coderabbitai
+        """
+        existing_record = {
+            'webhook': {
+                'id': 'abc123def4',
+                'name': 'Solo Hook',
+                'slug': 'solo-hook',
+                'description': None,
+                'notification_path': '/abc123def4',
+                'secret': None,
+            },
+            'tps': None,
+            'identifier_selector': None,
+            'user_subject_selector': None,
+            'identity_plugin_slug': None,
+            'rules': [],
+        }
+        self.mock_db.execute.side_effect = [[existing_record]]
+
+        with (
+            self._patch_encryption(),
+            mock.patch(
+                'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+            ),
+        ):
+            response = self.client.patch(
+                '/organizations/engineering/webhooks/solo-hook',
+                json=[
+                    {
+                        'op': 'replace',
+                        'path': '/user_subject_selector',
+                        'value': '/deployment/creator/id',
+                    }
+                ],
+            )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('third_party_service_slug', response.json()['detail'])
+
     def test_patch_webhook_slug_collision_returns_409(self) -> None:
         existing_record = {
             'webhook': {
@@ -1185,8 +1231,8 @@ class ProjectServicesEndpointsTestCase(unittest.TestCase):
         )
 
         self.mock_db = mock.AsyncMock(spec=graph.Graph)
-        self.test_app.dependency_overrides[graph._inject_graph] = (
-            lambda: self.mock_db
+        self.test_app.dependency_overrides[graph._inject_graph] = lambda: (
+            self.mock_db
         )
 
         self.client = testclient.TestClient(self.test_app)

--- a/tests/identity/test_repository.py
+++ b/tests/identity/test_repository.py
@@ -340,6 +340,23 @@ class FindUserBySubjectTestCase(unittest.IsolatedAsyncioTestCase):
         query, _params, _cols = db.execute.await_args.args
         self.assertIn("status = 'active'", query)
 
+    async def test_returns_none_when_parse_agtype_yields_non_list(
+        self,
+    ) -> None:
+        # Defensive guard: if AGE somehow returns a non-list payload,
+        # don't crash the comprehension. Suggested-by: coderabbitai
+        db = mock.AsyncMock()
+        db.execute.return_value = [{'user_ids': '"oops"'}]
+        with mock.patch.object(
+            repository.graph,
+            'parse_agtype',
+            return_value='oops',
+        ):
+            result = await repository.find_user_by_subject(
+                db, 'github', '12345'
+            )
+        self.assertIsNone(result)
+
 
 class StaleConnectionsTestCase(unittest.IsolatedAsyncioTestCase):
     """Verify stale_connections returns parsed rows."""

--- a/tests/identity/test_repository.py
+++ b/tests/identity/test_repository.py
@@ -269,6 +269,39 @@ class ListForUserTestCase(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result, [])
 
 
+class FindUserBySubjectTestCase(unittest.IsolatedAsyncioTestCase):
+    """Verify find_user_by_subject returns a user_id or None."""
+
+    async def test_returns_user_id_when_found(self) -> None:
+        db = mock.AsyncMock()
+        db.execute.return_value = [{'user_id': '"user-42"'}]
+        with mock.patch.object(
+            repository.graph,
+            'parse_agtype',
+            return_value='user-42',
+        ):
+            result = await repository.find_user_by_subject(
+                db, 'github', '12345'
+            )
+        self.assertEqual(result, 'user-42')
+        _query, params, _cols = db.execute.await_args.args
+        self.assertEqual(params['plugin_slug'], 'github')
+        self.assertEqual(params['subject'], '12345')
+
+    async def test_returns_none_when_no_rows(self) -> None:
+        db = mock.AsyncMock()
+        db.execute.return_value = []
+        result = await repository.find_user_by_subject(db, 'github', '99999')
+        self.assertIsNone(result)
+
+    async def test_query_filters_by_active_status(self) -> None:
+        db = mock.AsyncMock()
+        db.execute.return_value = []
+        await repository.find_user_by_subject(db, 'github', '1')
+        query, _params, _cols = db.execute.await_args.args
+        self.assertIn("status = 'active'", query)
+
+
 class StaleConnectionsTestCase(unittest.IsolatedAsyncioTestCase):
     """Verify stale_connections returns parsed rows."""
 

--- a/tests/identity/test_repository.py
+++ b/tests/identity/test_repository.py
@@ -272,13 +272,13 @@ class ListForUserTestCase(unittest.IsolatedAsyncioTestCase):
 class FindUserBySubjectTestCase(unittest.IsolatedAsyncioTestCase):
     """Verify find_user_by_subject returns a user_id or None."""
 
-    async def test_returns_user_id_when_found(self) -> None:
+    async def test_returns_user_id_when_exactly_one_match(self) -> None:
         db = mock.AsyncMock()
-        db.execute.return_value = [{'user_id': '"user-42"'}]
+        db.execute.return_value = [{'user_ids': '["user-42"]'}]
         with mock.patch.object(
             repository.graph,
             'parse_agtype',
-            return_value='user-42',
+            return_value=['user-42'],
         ):
             result = await repository.find_user_by_subject(
                 db, 'github', '12345'
@@ -293,6 +293,45 @@ class FindUserBySubjectTestCase(unittest.IsolatedAsyncioTestCase):
         db.execute.return_value = []
         result = await repository.find_user_by_subject(db, 'github', '99999')
         self.assertIsNone(result)
+
+    async def test_returns_none_when_no_users_in_collection(self) -> None:
+        # collect() over an empty match yields a row with an empty list.
+        db = mock.AsyncMock()
+        db.execute.return_value = [{'user_ids': '[]'}]
+        with mock.patch.object(
+            repository.graph,
+            'parse_agtype',
+            return_value=[],
+        ):
+            result = await repository.find_user_by_subject(
+                db, 'github', '12345'
+            )
+        self.assertIsNone(result)
+
+    async def test_returns_none_when_multiple_distinct_users_match(
+        self,
+    ) -> None:
+        # Two Imbi users link the same GitHub subject — fail closed
+        # rather than silently picking one. Suggested-by: coderabbitai
+        db = mock.AsyncMock()
+        db.execute.return_value = [{'user_ids': '["user-1","user-2"]'}]
+        with (
+            mock.patch.object(
+                repository.graph,
+                'parse_agtype',
+                return_value=['user-1', 'user-2'],
+            ),
+            self.assertLogs(
+                'imbi_api.identity.repository', level='ERROR'
+            ) as cm,
+        ):
+            result = await repository.find_user_by_subject(
+                db, 'github', '12345'
+            )
+        self.assertIsNone(result)
+        self.assertTrue(
+            any('multiple Imbi users' in line for line in cm.output)
+        )
 
     async def test_query_filters_by_active_status(self) -> None:
         db = mock.AsyncMock()


### PR DESCRIPTION
## Summary

Add a `GET /users/by-identity?plugin_slug=&subject=` endpoint and the
two new `IMPLEMENTED_BY`-edge selectors (`user_subject_selector`,
`identity_plugin_slug`) so inbound webhook gateways can attribute
external events (GitHub deployments and friends) to the Imbi user
that triggered them.

## Problem

`imbi-gateway` already accepts inbound webhooks and dispatches them
through `WebhookRule` handlers, but it has no way to map an external
actor (e.g. `deployment.creator.id` from GitHub) onto an Imbi user.
That means release / deployment-event records can't be properly
attributed, and every handler ends up reinventing the lookup.

## Solution

* New endpoint `GET /users/by-identity?plugin_slug=&subject=` on
  `users_router`, declared before `/{email}` so the path doesn't get
  swallowed by the catch-all. Wraps the existing graph helper.
* New `find_user_by_subject` graph helper in
  `identity/repository.py` that joins `IdentityConnection -> USES_PLUGIN
  -> Plugin {plugin_slug}` so the lookup naturally filters to
  identity-typed plugins.
* `WebhookCreate`, `WebhookUpdate`, and `WebhookResponse` models gain
  optional `user_subject_selector` (JSON Pointer) and
  `identity_plugin_slug` (override) fields. Validators reject either
  without a `third_party_service_slug`.
* `webhooks` endpoint Cypher writes / reads both new properties on the
  `IMPLEMENTED_BY` edge across `create_webhook`, `patch_webhook`, the
  fetch query, the list query, and the two `_UPDATE_RETURN_TAIL_*`
  constants.
* Tests: round-trip create/patch covering both new edge fields, plus
  /users/by-identity hit / miss / orphan-user / missing-param paths.

This is part of a feature set tracked in
[`plans/deployment-webhook.md`](https://github.com/AWeber-Imbi/imbi-development/blob/main/plans/deployment-webhook.md).

## Test plan

- [x] `just lint` clean (ruff, ruff-format, mypy, basedpyright)
- [x] `just test` clean — 1375 passed, 1 skipped, coverage 90.06%
- [ ] Smoke test against a running stack: create a webhook with
      `user_subject_selector=/deployment/creator/id` and
      `identity_plugin_slug=github`, GET it back, confirm the new
      fields round-trip.
- [ ] `curl -f /users/by-identity?plugin_slug=github&subject=12345`
      returns the Imbi user when an `IdentityConnection` matches and
      404s otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Companion PRs

- UI: https://github.com/AWeber-Imbi/imbi-ui/pull/224 — surfaces the new edge fields in the webhook form / detail view
- Gateway: https://github.com/AWeber-Imbi/imbi-gateway/pull/10 — implements the deployment-event handlers and consumes `/users/by-identity`
