### PR TITLE
Add event_type_selector to webhook CRUD

### DIFF
--- a/src/imbi_api/domain/models.py
+++ b/src/imbi_api/domain/models.py
@@ -978,6 +978,16 @@ class WebhookCreate(pydantic.BaseModel):
             'third-party service when unset.'
         ),
     )
+    event_type_selector: str | None = pydantic.Field(
+        default=None,
+        description=(
+            'Resolves the activity-feed event type for each webhook. '
+            'Values starting with "/" are JSON pointers evaluated against '
+            'the request body; otherwise the value is treated as an HTTP '
+            'header name (case-insensitive). When the header is absent, '
+            'the literal selector value is used as the label.'
+        ),
+    )
     rules: list[WebhookRuleCreate] = pydantic.Field(
         default_factory=list,
     )
@@ -996,6 +1006,10 @@ class WebhookCreate(pydantic.BaseModel):
         if self.identity_plugin_slug and not self.third_party_service_slug:
             raise ValueError(
                 'identity_plugin_slug requires third_party_service_slug'
+            )
+        if self.event_type_selector and not self.third_party_service_slug:
+            raise ValueError(
+                'event_type_selector requires third_party_service_slug'
             )
         return self
 
@@ -1037,6 +1051,16 @@ class WebhookUpdate(pydantic.BaseModel):
             'third-party service when unset.'
         ),
     )
+    event_type_selector: str | None = pydantic.Field(
+        default=None,
+        description=(
+            'Resolves the activity-feed event type for each webhook. '
+            'Values starting with "/" are JSON pointers evaluated against '
+            'the request body; otherwise the value is treated as an HTTP '
+            'header name (case-insensitive). When the header is absent, '
+            'the literal selector value is used as the label.'
+        ),
+    )
     rules: list[WebhookRuleCreate] = pydantic.Field(
         default_factory=list,
     )
@@ -1055,6 +1079,10 @@ class WebhookUpdate(pydantic.BaseModel):
         if self.identity_plugin_slug and not self.third_party_service_slug:
             raise ValueError(
                 'identity_plugin_slug requires third_party_service_slug'
+            )
+        if self.event_type_selector and not self.third_party_service_slug:
+            raise ValueError(
+                'event_type_selector requires third_party_service_slug'
             )
         return self
 
@@ -1084,6 +1112,7 @@ class WebhookResponse(pydantic.BaseModel):
     identifier_selector: str | None = None
     user_subject_selector: str | None = None
     identity_plugin_slug: str | None = None
+    event_type_selector: str | None = None
     rules: list[WebhookRuleResponse] = []
 
     @classmethod
@@ -1134,6 +1163,9 @@ class WebhookResponse(pydantic.BaseModel):
             ),
             identity_plugin_slug=graph.parse_agtype(
                 record.get('identity_plugin_slug')
+            ),
+            event_type_selector=graph.parse_agtype(
+                record.get('event_type_selector')
             ),
             rules=rules,
         )

