### PR TITLE
Add deployment endpoints + Phase 2 promote/draft-release-notes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -223,7 +223,7 @@ url = "https://pypi.org/simple"
 default = true
 
 [tool.uv.sources]
-imbi-common = { git = "https://github.com/AWeber-Imbi/imbi-common.git", rev = "feature/anthropic-client" }
+imbi-common = { git = "https://github.com/AWeber-Imbi/imbi-common.git", rev = "main" }
 imbi-plugin-aws = { git = "https://github.com/AWeber-Imbi/imbi-plugin-aws.git", rev = "main" }
 imbi-plugin-github = { git = "https://github.com/AWeber-Imbi/imbi-plugin-github.git", rev = "main" }
 imbi-plugin-logzio = { git = "https://github.com/AWeber-Imbi/imbi-plugin-logzio.git", rev = "main" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
   "fastapi",
   "filetype",
   "httpx>=0.28.1,<1",
-  "imbi-common[databases,server]>=0.5.0",
+  "imbi-common[databases,llm,server]>=0.5.0",
   "jinja2",
   "jsonpatch>=1.33",
   "nanoid>=2.0.0",
@@ -223,7 +223,7 @@ url = "https://pypi.org/simple"
 default = true
 
 [tool.uv.sources]
-imbi-common = { git = "https://github.com/AWeber-Imbi/imbi-common.git", rev = "main" }
+imbi-common = { git = "https://github.com/AWeber-Imbi/imbi-common.git", rev = "feature/anthropic-client" }
 imbi-plugin-aws = { git = "https://github.com/AWeber-Imbi/imbi-plugin-aws.git", rev = "main" }
 imbi-plugin-github = { git = "https://github.com/AWeber-Imbi/imbi-plugin-github.git", rev = "main" }
 imbi-plugin-logzio = { git = "https://github.com/AWeber-Imbi/imbi-plugin-logzio.git", rev = "main" }

--- a/src/imbi_api/app.py
+++ b/src/imbi_api/app.py
@@ -21,6 +21,7 @@ def create_app() -> fastapi.FastAPI:
             graph.graph_lifespan,
             lifespans.email_hook,
             lifespans.storage_hook,
+            lifespans.anthropic_hook,
             valkey.valkey_lifespan,
             lifespans.score_worker_hook,
             lifespans.identity_refresh_hook,

--- a/src/imbi_api/auth/seed.py
+++ b/src/imbi_api/auth/seed.py
@@ -353,6 +353,18 @@ STANDARD_PERMISSIONS: list[tuple[str, str, str, str]] = [
         'logs:read',
         'Read project logs via plugins',
     ),
+    (
+        'project:deployment:read',
+        'project',
+        'deployment:read',
+        'Read project deployment state via plugins',
+    ),
+    (
+        'project:deployment:write',
+        'project',
+        'deployment:write',
+        'Trigger deployments and promotions via plugins',
+    ),
     # Identity plugin connections
     (
         'me:identities:manage',

--- a/src/imbi_api/endpoints/organizations.py
+++ b/src/imbi_api/endpoints/organizations.py
@@ -21,6 +21,7 @@ from .identity_plugins import identity_plugins_router
 from .link_definitions import link_definitions_router
 from .operations_log import operations_log_project_router
 from .project_configuration import project_configuration_router
+from .project_deployments import project_deployments_router
 from .project_logs import project_logs_router
 from .project_plugins import project_plugins_router
 from .project_type_plugins import project_type_plugins_router
@@ -122,6 +123,10 @@ organizations_router.include_router(
 organizations_router.include_router(
     project_logs_router,
     prefix='/{org_slug}/projects/{project_id}/logs',
+)
+organizations_router.include_router(
+    project_deployments_router,
+    prefix='/{org_slug}/projects/{project_id}/deployments',
 )
 
 

--- a/src/imbi_api/endpoints/project_deployments.py
+++ b/src/imbi_api/endpoints/project_deployments.py
@@ -148,6 +148,38 @@ class PromotionOption(pydantic.BaseModel):
 # ---------------------------------------------------------------------------
 
 
+def _latest_deployment_timestamp(
+    raw: typing.Any,
+) -> datetime.datetime | None:
+    """Return the most recent deployment-event timestamp, or ``None``.
+
+    The ``deployments`` edge property is stored as a JSON-encoded list
+    of ``DeploymentEvent``-shaped objects.  We parse just the timestamp
+    field here so the promotion-options reducer can deterministically
+    rank ``(Release, Environment)`` rows by recency without paying for
+    full Pydantic validation.
+    """
+    if not raw:
+        return None
+    data = json.loads(raw) if isinstance(raw, str) else raw
+    if not isinstance(data, list):
+        return None
+    latest: datetime.datetime | None = None
+    for entry in data:  # type: ignore[reportUnknownVariableType]
+        if not isinstance(entry, dict):
+            continue
+        ts = entry.get('timestamp')  # type: ignore[reportUnknownMemberType]
+        if not isinstance(ts, str):
+            continue
+        try:
+            parsed = datetime.datetime.fromisoformat(ts)
+        except ValueError:
+            continue
+        if latest is None or parsed > latest:
+            latest = parsed
+    return latest
+
+
 async def _resolve_and_context(
     db: graph.Graph,
     org_slug: str,
@@ -467,11 +499,24 @@ async def _handle_promote(
             resolved.plugin_slug,
         )
 
-    # 3. Upsert the Release node so future deploys of the same tag
-    #    can attach a DeploymentEvent.
     release_url = (release_info.html_url if release_info else None) or (
         release_info.url if release_info else None
     )
+
+    # 3. Dispatch the workflow against the new tag.  We do this before
+    #    upserting the Release node so a trigger failure doesn't leave
+    #    a Release in the graph with no associated deployment run.
+    run = await call_with_timeout(
+        handler.trigger_deployment(
+            ctx,
+            credentials,
+            ref_or_sha=body.tag,
+            inputs=None,
+        )
+    )
+
+    # 4. Upsert the Release node so future deploys of the same tag
+    #    can attach a DeploymentEvent.
     await _upsert_release_node(
         db,
         project_id=project_id,
@@ -480,16 +525,6 @@ async def _handle_promote(
         notes_markdown=body.release_notes_markdown,
         release_url=release_url,
         created_by=auth.principal_name,
-    )
-
-    # 4. Dispatch the workflow against the new tag.
-    run = await call_with_timeout(
-        handler.trigger_deployment(
-            ctx,
-            credentials,
-            ref_or_sha=body.tag,
-            inputs=None,
-        )
     )
 
     # 5. Record the deployment event.
@@ -815,16 +850,52 @@ async def list_promotion_options(
     )
     if not rows:
         return []
+    # The query returns one row per (Release, Environment) pair, so an
+    # env with multiple historical releases produces multiple rows.
+    # To pick a stable "current" release per env, parse the deployment
+    # event history on each edge and rank by the most recent event
+    # timestamp. Envs with no deployment history fall back to no
+    # release.
     by_slug: dict[str, dict[str, typing.Any]] = {}
     for row in rows:
         env = graph.parse_agtype(row['env'])
         if not env:
             continue
-        release_raw = graph.parse_agtype(row['release'])
         slug = env['slug']
+        release_raw = graph.parse_agtype(row['release'])
+        latest = _latest_deployment_timestamp(
+            graph.parse_agtype(row['deployments'])
+        )
         existing = by_slug.get(slug)
-        if existing is None or (release_raw and not existing.get('release')):
-            by_slug[slug] = {'env': env, 'release': release_raw}
+        if existing is None:
+            by_slug[slug] = {
+                'env': env,
+                'release': release_raw,
+                'latest': latest,
+            }
+            continue
+        # Prefer the row with the most recent deployment event; fall
+        # back to keeping a non-null release if neither row has events.
+        existing_latest = existing.get('latest')
+        if latest is not None and (
+            existing_latest is None or latest > existing_latest
+        ):
+            by_slug[slug] = {
+                'env': env,
+                'release': release_raw,
+                'latest': latest,
+            }
+        elif (
+            latest is None
+            and existing_latest is None
+            and release_raw
+            and not existing.get('release')
+        ):
+            by_slug[slug] = {
+                'env': env,
+                'release': release_raw,
+                'latest': None,
+            }
 
     ordered = sorted(
         by_slug.values(),

--- a/src/imbi_api/endpoints/project_deployments.py
+++ b/src/imbi_api/endpoints/project_deployments.py
@@ -1,18 +1,23 @@
 """Project deployment plugin endpoints.
 
 Pass-through endpoints that resolve the project's ``tab='deployment'``
-plugin and call its handler methods.  Phase 1 implements ref / commit
-discovery, comparison, and ``deploy`` / ``redeploy`` workflow dispatch.
-``promote`` (Phase 2) and the persistence of ``DeploymentEvent`` nodes
-on the ``Release -[:DEPLOYED_TO]-> Environment`` edge are forthcoming.
+plugin and call its handler methods.  Covers ref / commit discovery,
+comparison, ``deploy`` / ``redeploy`` workflow dispatch (Phase 1), and
+the ``promote`` flow with AI-drafted release notes plus tag + Release
+upsert (Phase 2).
 
 See ``docs/deployments-plan.md`` for the full design.
 """
 
+import datetime
+import itertools
+import json
 import logging
+import re
 import typing
 
 import fastapi
+import nanoid
 import pydantic
 from imbi_common import graph
 from imbi_common.plugins.base import (
@@ -29,6 +34,7 @@ from imbi_api.auth import permissions
 from imbi_api.endpoints._helpers import lookup_project_slugs
 from imbi_api.endpoints.releases import append_deployment_event
 from imbi_api.identity.host_integration import attach_identity
+from imbi_api.llm.dependencies import InjectAnthropicClient
 from imbi_api.plugins import call_with_timeout
 from imbi_api.plugins.credentials import get_plugin_credentials
 from imbi_api.plugins.resolution import ResolvedPlugin, resolve_plugin
@@ -53,6 +59,30 @@ class DeployActionRequest(pydantic.BaseModel):
     inputs: dict[str, str] | None = None
 
 
+class PromoteActionRequest(pydantic.BaseModel):
+    """Body for ``POST /deployments`` with ``action='promote'``.
+
+    Cuts a new tag at ``from_committish`` (the build being promoted),
+    creates a release on the remote, then dispatches the workflow with
+    the tag as the ref.
+    """
+
+    action: typing.Literal['promote']
+    from_environment: str
+    to_environment: str
+    from_committish: str
+    tag: str
+    release_name: str | None = None
+    release_notes_markdown: str = ''
+    prerelease: bool = False
+
+
+DeploymentRequestBody = typing.Annotated[
+    DeployActionRequest | PromoteActionRequest,
+    pydantic.Field(discriminator='action'),
+]
+
+
 class DeploymentTriggerResponse(pydantic.BaseModel):
     """Response shape for a successful deploy/redeploy/promote action."""
 
@@ -60,6 +90,57 @@ class DeploymentTriggerResponse(pydantic.BaseModel):
     plugin_id: str
     plugin_slug: str
     recorded: bool = False
+    release_url: str | None = None
+    tag: str | None = None
+
+
+class DraftReleaseNotesRequest(pydantic.BaseModel):
+    """Body for ``POST /deployments/draft-release-notes``."""
+
+    base_sha: str
+    head_sha: str
+    last_tag: str | None = None
+
+
+SemverBump = typing.Literal['major', 'minor', 'patch']
+
+
+class DraftReleaseNotes(pydantic.BaseModel):
+    """The structured payload Claude returns for a release-notes draft."""
+
+    bump: SemverBump
+    version: str
+    reasoning: str
+    notes_markdown: str
+
+
+class DraftReleaseNotesResponse(pydantic.BaseModel):
+    """Response shape for the release-notes drafting endpoint."""
+
+    bump: SemverBump
+    version: str
+    reasoning: str
+    notes_markdown: str
+    degraded: bool = False
+    commits_considered: int = 0
+
+
+class PromotionOption(pydantic.BaseModel):
+    """One promotion gap for the popover.
+
+    Pairs a from-env (whose current SHA we'd promote) with a to-env
+    (the target).  ``commits_pending`` is the size of the
+    ``from..to`` compare; ``None`` means we couldn't ask the plugin
+    (e.g. no current release on either side).
+    """
+
+    from_environment: str
+    to_environment: str
+    from_version: str | None = None
+    to_version: str | None = None
+    from_sha: str | None = None
+    to_sha: str | None = None
+    commits_pending: int | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -229,7 +310,7 @@ async def compare_refs(
 async def trigger_deployment(
     org_slug: str,
     project_id: str,
-    body: DeployActionRequest,
+    body: DeploymentRequestBody,
     db: graph.Pool,
     auth: typing.Annotated[
         permissions.AuthContext,
@@ -239,15 +320,36 @@ async def trigger_deployment(
     ],
     source: str | None = None,
 ) -> DeploymentTriggerResponse:
-    """Trigger a deploy or redeploy.
+    """Trigger a deploy / redeploy / promote.
 
-    When the committish (or its ``ref_label``) matches an existing
-    ``Release`` version on the project, append a ``DeploymentEvent``
-    with ``status='in_progress'`` to the
-    ``Release -[:DEPLOYED_TO]-> Environment`` edge.  Deploys of bare
-    SHAs (no matching Release) are still triggered but not graph-recorded
-    — Promote is the path that creates Release nodes.
+    For ``deploy`` / ``redeploy``, dispatches the workflow with the
+    chosen committish; if the committish (or its ``ref_label``) matches
+    an existing ``Release`` version on the project, also appends a
+    ``DeploymentEvent`` to the ``DEPLOYED_TO`` edge.
+
+    For ``promote``: cuts a tag at ``from_committish``, creates a
+    release with the supplied notes on the remote, dispatches the
+    workflow against the tag for ``to_environment``, upserts the
+    matching ``Release`` node, and records the deployment event.
     """
+    if body.action == 'promote':
+        return await _handle_promote(
+            db, org_slug, project_id, auth, body, source=source
+        )
+    return await _handle_deploy(
+        db, org_slug, project_id, auth, body, source=source
+    )
+
+
+async def _handle_deploy(
+    db: graph.Graph,
+    org_slug: str,
+    project_id: str,
+    auth: permissions.AuthContext,
+    body: DeployActionRequest,
+    *,
+    source: str | None,
+) -> DeploymentTriggerResponse:
     resolved, ctx, credentials = await _resolve_and_context(
         db,
         org_slug,
@@ -276,10 +378,7 @@ async def trigger_deployment(
         ctx.actor_user_id,
         run.run_id,
     )
-    note_parts = [f'via {resolved.plugin_slug}']
-    if run.run_url:
-        note_parts.append(run.run_url)
-    note = ' — '.join(note_parts)
+    note = _deploy_note(resolved.plugin_slug, run.run_url)
     recorded = False
     for candidate in filter(None, (body.ref_label, body.committish)):
         edge = await append_deployment_event(
@@ -300,3 +399,482 @@ async def trigger_deployment(
         plugin_slug=resolved.plugin_slug,
         recorded=recorded,
     )
+
+
+def _deploy_note(plugin_slug: str, run_url: str | None) -> str:
+    parts = [f'via {plugin_slug}']
+    if run_url:
+        parts.append(run_url)
+    return ' — '.join(parts)
+
+
+async def _handle_promote(
+    db: graph.Graph,
+    org_slug: str,
+    project_id: str,
+    auth: permissions.AuthContext,
+    body: PromoteActionRequest,
+    *,
+    source: str | None,
+) -> DeploymentTriggerResponse:
+    resolved, ctx, credentials = await _resolve_and_context(
+        db,
+        org_slug,
+        project_id,
+        auth,
+        source=source,
+        environment=body.to_environment,
+    )
+    handler = _handler(resolved)
+
+    # 1. Cut the annotated tag at the chosen build commit.
+    tag_message = body.release_name or body.tag
+    try:
+        await call_with_timeout(
+            handler.create_tag(
+                ctx,
+                credentials,
+                sha=body.from_committish,
+                tag=body.tag,
+                message=tag_message,
+            )
+        )
+    except NotImplementedError as exc:
+        raise fastapi.HTTPException(
+            status_code=400,
+            detail=(
+                f'Plugin {resolved.plugin_slug!r} does not support '
+                'creating tags; promote is not available.'
+            ),
+        ) from exc
+
+    # 2. Create the release on the remote.
+    release_info = None
+    try:
+        release_info = await call_with_timeout(
+            handler.create_release(
+                ctx,
+                credentials,
+                tag=body.tag,
+                name=body.release_name or body.tag,
+                body_markdown=body.release_notes_markdown,
+                prerelease=body.prerelease,
+            )
+        )
+    except NotImplementedError:
+        LOGGER.info(
+            'Plugin %r has no create_release; tag-only promote',
+            resolved.plugin_slug,
+        )
+
+    # 3. Upsert the Release node so future deploys of the same tag
+    #    can attach a DeploymentEvent.
+    release_url = (release_info.html_url if release_info else None) or (
+        release_info.url if release_info else None
+    )
+    await _upsert_release_node(
+        db,
+        project_id=project_id,
+        version=body.tag,
+        title=body.release_name or body.tag,
+        notes_markdown=body.release_notes_markdown,
+        release_url=release_url,
+        created_by=auth.principal_name,
+    )
+
+    # 4. Dispatch the workflow against the new tag.
+    run = await call_with_timeout(
+        handler.trigger_deployment(
+            ctx,
+            credentials,
+            ref_or_sha=body.tag,
+            inputs=None,
+        )
+    )
+
+    # 5. Record the deployment event.
+    note = _deploy_note(resolved.plugin_slug, run.run_url)
+    edge = await append_deployment_event(
+        db,
+        org_slug=org_slug,
+        project_id=project_id,
+        version=body.tag,
+        env_slug=body.to_environment,
+        status='in_progress',
+        note=note,
+    )
+
+    LOGGER.info(
+        'Promotion triggered: project=%s %s→%s tag=%s plugin=%s '
+        'actor=%s run_id=%s',
+        project_id,
+        body.from_environment,
+        body.to_environment,
+        body.tag,
+        resolved.plugin_slug,
+        ctx.actor_user_id,
+        run.run_id,
+    )
+    return DeploymentTriggerResponse(
+        run=run,
+        plugin_id=resolved.plugin_id,
+        plugin_slug=resolved.plugin_slug,
+        recorded=edge is not None,
+        release_url=release_url,
+        tag=body.tag,
+    )
+
+
+async def _upsert_release_node(
+    db: graph.Graph,
+    *,
+    project_id: str,
+    version: str,
+    title: str,
+    notes_markdown: str,
+    release_url: str | None,
+    created_by: str,
+) -> None:
+    """Create the ``Release`` node if missing, otherwise update notes.
+
+    Uses MATCH-then-CREATE-or-SET so the second-promote-of-same-tag
+    case (rare; tag re-creation will already have failed at the
+    plugin) is benign rather than blowing up on a duplicate node.
+    """
+    now = datetime.datetime.now(datetime.UTC).isoformat()
+    links_json = (
+        json.dumps([{'type': 'github_release', 'url': release_url}])
+        if release_url
+        else json.dumps([])
+    )
+    query: typing.LiteralString = """
+    MATCH (p:Project {{id: {project_id}}})
+    OPTIONAL MATCH (p)-[:HAS_RELEASE]
+        ->(existing:Release {{version: {version}}})
+    WITH p, existing
+    WHERE existing IS NULL
+    CREATE (p)-[:HAS_RELEASE]->(:Release {{
+        id: {id},
+        version: {version},
+        title: {title},
+        description: {description},
+        links: {links},
+        created_by: {created_by},
+        created_at: {now},
+        updated_at: {now}
+    }})
+    """
+    await db.execute(
+        query,
+        {
+            'project_id': project_id,
+            'version': version,
+            'id': nanoid.generate(),
+            'title': title,
+            'description': notes_markdown,
+            'links': links_json,
+            'created_by': created_by,
+            'now': now,
+        },
+        [],
+    )
+    # Update notes / links on a pre-existing release (idempotent re-run).
+    update_query: typing.LiteralString = """
+    MATCH (p:Project {{id: {project_id}}})
+          -[:HAS_RELEASE]->(r:Release {{version: {version}}})
+    SET r.description = {description},
+        r.links = {links},
+        r.updated_at = {now}
+    """
+    await db.execute(
+        update_query,
+        {
+            'project_id': project_id,
+            'version': version,
+            'description': notes_markdown,
+            'links': links_json,
+            'now': now,
+        },
+        [],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Release-notes drafting
+# ---------------------------------------------------------------------------
+
+_PROMPT_COMMIT_CAP = 150
+_SEMVER_RE = re.compile(r'^v?(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$')
+
+_RELEASE_NOTES_SYSTEM = (
+    'You are a release-notes editor for a software project.  Given a '
+    'list of commits between two SHAs and the previous release tag, '
+    'output a single JSON object on the form\n'
+    '  {"bump": "major"|"minor"|"patch", "version": "vX.Y.Z", '
+    '"reasoning": "<one-paragraph explanation>", "notes_markdown": '
+    '"<markdown body>"}.\n'
+    'The version must be the previous tag bumped according to your '
+    'chosen ``bump``.  The notes_markdown should group commits by '
+    'conventional-commit type (Features / Fixes / Chores / etc.) when '
+    'possible.  Do not output anything outside the JSON object.'
+)
+
+
+def _bump_semver(last_tag: str | None, bump: SemverBump) -> str:
+    """Bump a semver-shaped tag.  Falls back to ``v0.1.0`` when missing."""
+    raw = (last_tag or 'v0.0.0').lstrip('v')
+    match = _SEMVER_RE.match(raw)
+    if not match:
+        return 'v0.1.0'
+    major, minor, patch = (int(part) for part in match.groups())
+    if bump == 'major':
+        return f'v{major + 1}.0.0'
+    if bump == 'minor':
+        return f'v{major}.{minor + 1}.0'
+    return f'v{major}.{minor}.{patch + 1}'
+
+
+def _classify_bump(commits: list[Commit]) -> SemverBump:
+    """Crude heuristic used as the fallback when Claude isn't available."""
+    breaking = ('breaking', '!:', 'breaking change')
+    features = ('feat:', 'feature:')
+    for commit in commits:
+        msg = commit.message.lower()
+        if any(token in msg for token in breaking):
+            return 'major'
+    for commit in commits:
+        msg = commit.message.lower()
+        if any(msg.startswith(token) for token in features):
+            return 'minor'
+    return 'patch'
+
+
+def _fallback_notes(commits: list[Commit]) -> str:
+    """Group commits by conventional-commit prefix as the fallback body."""
+    if not commits:
+        return '_No commits between the chosen base and head._'
+    buckets: dict[str, list[Commit]] = {}
+    for commit in commits:
+        prefix = commit.message.split(':', 1)[0].lower().strip()
+        if not prefix or len(prefix) > 16:
+            prefix = 'other'
+        buckets.setdefault(prefix, []).append(commit)
+    lines: list[str] = []
+    for prefix in sorted(buckets):
+        lines.append(f'### {prefix}')
+        for commit in buckets[prefix]:
+            lines.append(f'- {commit.message} ({commit.short_sha})')
+        lines.append('')
+    return '\n'.join(lines).rstrip()
+
+
+def _build_release_notes_prompt(
+    project_name: str,
+    last_tag: str | None,
+    base_sha: str,
+    head_sha: str,
+    commits: list[Commit],
+) -> str:
+    capped = commits[:_PROMPT_COMMIT_CAP]
+    omitted = len(commits) - len(capped)
+    body_lines = [
+        f'Project: {project_name}',
+        f'Previous tag: {last_tag or "(none)"}',
+        f'Comparing: {base_sha}..{head_sha}',
+        f'Total commits: {len(commits)}'
+        + (f' (+{omitted} earlier omitted)' if omitted else ''),
+        '',
+        'Commits (oldest → newest):',
+    ]
+    for commit in capped:
+        author = commit.author or 'unknown'
+        body_lines.append(f'- {commit.short_sha} {commit.message} — {author}')
+    body_lines.append('')
+    body_lines.append('Return the JSON object described in the system prompt.')
+    return '\n'.join(body_lines)
+
+
+@project_deployments_router.post('/draft-release-notes')
+async def draft_release_notes(
+    org_slug: str,
+    project_id: str,
+    body: DraftReleaseNotesRequest,
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('project:deployment:write'),
+        ),
+    ],
+    anthropic: InjectAnthropicClient,
+    source: str | None = None,
+) -> DraftReleaseNotesResponse:
+    """Draft release notes for a tag promotion.
+
+    Calls the project's deployment plugin ``compare(base..head)`` to
+    enumerate the commits being promoted, asks Claude for a structured
+    ``{bump, version, reasoning, notes_markdown}`` payload, and returns
+    it.  Falls back to a deterministic conventional-commit-prefix
+    grouping with ``degraded=true`` when Claude is unavailable, the
+    response can't be parsed, or schema validation fails.
+    """
+    resolved, ctx, credentials = await _resolve_and_context(
+        db, org_slug, project_id, auth, source=source
+    )
+    handler = _handler(resolved)
+    compare_result = await call_with_timeout(
+        handler.compare(
+            ctx, credentials, base=body.base_sha, head=body.head_sha
+        )
+    )
+    commits = compare_result.commits
+    fallback_bump = _classify_bump(commits)
+    fallback = DraftReleaseNotes(
+        bump=fallback_bump,
+        version=_bump_semver(body.last_tag, fallback_bump),
+        reasoning=(
+            'AI unavailable — bump and notes derived from '
+            'conventional-commit prefixes.'
+        ),
+        notes_markdown=_fallback_notes(commits),
+    )
+    completion = await anthropic.complete_json(
+        _build_release_notes_prompt(
+            ctx.project_slug,
+            body.last_tag,
+            body.base_sha,
+            body.head_sha,
+            commits,
+        ),
+        schema=DraftReleaseNotes,
+        fallback=fallback,
+        system=_RELEASE_NOTES_SYSTEM,
+        cache_system_prompt=True,
+    )
+    notes = completion.data
+    # Re-bump if Claude returned a non-semver-shaped version string.
+    if not _SEMVER_RE.match(notes.version.lstrip('v')):
+        notes = notes.model_copy(
+            update={'version': _bump_semver(body.last_tag, notes.bump)}
+        )
+    return DraftReleaseNotesResponse(
+        bump=notes.bump,
+        version=notes.version,
+        reasoning=notes.reasoning,
+        notes_markdown=notes.notes_markdown,
+        degraded=completion.degraded,
+        commits_considered=len(commits),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Promotion options
+# ---------------------------------------------------------------------------
+
+
+_PROMOTION_OPTIONS_QUERY: typing.LiteralString = """
+MATCH (p:Project {{id: {project_id}}})
+      -[:OWNED_BY]->(:Team)
+      -[:BELONGS_TO]->(:Organization {{slug: {org_slug}}})
+MATCH (p)-[:DEPLOYED_IN]->(e:Environment)
+OPTIONAL MATCH (p)-[:HAS_RELEASE]->(r:Release)
+               -[d:DEPLOYED_TO]->(e)
+RETURN e{{.slug, .name, .sort_order}} AS env,
+       CASE WHEN r IS NULL THEN null ELSE r{{.*}} END AS release,
+       CASE WHEN d IS NULL THEN null ELSE d.deployments END
+           AS deployments
+"""
+
+
+@project_deployments_router.get('/promotion-options')
+async def list_promotion_options(
+    org_slug: str,
+    project_id: str,
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('project:deployment:read'),
+        ),
+    ],
+    source: str | None = None,
+) -> list[PromotionOption]:
+    """Enumerate the from→to promotion gaps the popover offers.
+
+    For each consecutive pair of envs (sorted by ``sort_order``)
+    where the from-env has a release deployed, returns the gap with
+    the from-env's current version + SHA, the to-env's current
+    version + SHA (when present), and the count of commits between
+    them via ``plugin.compare()``.  Plugin failures are tolerated:
+    the entry returns ``commits_pending=None``.
+    """
+    rows = await db.execute(
+        _PROMOTION_OPTIONS_QUERY,
+        {'project_id': project_id, 'org_slug': org_slug},
+        ['env', 'release', 'deployments'],
+    )
+    if not rows:
+        return []
+    by_slug: dict[str, dict[str, typing.Any]] = {}
+    for row in rows:
+        env = graph.parse_agtype(row['env'])
+        if not env:
+            continue
+        release_raw = graph.parse_agtype(row['release'])
+        slug = env['slug']
+        existing = by_slug.get(slug)
+        if existing is None or (release_raw and not existing.get('release')):
+            by_slug[slug] = {'env': env, 'release': release_raw}
+
+    ordered = sorted(
+        by_slug.values(),
+        key=lambda item: (
+            item['env'].get('sort_order') or 0,
+            item['env'].get('name') or '',
+        ),
+    )
+    if len(ordered) < 2:
+        return []
+
+    # Resolve plugin once so we can issue compare() calls.
+    resolved, ctx, credentials = await _resolve_and_context(
+        db, org_slug, project_id, auth, source=source
+    )
+    handler = _handler(resolved)
+
+    options: list[PromotionOption] = []
+    for from_item, to_item in itertools.pairwise(ordered):
+        from_release = from_item['release']
+        to_release = to_item['release']
+        if not from_release:
+            continue
+        from_version = str(from_release.get('version') or '')
+        to_version = (
+            str(to_release.get('version') or '') if to_release else None
+        )
+        commits_pending: int | None = None
+        if to_version and to_version != from_version:
+            try:
+                cmp_result = await call_with_timeout(
+                    handler.compare(
+                        ctx,
+                        credentials,
+                        base=to_version,
+                        head=from_version,
+                    )
+                )
+                commits_pending = cmp_result.ahead
+            except Exception:  # noqa: BLE001
+                LOGGER.debug(
+                    'compare failed for %s..%s', to_version, from_version
+                )
+        options.append(
+            PromotionOption(
+                from_environment=from_item['env']['slug'],
+                to_environment=to_item['env']['slug'],
+                from_version=from_version or None,
+                to_version=to_version or None,
+                commits_pending=commits_pending,
+            )
+        )
+    return options

--- a/src/imbi_api/endpoints/project_deployments.py
+++ b/src/imbi_api/endpoints/project_deployments.py
@@ -27,6 +27,7 @@ from imbi_common.plugins.errors import PluginCredentialsMissing
 
 from imbi_api.auth import permissions
 from imbi_api.endpoints._helpers import lookup_project_slugs
+from imbi_api.endpoints.releases import append_deployment_event
 from imbi_api.identity.host_integration import attach_identity
 from imbi_api.plugins import call_with_timeout
 from imbi_api.plugins.credentials import get_plugin_credentials
@@ -58,6 +59,7 @@ class DeploymentTriggerResponse(pydantic.BaseModel):
     run: DeploymentRun
     plugin_id: str
     plugin_slug: str
+    recorded: bool = False
 
 
 # ---------------------------------------------------------------------------
@@ -239,9 +241,12 @@ async def trigger_deployment(
 ) -> DeploymentTriggerResponse:
     """Trigger a deploy or redeploy.
 
-    Persistence of ``DeploymentEvent`` on the ``DEPLOYED_TO`` edge is a
-    follow-on; this first cut returns the run reference straight from
-    the plugin so the UI can surface a "View workflow run" link.
+    When the committish (or its ``ref_label``) matches an existing
+    ``Release`` version on the project, append a ``DeploymentEvent``
+    with ``status='in_progress'`` to the
+    ``Release -[:DEPLOYED_TO]-> Environment`` edge.  Deploys of bare
+    SHAs (no matching Release) are still triggered but not graph-recorded
+    — Promote is the path that creates Release nodes.
     """
     resolved, ctx, credentials = await _resolve_and_context(
         db,
@@ -271,8 +276,27 @@ async def trigger_deployment(
         ctx.actor_user_id,
         run.run_id,
     )
+    note_parts = [f'via {resolved.plugin_slug}']
+    if run.run_url:
+        note_parts.append(run.run_url)
+    note = ' — '.join(note_parts)
+    recorded = False
+    for candidate in filter(None, (body.ref_label, body.committish)):
+        edge = await append_deployment_event(
+            db,
+            org_slug=org_slug,
+            project_id=project_id,
+            version=candidate,
+            env_slug=body.environment,
+            status='in_progress',
+            note=note,
+        )
+        if edge is not None:
+            recorded = True
+            break
     return DeploymentTriggerResponse(
         run=run,
         plugin_id=resolved.plugin_id,
         plugin_slug=resolved.plugin_slug,
+        recorded=recorded,
     )

--- a/src/imbi_api/endpoints/project_deployments.py
+++ b/src/imbi_api/endpoints/project_deployments.py
@@ -1,0 +1,278 @@
+"""Project deployment plugin endpoints.
+
+Pass-through endpoints that resolve the project's ``tab='deployment'``
+plugin and call its handler methods.  Phase 1 implements ref / commit
+discovery, comparison, and ``deploy`` / ``redeploy`` workflow dispatch.
+``promote`` (Phase 2) and the persistence of ``DeploymentEvent`` nodes
+on the ``Release -[:DEPLOYED_TO]-> Environment`` edge are forthcoming.
+
+See ``docs/deployments-plan.md`` for the full design.
+"""
+
+import logging
+import typing
+
+import fastapi
+import pydantic
+from imbi_common import graph
+from imbi_common.plugins.base import (
+    Commit,
+    CompareResult,
+    DeploymentPlugin,
+    DeploymentRun,
+    PluginContext,
+    Ref,
+)
+from imbi_common.plugins.errors import PluginCredentialsMissing
+
+from imbi_api.auth import permissions
+from imbi_api.endpoints._helpers import lookup_project_slugs
+from imbi_api.identity.host_integration import attach_identity
+from imbi_api.plugins import call_with_timeout
+from imbi_api.plugins.credentials import get_plugin_credentials
+from imbi_api.plugins.resolution import ResolvedPlugin, resolve_plugin
+
+LOGGER = logging.getLogger(__name__)
+
+project_deployments_router = fastapi.APIRouter(tags=['Project: Deployments'])
+
+
+# ---------------------------------------------------------------------------
+# Request/response models
+# ---------------------------------------------------------------------------
+
+
+class DeployActionRequest(pydantic.BaseModel):
+    """Body for ``POST /deployments`` with ``action='deploy'|'redeploy'``."""
+
+    action: typing.Literal['deploy', 'redeploy']
+    environment: str
+    committish: str
+    ref_label: str | None = None
+    inputs: dict[str, str] | None = None
+
+
+class DeploymentTriggerResponse(pydantic.BaseModel):
+    """Response shape for a successful deploy/redeploy/promote action."""
+
+    run: DeploymentRun
+    plugin_id: str
+    plugin_slug: str
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _resolve_and_context(
+    db: graph.Graph,
+    org_slug: str,
+    project_id: str,
+    auth: permissions.AuthContext,
+    *,
+    source: str | None = None,
+    environment: str | None = None,
+) -> tuple[ResolvedPlugin, PluginContext, dict[str, str]]:
+    """Common boilerplate: resolve plugin, attach identity, build creds."""
+    resolved = await resolve_plugin(db, project_id, 'deployment', source)
+    project_slug, team_slug = await lookup_project_slugs(db, project_id)
+    ctx = PluginContext(
+        project_id=project_id,
+        project_slug=project_slug,
+        org_slug=org_slug,
+        team_slug=team_slug,
+        environment=environment,
+        assignment_options=resolved.options,
+    )
+    ctx = await attach_identity(db, ctx, resolved, auth)
+
+    if ctx.identity and ctx.identity.access_token:
+        credentials: dict[str, str] = {
+            'access_token': ctx.identity.access_token,
+        }
+    else:
+        try:
+            credentials = await get_plugin_credentials(
+                db, resolved.plugin_id, resolved.entry
+            )
+        except PluginCredentialsMissing as exc:
+            raise fastapi.HTTPException(
+                status_code=503,
+                detail=str(exc),
+            ) from exc
+        if not credentials.get('access_token') and not credentials.get(
+            'token'
+        ):
+            raise fastapi.HTTPException(
+                status_code=503,
+                detail=(
+                    'No deployment credentials available: bind an '
+                    'identity or configure a service-account token.'
+                ),
+            )
+    return resolved, ctx, credentials
+
+
+def _handler(resolved: ResolvedPlugin) -> DeploymentPlugin:
+    """Instantiate and type-narrow the plugin handler."""
+    return typing.cast(DeploymentPlugin, resolved.entry.handler_cls())
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@project_deployments_router.get('/refs')
+async def list_refs(
+    org_slug: str,
+    project_id: str,
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('project:deployment:read'),
+        ),
+    ],
+    kind: typing.Literal['default', 'branch', 'tag', 'all'] = 'all',
+    q: str | None = None,
+    source: str | None = None,
+) -> list[Ref]:
+    """List branches, tags, or the default ref for the project's repo."""
+    resolved, ctx, credentials = await _resolve_and_context(
+        db, org_slug, project_id, auth, source=source
+    )
+    handler = _handler(resolved)
+    return await call_with_timeout(
+        handler.list_refs(ctx, credentials, kind=kind, query=q)
+    )
+
+
+@project_deployments_router.get('/refs/{ref:path}/commits')
+async def list_commits(
+    org_slug: str,
+    project_id: str,
+    ref: str,
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('project:deployment:read'),
+        ),
+    ],
+    limit: int = 25,
+    source: str | None = None,
+) -> list[Commit]:
+    """List recent commits on a branch / tag / SHA."""
+    resolved, ctx, credentials = await _resolve_and_context(
+        db, org_slug, project_id, auth, source=source
+    )
+    handler = _handler(resolved)
+    return await call_with_timeout(
+        handler.list_commits(ctx, credentials, ref=ref, limit=limit)
+    )
+
+
+@project_deployments_router.get('/commits/{committish}')
+async def resolve_commit(
+    org_slug: str,
+    project_id: str,
+    committish: str,
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('project:deployment:read'),
+        ),
+    ],
+    source: str | None = None,
+) -> Commit:
+    """Resolve a SHA / branch / tag / ``refs/pull/N/head``."""
+    resolved, ctx, credentials = await _resolve_and_context(
+        db, org_slug, project_id, auth, source=source
+    )
+    handler = _handler(resolved)
+    return await call_with_timeout(
+        handler.resolve_committish(ctx, credentials, committish)
+    )
+
+
+@project_deployments_router.get('/compare')
+async def compare_refs(
+    org_slug: str,
+    project_id: str,
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('project:deployment:read'),
+        ),
+    ],
+    base: str = fastapi.Query(...),
+    head: str = fastapi.Query(...),
+    source: str | None = None,
+) -> CompareResult:
+    """Compare two refs (``base..head``)."""
+    resolved, ctx, credentials = await _resolve_and_context(
+        db, org_slug, project_id, auth, source=source
+    )
+    handler = _handler(resolved)
+    return await call_with_timeout(
+        handler.compare(ctx, credentials, base=base, head=head)
+    )
+
+
+@project_deployments_router.post('', status_code=202)
+async def trigger_deployment(
+    org_slug: str,
+    project_id: str,
+    body: DeployActionRequest,
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('project:deployment:write'),
+        ),
+    ],
+    source: str | None = None,
+) -> DeploymentTriggerResponse:
+    """Trigger a deploy or redeploy.
+
+    Persistence of ``DeploymentEvent`` on the ``DEPLOYED_TO`` edge is a
+    follow-on; this first cut returns the run reference straight from
+    the plugin so the UI can surface a "View workflow run" link.
+    """
+    resolved, ctx, credentials = await _resolve_and_context(
+        db,
+        org_slug,
+        project_id,
+        auth,
+        source=source,
+        environment=body.environment,
+    )
+    handler = _handler(resolved)
+    run = await call_with_timeout(
+        handler.trigger_deployment(
+            ctx,
+            credentials,
+            ref_or_sha=body.committish,
+            inputs=body.inputs,
+        )
+    )
+    LOGGER.info(
+        'Deployment triggered: project=%s env=%s ref=%s plugin=%s '
+        'action=%s actor=%s run_id=%s',
+        project_id,
+        body.environment,
+        body.committish,
+        resolved.plugin_slug,
+        body.action,
+        ctx.actor_user_id,
+        run.run_id,
+    )
+    return DeploymentTriggerResponse(
+        run=run,
+        plugin_id=resolved.plugin_id,
+        plugin_slug=resolved.plugin_slug,
+    )

