### PR TITLE
Wire OAuth2 plugins to ServiceApplication via USES_APPLICATION

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
   "fastapi",
   "filetype",
   "httpx>=0.28.1,<1",
-  "imbi-common[databases,server]>=0.3.0",
+  "imbi-common[databases,server]>=0.5.0",
   "jinja2",
   "jsonpatch>=1.33",
   "nanoid>=2.0.0",

--- a/src/imbi_api/domain/models.py
+++ b/src/imbi_api/domain/models.py
@@ -821,6 +821,11 @@ class PluginUpdate(pydantic.BaseModel):
     # one of its own. Pass an explicit empty string to clear; ``None``
     # leaves the existing value untouched.
     identity_plugin_id: str | None = None
+    # Tri-state via ``model_fields_set``: omitted leaves the link
+    # alone, ``null`` clears it, a string sets/replaces it. Mirrors how
+    # an OAuth2 plugin instance picks the ServiceApplication that owns
+    # its client_id/secret.
+    service_application_slug: str | None = None
 
 
 class PluginResponse(pydantic.BaseModel):
@@ -837,6 +842,8 @@ class PluginResponse(pydantic.BaseModel):
     used_as_login: bool = False
     connects_users_to: str | None = None
     identity_plugin_id: str | None = None
+    application_slug: str | None = None
+    application_name: str | None = None
 
 
 class PluginAssignmentCreate(pydantic.BaseModel):

--- a/src/imbi_api/endpoints/service_plugins.py
+++ b/src/imbi_api/endpoints/service_plugins.py
@@ -41,6 +41,7 @@ def _build_plugin_response(
 ) -> models.PluginResponse:
     plugin = graph.parse_agtype(record['plugin'])
     svc = graph.parse_agtype(record.get('svc')) if record.get('svc') else {}  # pyright: ignore[reportUnknownVariableType,reportUnknownArgumentType]
+    app = graph.parse_agtype(record.get('app')) if record.get('app') else {}  # pyright: ignore[reportUnknownVariableType,reportUnknownArgumentType]
     slug = plugin['plugin_slug']
     return models.PluginResponse(
         id=plugin['id'],
@@ -56,6 +57,8 @@ def _build_plugin_response(
         identity_plugin_id=coerce_identity_plugin_id(
             plugin.get('identity_plugin_id')
         ),
+        application_slug=app.get('slug') if app else None,  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType]
+        application_name=app.get('name') if app else None,  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType]
     )
 
 
@@ -75,13 +78,14 @@ async def list_service_plugins(
     query: typing.LiteralString = """
     MATCH (p:Plugin)<-[:HAS_PLUGIN]-(s:ThirdPartyService {{slug: {svc_slug}}})
           -[:BELONGS_TO]->(o:Organization {{slug: {org_slug}}})
-    RETURN p{{.*}} AS plugin, s{{.*}} AS svc
+    OPTIONAL MATCH (p)-[:USES_APPLICATION]->(a:ServiceApplication)
+    RETURN p{{.*}} AS plugin, s{{.*}} AS svc, a{{.*}} AS app
     ORDER BY p.label
     """
     records = await db.execute(
         query,
         {'svc_slug': slug, 'org_slug': org_slug},
-        ['plugin', 'svc'],
+        ['plugin', 'svc', 'app'],
     )
     registry = _registry_slugs()
     return [_build_plugin_response(r, registry) for r in records]
@@ -129,6 +133,19 @@ async def create_service_plugin(
             ),
         )
 
