### PR TITLE
Drop version_format constraint on release creation

### DIFF
--- a/src/imbi_api/endpoints/releases.py
+++ b/src/imbi_api/endpoints/releases.py
@@ -16,8 +16,7 @@ import typing
 import fastapi
 import nanoid
 import pydantic
-from imbi_common import graph, models, versioning
-from imbi_common import settings as common_settings
+from imbi_common import graph, models
 
 from imbi_api import patch as json_patch
 from imbi_api.auth import permissions
@@ -139,11 +138,6 @@ _RELEASE_READONLY_PATHS: frozenset[str] = frozenset(
 )
 
 
-def _version_format() -> versioning.VersionFormat:
-    """Return the active configured release version format."""
-    return common_settings.Releases().version_format
-
-
 def _serialize_links(
     links: list[models.ReleaseLink] | list[dict[str, typing.Any]],
 ) -> str:
@@ -260,10 +254,7 @@ async def create_release(
     ],
 ) -> ReleaseResponse:
     """Create a new release for a project."""
-    try:
-        version = versioning.validate_version(data.version, _version_format())
-    except ValueError as e:
-        raise fastapi.HTTPException(status_code=422, detail=str(e)) from e
+    version = data.version
 
     if not await _project_exists(db, org_slug, project_id):
         raise fastapi.HTTPException(

--- a/tests/endpoints/test_releases.py
+++ b/tests/endpoints/test_releases.py
@@ -148,14 +148,6 @@ class CreateReleaseTestCase(_ReleasesTestBase):
         self.assertEqual(response.status_code, 201)
         self.assertEqual(response.json()['created_by'], 'deploy-bot')
 
-    def test_create_invalid_semver(self) -> None:
-        response = self.client.post(
-            self._url('/'),
-            json={'version': 'not.a.version', 'title': 'x'},
-        )
-        self.assertEqual(response.status_code, 422)
-        self.assertIn('semver', response.json()['detail'].lower())
-
     def test_create_project_not_found(self) -> None:
         self.mock_db.execute.side_effect = [[]]  # project_exists -> no rows
         with mock.patch(
@@ -206,24 +198,21 @@ class CreateReleaseTestCase(_ReleasesTestBase):
             )
         self.assertEqual(response.status_code, 201)
 
-    def test_create_commitish_format_rejects_semver(self) -> None:
-        """With version_format=commitish the semver regex is rejected."""
-        with mock.patch(
-            'imbi_api.endpoints.releases.common_settings.Releases'
-        ) as mock_releases:
-            mock_releases.return_value.version_format = 'commitish'
-            response = self.client.post(
-                self._url('/'),
-                json={'version': '1.2.3', 'title': 'x'},
-            )
-            self.assertEqual(response.status_code, 422)
-            self.assertIn('commitish', response.json()['detail'].lower())
+    def test_create_two_releases_commitish_then_semver(self) -> None:
+        """Create both a commitish and a semver release for one project.
 
-    def test_create_commitish_valid_sha(self) -> None:
+        ``version_format`` is fixed at process start, so this test does
+        not flip it mid-run.
+        """
         self.mock_db.execute.side_effect = [
+            # First create: 214e932
             [{'id': PROJECT_ID}],
             [],
-            [{'release': _release_row(version='abc1234')}],
+            [{'release': _release_row(version='214e932', id='rel-commitish')}],
+            # Second create: 2.2.0
+            [{'id': PROJECT_ID}],
+            [],
+            [{'release': _release_row(version='2.2.0', id='rel-semver')}],
         ]
         with (
             mock.patch(
@@ -232,18 +221,25 @@ class CreateReleaseTestCase(_ReleasesTestBase):
             ),
             mock.patch(
                 'imbi_api.endpoints.releases.nanoid.generate',
-                return_value=RELEASE_ID,
+                side_effect=['rel-commitish', 'rel-semver'],
             ),
-            mock.patch(
-                'imbi_api.endpoints.releases.common_settings.Releases'
-            ) as mock_releases,
         ):
-            mock_releases.return_value.version_format = 'commitish'
-            response = self.client.post(
+            first = self.client.post(
                 self._url('/'),
-                json={'version': 'abc1234', 'title': 'x'},
+                json={'version': '214e932', 'title': 'commitish build'},
             )
-        self.assertEqual(response.status_code, 201)
+            second = self.client.post(
+                self._url('/'),
+                json={'version': '2.2.0', 'title': 'semver release'},
+            )
+
+        self.assertEqual(first.status_code, 201)
+        self.assertEqual(first.json()['version'], '214e932')
+        self.assertEqual(first.json()['id'], 'rel-commitish')
+
+        self.assertEqual(second.status_code, 201)
+        self.assertEqual(second.json()['version'], '2.2.0')
+        self.assertEqual(second.json()['id'], 'rel-semver')
 
 
 class ListGetReleaseTestCase(_ReleasesTestBase):


### PR DESCRIPTION
## Summary
Remove the global `version_format` validation from `POST /organizations/{org}/projects/{id}/releases/` so a single project can hold both commitish (e.g. `214e932`) and semver (e.g. `2.2.0`) releases.

## Problem
`version_format` is read once at process start from `common_settings.Releases().version_format`, so the active format is fixed for the lifetime of the API server. That makes it impossible for a project that started with SHA-tagged builds and later adopted semver tags (or vice versa) to record both kinds of releases against the same project — every create is rejected with 422 unless it matches the format that was configured at boot.

## Solution
- `create_release` no longer calls `versioning.validate_version`; `data.version` is stored verbatim.
- Drop the now-unused `versioning` and `common_settings` imports and the `_version_format` helper from `endpoints/releases.py`.
- Remove tests that asserted format-specific rejection (`test_create_invalid_semver`, `test_create_commitish_format_rejects_semver`, `test_create_commitish_valid_sha`); they exercised behaviour the endpoint no longer has.
- Add `test_create_two_releases_commitish_then_semver` which POSTs `214e932` and `2.2.0` against the same project and asserts both creates return 201.

## Impact
- Public API: `POST /releases/` now accepts any non-empty version string. Clients that previously relied on the 422 to catch typos will need to validate client-side. Per-project version uniqueness (409 on duplicate) is unchanged.
- No database migration needed — the version is already stored as a plain string.
- The `Releases.version_format` setting becomes effectively unused by this endpoint; left in place for now so other consumers in the wider codebase aren't disturbed.

## Testing notes
- `just lint` (ruff, basedpyright, mypy) — all green.
- `just test tests/endpoints/test_releases.py` — 28 tests pass, including the new mixed-format test.