### PR TITLE
Phase 3: deployment status polling, audit log, run-URL plumbing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -223,7 +223,7 @@ url = "https://pypi.org/simple"
 default = true
 
 [tool.uv.sources]
-imbi-common = { git = "https://github.com/AWeber-Imbi/imbi-common.git", rev = "main" }
+imbi-common = { git = "https://github.com/AWeber-Imbi/imbi-common.git", rev = "feature/deployment-event-run-url" }
 imbi-plugin-aws = { git = "https://github.com/AWeber-Imbi/imbi-plugin-aws.git", rev = "main" }
 imbi-plugin-github = { git = "https://github.com/AWeber-Imbi/imbi-plugin-github.git", rev = "main" }
 imbi-plugin-logzio = { git = "https://github.com/AWeber-Imbi/imbi-plugin-logzio.git", rev = "main" }

--- a/src/imbi_api/endpoints/project_deployments.py
+++ b/src/imbi_api/endpoints/project_deployments.py
@@ -19,7 +19,8 @@ import typing
 import fastapi
 import nanoid
 import pydantic
-from imbi_common import graph
+from imbi_common import clickhouse, graph
+from imbi_common import models as common_models
 from imbi_common.plugins.base import (
     Commit,
     CompareResult,
@@ -234,6 +235,59 @@ def _handler(resolved: ResolvedPlugin) -> DeploymentPlugin:
     return typing.cast(DeploymentPlugin, resolved.entry.handler_cls())
 
 
+async def _record_deployment_audit(
+    *,
+    project_id: str,
+    project_slug: str,
+    environment_slug: str,
+    recorded_by: str,
+    action: str,
+    version: str,
+    plugin_slug: str,
+    run_url: str | None,
+    release_url: str | None = None,
+    from_environment: str | None = None,
+) -> None:
+    """Write a deployment audit row to the ``operations_log``.
+
+    Mirrors the configuration audit pattern in
+    ``project_configuration._record_configuration_event`` so the
+    project's history pane surfaces deploys/promotes the same way
+    it surfaces config changes.  Audit failures intentionally
+    propagate so a bad write never silently desyncs the log.
+    """
+    description = json.dumps(
+        {
+            'action': action,
+            'plugin_slug': plugin_slug,
+            'run_url': run_url,
+            'release_url': release_url,
+            'from_environment': from_environment,
+        },
+        sort_keys=True,
+    )
+    entry = common_models.OperationLog(
+        id=nanoid.generate(),
+        recorded_at=datetime.datetime.now(datetime.UTC),
+        recorded_by=recorded_by,
+        performed_by=recorded_by,
+        project_id=project_id,
+        project_slug=project_slug,
+        environment_slug=environment_slug,
+        entry_type='Deployed',
+        description=description,
+        link=run_url,
+        version=version,
+    )
+    row = entry.model_dump(by_alias=True, mode='python')
+    row['is_deleted'] = 1 if entry.is_deleted else 0
+    await clickhouse.client.Clickhouse.get_instance().insert(
+        'operations_log',
+        [list(row.values())],
+        list(row.keys()),
+    )
+
+
 # ---------------------------------------------------------------------------
 # Endpoints
 # ---------------------------------------------------------------------------
@@ -373,6 +427,44 @@ async def trigger_deployment(
     )
 
 
+@project_deployments_router.get('/runs/{run_id}')
+async def get_deployment_run(
+    org_slug: str,
+    project_id: str,
+    run_id: str,
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('project:deployment:read'),
+        ),
+    ],
+    source: str | None = None,
+) -> DeploymentRun:
+    """Fetch live status for an in-flight deployment workflow run.
+
+    Pass-through to plugin ``get_deployment_status``.  Used by the UI's
+    TanStack Query ``refetchInterval`` hook to flip
+    ``in_progress → success / failed`` without a page reload.
+    """
+    resolved, ctx, credentials = await _resolve_and_context(
+        db, org_slug, project_id, auth, source=source
+    )
+    handler = _handler(resolved)
+    try:
+        return await call_with_timeout(
+            handler.get_deployment_status(ctx, credentials, run_id=run_id)
+        )
+    except NotImplementedError as exc:
+        raise fastapi.HTTPException(
+            status_code=400,
+            detail=(
+                f'Plugin {resolved.plugin_slug!r} does not report '
+                'deployment status.'
+            ),
+        ) from exc
+
+
 async def _handle_deploy(
     db: graph.Graph,
     org_slug: str,
@@ -410,8 +502,9 @@ async def _handle_deploy(
         ctx.actor_user_id,
         run.run_id,
     )
-    note = _deploy_note(resolved.plugin_slug, run.run_url)
-    recorded = False
+    note = f'via {resolved.plugin_slug}'
+    recorded_version: str | None = None
+    edge = None
     for candidate in filter(None, (body.ref_label, body.committish)):
         edge = await append_deployment_event(
             db,
@@ -421,23 +514,28 @@ async def _handle_deploy(
             env_slug=body.environment,
             status='in_progress',
             note=note,
+            external_run_id=str(run.run_id) if run.run_id else None,
+            external_run_url=run.run_url,
         )
         if edge is not None:
-            recorded = True
+            recorded_version = candidate
             break
+    await _record_deployment_audit(
+        project_id=project_id,
+        project_slug=ctx.project_slug,
+        environment_slug=body.environment,
+        recorded_by=auth.principal_name,
+        action=body.action,
+        version=recorded_version or body.ref_label or body.committish,
+        plugin_slug=resolved.plugin_slug,
+        run_url=run.run_url,
+    )
     return DeploymentTriggerResponse(
         run=run,
         plugin_id=resolved.plugin_id,
         plugin_slug=resolved.plugin_slug,
-        recorded=recorded,
+        recorded=edge is not None,
     )
-
-
-def _deploy_note(plugin_slug: str, run_url: str | None) -> str:
-    parts = [f'via {plugin_slug}']
-    if run_url:
-        parts.append(run_url)
-    return ' — '.join(parts)
 
 
 async def _handle_promote(
@@ -528,7 +626,7 @@ async def _handle_promote(
     )
 
     # 5. Record the deployment event.
-    note = _deploy_note(resolved.plugin_slug, run.run_url)
+    note = f'via {resolved.plugin_slug}'
     edge = await append_deployment_event(
         db,
         org_slug=org_slug,
@@ -537,6 +635,8 @@ async def _handle_promote(
         env_slug=body.to_environment,
         status='in_progress',
         note=note,
+        external_run_id=str(run.run_id) if run.run_id else None,
+        external_run_url=run.run_url,
     )
 
     LOGGER.info(
@@ -549,6 +649,18 @@ async def _handle_promote(
         resolved.plugin_slug,
         ctx.actor_user_id,
         run.run_id,
+    )
+    await _record_deployment_audit(
+        project_id=project_id,
+        project_slug=ctx.project_slug,
+        environment_slug=body.to_environment,
+        recorded_by=auth.principal_name,
+        action='promote',
+        version=body.tag,
+        plugin_slug=resolved.plugin_slug,
+        run_url=run.run_url,
+        release_url=release_url,
+        from_environment=body.from_environment,
     )
     return DeploymentTriggerResponse(
         run=run,

--- a/src/imbi_api/endpoints/releases.py
+++ b/src/imbi_api/endpoints/releases.py
@@ -644,6 +644,8 @@ async def append_deployment_event(
         'pending', 'in_progress', 'success', 'failed', 'rolled_back'
     ],
     note: str | None = None,
+    external_run_id: str | None = None,
+    external_run_url: str | None = None,
 ) -> ReleaseEnvironmentEdgeResponse | None:
     """Append a ``DeploymentEvent`` to ``Release -[:DEPLOYED_TO]-> Env``.
 
@@ -664,6 +666,8 @@ async def append_deployment_event(
         timestamp=datetime.datetime.now(datetime.UTC),
         status=status,
         note=note,
+        external_run_id=external_run_id,
+        external_run_url=external_run_url,
     )
     deployments = [*existing, event]
     serialized = json.dumps(

--- a/tests/endpoints/test_project_deployments.py
+++ b/tests/endpoints/test_project_deployments.py
@@ -187,6 +187,18 @@ class ProjectDeploymentsTestCase(unittest.TestCase):
                     return_value=None,
                 )
             ),
+            'clickhouse': self._start(
+                mock.patch(
+                    f'{_MODULE}.clickhouse.client.Clickhouse.get_instance',
+                    return_value=mock.MagicMock(
+                        insert=mock.AsyncMock(return_value=None),
+                        initialize=mock.AsyncMock(return_value=True),
+                        setup_schema=mock.AsyncMock(return_value=None),
+                        aclose=mock.AsyncMock(return_value=None),
+                        close=mock.AsyncMock(return_value=None),
+                    ),
+                )
+            ),
         }
 
     def _start(self, patcher: typing.Any) -> mock.MagicMock:
@@ -287,7 +299,11 @@ class ProjectDeploymentsTestCase(unittest.TestCase):
         self.assertEqual(call.kwargs['version'], 'v6.4.0')
         self.assertEqual(call.kwargs['env_slug'], 'staging')
         self.assertEqual(call.kwargs['status'], 'in_progress')
-        self.assertIn('https://gh/runs/42', call.kwargs['note'] or '')
+        self.assertEqual(call.kwargs['external_run_id'], '42')
+        self.assertEqual(call.kwargs['external_run_url'], 'https://gh/runs/42')
+        # Note no longer encodes the run URL — that lives in the
+        # external_run_url field now.
+        self.assertNotIn('https://gh/runs/42', call.kwargs['note'] or '')
 
     def test_trigger_redeploy(self) -> None:
         with testclient.TestClient(self.test_app) as client:
@@ -461,6 +477,9 @@ class ProjectDeploymentsTestCase(unittest.TestCase):
         call = self.mocks['append_deployment_event'].call_args
         self.assertEqual(call.kwargs['version'], 'v6.4.0')
         self.assertEqual(call.kwargs['env_slug'], 'staging')
+        # Run id/url surface on the event, not in note.
+        self.assertEqual(call.kwargs['external_run_id'], '42')
+        self.assertEqual(call.kwargs['external_run_url'], 'https://gh/runs/42')
 
     def test_promote_falls_back_when_plugin_lacks_create_tag(self) -> None:
         class _NoTag(_FakeDeploymentPlugin):
@@ -627,6 +646,92 @@ class ProjectDeploymentsTestCase(unittest.TestCase):
         data = response.json()
         self.assertEqual(len(data), 1)
         self.assertEqual(data[0]['from_version'], 'v1.0.0')
+
+    def test_get_run_status_returns_plugin_status(self) -> None:
+        with testclient.TestClient(self.test_app) as client:
+            response = client.get(
+                '/organizations/myorg/projects/proj1/deployments/runs/42'
+            )
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data['run_id'], '42')
+        self.assertEqual(data['status'], 'in_progress')
+
+    def test_get_run_status_400_when_plugin_unsupported(self) -> None:
+        class _NoStatus(_FakeDeploymentPlugin):
+            async def get_deployment_status(  # type: ignore[override]
+                self, ctx, credentials, run_id
+            ):
+                raise NotImplementedError
+
+        self.mocks['resolve_plugin'].return_value = ResolvedPlugin(
+            plugin_id='p-1',
+            plugin_slug='no-status',
+            entry=RegistryEntry(
+                handler_cls=_NoStatus,
+                manifest=_NoStatus.manifest,
+                package_name='x',
+                package_version='1',
+            ),
+            options={},
+        )
+        with testclient.TestClient(self.test_app) as client:
+            response = client.get(
+                '/organizations/myorg/projects/proj1/deployments/runs/abc'
+            )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn(
+            'does not report deployment status', response.json()['detail']
+        )
+
+    def test_deploy_writes_operations_log_audit(self) -> None:
+        with testclient.TestClient(self.test_app) as client:
+            response = client.post(
+                '/organizations/myorg/projects/proj1/deployments',
+                json={
+                    'action': 'deploy',
+                    'environment': 'testing',
+                    'committish': 'main',
+                    'ref_label': 'main',
+                },
+            )
+        self.assertEqual(response.status_code, 202)
+        ch = self.mocks['clickhouse'].return_value
+        ch.insert.assert_awaited_once()
+        args, _kwargs = ch.insert.call_args
+        self.assertEqual(args[0], 'operations_log')
+        rows = args[1]
+        cols = args[2]
+        self.assertEqual(len(rows), 1)
+        row = dict(zip(cols, rows[0], strict=False))
+        self.assertEqual(row['entry_type'], 'Deployed')
+        self.assertEqual(row['environment_slug'], 'testing')
+        self.assertEqual(row['link'], 'https://gh/runs/42')
+        self.assertEqual(row['version'], 'main')
+
+    def test_promote_writes_operations_log_audit(self) -> None:
+        self.mocks['append_deployment_event'].return_value = mock.Mock()
+        with testclient.TestClient(self.test_app) as client:
+            response = client.post(
+                '/organizations/myorg/projects/proj1/deployments',
+                json={
+                    'action': 'promote',
+                    'from_environment': 'testing',
+                    'to_environment': 'staging',
+                    'from_committish': '1a9c610',
+                    'tag': 'v6.4.0',
+                },
+            )
+        self.assertEqual(response.status_code, 202)
+        ch = self.mocks['clickhouse'].return_value
+        ch.insert.assert_awaited_once()
+        args, _kwargs = ch.insert.call_args
+        rows = args[1]
+        cols = args[2]
+        row = dict(zip(cols, rows[0], strict=False))
+        self.assertEqual(row['entry_type'], 'Deployed')
+        self.assertEqual(row['environment_slug'], 'staging')
+        self.assertEqual(row['version'], 'v6.4.0')
 
 
 class FallbackNotesTestCase(unittest.TestCase):

--- a/uv.lock
+++ b/uv.lock
@@ -987,7 +987,7 @@ requires-dist = [
   { name = "fastapi" },
   { name = "filetype" },
   { name = "httpx", specifier = ">=0.28.1,<1" },
-  { name = "imbi-common", extras = ["databases", "llm", "server"], git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=main" },
+  { name = "imbi-common", extras = ["databases", "llm", "server"], git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=feature%2Fdeployment-event-run-url" },
   { name = "jinja2" },
   { name = "jsonpatch", specifier = ">=1.33" },
   { name = "nanoid", specifier = ">=2.0.0" },
@@ -1039,8 +1039,8 @@ plugins = [
 
 [[package]]
 name = "imbi-common"
-version = "0.7.1"
-source = { git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=main#3e04f673c3b0c8b7f187627bfbbc9a1fcbb03b78" }
+version = "0.8.0"
+source = { git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=feature%2Fdeployment-event-run-url#e6e780e26db9c19d3bb76d12cc8d3f12db2aec9b" }
 dependencies = [
   { name = "cryptography" },
   { name = "jsonschema-models" },


### PR DESCRIPTION
## Summary

Three of the four Phase-3 polish items from `docs/deployments-plan.md` lines 533–540:

1. **Status polling** — new `GET /deployments/runs/{run_id}` pass-through to `DeploymentPlugin.get_deployment_status`. The UI's TanStack `refetchInterval` hook will key on this to flip `in_progress → success/failure` without a page reload.
2. **Audit log** — every successful deploy / redeploy / promote writes an `OperationLog` row to ClickHouse with `entry_type='Deployed'`, the env slug, the version, and the workflow `run_url` as the `link`. JSON payload in `description` carries action, plugin slug, run/release URLs, and the from-environment for promotes. Mirrors `_record_configuration_event` so the project history pane surfaces deploys the same way it surfaces config changes.
3. **`external_run_id` / `external_run_url`** — these now ride on explicit, typed fields on `DeploymentEvent` rather than being parsed back out of the free-text `note`. The Operations Log + project history pane will render the URL as a proper link.

The fourth item (release-train CI status hydration for the deployed SHA per env) requires per-environment plugin calls in the read path and is deferred to a follow-up PR.

## Cross-repo dep

Companion to **AWeber-Imbi/imbi-common#86** — this PR's `[tool.uv.sources].imbi-common` is temporarily pinned to `rev = "feature/deployment-event-run-url"` so CI can resolve `DeploymentEvent.external_run_id` / `external_run_url`. A follow-up commit on this branch will reset the rev to `main` once #86 merges.

## Test plan

- [ ] `just test` — full suite passes; 4 new tests cover the runs/{run_id} endpoint (success + 400 on NotImplementedError) and the audit row written on both deploy and promote
- [ ] After #86 merges: reset `[tool.uv.sources].imbi-common` rev to `main`, re-lock