### PR TITLE
Plugin defaults and per-env identity hydration

### DIFF
--- a/src/imbi_api/app.py
+++ b/src/imbi_api/app.py
@@ -1,6 +1,8 @@
 import fastapi
+from fastapi import responses
 from fastapi.middleware import cors
 from imbi_common import graph, lifespan, valkey
+from imbi_common.plugins.errors import PluginCredentialsMissing
 from uvicorn.middleware import proxy_headers
 
 from imbi_api import endpoints, lifespans, openapi, settings, version
@@ -44,6 +46,19 @@ def create_app() -> fastapi.FastAPI:
         app.add_middleware(
             proxy_headers.ProxyHeadersMiddleware,
             trusted_hosts=server_config.forwarded_allow_ips,
+        )
+
+    # Translate plugin credential failures (raised either at credential
+    # lookup or from inside a plugin handler at runtime) into 503 so
+    # callers don't see opaque 500s when an integration isn't configured.
+    @app.exception_handler(PluginCredentialsMissing)
+    async def _plugin_credentials_missing(
+        _request: fastapi.Request,
+        exc: PluginCredentialsMissing,
+    ) -> responses.JSONResponse:
+        return responses.JSONResponse(
+            status_code=503,
+            content={'detail': str(exc)},
         )
 
     # Phase 5: Setup rate limiting middleware

--- a/src/imbi_api/app.py
+++ b/src/imbi_api/app.py
@@ -1,3 +1,5 @@
+import logging
+
 import fastapi
 from fastapi import responses
 from fastapi.middleware import cors
@@ -7,6 +9,8 @@ from uvicorn.middleware import proxy_headers
 
 from imbi_api import endpoints, lifespans, openapi, settings, version
 from imbi_api.middleware import rate_limit
+
+LOGGER = logging.getLogger(__name__)
 
 
 def create_app() -> fastapi.FastAPI:
@@ -56,6 +60,7 @@ def create_app() -> fastapi.FastAPI:
         _request: fastapi.Request,
         exc: PluginCredentialsMissing,
     ) -> responses.JSONResponse:
