### PR TITLE
Add user-profile activity endpoints

### DIFF
--- a/src/imbi_api/endpoints/__init__.py
+++ b/src/imbi_api/endpoints/__init__.py
@@ -2,7 +2,9 @@ import fastapi
 
 from imbi_api.identity.endpoints import me_identities_router
 
-from . import user_activity  # noqa: F401  # registers routes on users_router
+from . import (
+    user_activity,  # pyright: ignore[reportUnusedImport]  # noqa: F401  # registers routes on users_router
+)
 from .admin import admin_router
 from .admin_plugins import admin_plugins_router
 from .api_keys import api_keys_router

--- a/src/imbi_api/endpoints/__init__.py
+++ b/src/imbi_api/endpoints/__init__.py
@@ -2,6 +2,7 @@ import fastapi
 
 from imbi_api.identity.endpoints import me_identities_router
 
+from . import user_activity  # noqa: F401  # registers routes on users_router
 from .admin import admin_router
 from .admin_plugins import admin_plugins_router
 from .api_keys import api_keys_router

--- a/src/imbi_api/endpoints/user_activity.py
+++ b/src/imbi_api/endpoints/user_activity.py
@@ -17,6 +17,7 @@ import datetime
 import logging
 import typing
 import urllib.parse
+import zoneinfo
 
 import fastapi
 import fastapi.encoders
@@ -114,6 +115,21 @@ def _parse_iso(value: str, field_name: str) -> datetime.datetime:
     if parsed.tzinfo is None:
         parsed = parsed.replace(tzinfo=datetime.UTC)
     return parsed.astimezone(datetime.UTC)