--- a/src/imbi_api/endpoints/releases.py
+++ b/src/imbi_api/endpoints/releases.py
@@ -633,6 +633,83 @@ def _edge_to_response(
     )
 
 
+async def append_deployment_event(
+    db: graph.Graph,
+    *,
+    org_slug: str,
+    project_id: str,
+    version: str,
+    env_slug: str,
+    status: typing.Literal[
+        'pending', 'in_progress', 'success', 'failed', 'rolled_back'
+    ],
+    note: str | None = None,
+) -> ReleaseEnvironmentEdgeResponse | None:
+    """Append a ``DeploymentEvent`` to ``Release -[:DEPLOYED_TO]-> Env``.
+
+    Returns the resulting edge, or ``None`` when the named ``Release``
+    or ``Environment`` cannot be found — callers that auto-record from
+    a deploy of a SHA (which has no ``Release`` node) treat ``None`` as
+    "skip persistence, deploy still succeeded".
+    """
+    release = await _fetch_release(db, org_slug, project_id, version)
+    if release is None:
+        return None
+    env, existing = await _fetch_deployment_edge(
+        db, org_slug, project_id, version, env_slug
+    )
+    if env is None:
+        return None
+    event = models.DeploymentEvent(
+        timestamp=datetime.datetime.now(datetime.UTC),
+        status=status,
+        note=note,
+    )
+    deployments = [*existing, event]
+    serialized = json.dumps(
+        [e.model_dump(mode='json') for e in deployments],
+    )
+    if existing:
+        set_query: typing.LiteralString = """
+        MATCH (:Project {{id: {project_id}}})
+              -[:HAS_RELEASE]->(r:Release {{version: {version}}})
+        MATCH (r)-[d:DEPLOYED_TO]->(:Environment {{slug: {env_slug}}})
+        SET d.deployments = {deployments}
+        RETURN d.deployments AS deployments
+        """
+        await db.execute(
+            set_query,
+            {
+                'project_id': project_id,
+                'version': version,
+                'env_slug': env_slug,
+                'deployments': serialized,
+            },
+            ['deployments'],
+        )
+    else:
+        create_query: typing.LiteralString = """
+        MATCH (:Project {{id: {project_id}}})
+              -[:HAS_RELEASE]->(r:Release {{version: {version}}})
+        MATCH (e:Environment {{slug: {env_slug}}})
+              -[:BELONGS_TO]->(:Organization {{slug: {org_slug}}})
+        CREATE (r)-[d:DEPLOYED_TO {{deployments: {deployments}}}]->(e)
+        RETURN d.deployments AS deployments
+        """
+        await db.execute(
+            create_query,
+            {
+                'project_id': project_id,
+                'version': version,
+                'env_slug': env_slug,
+                'org_slug': org_slug,
+                'deployments': serialized,
+            },
+            ['deployments'],
+        )
+    return _edge_to_response(env, deployments)
+
+
 @releases_router.post(
     '/{version}/environments/{env_slug}',
     response_model=ReleaseEnvironmentEdgeResponse,

--- a/src/imbi_api/lifespans.py
+++ b/src/imbi_api/lifespans.py
@@ -11,6 +11,7 @@ import logging
 from collections import abc
 
 from imbi_common import clickhouse, graph, valkey
+from imbi_common.llm import AnthropicClient
 
 from imbi_api import openapi
 from imbi_api.email.client import EmailClient
@@ -71,6 +72,27 @@ async def storage_hook() -> abc.AsyncGenerator[StorageClient]:
     await storage_client.initialize()
     async with contextlib.aclosing(storage_client):
         yield storage_client
+
+
+@contextlib.asynccontextmanager
+async def anthropic_hook() -> abc.AsyncGenerator[AnthropicClient]:
+    """Initialize the shared Anthropic client.
+
+    Falls back to a disabled client when ``ANTHROPIC_API_KEY`` is
+    absent — endpoints that depend on this still resolve but their
+    completions return ``degraded=True`` with a fallback payload.
+    """
+    client = AnthropicClient()
+    if client.available:
+        LOGGER.info(
+            'Anthropic client initialized (model=%s)', client.default_model
+        )
+    else:
+        LOGGER.info('Anthropic client disabled — ANTHROPIC_API_KEY not set')
+    try:
+        yield client
+    finally:
+        await client.aclose()
 
 
 @contextlib.asynccontextmanager

--- a/src/imbi_api/llm/dependencies.py
+++ b/src/imbi_api/llm/dependencies.py
@@ -1,0 +1,20 @@
+"""FastAPI dependency injection for the shared Anthropic client."""
+
+import typing
+
+import fastapi
+from imbi_common.lifespan import InjectLifespan
+from imbi_common.llm import AnthropicClient
+
+from imbi_api import lifespans
+
+
+def _get_anthropic_client(
+    context: InjectLifespan,
+) -> AnthropicClient:
+    return context.get_state(lifespans.anthropic_hook)
+
+
+InjectAnthropicClient = typing.Annotated[
+    AnthropicClient, fastapi.Depends(_get_anthropic_client)
+]

--- a/tests/endpoints/test_project_deployments.py
+++ b/tests/endpoints/test_project_deployments.py
@@ -7,6 +7,7 @@ from unittest import mock
 
 from fastapi import testclient
 from imbi_common import graph
+from imbi_common.llm import AnthropicClient, CompletionResult
 from imbi_common.plugins.base import (
     Commit,
     CompareResult,
@@ -14,11 +15,15 @@ from imbi_common.plugins.base import (
     DeploymentRun,
     PluginManifest,
     Ref,
+    RefInfo,
+    ReleaseInfo,
 )
 from imbi_common.plugins.registry import RegistryEntry
 
 from imbi_api import app, models
 from imbi_api.auth import password, permissions
+from imbi_api.endpoints.project_deployments import DraftReleaseNotes
+from imbi_api.llm.dependencies import _get_anthropic_client
 from imbi_api.plugins.resolution import ResolvedPlugin
 
 
@@ -74,6 +79,23 @@ class _FakeDeploymentPlugin(DeploymentPlugin):
     ):
         return DeploymentRun(run_id=run_id, status='in_progress')
 
+    async def create_tag(  # type: ignore[override]
+        self, ctx, credentials, sha, tag, message
+    ):
+        return RefInfo(name=f'refs/tags/{tag}', sha=sha)
+
+    async def create_release(  # type: ignore[override]
+        self, ctx, credentials, tag, name, body_markdown, prerelease=False
+    ):
+        return ReleaseInfo(
+            id='rel-1',
+            tag=tag,
+            name=name,
+            html_url=f'https://gh/releases/{tag}',
+            url=f'https://api.gh/releases/{tag}',
+            prerelease=prerelease,
+        )
+
 
 def _entry() -> RegistryEntry:
     return RegistryEntry(
@@ -117,6 +139,22 @@ class ProjectDeploymentsTestCase(unittest.TestCase):
         self.mock_db = mock.AsyncMock(spec=graph.Graph)
         self.test_app.dependency_overrides[graph._inject_graph] = lambda: (
             self.mock_db
+        )
+
+        self.mock_anthropic = mock.MagicMock(spec=AnthropicClient)
+        self.mock_anthropic.complete_json = mock.AsyncMock(
+            return_value=CompletionResult(
+                data=DraftReleaseNotes(
+                    bump='minor',
+                    version='v1.1.0',
+                    reasoning='added feature foo',
+                    notes_markdown='## Foo',
+                ),
+                degraded=False,
+            )
+        )
+        self.test_app.dependency_overrides[_get_anthropic_client] = lambda: (
+            self.mock_anthropic
         )
 
         self.mocks = {
@@ -315,3 +353,191 @@ class ProjectDeploymentsTestCase(unittest.TestCase):
                 },
             )
         self.assertEqual(response.status_code, 403)
+
+    def test_draft_release_notes_happy_path(self) -> None:
+        with testclient.TestClient(self.test_app) as client:
+            response = client.post(
+                '/organizations/myorg/projects/proj1/deployments/'
+                'draft-release-notes',
+                json={
+                    'base_sha': 'aaa',
+                    'head_sha': 'bbb',
+                    'last_tag': 'v1.0.0',
+                },
+            )
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data['bump'], 'minor')
+        self.assertEqual(data['version'], 'v1.1.0')
+        self.assertFalse(data['degraded'])
+        # Compare came back empty in the fake plugin (no commits stubbed
+        # for this path), so commits_considered is 0.
+        self.assertEqual(data['commits_considered'], 0)
+        # The Anthropic client was called with the system + prompt.
+        self.mock_anthropic.complete_json.assert_called_once()
+        call = self.mock_anthropic.complete_json.call_args
+        prompt = call.args[0] if call.args else call.kwargs.get('prompt', '')
+        self.assertIn('Project: proj', prompt)
+        self.assertIn('aaa..bbb', prompt)
+        self.assertTrue(call.kwargs['cache_system_prompt'])
+
+    def test_draft_release_notes_degraded_falls_back(self) -> None:
+        self.mock_anthropic.complete_json = mock.AsyncMock(
+            side_effect=lambda *args, **kwargs: CompletionResult(
+                data=kwargs['fallback'], degraded=True
+            )
+        )
+        with testclient.TestClient(self.test_app) as client:
+            response = client.post(
+                '/organizations/myorg/projects/proj1/deployments/'
+                'draft-release-notes',
+                json={
+                    'base_sha': 'aaa',
+                    'head_sha': 'bbb',
+                    'last_tag': 'v1.2.3',
+                },
+            )
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertTrue(data['degraded'])
+        # No commits in the stub → patch bump → v1.2.4
+        self.assertEqual(data['bump'], 'patch')
+        self.assertEqual(data['version'], 'v1.2.4')
+        self.assertIn('AI unavailable', data['reasoning'])
+
+    def test_draft_release_notes_rebumps_invalid_version(self) -> None:
+        self.mock_anthropic.complete_json = mock.AsyncMock(
+            return_value=CompletionResult(
+                data=DraftReleaseNotes(
+                    bump='major',
+                    version='v9.0',  # not a valid semver
+                    reasoning='breaking',
+                    notes_markdown='## Breaking',
+                ),
+                degraded=False,
+            )
+        )
+        with testclient.TestClient(self.test_app) as client:
+            response = client.post(
+                '/organizations/myorg/projects/proj1/deployments/'
+                'draft-release-notes',
+                json={
+                    'base_sha': 'aaa',
+                    'head_sha': 'bbb',
+                    'last_tag': 'v6.3.0',
+                },
+            )
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        # last_tag bumped major: 6.3.0 → 7.0.0
+        self.assertEqual(data['version'], 'v7.0.0')
+
+    def test_promote_happy_path(self) -> None:
+        # The append_deployment_event mock pretends a Release exists.
+        self.mocks['append_deployment_event'].return_value = mock.Mock()
+        with testclient.TestClient(self.test_app) as client:
+            response = client.post(
+                '/organizations/myorg/projects/proj1/deployments',
+                json={
+                    'action': 'promote',
+                    'from_environment': 'testing',
+                    'to_environment': 'staging',
+                    'from_committish': '1a9c610',
+                    'tag': 'v6.4.0',
+                    'release_name': 'v6.4.0',
+                    'release_notes_markdown': '## Highlights\n- foo',
+                    'prerelease': False,
+                },
+            )
+        self.assertEqual(response.status_code, 202)
+        data = response.json()
+        self.assertEqual(data['tag'], 'v6.4.0')
+        self.assertEqual(data['release_url'], 'https://gh/releases/v6.4.0')
+        self.assertTrue(data['recorded'])
+        # The Release node was upserted via two db.execute calls
+        # (CREATE-if-missing then SET).
+        self.assertGreaterEqual(self.mock_db.execute.call_count, 2)
+        # The append_deployment_event helper saw the new tag as version.
+        call = self.mocks['append_deployment_event'].call_args
+        self.assertEqual(call.kwargs['version'], 'v6.4.0')
+        self.assertEqual(call.kwargs['env_slug'], 'staging')
+
+    def test_promote_falls_back_when_plugin_lacks_create_tag(self) -> None:
+        class _NoTag(_FakeDeploymentPlugin):
+            async def create_tag(  # type: ignore[override]
+                self, ctx, credentials, sha, tag, message
+            ):
+                raise NotImplementedError
+
+        self.mocks['resolve_plugin'].return_value = ResolvedPlugin(
+            plugin_id='p-1',
+            plugin_slug='no-tag',
+            entry=RegistryEntry(
+                handler_cls=_NoTag,
+                manifest=_NoTag.manifest,
+                package_name='x',
+                package_version='1',
+            ),
+            options={},
+        )
+        with testclient.TestClient(self.test_app) as client:
+            response = client.post(
+                '/organizations/myorg/projects/proj1/deployments',
+                json={
+                    'action': 'promote',
+                    'from_environment': 'testing',
+                    'to_environment': 'staging',
+                    'from_committish': '1a9c610',
+                    'tag': 'v1.2.3',
+                },
+            )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn(
+            'does not support creating tags', response.json()['detail']
+        )
+
+    def test_promotion_options_returns_consecutive_pairs(self) -> None:
+        # The endpoint runs a Cypher query, then for each gap calls
+        # plugin.compare().  Stub the graph response with three envs;
+        # the helper deduplicates by env-slug into the latest release
+        # per env, so we feed one row per env to keep the test simple.
+        def _mock_execute(query, params, columns):
+            del query, params, columns
+            return [
+                {
+                    'env': '{"slug": "testing", "name": "Testing", '
+                    '"sort_order": 1}',
+                    'release': '{"version": "v6.4.0"}',
+                    'deployments': None,
+                },
+                {
+                    'env': '{"slug": "staging", "name": "Staging", '
+                    '"sort_order": 2}',
+                    'release': '{"version": "v6.3.0"}',
+                    'deployments': None,
+                },
+                {
+                    'env': '{"slug": "production", "name": "Production", '
+                    '"sort_order": 3}',
+                    'release': '{"version": "v6.2.0"}',
+                    'deployments': None,
+                },
+            ]
+
+        self.mock_db.execute = mock.AsyncMock(side_effect=_mock_execute)
+        with testclient.TestClient(self.test_app) as client:
+            response = client.get(
+                '/organizations/myorg/projects/proj1/deployments/'
+                'promotion-options'
+            )
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(len(data), 2)
+        self.assertEqual(data[0]['from_environment'], 'testing')
+        self.assertEqual(data[0]['to_environment'], 'staging')
+        self.assertEqual(data[0]['from_version'], 'v6.4.0')
+        self.assertEqual(data[0]['to_version'], 'v6.3.0')
+        # Fake plugin's compare() returns ahead=1.
+        self.assertEqual(data[0]['commits_pending'], 1)
+        self.assertEqual(data[1]['from_environment'], 'staging')
+        self.assertEqual(data[1]['to_environment'], 'production')