+        LOGGER.warning('Plugin credentials missing: %s', exc)
         return responses.JSONResponse(
             status_code=503,
             content={'detail': str(exc)},

--- a/src/imbi_api/app.py
+++ b/src/imbi_api/app.py
@@ -52,7 +52,7 @@ def create_app() -> fastapi.FastAPI:
     # lookup or from inside a plugin handler at runtime) into 503 so
     # callers don't see opaque 500s when an integration isn't configured.
     @app.exception_handler(PluginCredentialsMissing)
-    async def _plugin_credentials_missing(
+    async def _plugin_credentials_missing(  # pyright: ignore[reportUnusedFunction]
         _request: fastapi.Request,
         exc: PluginCredentialsMissing,
     ) -> responses.JSONResponse:

--- a/src/imbi_api/domain/models.py
+++ b/src/imbi_api/domain/models.py
@@ -817,6 +817,10 @@ class PluginUpdate(pydantic.BaseModel):
     options: dict[str, typing.Any] = pydantic.Field(default_factory=dict)
     used_as_login: bool | None = None
     connects_users_to: str | None = None
+    # Default identity plugin used when a USES_PLUGIN edge does not name
+    # one of its own. Pass an explicit empty string to clear; ``None``
+    # leaves the existing value untouched.
+    identity_plugin_id: str | None = None
 
 
 class PluginResponse(pydantic.BaseModel):
@@ -832,6 +836,7 @@ class PluginResponse(pydantic.BaseModel):
     login_capable: bool = False
     used_as_login: bool = False
     connects_users_to: str | None = None
+    identity_plugin_id: str | None = None
 
 
 class PluginAssignmentCreate(pydantic.BaseModel):
@@ -857,6 +862,10 @@ class PluginAssignmentResponse(pydantic.BaseModel):
         'project_type'
     )
     identity_plugin_id: str | None = None
+    # Pulled from the plugin manifest so the UI can hide affordances
+    # (e.g. the histogram strip on the Logs tab) for plugins whose
+    # underlying API does not support them.
+    supports_histogram: bool = False
 
 
 # -- Configuration / Logs response models ---------------------------------
@@ -1040,7 +1049,7 @@ class WebhookResponse(pydantic.BaseModel):
                 config: dict[str, typing.Any] | list[typing.Any]
                 try:
                     config = json.loads(raw_config) if raw_config else {}
-                except (json.JSONDecodeError, TypeError):
+                except json.JSONDecodeError, TypeError:
                     config = {}
                 rules.append(
                     WebhookRuleResponse(

--- a/src/imbi_api/endpoints/project_logs.py
+++ b/src/imbi_api/endpoints/project_logs.py
@@ -68,18 +68,33 @@ async def _search_one_env(
     credentials: dict[str, typing.Any],
     query: LogQuery,
     environment: str | None,
+    db: graph.Graph,
+    auth: permissions.AuthContext,
+    identity_options: dict[str, typing.Any] | None,
 ) -> LogResult:
     """Run a single (env-scoped) plugin search.
 
-    The caller is responsible for hydrating identity and resolving
-    plugin credentials once — those operations don't vary by
-    environment, so doing them inside each fan-out task would
-    downgrade shared identity / credential failures into per-env
-    warnings.
+    Identity must be hydrated per-env: identity plugins like AWS IAM IC
+    walk ``Environment → MAPS_TO → AwsAccount`` to mint env-specific
+    STS keys, which can't be done before the env is known. Plugin
+    credentials are resolved once by the caller and shared.
     """
     ctx = ctx_template.model_copy(update={'environment': environment})
+    ctx = await attach_identity(
+        db, ctx, resolved, auth, identity_options=identity_options
+    )
     handler = typing.cast(LogsPlugin, resolved.entry.handler_cls())
-    return await call_with_timeout(handler.search(ctx, credentials, query))
+    result = await call_with_timeout(handler.search(ctx, credentials, query))
+    # Stamp the env slug onto each entry's ``raw`` so the UI can render an
+    # env column without requiring the upstream log source to include one.
+    # Existing values are preserved (handler-supplied env wins).
+    if environment:
+        for entry in result.entries:
+            raw = entry.raw if isinstance(entry.raw, dict) else {}
+            if 'environment' not in raw:
+                raw['environment'] = environment
+            entry.raw = raw
+    return result
 
 
 def _to_response_entries(
@@ -179,19 +194,16 @@ async def search_logs(
         team_slug=team_slug,
         assignment_options=resolved.options,
     )
-    # Hydrate identity and resolve plugin credentials once before
-    # fanning out — neither depends on ``ctx.environment`` and doing
-    # them per-task would downgrade shared identity / credential
-    # failures into per-env warnings on multi-env requests.
+    # Plugin credentials are env-independent so resolve them once.
+    # Identity must be hydrated per-env (handled inside _search_one_env)
+    # because env-aware identity plugins like AWS IAM IC mint different
+    # STS keys depending on the env's AwsAccount binding.
     identity_options = (
         await identity_resolution.load_plugin_options(
             db, resolved.identity_plugin_id
         )
         if resolved.identity_plugin_id
         else None
-    )
-    ctx_template = await attach_identity(
-        db, ctx_template, resolved, auth, identity_options=identity_options
     )
     try:
         credentials = await get_plugin_credentials(
@@ -213,6 +225,9 @@ async def search_logs(
                 credentials=credentials,
                 query=query,
                 environment=envs[0],
+                db=db,
+                auth=auth,
+                identity_options=identity_options,
             )
         except CursorExpiredError as exc:
             raise fastapi.HTTPException(
@@ -229,10 +244,11 @@ async def search_logs(
             warnings=result.warnings,
         )
 
-    # Multi-env fan-out.  Identity / credentials are already resolved
-    # above; per-env failures from ``handler.search`` are surfaced as
-    # warnings rather than failing the whole request — partial
-    # results are still useful.
+    # Multi-env fan-out. Each task hydrates its own identity (so
+    # env-aware identity plugins can mint per-env STS keys) and per-env
+    # failures from identity hydration or ``handler.search`` are
+    # surfaced as warnings rather than failing the whole request —
+    # partial results are still useful.
     raw_results = await asyncio.gather(
         *(
             _search_one_env(
@@ -241,6 +257,9 @@ async def search_logs(
                 credentials=credentials,
                 query=query,
                 environment=env,
+                db=db,
+                auth=auth,
+                identity_options=identity_options,
             )
             for env in envs
         ),
@@ -286,8 +305,14 @@ async def _histogram_one_env(
     query: LogQuery,
     bucket_count: int,
     environment: str | None,
+    db: graph.Graph,
+    auth: permissions.AuthContext,
+    identity_options: dict[str, typing.Any] | None,
 ) -> list[LogHistogramBucket]:
     ctx = ctx_template.model_copy(update={'environment': environment})
+    ctx = await attach_identity(
+        db, ctx, resolved, auth, identity_options=identity_options
+    )
     handler = typing.cast(LogsPlugin, resolved.entry.handler_cls())
     return await call_with_timeout(
         handler.histogram(ctx, credentials, query, bucket_count)
@@ -364,17 +389,12 @@ async def get_log_histogram(
         team_slug=team_slug,
         assignment_options=resolved.options,
     )
-    # Hydrate identity and resolve plugin credentials once before the
-    # fan-out — see the equivalent comment in ``search_logs``.
     identity_options = (
         await identity_resolution.load_plugin_options(
             db, resolved.identity_plugin_id
         )
         if resolved.identity_plugin_id
         else None
-    )
-    ctx_template = await attach_identity(
-        db, ctx_template, resolved, auth, identity_options=identity_options
     )
     try:
         credentials = await get_plugin_credentials(
@@ -396,6 +416,9 @@ async def get_log_histogram(
             query=query,
             bucket_count=bucket_count,
             environment=envs[0],
+            db=db,
+            auth=auth,
+            identity_options=identity_options,
         )
         return [
             models.LogHistogramBucketResponse(
@@ -407,9 +430,11 @@ async def get_log_histogram(
         ]
 
     # Multi-env fan-out: sum bucket counts at matching timestamps,
-    # aggregate level breakdowns.  Failures from any env are logged
-    # and that env's contribution is dropped — the histogram is not
-    # the place to surface partial-failure warnings (the search
+    # aggregate level breakdowns.  Identity is hydrated per-env inside
+    # ``_histogram_one_env`` so env-aware identity plugins (AWS IAM IC)
+    # mint the right STS keys per env.  Failures from any env are
+    # logged and that env's contribution is dropped — the histogram is
+    # not the place to surface partial-failure warnings (the search
     # endpoint already does).
     raw_results = await asyncio.gather(
         *(
@@ -420,6 +445,9 @@ async def get_log_histogram(
                 query=query,
                 bucket_count=bucket_count,
                 environment=env,
+                db=db,
+                auth=auth,
+                identity_options=identity_options,
             )
             for env in envs
         ),

--- a/src/imbi_api/endpoints/project_logs.py
+++ b/src/imbi_api/endpoints/project_logs.py
@@ -90,10 +90,8 @@ async def _search_one_env(
     # Existing values are preserved (handler-supplied env wins).
     if environment:
         for entry in result.entries:
-            raw = entry.raw if isinstance(entry.raw, dict) else {}
-            if 'environment' not in raw:
-                raw['environment'] = environment
-            entry.raw = raw
+            if 'environment' not in entry.raw:
+                entry.raw['environment'] = environment
     return result
 
 

--- a/src/imbi_api/endpoints/service_plugins.py
+++ b/src/imbi_api/endpoints/service_plugins.py
@@ -19,7 +19,10 @@ from imbi_api.auth import login_providers, permissions
 from imbi_api.domain import models
 from imbi_api.graph_sql import props_template, set_clause
 from imbi_api.plugins import parse_options as _parse_options
-from imbi_api.plugins.assignments import validate_identity_plugin_ids
+from imbi_api.plugins.assignments import (
+    coerce_identity_plugin_id,
+    validate_identity_plugin_ids,
+)
 from imbi_api.plugins.credentials import (
     get_plugin_configuration_keys,
     patch_plugin_configuration,
@@ -50,6 +53,9 @@ def _build_plugin_response(
         login_capable=bool(plugin.get('login_capable', False)),
         used_as_login=bool(plugin.get('used_as_login', False)),
         connects_users_to=plugin.get('connects_users_to'),
+        identity_plugin_id=coerce_identity_plugin_id(
+            plugin.get('identity_plugin_id')
+        ),
     )
 
 
@@ -204,6 +210,14 @@ async def update_service_plugin(
     }
     if data.connects_users_to is not None:
         props['connects_users_to'] = data.connects_users_to
+    if data.identity_plugin_id is not None:
+        # Empty string clears the binding; non-empty must reference a
+        # real identity plugin in this org.
+        if data.identity_plugin_id:
+            await validate_identity_plugin_ids(
+                db, org_slug, [data.identity_plugin_id]
+            )
+        props['identity_plugin_id'] = data.identity_plugin_id
     if data.used_as_login is not None:
         # Toggling on requires the manifest to declare login_capable=true.
         # Consult the registry — the Plugin node's snapshot may be stale
@@ -520,12 +534,6 @@ async def _list_assignments(
         edge: dict[str, typing.Any] = (  # pyright: ignore[reportUnknownVariableType,reportUnknownArgumentType]
             graph.parse_agtype(r.get('edge', '{}')) or {}
         )
-        raw_identity = edge.get('identity_plugin_id')
-        identity_plugin_id = (
-            str(raw_identity)
-            if isinstance(raw_identity, str) and raw_identity
-            else None
-        )
         rows.append(
             _AssignmentRow(
                 project_type_slug=pt.get('slug', ''),
@@ -533,7 +541,9 @@ async def _list_assignments(
                 tab=edge.get('tab', 'configuration'),
                 default=bool(edge.get('default', False)),
                 options=_parse_options(edge.get('options')),
-                identity_plugin_id=identity_plugin_id,
+                identity_plugin_id=coerce_identity_plugin_id(
+                    edge.get('identity_plugin_id')
+                ),
             )
         )
     return rows

--- a/src/imbi_api/plugins/assignments.py
+++ b/src/imbi_api/plugins/assignments.py
@@ -92,18 +92,27 @@ async def validate_identity_plugin_ids(
         )
 
 
+def coerce_identity_plugin_id(raw: typing.Any) -> str | None:
+    """Coerce a graph-stored identity_plugin_id to ``str | None``.
+
+    Treats empty strings and non-string types as missing.
+    """
+    return str(raw) if isinstance(raw, str) and raw else None
+
+
 def build_assignment_response(
     plugin: dict[str, typing.Any],
     edge: dict[str, typing.Any],
     source: typing.Literal['project', 'project_type', 'merged'],
 ) -> models.PluginAssignmentResponse:
     """Build a PluginAssignmentResponse from parsed plugin/edge dicts."""
-    raw_identity = edge.get('identity_plugin_id')
-    identity_plugin_id = (
-        str(raw_identity)
-        if isinstance(raw_identity, str) and raw_identity
-        else None
-    )
+    supports_histogram = False
+    try:
+        supports_histogram = bool(
+            get_plugin(plugin['plugin_slug']).manifest.supports_histogram
+        )
+    except PluginNotFoundError:
+        pass
     return models.PluginAssignmentResponse(
         plugin_id=plugin['id'],
         plugin_slug=plugin['plugin_slug'],
@@ -112,5 +121,8 @@ def build_assignment_response(
         default=bool(edge.get('default', False)),
         options=parse_options(edge.get('options')),
         source=source,
-        identity_plugin_id=identity_plugin_id,
+        identity_plugin_id=coerce_identity_plugin_id(
+            edge.get('identity_plugin_id')
+        ),
+        supports_histogram=supports_histogram,
     )

--- a/src/imbi_api/plugins/resolution.py
+++ b/src/imbi_api/plugins/resolution.py
@@ -48,6 +48,10 @@ async def resolve_plugin(
     # ``SQL.format()``-based template renderer doesn't treat them as
     # replacement fields. ``options`` is read from the edge (``pe`` /
     # ``pte``) so per-assignment overrides reach the plugin handler.
+    # ``plugin_identity_plugin_id`` is the default identity plugin set on
+    # the Plugin node itself (org-wide). It is used as the lowest-tier
+    # fallback when neither the project edge nor the project-type edge
+    # names an identity plugin of its own.
     query: typing.LiteralString = """
     MATCH (proj:Project {{id: {project_id}}})
     OPTIONAL MATCH (proj)-[pe:USES_PLUGIN]->(p:Plugin)
@@ -60,6 +64,7 @@ async def resolve_plugin(
                          edge_options: pe.options,
                          plugin_options: p.options,
                          identity_plugin_id: pe.identity_plugin_id,
+                         plugin_identity_plugin_id: p.identity_plugin_id,
                          default: pe.default,
                          src: 'project'}})
        AS proj_plugins,
@@ -67,6 +72,7 @@ async def resolve_plugin(
                          edge_options: pte.options,
                          plugin_options: p2.options,
                          identity_plugin_id: pte.identity_plugin_id,
+                         plugin_identity_plugin_id: p2.identity_plugin_id,
                          default: pte.default,
                          src: 'project_type'}})
        AS pt_plugins
@@ -116,6 +122,8 @@ async def resolve_plugin(
                 'pt_identity_plugin_id': pt_by_id[pid].get(
                     'identity_plugin_id'
                 ),
+                'plugin_identity_plugin_id': p.get('plugin_identity_plugin_id')
+                or pt_by_id[pid].get('plugin_identity_plugin_id'),
             }
         else:
             merged[pid] = p
@@ -199,12 +207,17 @@ async def resolve_plugin(
 def _select_identity_plugin_id(
     chosen: dict[str, typing.Any],
 ) -> str | None:
-    """Pick the identity plugin id, preferring the project-level binding.
+    """Pick the identity plugin id with three-tier precedence.
 
-    Falls back to the project-type binding (carried as
-    ``pt_identity_plugin_id``) when the chosen edge omits its own
-    ``identity_plugin_id`` so a partial project override does not drop the
-    type-level identity requirement.
+    Order, highest precedence first:
+
+    1. ``identity_plugin_id`` on the chosen edge (project or project-type
+       edge).
+    2. ``pt_identity_plugin_id`` — the project-type edge's value, carried
+       across when a project edge wins but did not name its own identity.
+    3. ``plugin_identity_plugin_id`` — the default declared on the Plugin
+       node itself, applied org-wide so admins do not have to repeat it
+       on every project-type assignment.
     """
     identity_plugin_id = chosen.get('identity_plugin_id')
     if isinstance(identity_plugin_id, str) and not identity_plugin_id:
@@ -213,4 +226,8 @@ def _select_identity_plugin_id(
         pt_identity = chosen.get('pt_identity_plugin_id')
         if isinstance(pt_identity, str) and pt_identity:
             identity_plugin_id = pt_identity
+    if identity_plugin_id is None:
+        plugin_identity = chosen.get('plugin_identity_plugin_id')
+        if isinstance(plugin_identity, str) and plugin_identity:
+            identity_plugin_id = plugin_identity
     return identity_plugin_id


### PR DESCRIPTION
## Summary

- **Per-env identity hydration on the logs endpoints.** `_search_one_env` and `_histogram_one_env` now call `attach_identity` themselves with the env-scoped `ctx`, instead of relying on a single pre-fan-out hydration. AWS IAM IC walks `Environment → MAPS_TO → AwsAccount` to mint env-specific STS keys, so calling it once with `ctx.environment=None` left multi-env log searches unable to resolve identity.
- **Default `identity_plugin_id` on the Plugin node.** Operators can now set the identity plugin once on a service-plugin's Default Options card and have all project-type assignments inherit it. `PluginUpdate.identity_plugin_id` accepts `''` to clear, `None` to leave untouched, and any non-empty value is validated via `validate_identity_plugin_ids`. `PluginResponse.identity_plugin_id` exposes the stored value. `resolve_plugin` collects it as a third-tier fallback (`plugin_identity_plugin_id`) used after the project edge and project-type edge.
- **`PluginAssignmentResponse.supports_histogram`** pulled from the plugin manifest in `build_assignment_response`, so the UI can hide the histogram strip for plugins (or plugin versions) that don't aggregate by time bucket.
- **Global `PluginCredentialsMissing` → 503 handler** registered in `app.py`. Replaces the prior pattern of catching the error only around `get_plugin_credentials` — it can now also surface from inside a plugin's `list_keys` / `search` / `materialize` and still produce a clean 503.
- **Stamp env slug onto each log entry's `raw` dict** in `_search_one_env`. The UI's new env column populates regardless of whether the upstream log source emits an `environment` field of its own; existing values are preserved.
- **`coerce_identity_plugin_id`** helper extracted in `plugins/assignments.py` to deduplicate the `isinstance(raw, str) and raw` coercion across three call-sites.

## Test plan

- [x] `just lint` (ruff + format + mypy + basedpyright via pre-commit)
- [ ] `just test` against the touched modules
- [ ] Manual: a project of a type whose configuration plugin has only a default `identity_plugin_id` (no per-type override) resolves correctly
- [ ] Manual: a multi-env log search (`?environment=production&environment=staging`) hydrates identity per env and returns merged results
- [ ] Manual: setting `identity_plugin_id=''` on `PUT /plugins/{id}` clears the property

🤖 Generated with [Claude Code](https://claude.com/claude-code)