### PR TITLE
Add log level filter + use JWT as IdP state token

### DIFF
--- a/src/imbi_api/endpoints/project_logs.py
+++ b/src/imbi_api/endpoints/project_logs.py
@@ -132,6 +132,9 @@ async def search_logs(
         default_factory=list,
         alias='filter',
     ),
+    level: list[str] = fastapi.Query(  # noqa: B008
+        default_factory=list,
+    ),
 ) -> models.LogResultResponse:
     """Search project logs via the assigned logs plugin.
 
@@ -142,6 +145,11 @@ async def search_logs(
     entries.  Pagination via ``cursor`` is only supported for
     single-env searches; multi-env returns ``next_cursor=None`` and
     surfaces partial-failure / truncation notes via ``warnings``.
+
+    ``level`` is a repeated query param (``?level=ERROR&level=WARN``)
+    that pushes severity filtering down into the plugin's underlying
+    query so rare levels can still be located even when total volume
+    is high.
     """
     resolved = await resolve_plugin(db, project_id, 'logs', source)
 
@@ -182,6 +190,7 @@ async def search_logs(
         filters=filters,
         limit=limit,
         cursor=cursor,
+        levels=list(level),
     )
 
     project_slug, team_slug = await lookup_project_slugs(db, project_id)

--- a/src/imbi_api/identity/flows.py
+++ b/src/imbi_api/identity/flows.py
@@ -3,6 +3,7 @@
 import json
 import logging
 import typing
+import urllib.parse
 
 from imbi_common import graph
 from imbi_common.plugins.base import (
@@ -164,7 +165,30 @@ async def start_flow(
         actor_user_id=actor_user_id,
         device_code=device_code,
     )
-    return request.authorization_url, state_token, request.polling
+    # Plugins mint a random ``state`` nonce internally for CSRF, but the
+    # callback handler decodes the IdP-echoed ``state`` as the signed
+    # identity-flow JWT.  Replace the plugin's nonce with the JWT in the
+    # authorization URL so the round-trip carries the trusted token.
+    # Skipped for device-code flows, which never round-trip ``state``
+    # through the IdP and reuse ``request.state`` as the device code.
+    authorization_url = (
+        request.authorization_url
+        if request.polling
+        else _replace_state(request.authorization_url, state_token)
+    )
+    return authorization_url, state_token, request.polling
+
+
+def _replace_state(url: str, state_token: str) -> str:
+    """Return ``url`` with its ``state`` param set to ``state_token``."""
+    parts = urllib.parse.urlsplit(url)
+    query = urllib.parse.parse_qsl(parts.query, keep_blank_values=True)
+    rewritten = [(k, state_token if k == 'state' else v) for k, v in query]
+    if not any(k == 'state' for k, _ in query):
+        rewritten.append(('state', state_token))
+    return urllib.parse.urlunsplit(
+        parts._replace(query=urllib.parse.urlencode(rewritten))
+    )
 
 
 async def complete_flow(

--- a/tests/identity/test_flows.py
+++ b/tests/identity/test_flows.py
@@ -107,7 +107,9 @@ class StartFlowTestCase(unittest.IsolatedAsyncioTestCase):
     async def test_returns_authorization_url_and_state_token(self) -> None:
         db = mock.AsyncMock()
         request = mock.MagicMock()
-        request.authorization_url = 'https://idp/authorize?...'
+        request.authorization_url = (
+            'https://idp/authorize?client_id=cid&state=idp-state'
+        )
         request.state = 'idp-state'
         request.code_verifier = 'pkce-verifier'
         request.polling = None
@@ -128,9 +130,44 @@ class StartFlowTestCase(unittest.IsolatedAsyncioTestCase):
                 redirect_uri='https://imbi/cb',
                 actor_user_id='user-1',
             )
-        self.assertEqual(url, 'https://idp/authorize?...')
+        # The plugin's nonce must be replaced with the signed JWT so the
+        # IdP echoes the trusted token back on the callback.
+        self.assertEqual(
+            url, 'https://idp/authorize?client_id=cid&state=state-token'
+        )
         self.assertEqual(state_token, 'state-token')
         self.assertIsNone(polling)
+
+    async def test_preserves_authorization_url_for_polling_flows(
+        self,
+    ) -> None:
+        db = mock.AsyncMock()
+        request = mock.MagicMock()
+        request.authorization_url = 'https://idp/device?user_code=ABCD-1234'
+        request.state = 'device-code-xyz'
+        request.code_verifier = None
+        request.polling = mock.MagicMock()
+        request.registered_credentials = None
+        handler = mock.MagicMock(spec=flows.IdentityPlugin)
+        handler.authorization_request = mock.AsyncMock(return_value=request)
+        with (
+            _patch_load_handler(handler),
+            mock.patch.object(
+                flows.state,
+                'encode_identity_state',
+                return_value='state-token',
+            ),
+        ):
+            url, _state_token, polling = await flows.start_flow(
+                db,
+                plugin_id='plugin-1',
+                redirect_uri='https://imbi/cb',
+                actor_user_id='user-1',
+            )
+        # Device-code flows never round-trip ``state`` through the IdP,
+        # so the authorization URL is preserved verbatim.
+        self.assertEqual(url, 'https://idp/device?user_code=ABCD-1234')
+        self.assertIs(polling, request.polling)
 
 
 class CompleteFlowTestCase(unittest.IsolatedAsyncioTestCase):

--- a/tests/identity/test_flows.py
+++ b/tests/identity/test_flows.py
@@ -158,7 +158,7 @@ class StartFlowTestCase(unittest.IsolatedAsyncioTestCase):
                 return_value='state-token',
             ),
         ):
-            url, _state_token, polling = await flows.start_flow(
+            url, state_token, polling = await flows.start_flow(
                 db,
                 plugin_id='plugin-1',
                 redirect_uri='https://imbi/cb',
@@ -167,6 +167,7 @@ class StartFlowTestCase(unittest.IsolatedAsyncioTestCase):
         # Device-code flows never round-trip ``state`` through the IdP,
         # so the authorization URL is preserved verbatim.
         self.assertEqual(url, 'https://idp/device?user_code=ABCD-1234')
+        self.assertEqual(state_token, 'state-token')
         self.assertIs(polling, request.polling)
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1003,7 +1003,7 @@ plugins = [
 [[package]]
 name = "imbi-common"
 version = "0.5.0"
-source = { git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=main#94c7e70dc5f9ba26278a76ff0e99c7cc541c704b" }
+source = { git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=main#3c89a42d3fc07f82d7215a253fd5b8860a3302be" }
 dependencies = [
   { name = "cryptography" },
   { name = "jsonschema-models" },


### PR DESCRIPTION
## Summary
Two unrelated fixes/updates batched into one PR per repo:

1. **Add `level` query param to project log search** — repeated `?level=ERROR&level=WARN` is forwarded to the plugin's `LogQuery.levels` so severity filtering is pushed down into the underlying log source.
2. **Replace plugin-minted state with signed JWT in auth URL** — identity plugins mint a random `state` nonce for CSRF, but the callback handler decodes the IdP-echoed `state` as the signed identity-flow JWT. Without rewriting the URL the IdP would echo the raw plugin nonce and the callback would fail. Skipped for device-code / polling flows, which never round-trip `state` through the IdP.

## Dependency
The log-level commit depends on AWeber-Imbi/imbi-common#79 (`LogQuery.levels`) being merged so the `git rev=main` resolution picks up the new field.

## Test plan
- [ ] CI green after imbi-common#79 lands
- [x] `tests/identity/test_flows.py` covers both polling and non-polling state-token round-trip