+    if (
+        data.service_application_slug is not None
+        and entry.manifest.auth_type == 'api_token'
+    ):
+        raise fastapi.HTTPException(
+            status_code=400,
+            detail=(
+                f'Plugin {data.plugin_slug!r} uses auth_type='
+                "'api_token'; service_application_slug is only valid for"
+                ' OAuth2/OIDC plugins'
+            ),
+        )
+
     plugin_id = nanoid.generate()
     options_str = json.dumps(data.options)
     props: dict[str, typing.Any] = {
@@ -140,19 +157,66 @@ async def create_service_plugin(
     }
     tpl = props_template(props)
 
-    create_query: str = (
-        'MATCH (s:ThirdPartyService {{slug: {svc_slug}}})'
-        ' -[:BELONGS_TO]->(o:Organization {{slug: {org_slug}}})'
-        f' CREATE (p:Plugin {tpl})'
-        ' CREATE (s)-[:HAS_PLUGIN]->(p)'
-        ' RETURN p{{.*}} AS plugin, s{{.*}} AS svc'
-    )
-    records = await db.execute(
-        create_query,
-        {'svc_slug': slug, 'org_slug': org_slug, **props},
-        ['plugin', 'svc'],
-    )
+    if data.service_application_slug is not None:
+        # Same-service guard is enforced atomically: the
+        # ServiceApplication must REGISTERED_IN the same service.
+        create_query: str = (
+            'MATCH (s:ThirdPartyService {{slug: {svc_slug}}})'
+            ' -[:BELONGS_TO]->(o:Organization {{slug: {org_slug}}})'
+            ' MATCH (a:ServiceApplication {{slug: {app_slug}}})'
+            ' -[:REGISTERED_IN]->(s)'
+            f' CREATE (p:Plugin {tpl})'
+            ' CREATE (s)-[:HAS_PLUGIN]->(p)'
+            ' CREATE (p)-[:USES_APPLICATION]->(a)'
+            ' RETURN p{{.*}} AS plugin, s{{.*}} AS svc, a{{.*}} AS app'
+        )
+        params: dict[str, typing.Any] = {
+            'svc_slug': slug,
+            'org_slug': org_slug,
+            'app_slug': data.service_application_slug,
+            **props,
+        }
+    else:
+        create_query = (
+            'MATCH (s:ThirdPartyService {{slug: {svc_slug}}})'
+            ' -[:BELONGS_TO]->(o:Organization {{slug: {org_slug}}})'
+            f' CREATE (p:Plugin {tpl})'
+            ' CREATE (s)-[:HAS_PLUGIN]->(p)'
+            ' RETURN p{{.*}} AS plugin, s{{.*}} AS svc, NULL AS app'
+        )
+        params = {'svc_slug': slug, 'org_slug': org_slug, **props}
+
+    records = await db.execute(create_query, params, ['plugin', 'svc', 'app'])
     if not records:
+        if data.service_application_slug is not None:
+            # Distinguish the two failure modes: service missing vs
+            # app-not-on-service. Re-check the service to give the
+            # operator a precise error.
+            svc_check: typing.LiteralString = (
+                'MATCH (s:ThirdPartyService {{slug: {svc_slug}}})'
+                ' -[:BELONGS_TO]->(o:Organization {{slug: {org_slug}}})'
+                ' RETURN count(s) AS cnt'
+            )
+            svc_records = await db.execute(
+                svc_check,
+                {'svc_slug': slug, 'org_slug': org_slug},
+                ['cnt'],
+            )
+            svc_count = (
+                graph.parse_agtype(svc_records[0]['cnt']) if svc_records else 0
+            )
+            if svc_count == 0:
+                raise fastapi.HTTPException(
+                    status_code=404,
+                    detail=f'Third-party service {slug!r} not found',
+                )
+            raise fastapi.HTTPException(
+                status_code=400,
+                detail=(
+                    f'ServiceApplication {data.service_application_slug!r}'
+                    f' is not registered to service {slug!r}'
+                ),
+            )
         raise fastapi.HTTPException(
             status_code=404,
             detail=f'Third-party service {slug!r} not found',
@@ -282,11 +346,55 @@ async def update_service_plugin(
             status_code=404,
             detail=f'Plugin {plugin_id!r} not found in service {slug!r}',
         )
-    # Bust the login-providers TTL cache when login flags changed so the
-    # next call to GET /auth/login-providers reflects the new state.
-    if data.used_as_login is not None or data.connects_users_to is not None:
+
+    # Apply the USES_APPLICATION link change only when the field was
+    # actually sent in the request body (tri-state via
+    # ``model_fields_set``: omitted = leave alone, null = clear,
+    # string = replace).
+    app_link_changed = 'service_application_slug' in data.model_fields_set
+    if app_link_changed:
+        await _set_plugin_application_link(
+            db,
+            org_slug=org_slug,
+            svc_slug=slug,
+            plugin_id=plugin_id,
+            app_slug=data.service_application_slug,
+        )
+
+    # Re-read with the (possibly updated) application link so the
+    # response reflects the new state.
+    final_query: typing.LiteralString = """
+    MATCH (p:Plugin {{id: {plugin_id}}})
+    <-[:HAS_PLUGIN]-(s:ThirdPartyService {{slug: {svc_slug}}})
+    -[:BELONGS_TO]->(o:Organization {{slug: {org_slug}}})
+    OPTIONAL MATCH (p)-[:USES_APPLICATION]->(a:ServiceApplication)
+    RETURN p{{.*}} AS plugin, s{{.*}} AS svc, a{{.*}} AS app
+    """
+    final_records = await db.execute(
+        final_query,
+        {
+            'plugin_id': plugin_id,
+            'svc_slug': slug,
+            'org_slug': org_slug,
+        },
+        ['plugin', 'svc', 'app'],
+    )
+    # Bust the login-providers TTL cache when login flags changed or
+    # the linked Application changed on a login-capable plugin.
+    if (
+        data.used_as_login is not None
+        or data.connects_users_to is not None
+        or (
+            app_link_changed
+            and bool(
+                graph.parse_agtype(final_records[0]['plugin']).get(
+                    'used_as_login', False
+                )
+            )
+        )
+    ):
         login_providers.invalidate_cache()
-    return _build_plugin_response(records[0], _registry_slugs())
+    return _build_plugin_response(final_records[0], _registry_slugs())
 
 
 @service_plugins_router.delete('/{plugin_id}', status_code=204)
@@ -358,6 +466,56 @@ async def delete_service_plugin(
         raise fastapi.HTTPException(
             status_code=404,
             detail=f'Plugin {plugin_id!r} not found in service {slug!r}',
+        )
+
+
+async def _set_plugin_application_link(
+    db: graph.Graph,
+    *,
+    org_slug: str,
+    svc_slug: str,
+    plugin_id: str,
+    app_slug: str | None,
+) -> None:
+    """Apply the USES_APPLICATION edge change for ``plugin_id``.
+
+    Drops any existing edge first; if ``app_slug`` is non-null, validates
+    that the named ServiceApplication is registered to the same service
+    and recreates the edge. Returns 400 when the same-service guard
+    fails so the operator can correct the slug.
+    """
+    delete_query: typing.LiteralString = """
+    MATCH (p:Plugin {{id: {plugin_id}}})-[r:USES_APPLICATION]->()
+    DELETE r
+    """
+    await db.execute(delete_query, {'plugin_id': plugin_id}, [])
+    if app_slug is None:
+        return
+    create_query: typing.LiteralString = """
+    MATCH (p:Plugin {{id: {plugin_id}}})
+    <-[:HAS_PLUGIN]-(s:ThirdPartyService {{slug: {svc_slug}}})
+    -[:BELONGS_TO]->(o:Organization {{slug: {org_slug}}})
+    MATCH (a:ServiceApplication {{slug: {app_slug}}})-[:REGISTERED_IN]->(s)
+    CREATE (p)-[:USES_APPLICATION]->(a)
+    RETURN a.slug AS slug
+    """
+    records = await db.execute(
+        create_query,
+        {
+            'plugin_id': plugin_id,
+            'svc_slug': svc_slug,
+            'org_slug': org_slug,
+            'app_slug': app_slug,
+        },
+        ['slug'],
+    )
+    if not records:
+        raise fastapi.HTTPException(
+            status_code=400,
+            detail=(
+                f'ServiceApplication {app_slug!r} is not registered to'
+                f' service {svc_slug!r}'
+            ),
         )
 
 

--- a/src/imbi_api/plugins/credentials.py
+++ b/src/imbi_api/plugins/credentials.py
@@ -25,44 +25,39 @@ async def get_plugin_credentials(
 
     Routing depends on the plugin manifest's ``auth_type``:
 
-    * ``api_token``: read the encrypted ``plugin_configuration`` blob
-      stored directly on the ``Plugin`` node.
-    * ``oauth2``: traverse ``Plugin <-[:HAS_PLUGIN]- ThirdPartyService
-      -[:HAS_APPLICATION]-> ServiceApplication`` and read the legacy
-      ``plugin_credentials`` field on the application.
+    * ``api_token`` / ``aws-iam-ic``: read the encrypted
+      ``plugin_configuration`` blob stored directly on the ``Plugin``
+      node. (``api_token`` is operator-pasted; ``aws-iam-ic`` self-mints
+      its OIDC client and the host persists creds back via
+      ``patch_plugin_configuration``.)
+    * ``oauth2`` / ``oidc``: traverse the ``USES_APPLICATION`` edge to
+      the linked ``ServiceApplication`` and pull plaintext
+      ``client_id`` plus Fernet-decrypted ``client_secret``.
 
     Raises:
-        PluginCredentialsMissing: If required credentials are absent.
+        PluginCredentialsMissing: If required credentials are absent or
+            the plugin is not linked to a ServiceApplication.
     """
     auth_type = entry.manifest.auth_type
-    # ``api_token`` and ``aws-iam-ic`` both store their credentials on
-    # the ``Plugin`` node itself: the former because the operator pastes
-    # a token directly, the latter because the plugin self-mints an OIDC
-    # client at start-time and the host persists those creds back via
-    # ``patch_plugin_configuration``.  ``oauth2`` / ``oidc`` plugins
-    # share OAuth client config across an org via a ``ServiceApplication``.
     if auth_type in ('api_token', 'aws-iam-ic'):
-        query: typing.LiteralString = """
-        MATCH (p:Plugin {{id: {plugin_id}}})
-        RETURN p.plugin_configuration AS creds
-        LIMIT 1
-        """
-    else:
-        # ``ThirdPartyService.service_application`` is a single edge in
-        # the domain model, so this MATCH cannot legally fan out to
-        # multiple apps. ``LIMIT 1`` is defensive.
-        query = """
-        MATCH (p:Plugin {{id: {plugin_id}}})
-        <-[:HAS_PLUGIN]-(s:ThirdPartyService)
-        -[:HAS_APPLICATION]->(a:ServiceApplication)
-        RETURN a.plugin_credentials AS creds
-        LIMIT 1
-        """
-    records = await db.execute(
-        query,
-        {'plugin_id': plugin_id},
-        ['creds'],
-    )
+        return await _get_plugin_configuration_credentials(
+            db, plugin_id, entry
+        )
+    return await _get_application_credentials(db, plugin_id, entry)
+
+
+async def _get_plugin_configuration_credentials(
+    db: graph.Graph,
+    plugin_id: str,
+    entry: RegistryEntry,
+) -> dict[str, str]:
+    """Resolve credentials for ``api_token``/``aws-iam-ic`` plugins."""
+    query: typing.LiteralString = """
+    MATCH (p:Plugin {{id: {plugin_id}}})
+    RETURN p.plugin_configuration AS creds
+    LIMIT 1
+    """
+    records = await db.execute(query, {'plugin_id': plugin_id}, ['creds'])
     if not records or records[0].get('creds') is None:
         creds_raw: str | None = None
     else:
@@ -102,6 +97,58 @@ async def get_plugin_credentials(
             f'{entry.manifest.slug!r}: {missing}'
         )
     return {k: str(v) for k, v in credentials.items() if v is not None}
+
+
+async def _get_application_credentials(
+    db: graph.Graph,
+    plugin_id: str,
+    entry: RegistryEntry,
+) -> dict[str, str]:
+    """Resolve OAuth2/OIDC credentials from the linked ServiceApplication."""
+    query: typing.LiteralString = """
+    MATCH (p:Plugin {{id: {plugin_id}}})
+    -[:USES_APPLICATION]->(a:ServiceApplication)
+    RETURN a.client_id AS client_id, a.client_secret AS client_secret
+    LIMIT 1
+    """
+    records = await db.execute(
+        query, {'plugin_id': plugin_id}, ['client_id', 'client_secret']
+    )
+    if not records:
+        raise PluginCredentialsMissing(
+            f'Plugin {entry.manifest.slug!r} is not linked to a'
+            ' ServiceApplication; pick one on the Plugins tab'
+        )
+    record = records[0]
+    client_id_raw = record.get('client_id')
+    client_secret_raw = record.get('client_secret')
+    if client_id_raw is None or client_secret_raw is None:
+        raise PluginCredentialsMissing(
+            f'Linked ServiceApplication for plugin {entry.manifest.slug!r}'
+            ' is missing client_id or client_secret'
+        )
+    client_id = graph.parse_agtype(client_id_raw)
+    client_secret_enc = graph.parse_agtype(client_secret_raw)
+    try:
+        client_secret = TokenEncryption.get_instance().decrypt(
+            client_secret_enc
+        )
+    except Exception as exc:
+        LOGGER.warning(
+            'client_secret decrypt failed for plugin_id=%s: %s',
+            plugin_id,
+            exc,
+        )
+        raise PluginCredentialsMissing(
+            f'Linked ServiceApplication for plugin {entry.manifest.slug!r}'
+            ' has a client_secret that could not be decrypted'
+        ) from exc
+    if not client_secret:
+        raise PluginCredentialsMissing(
+            f'Linked ServiceApplication for plugin {entry.manifest.slug!r}'
+            ' has no client_secret'
+        )
+    return {'client_id': str(client_id), 'client_secret': client_secret}
 
 
 async def _read_plugin_configuration(

--- a/tests/endpoints/test_service_plugins.py
+++ b/tests/endpoints/test_service_plugins.py
@@ -372,11 +372,12 @@ class ServicePluginsEndpointTestCase(unittest.TestCase):
             }
         )
         svc_raw = json.dumps({'slug': 'github'})
-        # PUT now runs a duplicate-label check before the update; supply
-        # a zero count for the check, then the updated row.
+        # PUT runs dup-label check, the update, then a final read that
+        # includes the OPTIONAL MATCH for the linked ServiceApplication.
         self.mock_db.execute.side_effect = [
             [{'cnt': '0'}],  # dup-label check
             [{'plugin': plugin_raw, 'svc': svc_raw}],  # update
+            [{'plugin': plugin_raw, 'svc': svc_raw, 'app': None}],  # re-read
         ]
         with mock.patch(
             'imbi_api.endpoints.service_plugins.list_plugins',
@@ -519,11 +520,12 @@ class ServicePluginsEndpointTestCase(unittest.TestCase):
             }
         )
         svc_raw = json.dumps({'slug': 'github'})
-        # dup-label check, slug lookup, update.
+        # dup-label check, slug lookup, update, final OPTIONAL-MATCH read.
         self.mock_db.execute.side_effect = [
             [{'cnt': '0'}],
             [{'slug': '"okta"'}],
             [{'plugin': plugin_raw, 'svc': svc_raw}],
+            [{'plugin': plugin_raw, 'svc': svc_raw, 'app': None}],
         ]
         with (
             mock.patch(
@@ -597,6 +599,7 @@ class ServicePluginsEndpointTestCase(unittest.TestCase):
         self.mock_db.execute.side_effect = [
             [{'cnt': '0'}],
             [{'plugin': plugin_raw, 'svc': svc_raw}],
+            [{'plugin': plugin_raw, 'svc': svc_raw, 'app': None}],
         ]
         with (
             mock.patch(
@@ -646,3 +649,310 @@ class ServicePluginsEndpointTestCase(unittest.TestCase):
                 'third-party-services/github/plugins/abc123'
             )
         self.assertEqual(response.status_code, 204)
+
+    def _make_oauth2_entry(self):  # type: ignore[no-untyped-def]
+        from imbi_common.plugins.base import (
+            IdentityCredentials,
+            IdentityPlugin,
+            IdentityProfile,
+            PluginManifest,
+        )
+        from imbi_common.plugins.registry import RegistryEntry
+
+        class _GHFake(IdentityPlugin):
+            manifest = PluginManifest(
+                slug='github-oauth2',
+                name='GitHub OAuth2',
+                plugin_type='identity',
+                auth_type='oauth2',
+            )
+
+            async def authorization_request(  # type: ignore[override]
+                self, ctx, credentials, redirect_uri, scopes
+            ):
+                raise NotImplementedError
+
+            async def exchange_code(  # type: ignore[override]
+                self, ctx, credentials, code, redirect_uri, code_verifier
+            ) -> tuple[IdentityProfile, IdentityCredentials]:
+                raise NotImplementedError
+
+            async def refresh(  # type: ignore[override]
+                self, ctx, credentials, refresh_token
+            ) -> IdentityCredentials:
+                raise NotImplementedError
+
+            async def revoke(  # type: ignore[override]
+                self, ctx, credentials, access_token
+            ) -> None:
+                return None
+
+        return RegistryEntry(
+            handler_cls=_GHFake,
+            manifest=_GHFake.manifest,
+            package_name='imbi-plugin-github',
+            package_version='1.0.0',
+        )
+
+    def _make_api_token_entry(self):  # type: ignore[no-untyped-def]
+        from imbi_common.plugins.base import (
+            ConfigurationPlugin,
+            PluginManifest,
+        )
+        from imbi_common.plugins.registry import RegistryEntry
+
+        class _Fake(ConfigurationPlugin):
+            manifest = PluginManifest(
+                slug='ssm', name='SSM', plugin_type='configuration'
+            )
+
+            async def list_keys(self, ctx, credentials):  # type: ignore[override]
+                return []
+
+            async def get_values(self, ctx, credentials, keys=None):  # type: ignore[override]
+                return []
+
+            async def set_value(self, ctx, credentials, key, value):  # type: ignore[override]
+                raise NotImplementedError
+
+            async def delete_key(self, ctx, credentials, key):  # type: ignore[override]
+                return None
+
+        return RegistryEntry(
+            handler_cls=_Fake,
+            manifest=_Fake.manifest,
+            package_name='imbi-plugin-ssm',
+            package_version='1.0.0',
+        )
+
+    def test_create_plugin_with_application_slug_success(self) -> None:
+        entry = self._make_oauth2_entry()
+        plugin_raw = json.dumps(
+            {
+                'id': 'newid',
+                'plugin_slug': 'github-oauth2',
+                'label': 'GitHub OAuth2',
+                'options': '{}',
+                'api_version': 1,
+            }
+        )
+        svc_raw = json.dumps({'slug': 'github'})
+        app_raw = json.dumps(
+            {'slug': 'gh-oauth-app', 'name': 'GitHub OAuth App'}
+        )
+        responses = [
+            [{'cnt': '0'}],  # dup-label
+            [{'plugin': plugin_raw, 'svc': svc_raw, 'app': app_raw}],
+        ]
+
+        def _exec(*_a: object, **_k: object) -> list[dict]:
+            return responses.pop(0)
+
+        self.mock_db.execute.side_effect = _exec
+        with (
+            mock.patch(
+                'imbi_api.endpoints.service_plugins.get_plugin',
+                return_value=entry,
+            ),
+            mock.patch(
+                'imbi_api.endpoints.service_plugins.list_plugins',
+                return_value=[entry],
+            ),
+        ):
+            with testclient.TestClient(self.test_app) as client:
+                response = client.post(
+                    '/organizations/myorg/'
+                    'third-party-services/github/plugins/',
+                    json={
+                        'plugin_slug': 'github-oauth2',
+                        'label': 'GitHub OAuth2',
+                        'options': {},
+                        'service_application_slug': 'gh-oauth-app',
+                    },
+                )
+        self.assertEqual(response.status_code, 201)
+        body = response.json()
+        self.assertEqual(body['application_slug'], 'gh-oauth-app')
+        self.assertEqual(body['application_name'], 'GitHub OAuth App')
+
+    def test_create_plugin_application_slug_rejected_for_api_token(
+        self,
+    ) -> None:
+        entry = self._make_api_token_entry()
+        # The pre-flight dup-label check still runs before the auth_type
+        # rejection — supply the count even though the rejection comes
+        # next.
+        self.mock_db.execute.side_effect = [[{'cnt': '0'}]]
+        with (
+            mock.patch(
+                'imbi_api.endpoints.service_plugins.get_plugin',
+                return_value=entry,
+            ),
+        ):
+            with testclient.TestClient(self.test_app) as client:
+                response = client.post(
+                    '/organizations/myorg/'
+                    'third-party-services/github/plugins/',
+                    json={
+                        'plugin_slug': 'ssm',
+                        'label': 'SSM',
+                        'options': {},
+                        'service_application_slug': 'something',
+                    },
+                )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn(
+            "auth_type='api_token'",
+            response.json()['detail'],
+        )
+
+    def test_create_plugin_app_not_in_service_returns_400(self) -> None:
+        entry = self._make_oauth2_entry()
+        # dup-label=0, create returns nothing (no app match), svc-check
+        # confirms the service exists.
+        responses = [
+            [{'cnt': '0'}],
+            [],
+            [{'cnt': '1'}],
+        ]
+
+        def _exec(*_a: object, **_k: object) -> list[dict]:
+            return responses.pop(0)
+
+        self.mock_db.execute.side_effect = _exec
+        with mock.patch(
+            'imbi_api.endpoints.service_plugins.get_plugin',
+            return_value=entry,
+        ):
+            with testclient.TestClient(self.test_app) as client:
+                response = client.post(
+                    '/organizations/myorg/'
+                    'third-party-services/github/plugins/',
+                    json={
+                        'plugin_slug': 'github-oauth2',
+                        'label': 'GitHub OAuth2',
+                        'options': {},
+                        'service_application_slug': 'wrong-app',
+                    },
+                )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn(
+            'not registered to service',
+            response.json()['detail'],
+        )
+
+    def test_update_plugin_sets_application_link(self) -> None:
+        plugin_raw = json.dumps(
+            {
+                'id': 'abc123',
+                'plugin_slug': 'github-oauth2',
+                'label': 'L',
+                'options': '{}',
+                'api_version': 1,
+            }
+        )
+        svc_raw = json.dumps({'slug': 'github'})
+        app_raw = json.dumps(
+            {'slug': 'gh-oauth-app', 'name': 'GitHub OAuth App'}
+        )
+        # dup-label, SET update, link delete, link create, final read.
+        self.mock_db.execute.side_effect = [
+            [{'cnt': '0'}],
+            [{'plugin': plugin_raw, 'svc': svc_raw}],
+            [],
+            [{'slug': '"gh-oauth-app"'}],
+            [{'plugin': plugin_raw, 'svc': svc_raw, 'app': app_raw}],
+        ]
+        with mock.patch(
+            'imbi_api.endpoints.service_plugins.list_plugins',
+            return_value=[],
+        ):
+            with testclient.TestClient(self.test_app) as client:
+                response = client.put(
+                    '/organizations/myorg/'
+                    'third-party-services/github/plugins/abc123',
+                    json={
+                        'label': 'L',
+                        'options': {},
+                        'service_application_slug': 'gh-oauth-app',
+                    },
+                )
+        self.assertEqual(response.status_code, 200)
+        body = response.json()
+        self.assertEqual(body['application_slug'], 'gh-oauth-app')
+
+    def test_update_plugin_clears_application_link(self) -> None:
+        plugin_raw = json.dumps(
+            {
+                'id': 'abc123',
+                'plugin_slug': 'github-oauth2',
+                'label': 'L',
+                'options': '{}',
+                'api_version': 1,
+            }
+        )
+        svc_raw = json.dumps({'slug': 'github'})
+        # Update path with explicit ``null`` in the body: dup-label,
+        # SET update, link delete (no create), final read.
+        self.mock_db.execute.side_effect = [
+            [{'cnt': '0'}],
+            [{'plugin': plugin_raw, 'svc': svc_raw}],
+            [],
+            [{'plugin': plugin_raw, 'svc': svc_raw, 'app': None}],
+        ]
+        with mock.patch(
+            'imbi_api.endpoints.service_plugins.list_plugins',
+            return_value=[],
+        ):
+            with testclient.TestClient(self.test_app) as client:
+                response = client.put(
+                    '/organizations/myorg/'
+                    'third-party-services/github/plugins/abc123',
+                    json={
+                        'label': 'L',
+                        'options': {},
+                        'service_application_slug': None,
+                    },
+                )
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNone(response.json()['application_slug'])
+
+    def test_update_plugin_application_slug_rejects_wrong_service(
+        self,
+    ) -> None:
+        plugin_raw = json.dumps(
+            {
+                'id': 'abc123',
+                'plugin_slug': 'github-oauth2',
+                'label': 'L',
+                'options': '{}',
+                'api_version': 1,
+            }
+        )
+        svc_raw = json.dumps({'slug': 'github'})
+        # dup-label, SET update, link delete, link create returns []
+        self.mock_db.execute.side_effect = [
+            [{'cnt': '0'}],
+            [{'plugin': plugin_raw, 'svc': svc_raw}],
+            [],
+            [],
+        ]
+        with mock.patch(
+            'imbi_api.endpoints.service_plugins.list_plugins',
+            return_value=[],
+        ):
+            with testclient.TestClient(self.test_app) as client:
+                response = client.put(
+                    '/organizations/myorg/'
+                    'third-party-services/github/plugins/abc123',
+                    json={
+                        'label': 'L',
+                        'options': {},
+                        'service_application_slug': 'foreign-app',
+                    },
+                )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn(
+            'not registered to service',
+            response.json()['detail'],
+        )

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -336,6 +336,9 @@ class InstallerTestCase(unittest.TestCase):
 def _make_registry_entry(
     slug: str = 'ssm',
     required_creds: bool = False,
+    auth_type: typing.Literal[
+        'api_token', 'oauth2', 'oidc', 'aws-iam-ic'
+    ] = 'api_token',
 ) -> RegistryEntry:
     """Build a RegistryEntry with a fake handler for resolution tests."""
     from imbi_common.plugins.base import (
@@ -350,6 +353,7 @@ def _make_registry_entry(
             slug=slug,
             name=slug.upper(),
             plugin_type='configuration',
+            auth_type=auth_type,
             credentials=(
                 [CredentialField(name='token', label='Token', required=True)]
                 if required_creds
@@ -705,6 +709,78 @@ class CredentialsTestCase(unittest.TestCase):
         ):
             with self.assertRaises(PluginCredentialsMissing):
                 asyncio.run(get_plugin_credentials(mock_db, 'p1', entry))
+
+    def test_oauth2_unlinked_plugin_raises(self) -> None:
+        from imbi_common.plugins.errors import PluginCredentialsMissing
+
+        from imbi_api.plugins.credentials import get_plugin_credentials
+
+        mock_db = mock.AsyncMock()
+        mock_db.execute.return_value = []
+        entry = _make_registry_entry('github', auth_type='oauth2')
+        with self.assertRaises(PluginCredentialsMissing) as ctx:
+            asyncio.run(get_plugin_credentials(mock_db, 'p1', entry))
+        self.assertIn('not linked to a ServiceApplication', str(ctx.exception))
+
+    def test_oauth2_linked_plugin_returns_decrypted(self) -> None:
+        from imbi_api.plugins.credentials import get_plugin_credentials
+
+        mock_db = mock.AsyncMock()
+        mock_db.execute.return_value = [
+            {
+                'client_id': '"my-client-id"',
+                'client_secret': '"ENCRYPTED-SECRET"',
+            }
+        ]
+        encryptor = mock.MagicMock()
+        encryptor.decrypt.return_value = 'plaintext-secret'
+        entry = _make_registry_entry('github', auth_type='oauth2')
+        with mock.patch(
+            'imbi_api.plugins.credentials.TokenEncryption.get_instance',
+            return_value=encryptor,
+        ):
+            creds = asyncio.run(get_plugin_credentials(mock_db, 'p1', entry))
+        self.assertEqual(
+            creds,
+            {'client_id': 'my-client-id', 'client_secret': 'plaintext-secret'},
+        )
+
+    def test_oauth2_decrypt_failure_raises_missing(self) -> None:
+        from imbi_common.plugins.errors import PluginCredentialsMissing
+
+        from imbi_api.plugins.credentials import get_plugin_credentials
+
+        mock_db = mock.AsyncMock()
+        mock_db.execute.return_value = [
+            {
+                'client_id': '"my-client-id"',
+                'client_secret': '"ENCRYPTED-SECRET"',
+            }
+        ]
+        encryptor = mock.MagicMock()
+        encryptor.decrypt.side_effect = RuntimeError('boom')
+        entry = _make_registry_entry('github', auth_type='oauth2')
+        with mock.patch(
+            'imbi_api.plugins.credentials.TokenEncryption.get_instance',
+            return_value=encryptor,
+        ):
+            with self.assertRaises(PluginCredentialsMissing) as ctx:
+                asyncio.run(get_plugin_credentials(mock_db, 'p1', entry))
+        self.assertIn('could not be decrypted', str(ctx.exception))
+
+    def test_oauth2_missing_client_id_raises(self) -> None:
+        from imbi_common.plugins.errors import PluginCredentialsMissing
+
+        from imbi_api.plugins.credentials import get_plugin_credentials
+
+        mock_db = mock.AsyncMock()
+        mock_db.execute.return_value = [
+            {'client_id': None, 'client_secret': '"ENCRYPTED"'}
+        ]
+        entry = _make_registry_entry('github', auth_type='oauth2')
+        with self.assertRaises(PluginCredentialsMissing) as ctx:
+            asyncio.run(get_plugin_credentials(mock_db, 'p1', entry))
+        self.assertIn('client_id or client_secret', str(ctx.exception))
 
 
 class ReloadSubscriberTestCase(unittest.TestCase):

--- a/uv.lock
+++ b/uv.lock
@@ -1002,8 +1002,8 @@ plugins = [
 
 [[package]]
 name = "imbi-common"
-version = "0.4.0"
-source = { git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=main#cd2ef6b50dad61ae2925c70a1569d9b12275da38" }
+version = "0.5.0"
+source = { git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=main#94c7e70dc5f9ba26278a76ff0e99c7cc541c704b" }
 dependencies = [
   { name = "cryptography" },
   { name = "jsonschema-models" },


### PR DESCRIPTION
## Summary

OAuth2/OIDC plugin instances now link to a \`ServiceApplication\` via a \`USES_APPLICATION\` edge, and the runtime credential resolution pulls \`client_id\`/\`client_secret\` from that linked application. This closes the long-standing TODO that the third-party-service Plugins tab cannot configure OAuth credentials for non-\`api_token\` plugins.

## Plan

This is step 2 of \`docs/plugin-service-application-link-plan.md\` in the orchestrator. **Depends on AWeber-Imbi/imbi-common#78** — the floor is bumped to \`imbi-common>=0.5.0\` and the new \`Plugin.service_application\` edge metadata lives there. Don't merge this until #78 is tagged.

## Changes

**Domain models** (\`src/imbi_api/domain/models.py\`)
- \`PluginCreate.service_application_slug\` is now honored.
- \`PluginUpdate.service_application_slug\` added (tri-state via \`model_fields_set\`: omitted = leave alone, \`null\` = clear, string = set/replace).
- \`PluginResponse.application_slug\` / \`application_name\` added so the UI can render the current selection.

**CRUD endpoints** (\`src/imbi_api/endpoints/service_plugins.py\`)
- Create: when \`service_application_slug\` is set, the CREATE Cypher \`MATCH\`es \`(a:ServiceApplication {slug})-[:REGISTERED_IN]->(s)\` so the same-service guard is atomic. \`api_token\` + slug → HTTP 400. App-not-on-service → HTTP 400 (with a fallback service-existence check to distinguish from 404).
- Update: extra \`_set_plugin_application_link\` helper drops any existing edge and (if non-null) recreates it under the same-service guard. The login-providers cache is busted on link change for \`used_as_login\` plugins.
- \`_build_plugin_response\` and the list/update queries now \`OPTIONAL MATCH (p)-[:USES_APPLICATION]->(a)\`.

**Runtime resolution** (\`src/imbi_api/plugins/credentials.py\`)
- OAuth2/OIDC branch traverses \`-[:USES_APPLICATION]->\` to the linked app and decrypts \`client_secret\` via Fernet.
- Unlinked plugins now raise \`PluginCredentialsMissing\` with a clear message instead of returning an empty dict that the upstream handler can't tell apart from \"no creds configured\".
- The api_token / aws-iam-ic branch is factored into \`_get_plugin_configuration_credentials\` for clarity. No behavior change there.

## Test plan

- [x] \`tests/test_plugins.py::CredentialsTestCase\` — new cases for unlinked, linked-decrypted, decrypt-failure, missing-client_id; original 4 api_token cases still pass
- [x] \`tests/endpoints/test_service_plugins.py\` — new cases: create-with-app, api_token+slug → 400, app-not-on-service → 400, update sets/clears link, update wrong-service → 400; pre-existing PUT tests updated to expect the new final-read query
- [x] \`tests/identity/test_flows.py\` — unchanged, still passes (mocks \`get_plugin_credentials\`)
- [x] Smoke: \`tests/endpoints/test_third_party_services.py\`, \`test_auth_providers.py\`, \`test_auth.py\`, \`test_login_providers.py\`, \`test_project_configuration.py\` all green
- [x] \`just lint\` clean (ruff, ruff-format, basedpyright, mypy)

## Migration / back-compat

No graph migration. Existing OAuth2 plugin instances with no link fail loudly at runtime — \`get_plugin_credentials\` raises \`PluginCredentialsMissing\` and the login-start endpoint translates that to HTTP 400. Operators link an Application via the new picker on the Plugins tab (UI PR follows).