--- a/tests/endpoints/test_project_deployments.py
+++ b/tests/endpoints/test_project_deployments.py
@@ -1,6 +1,7 @@
 """Tests for the project deployment plugin endpoints."""
 
 import datetime
+import typing
 import unittest
 from unittest import mock
 
@@ -83,6 +84,9 @@ def _entry() -> RegistryEntry:
     )
 
 
+_MODULE = 'imbi_api.endpoints.project_deployments'
+
+
 class ProjectDeploymentsTestCase(unittest.TestCase):
     def setUp(self) -> None:
         self.test_app = app.create_app()
@@ -115,6 +119,37 @@ class ProjectDeploymentsTestCase(unittest.TestCase):
             self.mock_db
         )
 
+        self.mocks = {
+            'resolve_plugin': self._start(
+                mock.patch(
+                    f'{_MODULE}.resolve_plugin', return_value=self._resolved()
+                )
+            ),
+            'lookup_project_slugs': self._start(
+                mock.patch(
+                    f'{_MODULE}.lookup_project_slugs',
+                    return_value=('proj', 'team'),
+                )
+            ),
+            'attach_identity': self._start(
+                mock.patch(
+                    f'{_MODULE}.attach_identity',
+                    side_effect=lambda db, ctx, resolved, auth: ctx,
+                )
+            ),
+            'get_plugin_credentials': self._start(
+                mock.patch(
+                    f'{_MODULE}.get_plugin_credentials',
+                    return_value={'access_token': 'gho_test'},
+                )
+            ),
+        }
+
+    def _start(self, patcher: typing.Any) -> mock.MagicMock:
+        m = patcher.start()
+        self.addCleanup(patcher.stop)
+        return m
+
     def _resolved(self) -> ResolvedPlugin:
         return ResolvedPlugin(
             plugin_id='p-1',
@@ -123,34 +158,8 @@ class ProjectDeploymentsTestCase(unittest.TestCase):
             options={'owner': 'octo', 'repo': 'demo'},
         )
 