+
+
+def _resolve_tz(tz: str) -> zoneinfo.ZoneInfo:
+    """Validate ``tz`` as an IANA timezone, returning a ZoneInfo.
+
+    Raises a 400 ``HTTPException`` for unknown identifiers so we never
+    forward invalid values into ClickHouse date functions.
+    """
+    try:
+        return zoneinfo.ZoneInfo(tz)
+    except (zoneinfo.ZoneInfoNotFoundError, ValueError) as err:
+        raise fastapi.HTTPException(
+            status_code=400,
+            detail=f'Invalid timezone identifier: {tz!r}',
+        ) from err
 
 
 def _resolve_window(
@@ -292,7 +308,7 @@ async def _graph_buckets(
     email: str,
     since: datetime.datetime,
     until: datetime.datetime,
-    tz: str,
+    zone: zoneinfo.ZoneInfo,
 ) -> dict[datetime.date, int]:
     template = _GRAPH_BUCKET_QUERIES[label]
     rows = await db.execute(
@@ -304,20 +320,6 @@ async def _graph_buckets(
         },
         ['ts'],
     )
-    try:
-        zone = datetime.datetime.now().astimezone().tzinfo
-        if tz != 'UTC':
-            try:
-                import zoneinfo
-
-                zone = zoneinfo.ZoneInfo(tz)
-            except Exception:  # noqa: BLE001
-                LOGGER.debug('Unknown tz %r — falling back to UTC', tz)
-                zone = datetime.UTC
-        else:
-            zone = datetime.UTC
-    except Exception:  # noqa: BLE001
-        zone = datetime.UTC
 
     counts: dict[datetime.date, int] = {}
     for row in rows:
@@ -353,6 +355,7 @@ async def get_user_contributions(
     del auth
     email = urllib.parse.unquote(email)
     await _ensure_user_exists(db, email)
+    zone = _resolve_tz(tz)
     start, end = _resolve_window(since, until)
 
     subjects = await _resolve_user_subjects(db, email)
@@ -360,7 +363,7 @@ async def get_user_contributions(
         _opslog_buckets(email=email, since=start, until=end, tz=tz),
         _events_buckets(subjects=subjects, since=start, until=end, tz=tz),
         _graph_buckets(
-            db, label='note', email=email, since=start, until=end, tz=tz
+            db, label='note', email=email, since=start, until=end, zone=zone
         ),
         _graph_buckets(
             db,
@@ -368,7 +371,7 @@ async def get_user_contributions(
             email=email,
             since=start,
             until=end,
-            tz=tz,
+            zone=zone,
         ),
         _graph_buckets(
             db,
@@ -376,7 +379,7 @@ async def get_user_contributions(
             email=email,
             since=start,
             until=end,
-            tz=tz,
+            zone=zone,
         ),
         _graph_buckets(
             db,
@@ -384,7 +387,7 @@ async def get_user_contributions(
             email=email,
             since=start,
             until=end,
-            tz=tz,
+            zone=zone,
         ),
     )
     leg_names = (
@@ -505,7 +508,8 @@ async def get_user_stats(
     tz: str = 'UTC',
 ) -> StatsResponse:
     """Return summary deployment / project tiles for the profile page."""
-    del auth, tz
+    del auth
+    _resolve_tz(tz)  # validate even though stats does not bucket by tz
     email = urllib.parse.unquote(email)
     await _ensure_user_exists(db, email)
     start, end = _resolve_window(since, until)
@@ -713,7 +717,7 @@ async def _opslog_activity(
         'FROM operations_log FINAL '
         'WHERE is_deleted = 0 '
         '  AND performed_by = {email:String} '
-        '  AND occurred_at < {before:DateTime64(3)} '
+        '  AND occurred_at <= {before:DateTime64(3)} '
         'ORDER BY occurred_at DESC, id DESC '
         'LIMIT {row_limit:UInt32}'
     )
@@ -766,7 +770,7 @@ async def _events_activity(
         'project_id, metadata '
         'FROM events '
         'WHERE attributed_to IN {subjects:Array(String)} '
-        '  AND recorded_at < {before:DateTime64(3)} '
+        '  AND recorded_at <= {before:DateTime64(3)} '
         'ORDER BY recorded_at DESC, id DESC '
         'LIMIT {row_limit:UInt32}'
     )
@@ -812,7 +816,7 @@ _GRAPH_ACTIVITY_QUERIES: dict[str, str] = {
     'note': """
         MATCH (n:Note)-[:ATTACHED_TO]->(p:Project)
         WHERE (n.created_by = {email} OR n.updated_by = {email})
-          AND n.created_at < {before}
+          AND n.created_at <= {before}
         RETURN n.id AS id,
                n.created_at AS ts,
                n.title AS title,
@@ -827,7 +831,7 @@ _GRAPH_ACTIVITY_QUERIES: dict[str, str] = {
     'release': """
         MATCH (r:Release)<-[:HAS_RELEASE]-(p:Project)
         WHERE r.created_by = {email}
-          AND r.created_at < {before}
+          AND r.created_at <= {before}
         RETURN r.id AS id,
                r.created_at AS ts,
                r.version AS version,
@@ -840,7 +844,7 @@ _GRAPH_ACTIVITY_QUERIES: dict[str, str] = {
     """,
     'upload': """
         MATCH (u:Upload {{uploaded_by: {email}}})
-        WHERE u.created_at < {before}
+        WHERE u.created_at <= {before}
         RETURN u.id AS id,
                u.created_at AS ts,
                u.filename AS filename
@@ -849,7 +853,7 @@ _GRAPH_ACTIVITY_QUERIES: dict[str, str] = {
     """,
     'conversation': """
         MATCH (c:Conversation {{user_email: {email}}})
-        WHERE c.created_at < {before}
+        WHERE c.created_at <= {before}
         RETURN c.id AS id,
                c.created_at AS ts,
                c.title AS title
@@ -1023,9 +1027,10 @@ async def get_user_activity(
         ]
 
     next_cursor: str | None = None
-    if len(merged) > limit:
+    has_more = len(merged) > limit
+    if has_more:
         merged = merged[:limit]
-    if len(merged) == limit:
+    if has_more and merged:
         last = merged[-1]
         next_cursor = _encode_cursor(last.occurred_at, last.id)
 

--- a/src/imbi_api/endpoints/user_activity.py
+++ b/src/imbi_api/endpoints/user_activity.py
@@ -1,0 +1,1037 @@
+"""User profile activity endpoints.
+
+Aggregates per-user activity from ClickHouse (`operations_log`,
+`events`) and the AGE graph (`Note`, `Release`, `Upload`,
+`Conversation`) into a small set of read-only endpoints that power the
+v2 UI's user profile page.
+
+All endpoints are mounted on the existing :data:`users_router` so they
+share the ``/users`` prefix and the OpenAPI tag.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import datetime
+import logging
+import typing
+import urllib.parse
+
+import fastapi
+import fastapi.encoders
+import fastapi.responses
+import pydantic
+from imbi_common import clickhouse, graph
+
+from imbi_api.auth import permissions
+from imbi_api.endpoints.users import users_router
+
+LOGGER = logging.getLogger(__name__)
+
+
+DEFAULT_WINDOW_DAYS: int = 365
+DEFAULT_ACTIVITY_LIMIT: int = 20
+MAX_ACTIVITY_LIMIT: int = 100
+
+
+ActivitySource = typing.Literal[
+    'operations_log',
+    'events',
+    'note',
+    'release',
+    'upload',
+    'conversation',
+]
+
+
+class ContributionBucket(pydantic.BaseModel):
+    date: datetime.date
+    count: int
+    by_source: dict[str, int]
+
+
+class ContributionsResponse(pydantic.BaseModel):
+    total: int
+    since: datetime.datetime
+    until: datetime.datetime
+    tz: str
+    buckets: list[ContributionBucket]
+
+
+class DeploymentStats(pydantic.BaseModel):
+    total: int
+    rolled_back: int
+    success_rate: float | None
+
+
+class StatsResponse(pydantic.BaseModel):
+    since: datetime.datetime
+    until: datetime.datetime
+    deployments: DeploymentStats
+    projects_touched: int
+    deployments_by_environment: dict[str, int]
+
+
+class IdentityRecord(pydantic.BaseModel):
+    provider: str
+    provider_user_id: str
+    email: str | None = None
+    display_name: str | None = None
+    linked_at: datetime.datetime | None = None
+    last_used: datetime.datetime | None = None
+
+
+class IdentitiesResponse(pydantic.BaseModel):
+    primary: IdentityRecord | None
+    all: list[IdentityRecord]
+
+
+class ActivityRecord(pydantic.BaseModel):
+    id: str
+    source: ActivitySource
+    occurred_at: datetime.datetime
+    summary: str
+    type: str
+    environment_slug: str | None = None
+    project_id: str | None = None
+    project_slug: str | None = None
+    link: str | None = None
+
+
+class ActivityResponse(pydantic.BaseModel):
+    data: list[ActivityRecord]
+
+
+def _parse_iso(value: str, field_name: str) -> datetime.datetime:
+    try:
+        parsed = datetime.datetime.fromisoformat(value)
+    except ValueError as err:
+        raise fastapi.HTTPException(
+            status_code=400,
+            detail=f'Invalid ISO timestamp for {field_name!r}',
+        ) from err
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=datetime.UTC)
+    return parsed.astimezone(datetime.UTC)
+
+
+def _resolve_window(
+    since: str | None,
+    until: str | None,
+) -> tuple[datetime.datetime, datetime.datetime]:
+    end = (
+        _parse_iso(until, 'until')
+        if until is not None
+        else datetime.datetime.now(datetime.UTC)
+    )
+    start = (
+        _parse_iso(since, 'since')
+        if since is not None
+        else end - datetime.timedelta(days=DEFAULT_WINDOW_DAYS)
+    )
+    if start >= end:
+        raise fastapi.HTTPException(
+            status_code=400,
+            detail='`since` must be earlier than `until`',
+        )
+    return start, end
+
+
+async def _ensure_user_exists(db: graph.Graph, email: str) -> None:
+    rows = await db.execute(
+        'MATCH (u:User {{email: {email}}}) RETURN u.id AS id LIMIT 1',
+        {'email': email},
+        ['id'],
+    )
+    if not rows:
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail=f'User with email {email!r} not found',
+        )
+
+
+async def _resolve_user_subjects(db: graph.Graph, email: str) -> list[str]:
+    """Return the user's external identity subjects.
+
+    Includes both legacy ``OAuthIdentity`` provider_user_ids and current
+    ``IdentityConnection`` subjects so the events leg can match either
+    attribution mechanism.
+    """
+    rows = await db.execute(
+        """
+        MATCH (u:User {{email: {email}}})
+        OPTIONAL MATCH (u)-[:HAS_IDENTITY]->(c:IdentityConnection)
+        OPTIONAL MATCH (oi:OAuthIdentity)-[:OAUTH_IDENTITY]->(u)
+        RETURN
+            collect(DISTINCT c.subject) AS conn_subjects,
+            collect(DISTINCT oi.provider_user_id) AS oauth_subjects
+        """,
+        {'email': email},
+        ['conn_subjects', 'oauth_subjects'],
+    )
+    if not rows:
+        return []
+    subjects: set[str] = set()
+    for column in ('conn_subjects', 'oauth_subjects'):
+        parsed = graph.parse_agtype(rows[0].get(column))
+        if isinstance(parsed, list):
+            items: list[typing.Any] = parsed  # pyright: ignore[reportUnknownVariableType]
+            for value in items:
+                if value:
+                    subjects.add(str(value))
+    return sorted(subjects)
+
+
+def _coerce_dt(value: typing.Any) -> datetime.datetime | None:
+    if value is None:
+        return None
+    parsed = graph.parse_agtype(value) if not isinstance(value, str) else value
+    if not parsed:
+        return None
+    if isinstance(parsed, datetime.datetime):
+        dt = parsed
+    else:
+        try:
+            dt = datetime.datetime.fromisoformat(str(parsed))
+        except ValueError:
+            return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=datetime.UTC)
+    return dt.astimezone(datetime.UTC)
+
+
+# ---------------------------------------------------------------------------
+# /contributions
+# ---------------------------------------------------------------------------
+
+
+async def _opslog_buckets(
+    *,
+    email: str,
+    since: datetime.datetime,
+    until: datetime.datetime,
+    tz: str,
+) -> dict[datetime.date, int]:
+    sql: str = (
+        'SELECT toDate(toStartOfDay(occurred_at, {tz:String})) AS d, '
+        'count() AS c '
+        'FROM operations_log FINAL '
+        'WHERE is_deleted = 0 '
+        '  AND performed_by = {email:String} '
+        '  AND occurred_at >= {since:DateTime64(3)} '
+        '  AND occurred_at <  {until:DateTime64(3)} '
+        'GROUP BY d'
+    )
+    rows = await clickhouse.query(
+        sql,
+        {'email': email, 'since': since, 'until': until, 'tz': tz},
+    )
+    return {row['d']: int(row['c']) for row in rows if row.get('d')}
+
+
+async def _events_buckets(
+    *,
+    subjects: list[str],
+    since: datetime.datetime,
+    until: datetime.datetime,
+    tz: str,
+) -> dict[datetime.date, int]:
+    if not subjects:
+        return {}
+    sql: str = (
+        'SELECT toDate(toStartOfDay(recorded_at, {tz:String})) AS d, '
+        'count() AS c '
+        'FROM events '
+        'WHERE attributed_to IN {subjects:Array(String)} '
+        '  AND recorded_at >= {since:DateTime64(3)} '
+        '  AND recorded_at <  {until:DateTime64(3)} '
+        'GROUP BY d'
+    )
+    rows = await clickhouse.query(
+        sql,
+        {'subjects': subjects, 'since': since, 'until': until, 'tz': tz},
+    )
+    return {row['d']: int(row['c']) for row in rows if row.get('d')}
+
+
+_GRAPH_BUCKET_QUERIES: dict[str, str] = {
+    'note': """
+        MATCH (n:Note)
+        WHERE (n.created_by = {email}
+               OR n.updated_by = {email})
+          AND n.created_at >= {since}
+          AND n.created_at <  {until}
+        RETURN n.created_at AS ts
+    """,
+    'release': """
+        MATCH (r:Release {{created_by: {email}}})
+        WHERE r.created_at >= {since}
+          AND r.created_at <  {until}
+        RETURN r.created_at AS ts
+    """,
+    'upload': """
+        MATCH (u:Upload {{uploaded_by: {email}}})
+        WHERE u.created_at >= {since}
+          AND u.created_at <  {until}
+        RETURN u.created_at AS ts
+    """,
+    'conversation': """
+        MATCH (c:Conversation {{user_email: {email}}})
+        WHERE c.created_at >= {since}
+          AND c.created_at <  {until}
+        RETURN c.created_at AS ts
+    """,
+}
+
+
+async def _graph_buckets(
+    db: graph.Graph,
+    *,
+    label: str,
+    email: str,
+    since: datetime.datetime,
+    until: datetime.datetime,
+    tz: str,
+) -> dict[datetime.date, int]:
+    template = _GRAPH_BUCKET_QUERIES[label]
+    rows = await db.execute(
+        template,
+        {
+            'email': email,
+            'since': since.isoformat(),
+            'until': until.isoformat(),
+        },
+        ['ts'],
+    )
+    try:
+        zone = datetime.datetime.now().astimezone().tzinfo
+        if tz != 'UTC':
+            try:
+                import zoneinfo
+
+                zone = zoneinfo.ZoneInfo(tz)
+            except Exception:  # noqa: BLE001
+                LOGGER.debug('Unknown tz %r — falling back to UTC', tz)
+                zone = datetime.UTC
+        else:
+            zone = datetime.UTC
+    except Exception:  # noqa: BLE001
+        zone = datetime.UTC
+
+    counts: dict[datetime.date, int] = {}
+    for row in rows:
+        dt = _coerce_dt(row.get('ts'))
+        if dt is None:
+            continue
+        local = dt.astimezone(zone)
+        day = local.date()
+        counts[day] = counts.get(day, 0) + 1
+    return counts
+
+
+@users_router.get(
+    '/{email}/contributions', response_model=ContributionsResponse
+)
+async def get_user_contributions(
+    email: str,
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(permissions.require_permission('user:read')),
+    ],
+    since: str | None = None,
+    until: str | None = None,
+    tz: str = 'UTC',
+) -> ContributionsResponse:
+    """Return per-day contribution counts for the user.
+
+    Aggregates ClickHouse opslog/events with graph-authored items (Note,
+    Release, Upload, Conversation) into one daily map keyed by the
+    requested ``tz``.
+    """
+    del auth
+    email = urllib.parse.unquote(email)
+    await _ensure_user_exists(db, email)
+    start, end = _resolve_window(since, until)
+
+    subjects = await _resolve_user_subjects(db, email)
+    legs = await asyncio.gather(
+        _opslog_buckets(email=email, since=start, until=end, tz=tz),
+        _events_buckets(subjects=subjects, since=start, until=end, tz=tz),
+        _graph_buckets(
+            db, label='note', email=email, since=start, until=end, tz=tz
+        ),
+        _graph_buckets(
+            db,
+            label='release',
+            email=email,
+            since=start,
+            until=end,
+            tz=tz,
+        ),
+        _graph_buckets(
+            db,
+            label='upload',
+            email=email,
+            since=start,
+            until=end,
+            tz=tz,
+        ),
+        _graph_buckets(
+            db,
+            label='conversation',
+            email=email,
+            since=start,
+            until=end,
+            tz=tz,
+        ),
+    )
+    leg_names = (
+        'operations_log',
+        'events',
+        'note',
+        'release',
+        'upload',
+        'conversation',
+    )
+
+    by_day: dict[datetime.date, dict[str, int]] = {}
+    total = 0
+    for source, leg in zip(leg_names, legs, strict=True):
+        for day, count in leg.items():
+            total += count
+            day_map = by_day.setdefault(day, {})
+            day_map[source] = day_map.get(source, 0) + count
+
+    buckets = [
+        ContributionBucket(
+            date=day,
+            count=sum(by_source.values()),
+            by_source=dict(by_source),
+        )
+        for day, by_source in sorted(by_day.items())
+    ]
+    return ContributionsResponse(
+        total=total,
+        since=start,
+        until=end,
+        tz=tz,
+        buckets=buckets,
+    )
+
+
+# ---------------------------------------------------------------------------
+# /stats
+# ---------------------------------------------------------------------------
+
+
+async def _projects_touched(
+    db: graph.Graph,
+    *,
+    email: str,
+    subjects: list[str],
+    since: datetime.datetime,
+    until: datetime.datetime,
+) -> int:
+    """Distinct project_ids the user touched across all activity sources."""
+    project_ids: set[str] = set()
+
+    opslog_rows = await clickhouse.query(
+        'SELECT DISTINCT project_id FROM operations_log FINAL '
+        'WHERE is_deleted = 0 '
+        '  AND performed_by = {email:String} '
+        '  AND occurred_at >= {since:DateTime64(3)} '
+        '  AND occurred_at <  {until:DateTime64(3)}',
+        {'email': email, 'since': since, 'until': until},
+    )
+    for row in opslog_rows:
+        pid = row.get('project_id')
+        if pid:
+            project_ids.add(str(pid))
+
+    if subjects:
+        events_rows = await clickhouse.query(
+            'SELECT DISTINCT project_id FROM events '
+            'WHERE attributed_to IN {subjects:Array(String)} '
+            '  AND recorded_at >= {since:DateTime64(3)} '
+            '  AND recorded_at <  {until:DateTime64(3)}',
+            {'subjects': subjects, 'since': since, 'until': until},
+        )
+        for row in events_rows:
+            pid = row.get('project_id')
+            if pid:
+                project_ids.add(str(pid))
+
+    graph_rows = await db.execute(
+        """
+        MATCH (p:Project)
+        OPTIONAL MATCH (p)<-[:ATTACHED_TO]-(n:Note)
+        WHERE (n.created_by = {email} OR n.updated_by = {email})
+          AND n.created_at >= {since}
+          AND n.created_at <  {until}
+        WITH p, count(n) AS note_count
+        OPTIONAL MATCH (p)-[:HAS_RELEASE]->(r:Release {{created_by: {email}}})
+        WHERE r.created_at >= {since} AND r.created_at < {until}
+        WITH p, note_count, count(r) AS release_count
+        WHERE note_count + release_count > 0
+        RETURN DISTINCT p.id AS project_id
+        """,
+        {
+            'email': email,
+            'since': since.isoformat(),
+            'until': until.isoformat(),
+        },
+        ['project_id'],
+    )
+    for row in graph_rows:
+        pid = graph.parse_agtype(row.get('project_id'))
+        if pid:
+            project_ids.add(str(pid))
+
+    return len(project_ids)
+
+
+@users_router.get('/{email}/stats', response_model=StatsResponse)
+async def get_user_stats(
+    email: str,
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(permissions.require_permission('user:read')),
+    ],
+    since: str | None = None,
+    until: str | None = None,
+    tz: str = 'UTC',
+) -> StatsResponse:
+    """Return summary deployment / project tiles for the profile page."""
+    del auth, tz
+    email = urllib.parse.unquote(email)
+    await _ensure_user_exists(db, email)
+    start, end = _resolve_window(since, until)
+    subjects = await _resolve_user_subjects(db, email)
+
+    deploy_totals_sql = (
+        'SELECT '
+        "countIf(entry_type = 'Deployed') AS deployed, "
+        "countIf(entry_type = 'Rolled Back') AS rolled_back "
+        'FROM operations_log FINAL '
+        'WHERE is_deleted = 0 '
+        '  AND performed_by = {email:String} '
+        '  AND occurred_at >= {since:DateTime64(3)} '
+        '  AND occurred_at <  {until:DateTime64(3)}'
+    )
+    by_env_sql = (
+        'SELECT environment_slug, count() AS c '
+        'FROM operations_log FINAL '
+        'WHERE is_deleted = 0 '
+        '  AND performed_by = {email:String} '
+        "  AND entry_type = 'Deployed' "
+        '  AND occurred_at >= {since:DateTime64(3)} '
+        '  AND occurred_at <  {until:DateTime64(3)} '
+        'GROUP BY environment_slug'
+    )
+    params = {'email': email, 'since': start, 'until': end}
+
+    totals_rows, env_rows, projects_touched = await asyncio.gather(
+        clickhouse.query(deploy_totals_sql, params),
+        clickhouse.query(by_env_sql, params),
+        _projects_touched(
+            db,
+            email=email,
+            subjects=subjects,
+            since=start,
+            until=end,
+        ),
+    )
+
+    totals = totals_rows[0] if totals_rows else {}
+    deployed = int(totals.get('deployed', 0) or 0)
+    rolled_back = int(totals.get('rolled_back', 0) or 0)
+    success_rate: float | None = None
+    if deployed > 0:
+        success_rate = max(0.0, 1.0 - (rolled_back / deployed))
+
+    deploys_by_env = {
+        str(row['environment_slug']): int(row['c'])
+        for row in env_rows
+        if row.get('environment_slug')
+    }
+
+    return StatsResponse(
+        since=start,
+        until=end,
+        deployments=DeploymentStats(
+            total=deployed,
+            rolled_back=rolled_back,
+            success_rate=success_rate,
+        ),
+        projects_touched=projects_touched,
+        deployments_by_environment=deploys_by_env,
+    )
+
+
+# ---------------------------------------------------------------------------
+# /identities
+# ---------------------------------------------------------------------------
+
+
+@users_router.get('/{email}/identities', response_model=IdentitiesResponse)
+async def get_user_identities(
+    email: str,
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(permissions.require_permission('user:read')),
+    ],
+) -> IdentitiesResponse:
+    """Return the user's linked OAuth identities (no tokens)."""
+    del auth
+    email = urllib.parse.unquote(email)
+    await _ensure_user_exists(db, email)
+
+    rows = await db.execute(
+        """
+        MATCH (oi:OAuthIdentity)-[:OAUTH_IDENTITY]->(u:User {{email: {email}}})
+        RETURN oi.provider AS provider,
+               oi.provider_user_id AS provider_user_id,
+               oi.email AS email,
+               oi.display_name AS display_name,
+               oi.linked_at AS linked_at,
+               oi.last_used AS last_used
+        """,
+        {'email': email},
+        [
+            'provider',
+            'provider_user_id',
+            'email',
+            'display_name',
+            'linked_at',
+            'last_used',
+        ],
+    )
+
+    identities: list[IdentityRecord] = []
+    for row in rows:
+        identities.append(
+            IdentityRecord(
+                provider=str(graph.parse_agtype(row.get('provider')) or ''),
+                provider_user_id=str(
+                    graph.parse_agtype(row.get('provider_user_id')) or ''
+                ),
+                email=(
+                    str(graph.parse_agtype(row.get('email')))
+                    if row.get('email') is not None
+                    else None
+                ),
+                display_name=(
+                    str(graph.parse_agtype(row.get('display_name')))
+                    if row.get('display_name') is not None
+                    else None
+                ),
+                linked_at=_coerce_dt(row.get('linked_at')),
+                last_used=_coerce_dt(row.get('last_used')),
+            )
+        )
+
+    def _sort_key(rec: IdentityRecord) -> tuple[float, float]:
+        last = rec.last_used.timestamp() if rec.last_used else 0.0
+        linked = rec.linked_at.timestamp() if rec.linked_at else 0.0
+        return (last, linked)
+
+    sorted_identities = sorted(identities, key=_sort_key, reverse=True)
+    primary = sorted_identities[0] if sorted_identities else None
+    return IdentitiesResponse(primary=primary, all=sorted_identities)
+
+
+# ---------------------------------------------------------------------------
+# /activity
+# ---------------------------------------------------------------------------
+
+
+def _encode_cursor(occurred_at: datetime.datetime, entry_id: str) -> str:
+    payload = f'{occurred_at.isoformat()}|{entry_id}'.encode()
+    return base64.urlsafe_b64encode(payload).rstrip(b'=').decode('ascii')
+
+
+def _decode_cursor(
+    cursor: str,
+) -> tuple[datetime.datetime, str] | None:
+    if not cursor:
+        return None
+    padding = '=' * (-len(cursor) % 4)
+    try:
+        raw = base64.urlsafe_b64decode(cursor + padding).decode('utf-8')
+    except ValueError, UnicodeDecodeError:
+        return None
+    if '|' not in raw:
+        return None
+    ts_str, _, entry_id = raw.partition('|')
+    if not entry_id:
+        return None
+    try:
+        ts = datetime.datetime.fromisoformat(ts_str)
+    except ValueError:
+        return None
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=datetime.UTC)
+    return ts.astimezone(datetime.UTC), entry_id
+
+
+def _build_link_header(
+    request: fastapi.Request,
+    next_cursor: str | None,
+) -> str:
+    url = request.url
+    base_params = {
+        k: v for k, v in request.query_params.multi_items() if k != 'cursor'
+    }
+
+    def _url_with(params: dict[str, str]) -> str:
+        scheme_host_path = f'{url.scheme}://{url.netloc}{url.path}'
+        if not params:
+            return scheme_host_path
+        return f'{scheme_host_path}?{urllib.parse.urlencode(params)}'
+
+    links = [f'<{_url_with(base_params)}>; rel="first"']
+    if next_cursor is not None:
+        next_params = dict(base_params)
+        next_params['cursor'] = next_cursor
+        links.append(f'<{_url_with(next_params)}>; rel="next"')
+    return ', '.join(links)
+
+
+async def _opslog_activity(
+    *,
+    email: str,
+    before: datetime.datetime,
+    limit: int,
+) -> list[ActivityRecord]:
+    sql: str = (
+        'SELECT id, occurred_at, entry_type, environment_slug, '
+        'project_id, project_slug, description, version '
+        'FROM operations_log FINAL '
+        'WHERE is_deleted = 0 '
+        '  AND performed_by = {email:String} '
+        '  AND occurred_at < {before:DateTime64(3)} '
+        'ORDER BY occurred_at DESC, id DESC '
+        'LIMIT {row_limit:UInt32}'
+    )
+    rows = await clickhouse.query(
+        sql,
+        {'email': email, 'before': before, 'row_limit': limit},
+    )
+    out: list[ActivityRecord] = []
+    for row in rows:
+        ts = row['occurred_at']
+        if isinstance(ts, datetime.datetime) and ts.tzinfo is None:
+            ts = ts.replace(tzinfo=datetime.UTC)
+        version = row.get('version')
+        env = row.get('environment_slug') or ''
+        entry_type = str(row.get('entry_type') or '')
+        version_part = f' {version}' if version else ''
+        env_part = f' to {env}' if env else ''
+        description = row.get('description') or ''
+        summary = f'{entry_type}{version_part}{env_part}'
+        if description:
+            summary = f'{summary} — {description}'
+        out.append(
+            ActivityRecord(
+                id=str(row['id']),
+                source='operations_log',
+                occurred_at=ts,
+                summary=summary,
+                type=entry_type,
+                environment_slug=env or None,
+                project_id=row.get('project_id') or None,
+                project_slug=row.get('project_slug') or None,
+                link=(
+                    f'/operations-log/{row["id"]}' if row.get('id') else None
+                ),
+            )
+        )
+    return out
+
+
+async def _events_activity(
+    *,
+    subjects: list[str],
+    before: datetime.datetime,
+    limit: int,
+) -> list[ActivityRecord]:
+    if not subjects:
+        return []
+    sql: str = (
+        'SELECT id, recorded_at, type, third_party_service, '
+        'project_id, metadata '
+        'FROM events '
+        'WHERE attributed_to IN {subjects:Array(String)} '
+        '  AND recorded_at < {before:DateTime64(3)} '
+        'ORDER BY recorded_at DESC, id DESC '
+        'LIMIT {row_limit:UInt32}'
+    )
+    rows = await clickhouse.query(
+        sql,
+        {'subjects': subjects, 'before': before, 'row_limit': limit},
+    )
+    out: list[ActivityRecord] = []
+    for row in rows:
+        ts = row['recorded_at']
+        if isinstance(ts, datetime.datetime) and ts.tzinfo is None:
+            ts = ts.replace(tzinfo=datetime.UTC)
+        meta_raw: typing.Any = row.get('metadata') or {}
+        meta_summary: str | None = None
+        if isinstance(meta_raw, dict):
+            meta_dict = typing.cast(
+                'dict[str, typing.Any]',
+                meta_raw,  # pyright: ignore[reportUnknownArgumentType]
+            )
+            value = meta_dict.get('summary')
+            if isinstance(value, str):
+                meta_summary = value
+        type_str = str(row.get('type') or '')
+        service = str(row.get('third_party_service') or '')
+        head = type_str
+        if service:
+            head = f'{type_str} via {service}' if type_str else service
+        summary = f'{head} — {meta_summary}' if meta_summary else head
+        out.append(
+            ActivityRecord(
+                id=str(row['id']),
+                source='events',
+                occurred_at=ts,
+                summary=summary,
+                type=type_str,
+                project_id=row.get('project_id') or None,
+            )
+        )
+    return out
+
+
+_GRAPH_ACTIVITY_QUERIES: dict[str, str] = {
+    'note': """
+        MATCH (n:Note)-[:ATTACHED_TO]->(p:Project)
+        WHERE (n.created_by = {email} OR n.updated_by = {email})
+          AND n.created_at < {before}
+        RETURN n.id AS id,
+               n.created_at AS ts,
+               n.title AS title,
+               n.created_by AS created_by,
+               n.updated_by AS updated_by,
+               p.id AS project_id,
+               p.slug AS project_slug,
+               p.name AS project_name
+        ORDER BY n.created_at DESC, n.id DESC
+        LIMIT {row_limit}
+    """,
+    'release': """
+        MATCH (r:Release)<-[:HAS_RELEASE]-(p:Project)
+        WHERE r.created_by = {email}
+          AND r.created_at < {before}
+        RETURN r.id AS id,
+               r.created_at AS ts,
+               r.version AS version,
+               r.title AS title,
+               p.id AS project_id,
+               p.slug AS project_slug,
+               p.name AS project_name
+        ORDER BY r.created_at DESC, r.id DESC
+        LIMIT {row_limit}
+    """,
+    'upload': """
+        MATCH (u:Upload {{uploaded_by: {email}}})
+        WHERE u.created_at < {before}
+        RETURN u.id AS id,
+               u.created_at AS ts,
+               u.filename AS filename
+        ORDER BY u.created_at DESC, u.id DESC
+        LIMIT {row_limit}
+    """,
+    'conversation': """
+        MATCH (c:Conversation {{user_email: {email}}})
+        WHERE c.created_at < {before}
+        RETURN c.id AS id,
+               c.created_at AS ts,
+               c.title AS title
+        ORDER BY c.created_at DESC, c.id DESC
+        LIMIT {row_limit}
+    """,
+}
+
+
+def _graph_summary(label: str, row: dict[str, typing.Any]) -> str:
+    if label == 'note':
+        title = graph.parse_agtype(row.get('title')) or '(untitled)'
+        proj = (
+            graph.parse_agtype(row.get('project_name'))
+            or graph.parse_agtype(row.get('project_slug'))
+            or 'a project'
+        )
+        return f'Wrote note "{title}" on {proj}'
+    if label == 'release':
+        version = graph.parse_agtype(row.get('version')) or ''
+        proj = (
+            graph.parse_agtype(row.get('project_name'))
+            or graph.parse_agtype(row.get('project_slug'))
+            or 'a project'
+        )
+        return f'Released {version} of {proj}'.strip()
+    if label == 'upload':
+        filename = graph.parse_agtype(row.get('filename')) or '(unknown)'
+        return f'Uploaded {filename}'
+    if label == 'conversation':
+        title = graph.parse_agtype(row.get('title')) or '(untitled)'
+        return f'Started conversation: {title}'
+    return label
+
+
+_LABEL_TO_SOURCE: dict[str, ActivitySource] = {
+    'note': 'note',
+    'release': 'release',
+    'upload': 'upload',
+    'conversation': 'conversation',
+}
+
+_LABEL_TO_TYPE: dict[str, str] = {
+    'note': 'Note',
+    'release': 'Release',
+    'upload': 'Upload',
+    'conversation': 'Conversation',
+}
+
+
+async def _graph_activity(
+    db: graph.Graph,
+    *,
+    label: str,
+    email: str,
+    before: datetime.datetime,
+    limit: int,
+) -> list[ActivityRecord]:
+    template = _GRAPH_ACTIVITY_QUERIES[label]
+    rows = await db.execute(
+        template,
+        {
+            'email': email,
+            'before': before.isoformat(),
+            'row_limit': limit,
+        },
+    )
+    out: list[ActivityRecord] = []
+    for row in rows:
+        ts = _coerce_dt(row.get('ts'))
+        if ts is None:
+            continue
+        entry_id = graph.parse_agtype(row.get('id')) or ''
+        project_slug = (
+            graph.parse_agtype(row.get('project_slug'))
+            if row.get('project_slug') is not None
+            else None
+        )
+        project_id = (
+            graph.parse_agtype(row.get('project_id'))
+            if row.get('project_id') is not None
+            else None
+        )
+        out.append(
+            ActivityRecord(
+                id=str(entry_id),
+                source=_LABEL_TO_SOURCE[label],
+                occurred_at=ts,
+                summary=_graph_summary(label, row),
+                type=_LABEL_TO_TYPE[label],
+                project_id=str(project_id) if project_id else None,
+                project_slug=str(project_slug) if project_slug else None,
+            )
+        )
+    return out
+
+
+@users_router.get('/{email}/activity', response_model=ActivityResponse)
+async def get_user_activity(
+    request: fastapi.Request,
+    email: str,
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(permissions.require_permission('user:read')),
+    ],
+    limit: int = DEFAULT_ACTIVITY_LIMIT,
+    cursor: str | None = None,
+) -> fastapi.Response:
+    """Cursor-paginated, mixed-source activity feed for the user."""
+    del auth
+    if limit < 1 or limit > MAX_ACTIVITY_LIMIT:
+        raise fastapi.HTTPException(
+            status_code=400,
+            detail=f'limit must be 1..{MAX_ACTIVITY_LIMIT}',
+        )
+    email = urllib.parse.unquote(email)
+    await _ensure_user_exists(db, email)
+
+    before = datetime.datetime.now(datetime.UTC) + datetime.timedelta(days=1)
+    cursor_id: str | None = None
+    if cursor is not None:
+        decoded = _decode_cursor(cursor)
+        if decoded is None:
+            raise fastapi.HTTPException(
+                status_code=400, detail='Invalid cursor'
+            )
+        before, cursor_id = decoded
+
+    subjects = await _resolve_user_subjects(db, email)
+    per_source = limit + 1
+    legs = await asyncio.gather(
+        _opslog_activity(email=email, before=before, limit=per_source),
+        _events_activity(subjects=subjects, before=before, limit=per_source),
+        _graph_activity(
+            db, label='note', email=email, before=before, limit=per_source
+        ),
+        _graph_activity(
+            db,
+            label='release',
+            email=email,
+            before=before,
+            limit=per_source,
+        ),
+        _graph_activity(
+            db,
+            label='upload',
+            email=email,
+            before=before,
+            limit=per_source,
+        ),
+        _graph_activity(
+            db,
+            label='conversation',
+            email=email,
+            before=before,
+            limit=per_source,
+        ),
+    )
+
+    merged: list[ActivityRecord] = []
+    for leg in legs:
+        merged.extend(leg)
+    merged.sort(
+        key=lambda r: (r.occurred_at, r.id),
+        reverse=True,
+    )
+    if cursor_id is not None:
+        merged = [
+            r for r in merged if (r.occurred_at, r.id) < (before, cursor_id)
+        ]
+
+    next_cursor: str | None = None
+    if len(merged) > limit:
+        merged = merged[:limit]
+    if len(merged) == limit:
+        last = merged[-1]
+        next_cursor = _encode_cursor(last.occurred_at, last.id)
+
+    body = ActivityResponse(data=merged)
+    response = fastapi.responses.JSONResponse(
+        fastapi.encoders.jsonable_encoder(body.model_dump(mode='json'))
+    )
+    response.headers['Link'] = _build_link_header(request, next_cursor)
+    return response

--- a/tests/endpoints/test_user_activity.py
+++ b/tests/endpoints/test_user_activity.py
@@ -1,0 +1,379 @@
+"""Tests for user-profile activity endpoints."""
+
+from __future__ import annotations
+
+import datetime
+import typing
+import unittest
+from unittest import mock
+
+from fastapi import testclient
+from imbi_common import graph
+
+from imbi_api import app
+from imbi_api import models as api_models
+from imbi_api.auth import permissions as api_permissions
+from imbi_api.endpoints import user_activity
+
+
+def _make_auth(
+    *,
+    perms: typing.Iterable[str] = ('user:read',),
+    is_admin: bool = True,
+) -> api_permissions.AuthContext:
+    user = api_models.User(
+        email='alice@example.com',
+        display_name='Alice',
+        is_active=True,
+        is_admin=is_admin,
+        is_service_account=False,
+        created_at=datetime.datetime.now(datetime.UTC),
+    )
+    return api_permissions.AuthContext(
+        user=user,
+        session_id='test',
+        auth_method='jwt',
+        permissions=set(perms),
+    )
+
+
+class _Base(unittest.TestCase):
+    def setUp(self) -> None:
+        self.test_app = app.create_app()
+        self.auth = _make_auth()
+
+        async def _current_user() -> api_permissions.AuthContext:
+            return self.auth
+
+        self.test_app.dependency_overrides[
+            api_permissions.get_current_user
+        ] = _current_user
+
+        self.mock_db = mock.AsyncMock(spec=graph.Graph)
+        self.test_app.dependency_overrides[graph._inject_graph] = lambda: (
+            self.mock_db
+        )
+
+        self.query_patcher = mock.patch(
+            'imbi_common.clickhouse.query',
+            new_callable=mock.AsyncMock,
+        )
+        self.mock_query = self.query_patcher.start()
+        self.addCleanup(self.query_patcher.stop)
+
+        self.parse_patcher = mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda v: v,
+        )
+        self.parse_patcher.start()
+        self.addCleanup(self.parse_patcher.stop)
+
+        # Also patch the alias imported by the module under test.
+        self.parse_patcher_local = mock.patch(
+            'imbi_api.endpoints.user_activity.graph.parse_agtype',
+            side_effect=lambda v: v,
+        )
+        self.parse_patcher_local.start()
+        self.addCleanup(self.parse_patcher_local.stop)
+
+        self.client = testclient.TestClient(self.test_app)
+        self.addCleanup(self.client.close)
+
+    def _execute_returns(
+        self, payloads: list[list[dict[str, typing.Any]]]
+    ) -> None:
+        """Set ``mock_db.execute`` to return ``payloads`` in order."""
+        self.mock_db.execute.side_effect = list(payloads)
+
+
+class WindowAndCursorTests(unittest.TestCase):
+    def test_resolve_window_default(self) -> None:
+        start, end = user_activity._resolve_window(None, None)
+        self.assertGreater(end, start)
+        self.assertAlmostEqual(
+            (end - start).days,
+            user_activity.DEFAULT_WINDOW_DAYS,
+            delta=1,
+        )
+
+    def test_resolve_window_invalid_iso(self) -> None:
+        import fastapi
+
+        with self.assertRaises(fastapi.HTTPException):
+            user_activity._resolve_window('not-a-date', None)
+
+    def test_resolve_window_inverted(self) -> None:
+        import fastapi
+
+        with self.assertRaises(fastapi.HTTPException):
+            user_activity._resolve_window(
+                '2026-01-02T00:00:00Z', '2026-01-01T00:00:00Z'
+            )
+
+    def test_cursor_round_trip(self) -> None:
+        ts = datetime.datetime(2026, 4, 1, 12, 0, tzinfo=datetime.UTC)
+        encoded = user_activity._encode_cursor(ts, 'evt-1')
+        decoded = user_activity._decode_cursor(encoded)
+        self.assertIsNotNone(decoded)
+        assert decoded is not None
+        self.assertEqual(decoded[0], ts)
+        self.assertEqual(decoded[1], 'evt-1')
+
+    def test_cursor_decode_invalid(self) -> None:
+        self.assertIsNone(user_activity._decode_cursor(''))
+        self.assertIsNone(user_activity._decode_cursor('not-base64-!@#$'))
+
+
+class ContributionsTests(_Base):
+    def test_unknown_user_returns_404(self) -> None:
+        self._execute_returns([[]])  # _ensure_user_exists -> no rows
+        resp = self.client.get('/users/missing@example.com/contributions')
+        self.assertEqual(resp.status_code, 404)
+
+    def test_aggregates_all_legs(self) -> None:
+        # _ensure_user_exists, _resolve_user_subjects, then 4 graph legs
+        self._execute_returns(
+            [
+                [{'id': 'u1'}],
+                [
+                    {
+                        'conn_subjects': ['ext-42'],
+                        'oauth_subjects': ['oauth-1'],
+                    }
+                ],
+                [
+                    {
+                        'ts': datetime.datetime(
+                            2026, 4, 17, 10, 0, tzinfo=datetime.UTC
+                        ).isoformat(),
+                    },
+                    {
+                        'ts': datetime.datetime(
+                            2026, 4, 17, 11, 0, tzinfo=datetime.UTC
+                        ).isoformat(),
+                    },
+                ],  # notes
+                [],  # releases
+                [],  # uploads
+                [],  # conversations
+            ]
+        )
+        opslog_day = datetime.date(2026, 4, 16)
+        events_day = datetime.date(2026, 4, 18)
+        self.mock_query.side_effect = [
+            [{'d': opslog_day, 'c': 5}],  # opslog buckets
+            [{'d': events_day, 'c': 2}],  # events buckets
+        ]
+        resp = self.client.get('/users/alice@example.com/contributions')
+        self.assertEqual(resp.status_code, 200, resp.text)
+        body = resp.json()
+        self.assertEqual(body['total'], 5 + 2 + 2)
+        self.assertEqual(len(body['buckets']), 3)
+        sources = {b['date']: b['by_source'] for b in body['buckets']}
+        self.assertEqual(sources[opslog_day.isoformat()]['operations_log'], 5)
+        self.assertEqual(sources[events_day.isoformat()]['events'], 2)
+        self.assertEqual(sources['2026-04-17']['note'], 2)
+
+
+class StatsTests(_Base):
+    def test_returns_success_rate_and_envs(self) -> None:
+        self._execute_returns(
+            [
+                [{'id': 'u1'}],
+                [{'conn_subjects': [], 'oauth_subjects': []}],
+                [],  # _projects_touched -> graph
+            ]
+        )
+        self.mock_query.side_effect = [
+            [{'deployed': 50, 'rolled_back': 3}],  # totals
+            [
+                {'environment_slug': 'production', 'c': 30},
+                {'environment_slug': 'staging', 'c': 20},
+            ],  # by env
+            [{'project_id': 'p1'}, {'project_id': 'p2'}],  # opslog distinct
+        ]
+        resp = self.client.get('/users/alice@example.com/stats')
+        self.assertEqual(resp.status_code, 200, resp.text)
+        body = resp.json()
+        self.assertEqual(body['deployments']['total'], 50)
+        self.assertEqual(body['deployments']['rolled_back'], 3)
+        self.assertAlmostEqual(
+            body['deployments']['success_rate'],
+            1.0 - 3 / 50,
+        )
+        self.assertEqual(body['projects_touched'], 2)
+        self.assertEqual(
+            body['deployments_by_environment'],
+            {'production': 30, 'staging': 20},
+        )
+
+    def test_zero_deployments_yields_null_success_rate(self) -> None:
+        self._execute_returns(
+            [
+                [{'id': 'u1'}],
+                [{'conn_subjects': [], 'oauth_subjects': []}],
+                [],
+            ]
+        )
+        self.mock_query.side_effect = [
+            [{'deployed': 0, 'rolled_back': 0}],
+            [],
+            [],
+        ]
+        resp = self.client.get('/users/alice@example.com/stats')
+        self.assertEqual(resp.status_code, 200)
+        self.assertIsNone(resp.json()['deployments']['success_rate'])
+
+
+class IdentitiesTests(_Base):
+    def test_primary_is_most_recent_last_used(self) -> None:
+        recent = datetime.datetime(2026, 5, 1, tzinfo=datetime.UTC)
+        older = datetime.datetime(2026, 1, 1, tzinfo=datetime.UTC)
+        self._execute_returns(
+            [
+                [{'id': 'u1'}],  # _ensure_user_exists
+                [
+                    {
+                        'provider': 'google',
+                        'provider_user_id': '999',
+                        'email': 'alice@example.com',
+                        'display_name': 'Alice',
+                        'linked_at': older.isoformat(),
+                        'last_used': older.isoformat(),
+                    },
+                    {
+                        'provider': 'github',
+                        'provider_user_id': '42',
+                        'email': 'alice@example.com',
+                        'display_name': 'Alice',
+                        'linked_at': older.isoformat(),
+                        'last_used': recent.isoformat(),
+                    },
+                ],
+            ]
+        )
+        resp = self.client.get('/users/alice@example.com/identities')
+        self.assertEqual(resp.status_code, 200, resp.text)
+        body = resp.json()
+        self.assertEqual(body['primary']['provider'], 'github')
+        self.assertEqual(len(body['all']), 2)
+
+
+class ActivityFeedTests(_Base):
+    def test_merges_and_orders_descending(self) -> None:
+        ts1 = datetime.datetime(2026, 4, 1, 10, tzinfo=datetime.UTC)
+        ts2 = datetime.datetime(2026, 4, 2, 10, tzinfo=datetime.UTC)
+        ts3 = datetime.datetime(2026, 4, 3, 10, tzinfo=datetime.UTC)
+
+        self._execute_returns(
+            [
+                [{'id': 'u1'}],  # _ensure_user_exists
+                [{'conn_subjects': [], 'oauth_subjects': []}],  # subjects
+                # graph legs in registration order (note, release, upload,
+                # conversation)
+                [
+                    {
+                        'id': 'note-1',
+                        'ts': ts2.isoformat(),
+                        'title': 'A note',
+                        'created_by': 'alice@example.com',
+                        'updated_by': None,
+                        'project_id': 'p1',
+                        'project_slug': 'imbi-api',
+                        'project_name': 'Imbi API',
+                    }
+                ],
+                [],  # releases
+                [],  # uploads
+                [],  # conversations
+            ]
+        )
+        self.mock_query.side_effect = [
+            # opslog
+            [
+                {
+                    'id': 'op-1',
+                    'occurred_at': ts1,
+                    'entry_type': 'Deployed',
+                    'environment_slug': 'production',
+                    'project_id': 'p1',
+                    'project_slug': 'imbi-api',
+                    'description': 'rolled v1.0.0',
+                    'version': 'v1.0.0',
+                },
+                {
+                    'id': 'op-2',
+                    'occurred_at': ts3,
+                    'entry_type': 'Rolled Back',
+                    'environment_slug': 'production',
+                    'project_id': 'p1',
+                    'project_slug': 'imbi-api',
+                    'description': 'reverted',
+                    'version': 'v0.9.9',
+                },
+            ],
+            [],  # events
+        ]
+        resp = self.client.get('/users/alice@example.com/activity?limit=2')
+        self.assertEqual(resp.status_code, 200, resp.text)
+        body = resp.json()
+        self.assertEqual(len(body['data']), 2)
+        # Newest first: op-2 (ts3), note-1 (ts2)
+        self.assertEqual(body['data'][0]['id'], 'op-2')
+        self.assertEqual(body['data'][0]['source'], 'operations_log')
+        self.assertEqual(body['data'][1]['id'], 'note-1')
+        self.assertEqual(body['data'][1]['source'], 'note')
+        # Has Link header
+        self.assertIn('Link', resp.headers)
+
+    def test_limit_validation(self) -> None:
+        resp = self.client.get('/users/a@b/activity?limit=0')
+        self.assertEqual(resp.status_code, 400)
+        resp = self.client.get('/users/a@b/activity?limit=999')
+        self.assertEqual(resp.status_code, 400)
+
+    def test_invalid_cursor(self) -> None:
+        self._execute_returns([[{'id': 'u1'}]])
+        resp = self.client.get(
+            '/users/alice@example.com/activity?cursor=garbage!@#'
+        )
+        self.assertEqual(resp.status_code, 400)
+
+
+class PermissionTests(unittest.TestCase):
+    """Endpoints must require user:read."""
+
+    def setUp(self) -> None:
+        self.test_app = app.create_app()
+        self.auth = _make_auth(perms=(), is_admin=False)  # no permissions
+
+        async def _current_user() -> api_permissions.AuthContext:
+            return self.auth
+
+        self.test_app.dependency_overrides[
+            api_permissions.get_current_user
+        ] = _current_user
+        # Also override graph so require_permission doesn't trip on a
+        # missing pool when it short-circuits on the 403.
+        self.mock_db = mock.AsyncMock(spec=graph.Graph)
+        self.test_app.dependency_overrides[graph._inject_graph] = lambda: (
+            self.mock_db
+        )
+        self.client = testclient.TestClient(self.test_app)
+        self.addCleanup(self.client.close)
+
+    def test_contributions_requires_user_read(self) -> None:
+        resp = self.client.get('/users/alice@example.com/contributions')
+        self.assertEqual(resp.status_code, 403)
+
+    def test_stats_requires_user_read(self) -> None:
+        resp = self.client.get('/users/alice@example.com/stats')
+        self.assertEqual(resp.status_code, 403)
+
+    def test_activity_requires_user_read(self) -> None:
+        resp = self.client.get('/users/alice@example.com/activity')
+        self.assertEqual(resp.status_code, 403)
+
+    def test_identities_requires_user_read(self) -> None:
+        resp = self.client.get('/users/alice@example.com/identities')
+        self.assertEqual(resp.status_code, 403)

--- a/tests/endpoints/test_user_activity.py
+++ b/tests/endpoints/test_user_activity.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import collections.abc
 import datetime
 import typing
 import unittest
@@ -18,7 +19,7 @@ from imbi_api.endpoints import user_activity
 
 def _make_auth(
     *,
-    perms: typing.Iterable[str] = ('user:read',),
+    perms: collections.abc.Iterable[str] = ('user:read',),
     is_admin: bool = True,
 ) -> api_permissions.AuthContext:
     user = api_models.User(
@@ -123,6 +124,19 @@ class WindowAndCursorTests(unittest.TestCase):
         self.assertIsNone(user_activity._decode_cursor(''))
         self.assertIsNone(user_activity._decode_cursor('not-base64-!@#$'))
 
+    def test_resolve_tz_valid(self) -> None:
+        zone = user_activity._resolve_tz('UTC')
+        self.assertEqual(str(zone), 'UTC')
+        zone = user_activity._resolve_tz('America/New_York')
+        self.assertEqual(str(zone), 'America/New_York')
+
+    def test_resolve_tz_invalid(self) -> None:
+        import fastapi
+
+        with self.assertRaises(fastapi.HTTPException) as ctx:
+            user_activity._resolve_tz('Not/A_Zone')
+        self.assertEqual(ctx.exception.status_code, 400)
+
 
 class ContributionsTests(_Base):
     def test_unknown_user_returns_404(self) -> None:
@@ -173,6 +187,13 @@ class ContributionsTests(_Base):
         self.assertEqual(sources[opslog_day.isoformat()]['operations_log'], 5)
         self.assertEqual(sources[events_day.isoformat()]['events'], 2)
         self.assertEqual(sources['2026-04-17']['note'], 2)
+
+    def test_invalid_tz_returns_400(self) -> None:
+        self._execute_returns([[{'id': 'u1'}]])
+        resp = self.client.get(
+            '/users/alice@example.com/contributions?tz=Not/A_Zone'
+        )
+        self.assertEqual(resp.status_code, 400)
 
 
 class StatsTests(_Base):
@@ -338,6 +359,53 @@ class ActivityFeedTests(_Base):
             '/users/alice@example.com/activity?cursor=garbage!@#'
         )
         self.assertEqual(resp.status_code, 400)
+
+    def test_no_next_link_when_results_match_limit_exactly(self) -> None:
+        """No next cursor when fewer than limit+1 rows are available."""
+        ts1 = datetime.datetime(2026, 4, 1, 10, tzinfo=datetime.UTC)
+        ts2 = datetime.datetime(2026, 4, 2, 10, tzinfo=datetime.UTC)
+        self._execute_returns(
+            [
+                [{'id': 'u1'}],  # _ensure_user_exists
+                [{'conn_subjects': [], 'oauth_subjects': []}],  # subjects
+                [],  # notes
+                [],  # releases
+                [],  # uploads
+                [],  # conversations
+            ]
+        )
+        self.mock_query.side_effect = [
+            [
+                {
+                    'id': 'op-1',
+                    'occurred_at': ts1,
+                    'entry_type': 'Deployed',
+                    'environment_slug': 'production',
+                    'project_id': 'p1',
+                    'project_slug': 'imbi-api',
+                    'description': '',
+                    'version': 'v1',
+                },
+                {
+                    'id': 'op-2',
+                    'occurred_at': ts2,
+                    'entry_type': 'Deployed',
+                    'environment_slug': 'production',
+                    'project_id': 'p1',
+                    'project_slug': 'imbi-api',
+                    'description': '',
+                    'version': 'v2',
+                },
+            ],
+            [],  # events
+        ]
+        resp = self.client.get('/users/alice@example.com/activity?limit=2')
+        self.assertEqual(resp.status_code, 200, resp.text)
+        body = resp.json()
+        self.assertEqual(len(body['data']), 2)
+        # Only first/self link, no rel="next" because available rows == limit
+        link = resp.headers.get('Link', '')
+        self.assertNotIn('rel="next"', link)
 
 
 class PermissionTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

Implements Phase 1 of `docs/user-profile-page-plan.md`: four read-only aggregation endpoints under `/users/{email}` that the new v2 UI profile page reads from.

- `/contributions` — per-day counts unioned across `operations_log`, `events`, `Note`, `Release`, `Upload`, `Conversation` for the 52-week heatmap. Accepts `since`, `until`, `tz`.
- `/stats` — deployments / rolled-back / success rate / projects-touched / deployments-by-environment over a trailing window.
- `/activity` — cursor-paginated mixed-source feed (`Link: rel=next`). Source queries fan out via `asyncio.gather`; results merge in memory ordered by `(occurred_at, id)` desc.
- `/identities` — linked `OAuthIdentity` records (no tokens). Primary = most recent `last_used`.

All endpoints require `user:read` and 404 on unknown emails. The events leg matches `attributed_to` against the user's `IdentityConnection` subjects plus legacy `OAuthIdentity.provider_user_id`s.

## Test plan

- [x] `tests/endpoints/test_user_activity.py` — 17 tests covering cursor codec, window resolution, the four endpoints (happy path, 404, permission gating, malformed cursor)
- [ ] Smoke against staging once merged