--- a/src/imbi_api/endpoints/third_party_services.py
+++ b/src/imbi_api/endpoints/third_party_services.py
@@ -475,6 +475,7 @@ async def list_service_webhooks(
     RETURN w{{.*}} AS webhook,
            tps{{.*}} AS tps,
            impl.identifier_selector AS identifier_selector,
+           impl.event_type_selector AS event_type_selector,
            [x IN all_rules
             | x {{.filter_expression, .handler,
                   .handler_config}}]
@@ -484,7 +485,13 @@ async def list_service_webhooks(
     records = await db.execute(
         query,
         {'slug': slug, 'org_slug': org_slug},
-        ['webhook', 'tps', 'identifier_selector', 'rules'],
+        [
+            'webhook',
+            'tps',
+            'identifier_selector',
+            'event_type_selector',
+            'rules',
+        ],
     )
     return [models.WebhookResponse.from_graph_record(r) for r in records]
 

--- a/src/imbi_api/endpoints/webhooks.py
+++ b/src/imbi_api/endpoints/webhooks.py
@@ -146,6 +146,7 @@ RETURN w{{.*}} AS webhook,
        impl.identifier_selector AS identifier_selector,
        impl.user_subject_selector AS user_subject_selector,
        impl.identity_plugin_slug AS identity_plugin_slug,
+       impl.event_type_selector AS event_type_selector,
        [x IN all_rules
         | x {{.filter_expression, .handler,
               .handler_config}}]
@@ -165,6 +166,7 @@ _UPDATE_RETURN_TAIL_WITH_TPS: typing.LiteralString = (
     ' impl.identifier_selector AS identifier_selector,'
     ' impl.user_subject_selector AS user_subject_selector,'
     ' impl.identity_plugin_slug AS identity_plugin_slug,'
+    ' impl.event_type_selector AS event_type_selector,'
     ' [x IN all_rules'
     ' | x {{.filter_expression, .handler,'
     ' .handler_config}}] AS rules'
@@ -183,6 +185,7 @@ _UPDATE_RETURN_TAIL_NO_TPS: typing.LiteralString = (
     ' null AS identifier_selector,'
     ' null AS user_subject_selector,'
     ' null AS identity_plugin_slug,'
+    ' null AS event_type_selector,'
     ' [x IN all_rules'
     ' | x {{.filter_expression, .handler,'
     ' .handler_config}}] AS rules'
@@ -272,7 +275,8 @@ async def create_webhook(
             ' CREATE (w)-[:IMPLEMENTED_BY {{'
             'identifier_selector: {identifier_selector},'
             ' user_subject_selector: {user_subject_selector},'
-            ' identity_plugin_slug: {identity_plugin_slug}'
+            ' identity_plugin_slug: {identity_plugin_slug},'
+            ' event_type_selector: {event_type_selector}'
             '}}]->(tps)' + rule_clauses + ' RETURN w.id AS id'
         )
         write_params: dict[str, typing.Any] = {
@@ -281,6 +285,7 @@ async def create_webhook(
             'identifier_selector': data.identifier_selector,
             'user_subject_selector': data.user_subject_selector,
             'identity_plugin_slug': data.identity_plugin_slug,
+            'event_type_selector': data.event_type_selector,
         }
     else:
         write_query = (
@@ -330,6 +335,7 @@ async def create_webhook(
             'identifier_selector',
             'user_subject_selector',
             'identity_plugin_slug',
+            'event_type_selector',
             'rules',
         ],
     )
@@ -367,6 +373,7 @@ async def list_webhooks(
            impl.identifier_selector AS identifier_selector,
            impl.user_subject_selector AS user_subject_selector,
            impl.identity_plugin_slug AS identity_plugin_slug,
+           impl.event_type_selector AS event_type_selector,
            [x IN all_rules
             | x {{.filter_expression, .handler,
                   .handler_config}}]
@@ -382,6 +389,7 @@ async def list_webhooks(
             'identifier_selector',
             'user_subject_selector',
             'identity_plugin_slug',
+            'event_type_selector',
             'rules',
         ],
     )
@@ -410,6 +418,7 @@ async def get_webhook(
             'identifier_selector',
             'user_subject_selector',
             'identity_plugin_slug',
+            'event_type_selector',
             'rules',
         ],
     )
@@ -460,6 +469,7 @@ async def patch_webhook(
             'identifier_selector',
             'user_subject_selector',
             'identity_plugin_slug',
+            'event_type_selector',
             'rules',
         ],
     )
@@ -495,6 +505,9 @@ async def patch_webhook(
         ),
         'identity_plugin_slug': graph.parse_agtype(
             existing[0].get('identity_plugin_slug')
+        ),
+        'event_type_selector': graph.parse_agtype(
+            existing[0].get('event_type_selector')
         ),
         'rules': [
             {
@@ -594,7 +607,8 @@ async def patch_webhook(
             ' SET impl.identifier_selector'
             ' = {identifier_selector},'
             ' impl.user_subject_selector = {user_subject_selector},'
-            ' impl.identity_plugin_slug = {identity_plugin_slug}'
+            ' impl.identity_plugin_slug = {identity_plugin_slug},'
+            ' impl.event_type_selector = {event_type_selector}'
             + rule_clauses
             + ' RETURN w.id AS id'
         )
@@ -606,6 +620,7 @@ async def patch_webhook(
             'identifier_selector': data.identifier_selector,
             'user_subject_selector': data.user_subject_selector,
             'identity_plugin_slug': data.identity_plugin_slug,
+            'event_type_selector': data.event_type_selector,
             **rules_params,
         }
     else:
@@ -657,6 +672,7 @@ async def patch_webhook(
             'identifier_selector',
             'user_subject_selector',
             'identity_plugin_slug',
+            'event_type_selector',
             'rules',
         ],
     )

--- a/tests/endpoints/test_webhooks.py
+++ b/tests/endpoints/test_webhooks.py
@@ -36,6 +36,7 @@ class _WebhookRecord(typing.TypedDict):
     identifier_selector: typing.NotRequired[str | None]
     user_subject_selector: typing.NotRequired[str | None]
     identity_plugin_slug: typing.NotRequired[str | None]
+    event_type_selector: typing.NotRequired[str | None]
     rules: list[_WebhookRule | None]
 
 
@@ -360,6 +361,46 @@ class WebhookEndpointsTestCase(unittest.TestCase):
             json={
                 'name': 'Test',
                 'identity_plugin_slug': 'github',
+            },
+        )
+        self.assertEqual(response.status_code, 422)
+
+    def test_create_with_event_type_selector(self) -> None:
+        """event_type_selector round-trips through CREATE/GET."""
+        record = copy.deepcopy(self.webhook_record)
+        record['tps'] = {'name': 'GitHub', 'slug': 'github'}
+        record['identifier_selector'] = '/repository/full_name'
+        record['event_type_selector'] = 'x-github-event'
+
+        self.mock_db.execute.return_value = [record]
+        with (
+            self._patch_encryption(),
+            mock.patch(
+                'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+            ),
+        ):
+            payload = {
+                'name': 'GitHub Events',
+                'third_party_service_slug': 'github',
+                'identifier_selector': '/repository/full_name',
+                'event_type_selector': 'x-github-event',
+            }
+            response = self.client.post(
+                '/organizations/engineering/webhooks/',
+                json=payload,
+            )
+
+        self.assertEqual(response.status_code, 201)
+        data = response.json()
+        self.assertEqual(data['event_type_selector'], 'x-github-event')
+
+    def test_create_event_type_selector_without_service(self) -> None:
+        """event_type_selector requires a third-party service."""
+        response = self.client.post(
+            '/organizations/engineering/webhooks/',
+            json={
+                'name': 'Test',
+                'event_type_selector': 'x-github-event',
             },
         )
         self.assertEqual(response.status_code, 422)
@@ -773,6 +814,54 @@ class WebhookEndpointsTestCase(unittest.TestCase):
         )
         self.assertEqual(data['identity_plugin_slug'], 'github')
 
+    def test_patch_event_type_selector(self) -> None:
+        """Patching event_type_selector round-trips through the edge."""
+        existing_record = {
+            'webhook': {
+                'id': 'abc123def4',
+                'name': 'GitHub Hook',
+                'slug': 'github-hook',
+                'description': None,
+                'notification_path': '/abc123def4',
+                'secret': None,
+            },
+            'tps': {'slug': 'github', 'name': 'GitHub'},
+            'identifier_selector': '/repository/full_name',
+            'user_subject_selector': None,
+            'identity_plugin_slug': None,
+            'event_type_selector': None,
+            'rules': [],
+        }
+        updated_record = copy.deepcopy(existing_record)
+        updated_record['event_type_selector'] = 'x-github-event'
+
+        self.mock_db.execute.side_effect = [
+            [existing_record],
+            [updated_record],
+            [updated_record],
+        ]
+
+        with (
+            self._patch_encryption(),
+            mock.patch(
+                'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+            ),
+        ):
+            response = self.client.patch(
+                '/organizations/engineering/webhooks/github-hook',
+                json=[
+                    {
+                        'op': 'replace',
+                        'path': '/event_type_selector',
+                        'value': 'x-github-event',
+                    },
+                ],
+            )
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data['event_type_selector'], 'x-github-event')
+
     def test_patch_identity_fields_rejected_without_tps(self) -> None:
         """Setting identity selectors on a TPS-less webhook is a 400.
 
@@ -858,6 +947,46 @@ class WebhookEndpointsTestCase(unittest.TestCase):
                         'op': 'replace',
                         'path': '/identity_plugin_slug',
                         'value': 'github',
+                    }
+                ],
+            )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('third_party_service_slug', response.json()['detail'])
+
+    def test_patch_event_type_selector_rejected_without_tps(self) -> None:
+        """Setting event_type_selector on a TPS-less webhook is a 400."""
+        existing_record = {
+            'webhook': {
+                'id': 'abc123def4',
+                'name': 'Solo Hook',
+                'slug': 'solo-hook',
+                'description': None,
+                'notification_path': '/abc123def4',
+                'secret': None,
+            },
+            'tps': None,
+            'identifier_selector': None,
+            'user_subject_selector': None,
+            'identity_plugin_slug': None,
+            'event_type_selector': None,
+            'rules': [],
+        }
+        self.mock_db.execute.side_effect = [[existing_record]]
+
+        with (
+            self._patch_encryption(),
+            mock.patch(
+                'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+            ),
+        ):
+            response = self.client.patch(
+                '/organizations/engineering/webhooks/solo-hook',
+                json=[
+                    {
+                        'op': 'replace',
+                        'path': '/event_type_selector',
+                        'value': 'x-github-event',
                     }
                 ],
             )

--- a/uv.lock
+++ b/uv.lock
@@ -1002,8 +1002,8 @@ plugins = [
 
 [[package]]
 name = "imbi-common"
-version = "0.5.0"
-source = { git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=main#ea0b8369fa50802751149d457c112acfb22c821f" }
+version = "0.7.1"
+source = { git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=main#70998e44d407d1b5d87de0c4ec309df9acb4853d" }
 dependencies = [
   { name = "cryptography" },
   { name = "jsonschema-models" },


### PR DESCRIPTION
## Summary
Plumb a per-webhook `event_type_selector` field through the webhook CRUD endpoints so operators can configure how the gateway derives `events.type` for each row it inserts into ClickHouse.

## Problem
imbi-gateway's new webhook-event insert path needs a per-source way to label `events.type` (rendered as the activity-feed row body in `ProjectActivityLog`). GitHub uses an `X-GitHub-Event` header, SonarQube has no useful identifier at all, and a JSON pointer into the body is the right answer for some sources. Hardcoding any one of these would break the others.

## Solution
- Add `event_type_selector: str | None = None` to `WebhookCreate`, `WebhookUpdate`, and `WebhookResponse` (and to `from_graph_record`), with the same TPS-required model validator the other selector fields use.
- Plumb the field through every Cypher query touching the `IMPLEMENTED_BY` edge: CREATE props, `_FETCH_WEBHOOK_QUERY`, `list_webhooks`, `_UPDATE_RETURN_TAIL_*`, the PATCH SET clause and patchable dict, and every `db.execute` columns list.
- Surface the field in the third-party-services webhook list query for symmetry with `identifier_selector`.
- Tests: CREATE/PATCH round-trips, validator-rejection for both create and patch paths.
- Bump `imbi-common` to v0.7.1 (just released) so the lock tracks the new `Event` model fields.

The selector resolves `events.type` per the rule the gateway implements:
- Values starting with `/` are JSON pointers evaluated against the request body.
- Otherwise the value is treated as an HTTP header name (case-insensitive).
- If the header is absent (or the selector can't be a valid header, e.g. `SonarQube Notification`), the literal selector value is used as the label.

## Impact
- **Backwards compatible**: optional field, defaults to `None`. Existing webhooks without a selector continue to work — they just produce an empty `type` on insert.
- **Companion PRs (must merge in this order):**
  - imbi-common 0.7.1 ✅ released (Event model fields)
  - **this PR**
  - imbi-ui PR #232: surfaces the selector on the webhook admin form
  - imbi-gateway: lifespan + ClickHouse insert (in flight)
- Plan of record: `imbi-development:plans/webhook-events-to-clickhouse.md`

## Testing
- `just lint` — clean
- `just test` — 1417 tests pass