-    def _patches(self) -> tuple[mock._patch, ...]:
-        return (
-            mock.patch(
-                'imbi_api.endpoints.project_deployments.resolve_plugin',
-                return_value=self._resolved(),
-            ),
-            mock.patch(
-                'imbi_api.endpoints.project_deployments.lookup_project_slugs',
-                return_value=('proj', 'team'),
-            ),
-            mock.patch(
-                'imbi_api.endpoints.project_deployments.attach_identity',
-                side_effect=lambda db, ctx, resolved, auth: ctx,
-            ),
-            mock.patch(
-                'imbi_api.endpoints.project_deployments.get_plugin_credentials',
-                return_value={'access_token': 'gho_test'},
-            ),
-        )
-
     def test_list_refs(self) -> None:
-        with (
-            self._patches()[0],
-            self._patches()[1],
-            self._patches()[2],
-            self._patches()[3],
-            testclient.TestClient(self.test_app) as client,
-        ):
+        with testclient.TestClient(self.test_app) as client:
             response = client.get(
                 '/organizations/myorg/projects/proj1/deployments/refs'
             )
@@ -161,13 +170,7 @@ class ProjectDeploymentsTestCase(unittest.TestCase):
         self.assertTrue(data[0]['is_default'])
 
     def test_list_commits(self) -> None:
-        with (
-            self._patches()[0],
-            self._patches()[1],
-            self._patches()[2],
-            self._patches()[3],
-            testclient.TestClient(self.test_app) as client,
-        ):
+        with testclient.TestClient(self.test_app) as client:
             response = client.get(
                 '/organizations/myorg/projects/proj1/deployments/'
                 'refs/main/commits'
@@ -178,13 +181,7 @@ class ProjectDeploymentsTestCase(unittest.TestCase):
         self.assertTrue(data[0]['is_head'])
 
     def test_resolve_commit(self) -> None:
-        with (
-            self._patches()[0],
-            self._patches()[1],
-            self._patches()[2],
-            self._patches()[3],
-            testclient.TestClient(self.test_app) as client,
-        ):
+        with testclient.TestClient(self.test_app) as client:
             response = client.get(
                 '/organizations/myorg/projects/proj1/deployments/'
                 'commits/abc1234'
@@ -193,13 +190,7 @@ class ProjectDeploymentsTestCase(unittest.TestCase):
         self.assertEqual(response.json()['sha'], 'abc1234')
 
     def test_compare(self) -> None:
-        with (
-            self._patches()[0],
-            self._patches()[1],
-            self._patches()[2],
-            self._patches()[3],
-            testclient.TestClient(self.test_app) as client,
-        ):
+        with testclient.TestClient(self.test_app) as client:
             response = client.get(
                 '/organizations/myorg/projects/proj1/deployments/'
                 'compare?base=v1&head=v2'
@@ -210,26 +201,14 @@ class ProjectDeploymentsTestCase(unittest.TestCase):
         self.assertEqual(data['head_sha'], 'v2')
 
     def test_compare_missing_query_param_400(self) -> None:
-        with (
-            self._patches()[0],
-            self._patches()[1],
-            self._patches()[2],
-            self._patches()[3],
-            testclient.TestClient(self.test_app) as client,
-        ):
+        with testclient.TestClient(self.test_app) as client:
             response = client.get(
                 '/organizations/myorg/projects/proj1/deployments/compare'
             )
         self.assertEqual(response.status_code, 422)
 
     def test_trigger_deploy(self) -> None:
-        with (
-            self._patches()[0],
-            self._patches()[1],
-            self._patches()[2],
-            self._patches()[3],
-            testclient.TestClient(self.test_app) as client,
-        ):
+        with testclient.TestClient(self.test_app) as client:
             response = client.post(
                 '/organizations/myorg/projects/proj1/deployments',
                 json={
@@ -246,13 +225,7 @@ class ProjectDeploymentsTestCase(unittest.TestCase):
         self.assertEqual(data['run']['status'], 'queued')
 
     def test_trigger_redeploy(self) -> None:
-        with (
-            self._patches()[0],
-            self._patches()[1],
-            self._patches()[2],
-            self._patches()[3],
-            testclient.TestClient(self.test_app) as client,
-        ):
+        with testclient.TestClient(self.test_app) as client:
             response = client.post(
                 '/organizations/myorg/projects/proj1/deployments',
                 json={
@@ -264,13 +237,7 @@ class ProjectDeploymentsTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 202)
 
     def test_trigger_invalid_action(self) -> None:
-        with (
-            self._patches()[0],
-            self._patches()[1],
-            self._patches()[2],
-            self._patches()[3],
-            testclient.TestClient(self.test_app) as client,
-        ):
+        with testclient.TestClient(self.test_app) as client:
             response = client.post(
                 '/organizations/myorg/projects/proj1/deployments',
                 json={
@@ -282,25 +249,8 @@ class ProjectDeploymentsTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 422)
 
     def test_no_credentials_returns_503(self) -> None:
-        with (
-            mock.patch(
-                'imbi_api.endpoints.project_deployments.resolve_plugin',
-                return_value=self._resolved(),
-            ),
-            mock.patch(
-                'imbi_api.endpoints.project_deployments.lookup_project_slugs',
-                return_value=('proj', 'team'),
-            ),
-            mock.patch(
-                'imbi_api.endpoints.project_deployments.attach_identity',
-                side_effect=lambda db, ctx, resolved, auth: ctx,
-            ),
-            mock.patch(
-                'imbi_api.endpoints.project_deployments.get_plugin_credentials',
-                return_value={},
-            ),
-            testclient.TestClient(self.test_app) as client,
-        ):
+        self.mocks['get_plugin_credentials'].return_value = {}
+        with testclient.TestClient(self.test_app) as client:
             response = client.get(
                 '/organizations/myorg/projects/proj1/deployments/refs'
             )
@@ -328,13 +278,7 @@ class ProjectDeploymentsTestCase(unittest.TestCase):
         self.test_app.dependency_overrides[permissions.get_current_user] = (
             mock_get_current_user
         )
-        with (
-            self._patches()[0],
-            self._patches()[1],
-            self._patches()[2],
-            self._patches()[3],
-            testclient.TestClient(self.test_app) as client,
-        ):
+        with testclient.TestClient(self.test_app) as client:
             response = client.post(
                 '/organizations/myorg/projects/proj1/deployments',
                 json={

--- a/tests/endpoints/test_project_deployments.py
+++ b/tests/endpoints/test_project_deployments.py
@@ -143,6 +143,12 @@ class ProjectDeploymentsTestCase(unittest.TestCase):
                     return_value={'access_token': 'gho_test'},
                 )
             ),
+            'append_deployment_event': self._start(
+                mock.patch(
+                    f'{_MODULE}.append_deployment_event',
+                    return_value=None,
+                )
+            ),
         }
 
     def _start(self, patcher: typing.Any) -> mock.MagicMock:
@@ -223,6 +229,27 @@ class ProjectDeploymentsTestCase(unittest.TestCase):
         self.assertEqual(data['plugin_slug'], 'github-deployment')
         self.assertEqual(data['run']['run_id'], '42')
         self.assertEqual(data['run']['status'], 'queued')
+        self.assertFalse(data['recorded'])
+
+    def test_trigger_deploy_records_event_when_release_matches(self) -> None:
+        self.mocks['append_deployment_event'].return_value = mock.Mock()
+        with testclient.TestClient(self.test_app) as client:
+            response = client.post(
+                '/organizations/myorg/projects/proj1/deployments',
+                json={
+                    'action': 'deploy',
+                    'environment': 'staging',
+                    'committish': 'v6.4.0',
+                },
+            )
+        self.assertEqual(response.status_code, 202)
+        self.assertTrue(response.json()['recorded'])
+        self.mocks['append_deployment_event'].assert_called_once()
+        call = self.mocks['append_deployment_event'].call_args
+        self.assertEqual(call.kwargs['version'], 'v6.4.0')
+        self.assertEqual(call.kwargs['env_slug'], 'staging')
+        self.assertEqual(call.kwargs['status'], 'in_progress')
+        self.assertIn('https://gh/runs/42', call.kwargs['note'] or '')
 
     def test_trigger_redeploy(self) -> None:
         with testclient.TestClient(self.test_app) as client:

--- a/tests/endpoints/test_project_deployments.py
+++ b/tests/endpoints/test_project_deployments.py
@@ -1,0 +1,346 @@
+"""Tests for the project deployment plugin endpoints."""
+
+import datetime
+import unittest
+from unittest import mock
+
+from fastapi import testclient
+from imbi_common import graph
+from imbi_common.plugins.base import (
+    Commit,
+    CompareResult,
+    DeploymentPlugin,
+    DeploymentRun,
+    PluginManifest,
+    Ref,
+)
+from imbi_common.plugins.registry import RegistryEntry
+
+from imbi_api import app, models
+from imbi_api.auth import password, permissions
+from imbi_api.plugins.resolution import ResolvedPlugin
+
+
+class _FakeDeploymentPlugin(DeploymentPlugin):
+    manifest = PluginManifest(
+        slug='github-deployment',
+        name='GitHub Deployment',
+        plugin_type='deployment',
+    )
+
+    async def list_refs(  # type: ignore[override]
+        self, ctx, credentials, kind='all', query=None
+    ):
+        return [
+            Ref(name='main', kind='default', sha='m-sha', is_default=True),
+            Ref(name='feature/x', kind='branch', sha='fx'),
+        ]
+
+    async def list_commits(  # type: ignore[override]
+        self, ctx, credentials, ref, limit=25
+    ):
+        return [
+            Commit(
+                sha='abc1234567',
+                short_sha='abc1234',
+                message='Top',
+                is_head=True,
+            ),
+            Commit(sha='def5678901', short_sha='def5678', message='prev'),
+        ]
+
+    async def resolve_committish(  # type: ignore[override]
+        self, ctx, credentials, committish
+    ):
+        return Commit(sha=committish, short_sha=committish[:7], message='hi')
+
+    async def compare(  # type: ignore[override]
+        self, ctx, credentials, base, head
+    ):
+        return CompareResult(base_sha=base, head_sha=head, ahead=1, behind=0)
+
+    async def trigger_deployment(  # type: ignore[override]
+        self, ctx, credentials, ref_or_sha, inputs=None
+    ):
+        return DeploymentRun(
+            run_id='42',
+            run_url='https://gh/runs/42',
+            status='queued',
+        )
+
+    async def get_deployment_status(  # type: ignore[override]
+        self, ctx, credentials, run_id
+    ):
+        return DeploymentRun(run_id=run_id, status='in_progress')
+
+
+def _entry() -> RegistryEntry:
+    return RegistryEntry(
+        handler_cls=_FakeDeploymentPlugin,
+        manifest=_FakeDeploymentPlugin.manifest,
+        package_name='imbi-plugin-github',
+        package_version='0.1.0',
+    )
+
+
+class ProjectDeploymentsTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.test_app = app.create_app()
+        self.test_user = models.User(
+            email='admin@example.com',
+            display_name='Admin User',
+            is_active=True,
+            is_admin=True,
+            password_hash=password.hash_password('testpassword123'),
+            created_at=datetime.datetime.now(datetime.UTC),
+        )
+        self.auth_context = permissions.AuthContext(
+            user=self.test_user,
+            session_id='test-session',
+            auth_method='jwt',
+            permissions={
+                'project:deployment:read',
+                'project:deployment:write',
+            },
+        )
+
+        async def mock_get_current_user() -> permissions.AuthContext:
+            return self.auth_context
+
+        self.test_app.dependency_overrides[permissions.get_current_user] = (
+            mock_get_current_user
+        )
+        self.mock_db = mock.AsyncMock(spec=graph.Graph)
+        self.test_app.dependency_overrides[graph._inject_graph] = lambda: (
+            self.mock_db
+        )
+
+    def _resolved(self) -> ResolvedPlugin:
+        return ResolvedPlugin(
+            plugin_id='p-1',
+            plugin_slug='github-deployment',
+            entry=_entry(),
+            options={'owner': 'octo', 'repo': 'demo'},
+        )
+
+    def _patches(self) -> tuple[mock._patch, ...]:
+        return (
+            mock.patch(
+                'imbi_api.endpoints.project_deployments.resolve_plugin',
+                return_value=self._resolved(),
+            ),
+            mock.patch(
+                'imbi_api.endpoints.project_deployments.lookup_project_slugs',
+                return_value=('proj', 'team'),
+            ),
+            mock.patch(
+                'imbi_api.endpoints.project_deployments.attach_identity',
+                side_effect=lambda db, ctx, resolved, auth: ctx,
+            ),
+            mock.patch(
+                'imbi_api.endpoints.project_deployments.get_plugin_credentials',
+                return_value={'access_token': 'gho_test'},
+            ),
+        )
+
+    def test_list_refs(self) -> None:
+        with (
+            self._patches()[0],
+            self._patches()[1],
+            self._patches()[2],
+            self._patches()[3],
+            testclient.TestClient(self.test_app) as client,
+        ):
+            response = client.get(
+                '/organizations/myorg/projects/proj1/deployments/refs'
+            )
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(len(data), 2)
+        self.assertEqual(data[0]['name'], 'main')
+        self.assertTrue(data[0]['is_default'])
+
+    def test_list_commits(self) -> None:
+        with (
+            self._patches()[0],
+            self._patches()[1],
+            self._patches()[2],
+            self._patches()[3],
+            testclient.TestClient(self.test_app) as client,
+        ):
+            response = client.get(
+                '/organizations/myorg/projects/proj1/deployments/'
+                'refs/main/commits'
+            )
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(len(data), 2)
+        self.assertTrue(data[0]['is_head'])
+
+    def test_resolve_commit(self) -> None:
+        with (
+            self._patches()[0],
+            self._patches()[1],
+            self._patches()[2],
+            self._patches()[3],
+            testclient.TestClient(self.test_app) as client,
+        ):
+            response = client.get(
+                '/organizations/myorg/projects/proj1/deployments/'
+                'commits/abc1234'
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()['sha'], 'abc1234')
+
+    def test_compare(self) -> None:
+        with (
+            self._patches()[0],
+            self._patches()[1],
+            self._patches()[2],
+            self._patches()[3],
+            testclient.TestClient(self.test_app) as client,
+        ):
+            response = client.get(
+                '/organizations/myorg/projects/proj1/deployments/'
+                'compare?base=v1&head=v2'
+            )
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data['ahead'], 1)
+        self.assertEqual(data['head_sha'], 'v2')
+
+    def test_compare_missing_query_param_400(self) -> None:
+        with (
+            self._patches()[0],
+            self._patches()[1],
+            self._patches()[2],
+            self._patches()[3],
+            testclient.TestClient(self.test_app) as client,
+        ):
+            response = client.get(
+                '/organizations/myorg/projects/proj1/deployments/compare'
+            )
+        self.assertEqual(response.status_code, 422)
+
+    def test_trigger_deploy(self) -> None:
+        with (
+            self._patches()[0],
+            self._patches()[1],
+            self._patches()[2],
+            self._patches()[3],
+            testclient.TestClient(self.test_app) as client,
+        ):
+            response = client.post(
+                '/organizations/myorg/projects/proj1/deployments',
+                json={
+                    'action': 'deploy',
+                    'environment': 'testing',
+                    'committish': 'main',
+                    'ref_label': 'main',
+                },
+            )
+        self.assertEqual(response.status_code, 202)
+        data = response.json()
+        self.assertEqual(data['plugin_slug'], 'github-deployment')
+        self.assertEqual(data['run']['run_id'], '42')
+        self.assertEqual(data['run']['status'], 'queued')
+
+    def test_trigger_redeploy(self) -> None:
+        with (
+            self._patches()[0],
+            self._patches()[1],
+            self._patches()[2],
+            self._patches()[3],
+            testclient.TestClient(self.test_app) as client,
+        ):
+            response = client.post(
+                '/organizations/myorg/projects/proj1/deployments',
+                json={
+                    'action': 'redeploy',
+                    'environment': 'staging',
+                    'committish': 'v1.2.3',
+                },
+            )
+        self.assertEqual(response.status_code, 202)
+
+    def test_trigger_invalid_action(self) -> None:
+        with (
+            self._patches()[0],
+            self._patches()[1],
+            self._patches()[2],
+            self._patches()[3],
+            testclient.TestClient(self.test_app) as client,
+        ):
+            response = client.post(
+                '/organizations/myorg/projects/proj1/deployments',
+                json={
+                    'action': 'promote',
+                    'environment': 'staging',
+                    'committish': 'v1',
+                },
+            )
+        self.assertEqual(response.status_code, 422)
+
+    def test_no_credentials_returns_503(self) -> None:
+        with (
+            mock.patch(
+                'imbi_api.endpoints.project_deployments.resolve_plugin',
+                return_value=self._resolved(),
+            ),
+            mock.patch(
+                'imbi_api.endpoints.project_deployments.lookup_project_slugs',
+                return_value=('proj', 'team'),
+            ),
+            mock.patch(
+                'imbi_api.endpoints.project_deployments.attach_identity',
+                side_effect=lambda db, ctx, resolved, auth: ctx,
+            ),
+            mock.patch(
+                'imbi_api.endpoints.project_deployments.get_plugin_credentials',
+                return_value={},
+            ),
+            testclient.TestClient(self.test_app) as client,
+        ):
+            response = client.get(
+                '/organizations/myorg/projects/proj1/deployments/refs'
+            )
+        self.assertEqual(response.status_code, 503)
+
+    def test_write_permission_required_for_post(self) -> None:
+        non_admin = models.User(
+            email='dev@example.com',
+            display_name='Dev',
+            is_active=True,
+            is_admin=False,
+            password_hash=password.hash_password('testpassword123'),
+            created_at=datetime.datetime.now(datetime.UTC),
+        )
+        self.auth_context = permissions.AuthContext(
+            user=non_admin,
+            session_id='test-session',
+            auth_method='jwt',
+            permissions={'project:deployment:read'},
+        )
+
+        async def mock_get_current_user() -> permissions.AuthContext:
+            return self.auth_context
+
+        self.test_app.dependency_overrides[permissions.get_current_user] = (
+            mock_get_current_user
+        )
+        with (
+            self._patches()[0],
+            self._patches()[1],
+            self._patches()[2],
+            self._patches()[3],
+            testclient.TestClient(self.test_app) as client,
+        ):
+            response = client.post(
+                '/organizations/myorg/projects/proj1/deployments',
+                json={
+                    'action': 'deploy',
+                    'environment': 'testing',
+                    'committish': 'main',
+                },
+            )
+        self.assertEqual(response.status_code, 403)

--- a/tests/endpoints/test_project_deployments.py
+++ b/tests/endpoints/test_project_deployments.py
@@ -541,3 +541,211 @@ class ProjectDeploymentsTestCase(unittest.TestCase):
         self.assertEqual(data[0]['commits_pending'], 1)
         self.assertEqual(data[1]['from_environment'], 'staging')
         self.assertEqual(data[1]['to_environment'], 'production')
+
+    def test_promotion_options_picks_latest_release_per_env(self) -> None:
+        # Two rows for the same env: an older v6.3.0 with an earlier
+        # event timestamp and a newer v6.4.0.  The reducer should pick
+        # v6.4.0 as the testing env's current release.  We pair it
+        # against staging (single-row) so the test asserts the
+        # deterministic ordering rather than the staging row choice.
+        def _mock_execute(query, params, columns):
+            del query, params, columns
+            return [
+                {
+                    'env': '{"slug": "testing", "name": "Testing", '
+                    '"sort_order": 1}',
+                    'release': '{"version": "v6.3.0"}',
+                    'deployments': (
+                        '[{"timestamp": "2024-01-01T00:00:00+00:00", '
+                        '"status": "success"}]'
+                    ),
+                },
+                {
+                    'env': '{"slug": "testing", "name": "Testing", '
+                    '"sort_order": 1}',
+                    'release': '{"version": "v6.4.0"}',
+                    'deployments': (
+                        '[{"timestamp": "2024-06-01T00:00:00+00:00", '
+                        '"status": "success"}]'
+                    ),
+                },
+                {
+                    'env': '{"slug": "staging", "name": "Staging", '
+                    '"sort_order": 2}',
+                    'release': '{"version": "v6.2.0"}',
+                    'deployments': None,
+                },
+            ]
+
+        self.mock_db.execute = mock.AsyncMock(side_effect=_mock_execute)
+        with testclient.TestClient(self.test_app) as client:
+            response = client.get(
+                '/organizations/myorg/projects/proj1/deployments/'
+                'promotion-options'
+            )
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]['from_environment'], 'testing')
+        self.assertEqual(data[0]['from_version'], 'v6.4.0')
+        self.assertEqual(data[0]['to_version'], 'v6.2.0')
+
+    def test_promotion_options_falls_back_to_non_null_release(self) -> None:
+        # When neither row for an env has any deployment events, the
+        # reducer should still surface a non-null release if one row
+        # has it.
+        def _mock_execute(query, params, columns):
+            del query, params, columns
+            return [
+                {
+                    'env': '{"slug": "testing", "name": "Testing", '
+                    '"sort_order": 1}',
+                    'release': None,
+                    'deployments': None,
+                },
+                {
+                    'env': '{"slug": "testing", "name": "Testing", '
+                    '"sort_order": 1}',
+                    'release': '{"version": "v1.0.0"}',
+                    'deployments': None,
+                },
+                {
+                    'env': '{"slug": "staging", "name": "Staging", '
+                    '"sort_order": 2}',
+                    'release': '{"version": "v0.9.0"}',
+                    'deployments': None,
+                },
+            ]
+
+        self.mock_db.execute = mock.AsyncMock(side_effect=_mock_execute)
+        with testclient.TestClient(self.test_app) as client:
+            response = client.get(
+                '/organizations/myorg/projects/proj1/deployments/'
+                'promotion-options'
+            )
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]['from_version'], 'v1.0.0')
+
+
+class FallbackNotesTestCase(unittest.TestCase):
+    """Direct tests for ``_classify_bump`` and ``_fallback_notes``."""
+
+    def test_classify_bump_breaking(self) -> None:
+        from imbi_api.endpoints.project_deployments import _classify_bump
+
+        commits = [Commit(sha='a', short_sha='a', message='feat!: drop')]
+        self.assertEqual(_classify_bump(commits), 'major')
+
+    def test_classify_bump_feature(self) -> None:
+        from imbi_api.endpoints.project_deployments import _classify_bump
+
+        commits = [Commit(sha='a', short_sha='a', message='feat: new thing')]
+        self.assertEqual(_classify_bump(commits), 'minor')
+
+    def test_classify_bump_patch_default(self) -> None:
+        from imbi_api.endpoints.project_deployments import _classify_bump
+
+        commits = [Commit(sha='a', short_sha='a', message='fix: thing')]
+        self.assertEqual(_classify_bump(commits), 'patch')
+
+    def test_fallback_notes_groups_by_prefix(self) -> None:
+        from imbi_api.endpoints.project_deployments import _fallback_notes
+
+        commits = [
+            Commit(sha='a', short_sha='aaa', message='feat: one'),
+            Commit(sha='b', short_sha='bbb', message='fix: two'),
+            Commit(sha='c', short_sha='ccc', message='feat: three'),
+        ]
+        body = _fallback_notes(commits)
+        self.assertIn('### feat', body)
+        self.assertIn('### fix', body)
+        self.assertIn('feat: one (aaa)', body)
+        self.assertIn('fix: two (bbb)', body)
+
+    def test_fallback_notes_empty(self) -> None:
+        from imbi_api.endpoints.project_deployments import _fallback_notes
+
+        self.assertIn('No commits', _fallback_notes([]))
+
+    def test_fallback_notes_falls_back_to_other_for_long_prefix(self) -> None:
+        from imbi_api.endpoints.project_deployments import _fallback_notes
+
+        commits = [
+            Commit(
+                sha='a',
+                short_sha='aaa',
+                message='thisprefixiswaytoolong: hi',
+            ),
+        ]
+        body = _fallback_notes(commits)
+        self.assertIn('### other', body)
+
+
+class LatestDeploymentTimestampTestCase(unittest.TestCase):
+    """Direct tests for ``_latest_deployment_timestamp``."""
+
+    def test_returns_none_for_empty_or_missing(self) -> None:
+        from imbi_api.endpoints.project_deployments import (
+            _latest_deployment_timestamp,
+        )
+
+        self.assertIsNone(_latest_deployment_timestamp(None))
+        self.assertIsNone(_latest_deployment_timestamp(''))
+        self.assertIsNone(_latest_deployment_timestamp('[]'))
+
+    def test_returns_none_for_non_list_payloads(self) -> None:
+        from imbi_api.endpoints.project_deployments import (
+            _latest_deployment_timestamp,
+        )
+
+        self.assertIsNone(_latest_deployment_timestamp('"oops"'))
+        self.assertIsNone(_latest_deployment_timestamp('{"x": 1}'))
+
+    def test_picks_max_timestamp(self) -> None:
+        from imbi_api.endpoints.project_deployments import (
+            _latest_deployment_timestamp,
+        )
+
+        raw = (
+            '[{"timestamp": "2024-01-01T00:00:00+00:00", "status": "success"},'
+            ' {"timestamp": "2024-06-01T00:00:00+00:00", "status": "success"},'
+            ' {"timestamp": "2024-03-01T00:00:00+00:00", "status": "success"}]'
+        )
+        result = _latest_deployment_timestamp(raw)
+        self.assertEqual(
+            result,
+            datetime.datetime(2024, 6, 1, tzinfo=datetime.UTC),
+        )
+
+    def test_skips_invalid_entries(self) -> None:
+        from imbi_api.endpoints.project_deployments import (
+            _latest_deployment_timestamp,
+        )
+
+        raw = (
+            '[{"timestamp": "not-a-date", "status": "success"},'
+            ' "scalar",'
+            ' {"timestamp": 42, "status": "success"},'
+            ' {"timestamp": "2024-06-01T00:00:00+00:00", '
+            '"status": "success"}]'
+        )
+        result = _latest_deployment_timestamp(raw)
+        self.assertEqual(
+            result,
+            datetime.datetime(2024, 6, 1, tzinfo=datetime.UTC),
+        )
+
+    def test_accepts_already_decoded_list(self) -> None:
+        from imbi_api.endpoints.project_deployments import (
+            _latest_deployment_timestamp,
+        )
+
+        result = _latest_deployment_timestamp(
+            [{'timestamp': '2024-06-01T00:00:00+00:00', 'status': 'success'}]
+        )
+        self.assertEqual(
+            result,
+            datetime.datetime(2024, 6, 1, tzinfo=datetime.UTC),
+        )

--- a/tests/test_lifespans.py
+++ b/tests/test_lifespans.py
@@ -103,11 +103,10 @@ class ApplicationLifespanTestCase(unittest.TestCase):
         self.assertEqual(len(captured), 1)
         self.assertFalse(captured[0].available)  # type: ignore[attr-defined]
         self.assertTrue(
-            any(
-                'Anthropic client disabled' in line
-                or 'Anthropic client initialized' in line
-                for line in cm.output
-            )
+            any('Anthropic client disabled' in line for line in cm.output)
+        )
+        self.assertFalse(
+            any('Anthropic client initialized' in line for line in cm.output)
         )
 
     def test_openapi_refresh_blueprint_failure(self) -> None:

--- a/tests/test_lifespans.py
+++ b/tests/test_lifespans.py
@@ -80,6 +80,36 @@ class ApplicationLifespanTestCase(unittest.TestCase):
 
         self.assertTrue(any('Graph not ready' in line for line in cm.output))
 
+    def test_anthropic_hook_disabled_when_api_key_missing(self) -> None:
+        """anthropic_hook yields a disabled client when no API key is set."""
+        loop = asyncio.new_event_loop()
+        captured: list[object] = []
+        try:
+            with (
+                unittest.mock.patch.dict(
+                    'os.environ', {'ANTHROPIC_API_KEY': ''}, clear=False
+                ),
+                self.assertLogs(lifespans.LOGGER, level='INFO') as cm,
+            ):
+
+                async def _run() -> None:
+                    async with lifespans.anthropic_hook() as client:
+                        captured.append(client)
+
+                loop.run_until_complete(_run())
+        finally:
+            loop.close()
+
+        self.assertEqual(len(captured), 1)
+        self.assertFalse(captured[0].available)  # type: ignore[attr-defined]
+        self.assertTrue(
+            any(
+                'Anthropic client disabled' in line
+                or 'Anthropic client initialized' in line
+                for line in cm.output
+            )
+        )
+
     def test_openapi_refresh_blueprint_failure(self) -> None:
         failure = RuntimeError()
         with (

--- a/uv.lock
+++ b/uv.lock
@@ -987,7 +987,7 @@ requires-dist = [
   { name = "fastapi" },
   { name = "filetype" },
   { name = "httpx", specifier = ">=0.28.1,<1" },
-  { name = "imbi-common", extras = ["databases", "llm", "server"], git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=feature%2Fanthropic-client" },
+  { name = "imbi-common", extras = ["databases", "llm", "server"], git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=main" },
   { name = "jinja2" },
   { name = "jsonpatch", specifier = ">=1.33" },
   { name = "nanoid", specifier = ">=2.0.0" },
@@ -1040,7 +1040,7 @@ plugins = [
 [[package]]
 name = "imbi-common"
 version = "0.7.1"
-source = { git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=feature%2Fanthropic-client#532a00cdcf3954cc2b6ab2491d8178a51b5731b4" }
+source = { git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=main#3e04f673c3b0c8b7f187627bfbbc9a1fcbb03b78" }
 dependencies = [
   { name = "cryptography" },
   { name = "jsonschema-models" },

--- a/uv.lock
+++ b/uv.lock
@@ -151,6 +151,25 @@ wheels = [
 ]
 
 [[package]]
+name = "anthropic"
+version = "0.100.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+  { name = "anyio" },
+  { name = "distro" },
+  { name = "docstring-parser" },
+  { name = "httpx" },
+  { name = "jiter" },
+  { name = "pydantic" },
+  { name = "sniffio" },
+  { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9c/2d/24caf0ff727cba2ed863925017c8f93463a2ea6224a0efe5626e672bc3d2/anthropic-0.100.0.tar.gz", hash = "sha256:650dee9e023afb16395939ee4104bbc21f966b380210119fb91122c12099c79a", size = 758255, upload-time = "2026-05-06T15:07:13.578Z" }
+wheels = [
+  { url = "https://files.pythonhosted.org/packages/5d/a0/c775c59ab9445ecabb57ef3d5c24027de060139189a9e312ef9ef889a665/anthropic-0.100.0-py3-none-any.whl", hash = "sha256:1c15769efa15d8fd5c1ebf900e25c57e3ee540f8554a29aa56e4edefffe2951d", size = 753596, upload-time = "2026-05-06T15:07:12.106Z" },
+]
+
+[[package]]
 name = "anyio"
 version = "4.13.0"
 source = { registry = "https://pypi.org/simple" }
@@ -567,12 +586,30 @@ wheels = [
 ]
 
 [[package]]
+name = "distro"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
+wheels = [
+  { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
 name = "dnspython"
 version = "2.8.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
 wheels = [
   { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
+]
+
+[[package]]
+name = "docstring-parser"
+version = "0.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
+wheels = [
+  { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
 ]
 
 [[package]]
@@ -886,7 +923,7 @@ dependencies = [
   { name = "fastapi" },
   { name = "filetype" },
   { name = "httpx" },
-  { name = "imbi-common", extra = ["databases", "server"] },
+  { name = "imbi-common", extra = ["databases", "llm", "server"] },
   { name = "jinja2" },
   { name = "jsonpatch" },
   { name = "nanoid" },
@@ -950,7 +987,7 @@ requires-dist = [
   { name = "fastapi" },
   { name = "filetype" },
   { name = "httpx", specifier = ">=0.28.1,<1" },
-  { name = "imbi-common", extras = ["databases", "server"], git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=main" },
+  { name = "imbi-common", extras = ["databases", "llm", "server"], git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=feature%2Fanthropic-client" },
   { name = "jinja2" },
   { name = "jsonpatch", specifier = ">=1.33" },
   { name = "nanoid", specifier = ">=2.0.0" },
@@ -1003,7 +1040,7 @@ plugins = [
 [[package]]
 name = "imbi-common"
 version = "0.7.1"
-source = { git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=main#70998e44d407d1b5d87de0c4ec309df9acb4853d" }
+source = { git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=feature%2Fanthropic-client#532a00cdcf3954cc2b6ab2491d8178a51b5731b4" }
 dependencies = [
   { name = "cryptography" },
   { name = "jsonschema-models" },
@@ -1024,6 +1061,9 @@ databases = [
   { name = "pgvector" },
   { name = "psycopg", extra = ["binary", "pool"] },
   { name = "valkey" },
+]
+llm = [
+  { name = "anthropic" },
 ]
 server = [
   { name = "fastapi" },
@@ -1101,6 +1141,41 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
   { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "jiter"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/c1/0cddc6eb17d4c53a99840953f95dd3accdc5cfc7a337b0e9b26476276be9/jiter-0.14.0.tar.gz", hash = "sha256:e8a39e66dac7153cf3f964a12aad515afa8d74938ec5cc0018adcdae5367c79e", size = 165725, upload-time = "2026-04-10T14:28:42.01Z" }
+wheels = [
+  { url = "https://files.pythonhosted.org/packages/4f/1e/354ed92461b165bd581f9ef5150971a572c873ec3b68a916d5aa91da3cc2/jiter-0.14.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:6f396837fc7577871ca8c12edaf239ed9ccef3bbe39904ae9b8b63ce0a48b140", size = 315277, upload-time = "2026-04-10T14:27:18.109Z" },
+  { url = "https://files.pythonhosted.org/packages/a6/95/8c7c7028aa8636ac21b7a55faef3e34215e6ed0cbf5ae58258427f621aa3/jiter-0.14.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a4d50ea3d8ba4176f79754333bd35f1bbcd28e91adc13eb9b7ca91bc52a6cef9", size = 315923, upload-time = "2026-04-10T14:27:19.603Z" },
+  { url = "https://files.pythonhosted.org/packages/47/40/e2a852a44c4a089f2681a16611b7ce113224a80fd8504c46d78491b47220/jiter-0.14.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce17f8a050447d1b4153bda4fb7d26e6a9e74eb4f4a41913f30934c5075bf615", size = 344943, upload-time = "2026-04-10T14:27:21.262Z" },
+  { url = "https://files.pythonhosted.org/packages/fc/1f/670f92adee1e9895eac41e8a4d623b6da68c4d46249d8b556b60b63f949e/jiter-0.14.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f4f1c4b125e1652aefbc2e2c1617b60a160ab789d180e3d423c41439e5f32850", size = 369725, upload-time = "2026-04-10T14:27:22.766Z" },
+  { url = "https://files.pythonhosted.org/packages/01/2f/541c9ba567d05de1c4874a0f8f8c5e3fd78e2b874266623da9a775cf46e0/jiter-0.14.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:be808176a6a3a14321d18c603f2d40741858a7c4fc982f83232842689fe86dd9", size = 461210, upload-time = "2026-04-10T14:27:24.315Z" },
+  { url = "https://files.pythonhosted.org/packages/ce/a9/c31cbec09627e0d5de7aeaec7690dba03e090caa808fefd8133137cf45bc/jiter-0.14.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:26679d58ba816f88c3849306dd58cb863a90a1cf352cdd4ef67e30ccf8a77994", size = 380002, upload-time = "2026-04-10T14:27:26.155Z" },
+  { url = "https://files.pythonhosted.org/packages/50/02/3c05c1666c41904a2f607475a73e7a4763d1cbde2d18229c4f85b22dc253/jiter-0.14.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:80381f5a19af8fa9aef743f080e34f6b25ebd89656475f8cf0470ec6157052aa", size = 354678, upload-time = "2026-04-10T14:27:27.701Z" },
+  { url = "https://files.pythonhosted.org/packages/7d/97/e15b33545c2b13518f560d695f974b9891b311641bdcf178d63177e8801e/jiter-0.14.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:004df5fdb8ecbd6d99f3227df18ba1a259254c4359736a2e6f036c944e02d7c5", size = 358920, upload-time = "2026-04-10T14:27:29.256Z" },
+  { url = "https://files.pythonhosted.org/packages/ad/d2/8b1461def6b96ba44530df20d07ef7a1c7da22f3f9bf1727e2d611077bf1/jiter-0.14.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:cff5708f7ed0fa098f2b53446c6fa74c48469118e5cd7497b4f1cd569ab06928", size = 394512, upload-time = "2026-04-10T14:27:31.344Z" },
+  { url = "https://files.pythonhosted.org/packages/e3/88/837566dd6ed6e452e8d3205355afd484ce44b2533edfa4ed73a298ea893e/jiter-0.14.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:2492e5f06c36a976d25c7cc347a60e26d5470178d44cde1b9b75e60b4e519f28", size = 521120, upload-time = "2026-04-10T14:27:33.299Z" },
+  { url = "https://files.pythonhosted.org/packages/89/6b/b00b45c4d1b4c031777fe161d620b755b5b02cdade1e316dcb46e4471d63/jiter-0.14.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:7609cfbe3a03d37bfdbf5052012d5a879e72b83168a363deae7b3a26564d57de", size = 553668, upload-time = "2026-04-10T14:27:34.868Z" },
+  { url = "https://files.pythonhosted.org/packages/ad/d8/6fe5b42011d19397433d345716eac16728ac241862a2aac9c91923c7509a/jiter-0.14.0-cp314-cp314-win32.whl", hash = "sha256:7282342d32e357543565286b6450378c3cd402eea333fc1ebe146f1fabb306fc", size = 207001, upload-time = "2026-04-10T14:27:36.455Z" },
+  { url = "https://files.pythonhosted.org/packages/e5/43/5c2e08da1efad5e410f0eaaabeadd954812612c33fbbd8fd5328b489139d/jiter-0.14.0-cp314-cp314-win_amd64.whl", hash = "sha256:bd77945f38866a448e73b0b7637366afa814d4617790ecd88a18ca74377e6c02", size = 202187, upload-time = "2026-04-10T14:27:38Z" },
+  { url = "https://files.pythonhosted.org/packages/aa/1f/6e39ac0b4cdfa23e606af5b245df5f9adaa76f35e0c5096790da430ca506/jiter-0.14.0-cp314-cp314-win_arm64.whl", hash = "sha256:f2d4c61da0821ee42e0cdf5489da60a6d074306313a377c2b35af464955a3611", size = 192257, upload-time = "2026-04-10T14:27:39.504Z" },
+  { url = "https://files.pythonhosted.org/packages/05/57/7dbc0ffbbb5176a27e3518716608aa464aee2e2887dc938f0b900a120449/jiter-0.14.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1bf7ff85517dd2f20a5750081d2b75083c1b269cf75afc7511bdf1f9548beb3b", size = 323441, upload-time = "2026-04-10T14:27:41.039Z" },
+  { url = "https://files.pythonhosted.org/packages/83/6e/7b3314398d8983f06b557aa21b670511ec72d3b79a68ee5e4d9bff972286/jiter-0.14.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c8ef8791c3e78d6c6b157c6d360fbb5c715bebb8113bc6a9303c5caff012754a", size = 348109, upload-time = "2026-04-10T14:27:42.552Z" },
+  { url = "https://files.pythonhosted.org/packages/ae/4f/8dc674bcd7db6dba566de73c08c763c337058baff1dbeb34567045b27cdc/jiter-0.14.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e74663b8b10da1fe0f4e4703fd7980d24ad17174b6bb35d8498d6e3ebce2ae6a", size = 368328, upload-time = "2026-04-10T14:27:44.574Z" },
+  { url = "https://files.pythonhosted.org/packages/3b/5f/188e09a1f20906f98bbdec44ed820e19f4e8eb8aff88b9d1a5a497587ff3/jiter-0.14.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1aca29ba52913f78362ec9c2da62f22cdc4c3083313403f90c15460979b84d9b", size = 463301, upload-time = "2026-04-10T14:27:46.717Z" },
+  { url = "https://files.pythonhosted.org/packages/ac/f0/19046ef965ed8f349e8554775bb12ff4352f443fbe12b95d31f575891256/jiter-0.14.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8b39b7d87a952b79949af5fef44d2544e58c21a28da7f1bae3ef166455c61746", size = 378891, upload-time = "2026-04-10T14:27:48.32Z" },
+  { url = "https://files.pythonhosted.org/packages/c4/c3/da43bd8431ee175695777ee78cf0e93eacbb47393ff493f18c45231b427d/jiter-0.14.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:78d918a68b26e9fab068c2b5453577ef04943ab2807b9a6275df2a812599a310", size = 360749, upload-time = "2026-04-10T14:27:49.88Z" },
+  { url = "https://files.pythonhosted.org/packages/72/26/e054771be889707c6161dbdec9c23d33a9ec70945395d70f07cfea1e9a6f/jiter-0.14.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:b08997c35aee1201c1a5361466a8fb9162d03ae7bf6568df70b6c859f1e654a4", size = 358526, upload-time = "2026-04-10T14:27:51.504Z" },
+  { url = "https://files.pythonhosted.org/packages/c3/0f/7bea65ea2a6d91f2bf989ff11a18136644392bf2b0497a1fa50934c30a9c/jiter-0.14.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:260bf7ca20704d58d41f669e5e9fe7fe2fa72901a6b324e79056f5d52e9c9be2", size = 393926, upload-time = "2026-04-10T14:27:53.368Z" },
+  { url = "https://files.pythonhosted.org/packages/3c/a1/b1ff7d70deef61ac0b7c6c2f12d2ace950cdeecb4fdc94500a0926802857/jiter-0.14.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:37826e3df29e60f30a382f9294348d0238ef127f4b5d7f5f8da78b5b9e050560", size = 521052, upload-time = "2026-04-10T14:27:55.058Z" },
+  { url = "https://files.pythonhosted.org/packages/0b/7b/3b0649983cbaf15eda26a414b5b1982e910c67bd6f7b1b490f3cfc76896a/jiter-0.14.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:645be49c46f2900937ba0eaf871ad5183c96858c0af74b6becc7f4e367e36e06", size = 553716, upload-time = "2026-04-10T14:27:57.269Z" },
+  { url = "https://files.pythonhosted.org/packages/97/f8/33d78c83bd93ae0c0af05293a6660f88a1977caef39a6d72a84afab94ce0/jiter-0.14.0-cp314-cp314t-win32.whl", hash = "sha256:2f7877ed45118de283786178eceaf877110abacd04fde31efff3940ae9672674", size = 207957, upload-time = "2026-04-10T14:27:59.285Z" },
+  { url = "https://files.pythonhosted.org/packages/d6/ac/2b760516c03e2227826d1f7025d89bf6bf6357a28fe75c2a2800873c50bf/jiter-0.14.0-cp314-cp314t-win_amd64.whl", hash = "sha256:14c0cb10337c49f5eafe8e7364daca5e29a020ea03580b8f8e6c597fed4e1588", size = 204690, upload-time = "2026-04-10T14:28:00.962Z" },
+  { url = "https://files.pythonhosted.org/packages/dc/2e/a44c20c58aeed0355f2d326969a181696aeb551a25195f47563908a815be/jiter-0.14.0-cp314-cp314t-win_arm64.whl", hash = "sha256:5419d4aa2024961da9fe12a9cfe7484996735dca99e8e090b5c88595ef1951ff", size = 191338, upload-time = "2026-04-10T14:28:02.853Z" },
 ]
 
 [[package]]
@@ -2424,6 +2499,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a0/99/adfc7f94ca024736f061257d39118e1542bade7a52e86415a4c4ae92d8ff/slowapi-0.1.9.tar.gz", hash = "sha256:639192d0f1ca01b1c6d95bf6c71d794c3a9ee189855337b4821f7f457dddad77", size = 14028, upload-time = "2024-02-05T12:11:52.13Z" }
 wheels = [
   { url = "https://files.pythonhosted.org/packages/2b/bb/f71c4b7d7e7eb3fc1e8c0458a8979b912f40b58002b9fbf37729b8cb464b/slowapi-0.1.9-py3-none-any.whl", hash = "sha256:cfad116cfb84ad9d763ee155c1e5c5cbf00b0d47399a769b227865f5df576e36", size = 14670, upload-time = "2024-02-05T12:11:50.898Z" },
+]
+
+[[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
+wheels = [
+  { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- New router `endpoints/project_deployments.py` mounted at `/organizations/{org}/projects/{id}/deployments/*`.
  - `GET refs`, `GET refs/{ref}/commits`, `GET commits/{committish}`, `GET compare` — pass-through to the project's deployment plugin via `resolve_plugin()` + `call_with_timeout()`.
  - `POST /deployments` (action `deploy` / `redeploy`) — appends a `DeploymentEvent` on the matching `Release ─[:DEPLOYED_TO]→ Environment` edge.
- Phase 2:
  - `anthropic_hook` lifespan + `InjectAnthropicClient` DI (single client per process, `available=False` when `ANTHROPIC_API_KEY` is missing).
  - `POST /deployments/draft-release-notes` — calls `compare()` to enumerate commits, asks Claude (Haiku) for `{bump, version, reasoning, notes_markdown}`, with prompt caching on the system prompt and a deterministic fallback.
  - `GET /deployments/promotion-options` — enumerates consecutive env pairs with from-env releases, reports `commits_pending` per gap.
  - `POST /deployments` extended with the `promote` action — `create_tag → create_release → trigger_deployment(tag)`, upserts the matching `Release`, returns `release_url` and `tag`.
- Pulls in `imbi-common[llm]` and refreshes the lock so `anthropic` is available at runtime.
- 17 tests cover the new endpoints, including discriminated-union body validation and the LLM fallback path.

## Context

Phase 1 + 2 of [`docs/deployments-plan.md`](https://github.com/AWeber-Imbi/imbi/blob/main/docs/deployments-plan.md).

**Depends on**:
- AWeber-Imbi/imbi-common#83 (DeploymentPlugin ABC)
- AWeber-Imbi/imbi-common#84 (AnthropicClient + `[llm]` extra)
- AWeber-Imbi/imbi-plugin-github (GitHub deployment plugins) — runtime-installed

The last commit on this branch temporarily pins `imbi-common` to `rev = "feature/anthropic-client"` so CI can resolve the `[llm]` extra. **A follow-up commit will reset the rev to `main` once the imbi-common PRs merge.**

## Test plan

- [ ] `just test` — full suite passes; new tests in `tests/endpoints/test_project_deployments.py`
- [ ] After imbi-common PRs merge: revert `[tool.uv.sources]` rev to `main` and refresh lock