### PR TITLE
Hydrate release-train with live deploy + CI status

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -223,8 +223,8 @@ url = "https://pypi.org/simple"
 default = true
 
 [tool.uv.sources]
-imbi-common = { git = "https://github.com/AWeber-Imbi/imbi-common.git", rev = "feature/deployment-event-run-url" }
+imbi-common = { git = "https://github.com/AWeber-Imbi/imbi-common.git", rev = "feature/release-train-ci-status" }
 imbi-plugin-aws = { git = "https://github.com/AWeber-Imbi/imbi-plugin-aws.git", rev = "main" }
-imbi-plugin-github = { git = "https://github.com/AWeber-Imbi/imbi-plugin-github.git", rev = "main" }
+imbi-plugin-github = { git = "https://github.com/AWeber-Imbi/imbi-plugin-github.git", rev = "feature/release-train-ci-status" }
 imbi-plugin-logzio = { git = "https://github.com/AWeber-Imbi/imbi-plugin-logzio.git", rev = "main" }
 imbi-plugin-oidc = { git = "https://github.com/AWeber-Imbi/imbi-plugin-oidc.git", rev = "main" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
   "fastapi",
   "filetype",
   "httpx>=0.28.1,<1",
-  "imbi-common[databases,llm,server]>=0.5.0",
+  "imbi-common[databases,llm,server]>=0.8.2",
   "jinja2",
   "jsonpatch>=1.33",
   "nanoid>=2.0.0",
@@ -223,8 +223,8 @@ url = "https://pypi.org/simple"
 default = true
 
 [tool.uv.sources]
-imbi-common = { git = "https://github.com/AWeber-Imbi/imbi-common.git", rev = "feature/release-train-ci-status" }
+imbi-common = { git = "https://github.com/AWeber-Imbi/imbi-common.git", tag = "v0.8.2" }
 imbi-plugin-aws = { git = "https://github.com/AWeber-Imbi/imbi-plugin-aws.git", rev = "main" }
-imbi-plugin-github = { git = "https://github.com/AWeber-Imbi/imbi-plugin-github.git", rev = "feature/release-train-ci-status" }
+imbi-plugin-github = { git = "https://github.com/AWeber-Imbi/imbi-plugin-github.git", rev = "main" }
 imbi-plugin-logzio = { git = "https://github.com/AWeber-Imbi/imbi-plugin-logzio.git", rev = "main" }
 imbi-plugin-oidc = { git = "https://github.com/AWeber-Imbi/imbi-plugin-oidc.git", rev = "main" }

--- a/src/imbi_api/endpoints/releases.py
+++ b/src/imbi_api/endpoints/releases.py
@@ -8,6 +8,7 @@ deployed to via a ``DEPLOYED_TO`` edge carrying an append-only
 
 """
 
+import asyncio
 import datetime
 import json
 import logging
@@ -17,9 +18,11 @@ import fastapi
 import nanoid
 import pydantic
 from imbi_common import graph, models
+from imbi_common.plugins.base import CheckStatus
 
 from imbi_api import patch as json_patch
 from imbi_api.auth import permissions
+from imbi_api.plugins import call_with_timeout
 
 LOGGER = logging.getLogger(__name__)
 
@@ -115,12 +118,20 @@ class CurrentReleaseEnvironment(pydantic.BaseModel):
     ``release`` and ``current_status`` are ``None`` when the project is
     configured to deploy in the environment but has no recorded
     deployment events there yet.
+
+    ``external_run_url`` and ``ci_status`` are populated by the
+    deployment-plugin hydration pass: the former is the workflow run
+    URL of the latest event (when present), the latter the aggregate
+    check-runs status of the deployed version (``None`` when the
+    plugin can't or won't report it).
     """
 
     environment: ReleaseEnvironmentRef
     release: ReleaseResponse | None = None
     current_status: _DEPLOYMENT_STATUS | None = None
     last_event_at: datetime.datetime | None = None
+    external_run_url: str | None = None
+    ci_status: CheckStatus | None = None
 
 
 # -- Helpers ------------------------------------------------------------
@@ -235,6 +246,150 @@ async def _fetch_release(
     return typing.cast(
         dict[str, typing.Any], graph.parse_agtype(rows[0]['release'])
     )
+
+
+_RUN_STATUS_TO_EVENT_STATUS: dict[str, _DEPLOYMENT_STATUS] = {
+    'queued': 'pending',
+    'in_progress': 'in_progress',
+    'success': 'success',
+    'failure': 'failed',
+    # The DeploymentEvent literal has no 'cancelled' bucket; treat
+    # it as a failed terminal so the train stops showing "deploying…".
+    'cancelled': 'failed',
+}
+
+
+async def _hydrate_release_train(
+    db: graph.Graph,
+    org_slug: str,
+    project_id: str,
+    auth: permissions.AuthContext,
+    by_env: dict[
+        str,
+        tuple[
+            dict[str, typing.Any],
+            dict[str, typing.Any] | None,
+            models.DeploymentEvent | None,
+        ],
+    ],
+) -> dict[str, CheckStatus | None]:
+    """Hydrate live deploy run + CI check-runs status per env.
+
+    Mutates ``by_env`` in place: when the plugin reports a terminal
+    status for an in-flight workflow run we update the in-memory event
+    so the response reflects the live state, and we append a fresh
+    ``DeploymentEvent`` to the edge so the system self-heals on
+    subsequent reads.  Returns a slug → ``CheckStatus`` map that the
+    caller folds into the response.
+
+    Failures are tolerated silently — the release train must keep
+    rendering even if the plugin can't be resolved or its calls hiccup.
+    """
+    in_flight: list[tuple[str, str, models.DeploymentEvent]] = []
+    deployed: list[tuple[str, str]] = []
+    for slug, (_env, release_raw, event) in by_env.items():
+        if release_raw is None:
+            continue
+        version = str(release_raw.get('version') or '')
+        if not version:
+            continue
+        deployed.append((slug, version))
+        if (
+            event is not None
+            and event.status == 'in_progress'
+            and event.external_run_id
+        ):
+            in_flight.append((slug, version, event))
+
+    if not in_flight and not deployed:
+        return {}
+
+    # Lazy import to avoid a circular dependency: project_deployments
+    # already imports ``append_deployment_event`` from this module.
+    from imbi_api.endpoints.project_deployments import (
+        _handler,  # pyright: ignore[reportPrivateUsage]
+        _resolve_and_context,  # pyright: ignore[reportPrivateUsage]
+    )
+
+    try:
+        resolved, ctx, credentials = await _resolve_and_context(
+            db, org_slug, project_id, auth
+        )
+    except fastapi.HTTPException:
+        return {}
+    except Exception:  # noqa: BLE001
+        LOGGER.debug(
+            'release-train hydration: plugin resolution failed',
+            exc_info=True,
+        )
+        return {}
+    handler = _handler(resolved)
+
+    run_results = await asyncio.gather(
+        *(
+            call_with_timeout(
+                handler.get_deployment_status(
+                    ctx, credentials, run_id=str(event.external_run_id)
+                )
+            )
+            for _, _, event in in_flight
+        ),
+        return_exceptions=True,
+    )
+    ci_results = await asyncio.gather(
+        *(
+            call_with_timeout(
+                handler.get_check_status(ctx, credentials, committish=version)
+            )
+            for _, version in deployed
+        ),
+        return_exceptions=True,
+    )
+
+    for (slug, version, event), result in zip(
+        in_flight, run_results, strict=True
+    ):
+        if isinstance(result, BaseException):
+            continue
+        new_status = _RUN_STATUS_TO_EVENT_STATUS.get(result.status)
+        if new_status is None or new_status == event.status:
+            continue
+        new_event = event.model_copy(
+            update={
+                'status': new_status,
+                'timestamp': datetime.datetime.now(datetime.UTC),
+            }
+        )
+        env, release_raw, _ = by_env[slug]
+        by_env[slug] = (env, release_raw, new_event)
+        if new_status in ('success', 'failed'):
+            try:
+                await append_deployment_event(
+                    db,
+                    org_slug=org_slug,
+                    project_id=project_id,
+                    version=version,
+                    env_slug=slug,
+                    status=new_status,
+                    note='via release-train hydration',
+                    external_run_id=event.external_run_id,
+                    external_run_url=event.external_run_url,
+                )
+            except Exception:
+                LOGGER.exception(
+                    'release-train hydration: failed to persist '
+                    'terminal event for %s/%s',
+                    project_id,
+                    slug,
+                )
+
+    ci_status_by_slug: dict[str, CheckStatus | None] = {}
+    for (slug, _version), ci_result in zip(deployed, ci_results, strict=True):
+        if isinstance(ci_result, BaseException) or ci_result == 'unknown':
+            ci_status_by_slug[slug] = None
+        else:
+            ci_status_by_slug[slug] = ci_result
+    return ci_status_by_slug
 
 
 # -- Endpoints ----------------------------------------------------------
@@ -384,8 +539,12 @@ async def list_current_releases(
     Environments with no deployment events are returned with
     ``release=None``. Results are sorted by ``Environment.sort_order``
     ascending, then by name.
+
+    The deployment plugin (when bound) is consulted for live workflow
+    run status on any in-flight ``DeploymentEvent`` and aggregate CI
+    check-runs status on each env's currently-deployed version.
+    Hydration failures are tolerated silently.
     """
-    del auth
     if not await _project_exists(db, org_slug, project_id):
         raise fastapi.HTTPException(
             status_code=404,
@@ -442,6 +601,10 @@ async def list_current_releases(
         ):
             by_env[slug] = (env, release_raw, latest)
 
+    ci_status_by_slug = await _hydrate_release_train(
+        db, org_slug, project_id, auth, by_env
+    )
+
     sortable: list[tuple[int, str, CurrentReleaseEnvironment]] = []
     for env, release_raw, event in by_env.values():
         release_resp = (
@@ -456,6 +619,8 @@ async def list_current_releases(
             release=release_resp,
             current_status=event.status if event else None,
             last_event_at=event.timestamp if event else None,
+            external_run_url=event.external_run_url if event else None,
+            ci_status=ci_status_by_slug.get(env['slug']),
         )
         sortable.append((env.get('sort_order') or 0, env['name'], item))
 

--- a/tests/endpoints/test_releases.py
+++ b/tests/endpoints/test_releases.py
@@ -68,8 +68,8 @@ class _ReleasesTestBase(unittest.TestCase):
         )
 
         self.mock_db = mock.AsyncMock(spec=graph.Graph)
-        self.test_app.dependency_overrides[graph._inject_graph] = (
-            lambda: self.mock_db
+        self.test_app.dependency_overrides[graph._inject_graph] = lambda: (
+            self.mock_db
         )
         self.client = fastapi.testclient.TestClient(self.test_app)
         self.addCleanup(self.client.close)
@@ -763,3 +763,210 @@ class CurrentReleasesTestCase(_ReleasesTestBase):
         by_slug = {row['environment']['slug']: row for row in data}
         self.assertIsNone(by_slug['testing']['release'])
         self.assertEqual(by_slug['production']['release']['version'], '1.0.0')
+
+
+class CurrentReleasesHydrationTestCase(_ReleasesTestBase):
+    """GET /releases/current — deployment-plugin hydration pass.
+
+    Exercises the optional ``_hydrate_release_train`` step that asks the
+    project's bound deployment plugin for live workflow run status (for
+    in-flight events with an ``external_run_id``) and aggregate CI
+    check-runs status (for each env's currently-deployed version).
+    """
+
+    @staticmethod
+    def _env(slug: str, sort_order: int = 0) -> dict[str, typing.Any]:
+        return {
+            'slug': slug,
+            'name': slug.title(),
+            'sort_order': sort_order,
+        }
+
+    @staticmethod
+    def _events_with_run(
+        ts: str,
+        status: str,
+        run_id: str | None = None,
+        run_url: str | None = None,
+    ) -> str:
+        entry: dict[str, typing.Any] = {
+            'timestamp': ts,
+            'status': status,
+            'note': None,
+        }
+        if run_id is not None:
+            entry['external_run_id'] = run_id
+        if run_url is not None:
+            entry['external_run_url'] = run_url
+        return json.dumps([entry])
+
+    def _patch_plugin_resolution(
+        self,
+        *,
+        get_deployment_status: mock.AsyncMock | None = None,
+        get_check_status: mock.AsyncMock | None = None,
+    ) -> tuple[mock.AsyncMock, mock.AsyncMock]:
+        """Return (run_mock, ci_mock) bound to a stub plugin handler."""
+        run_mock = get_deployment_status or mock.AsyncMock(
+            return_value=mock.MagicMock(
+                status='in_progress',
+                run_id='42',
+                run_url=None,
+            )
+        )
+        ci_mock = get_check_status or mock.AsyncMock(return_value='unknown')
+
+        class _Handler:
+            get_deployment_status = run_mock
+            get_check_status = ci_mock
+
+        resolved = mock.MagicMock()
+        resolved.entry.handler_cls = lambda: _Handler()
+        resolved.options = {}
+
+        async def _resolve_and_context(
+            db: typing.Any, org_slug: str, project_id: str, auth: typing.Any
+        ) -> tuple[typing.Any, typing.Any, dict[str, str]]:
+            del db, org_slug, project_id, auth
+            return resolved, mock.MagicMock(), {'access_token': 'x'}
+
+        self._patcher = mock.patch(
+            'imbi_api.endpoints.project_deployments._resolve_and_context',
+            new=_resolve_and_context,
+        )
+        self._patcher.start()
+        self.addCleanup(self._patcher.stop)
+        return run_mock, ci_mock
+
+    def test_hydration_skipped_when_no_plugin_bound(self) -> None:
+        # Three db.execute calls: project_exists, deployments query,
+        # then the plugin-resolution query (returns no rows → 404 →
+        # hydration skipped).  No fields populated by hydration.
+        self.mock_db.execute.side_effect = [
+            [{'id': PROJECT_ID}],
+            [
+                {
+                    'env': self._env('production', sort_order=30),
+                    'release': _release_row(version='1.0.0', id='r1'),
+                    'deployments': self._events_with_run(
+                        '2026-04-20T10:00:00+00:00', 'success'
+                    ),
+                },
+            ],
+            [],  # resolve_plugin → no plugin → HTTPException(404)
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            response = self.client.get(self._url('/current'))
+        self.assertEqual(response.status_code, 200)
+        body = response.json()[0]
+        self.assertIsNone(body['ci_status'])
+        self.assertIsNone(body['external_run_url'])
+
+    def test_in_flight_run_promoted_to_terminal(self) -> None:
+        run_mock = mock.AsyncMock(
+            return_value=mock.MagicMock(
+                status='success',
+                run_id='42',
+                run_url='https://gh/runs/42',
+            )
+        )
+        ci_mock = mock.AsyncMock(return_value='pass')
+        self._patch_plugin_resolution(
+            get_deployment_status=run_mock,
+            get_check_status=ci_mock,
+        )
+        self.mock_db.execute.side_effect = [
+            [{'id': PROJECT_ID}],
+            [
+                {
+                    'env': self._env('production', sort_order=30),
+                    'release': _release_row(version='1.0.0', id='r1'),
+                    'deployments': self._events_with_run(
+                        '2026-04-20T10:00:00+00:00',
+                        'in_progress',
+                        run_id='42',
+                        run_url='https://gh/runs/42',
+                    ),
+                },
+            ],
+            # The persistence path does additional db.execute calls
+            # (re-fetch release, edge MATCH, SET).  Provide enough
+            # truthy results so append_deployment_event can land.
+            [{'release': _release_row(version='1.0.0', id='r1')}],
+            [{'env': self._env('production'), 'deployments': None}],
+            [{'deployments': '[]'}],
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            response = self.client.get(self._url('/current'))
+        self.assertEqual(response.status_code, 200)
+        body = response.json()[0]
+        self.assertEqual(body['current_status'], 'success')
+        self.assertEqual(body['ci_status'], 'pass')
+        self.assertEqual(body['external_run_url'], 'https://gh/runs/42')
+        run_mock.assert_awaited_once()
+        ci_mock.assert_awaited_once()
+
+    def test_unknown_ci_status_returns_null(self) -> None:
+        self._patch_plugin_resolution(
+            get_check_status=mock.AsyncMock(return_value='unknown'),
+        )
+        self.mock_db.execute.side_effect = [
+            [{'id': PROJECT_ID}],
+            [
+                {
+                    'env': self._env('production', sort_order=30),
+                    'release': _release_row(version='1.0.0', id='r1'),
+                    'deployments': self._events_with_run(
+                        '2026-04-20T10:00:00+00:00', 'success'
+                    ),
+                },
+            ],
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            response = self.client.get(self._url('/current'))
+        self.assertEqual(response.status_code, 200)
+        body = response.json()[0]
+        self.assertIsNone(body['ci_status'])
+
+    def test_plugin_call_failure_does_not_break_response(self) -> None:
+        run_mock = mock.AsyncMock(
+            side_effect=RuntimeError('plugin boom'),
+        )
+        ci_mock = mock.AsyncMock(side_effect=RuntimeError('ci boom'))
+        self._patch_plugin_resolution(
+            get_deployment_status=run_mock,
+            get_check_status=ci_mock,
+        )
+        self.mock_db.execute.side_effect = [
+            [{'id': PROJECT_ID}],
+            [
+                {
+                    'env': self._env('production', sort_order=30),
+                    'release': _release_row(version='1.0.0', id='r1'),
+                    'deployments': self._events_with_run(
+                        '2026-04-20T10:00:00+00:00',
+                        'in_progress',
+                        run_id='42',
+                    ),
+                },
+            ],
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            response = self.client.get(self._url('/current'))
+        self.assertEqual(response.status_code, 200)
+        body = response.json()[0]
+        # Status untouched (still in_progress); ci_status null.
+        self.assertEqual(body['current_status'], 'in_progress')
+        self.assertIsNone(body['ci_status'])

--- a/uv.lock
+++ b/uv.lock
@@ -987,7 +987,7 @@ requires-dist = [
   { name = "fastapi" },
   { name = "filetype" },
   { name = "httpx", specifier = ">=0.28.1,<1" },
-  { name = "imbi-common", extras = ["databases", "llm", "server"], git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=feature%2Fdeployment-event-run-url" },
+  { name = "imbi-common", extras = ["databases", "llm", "server"], git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=feature%2Frelease-train-ci-status" },
   { name = "jinja2" },
   { name = "jsonpatch", specifier = ">=1.33" },
   { name = "nanoid", specifier = ">=2.0.0" },
@@ -1032,15 +1032,15 @@ docs = [
 ]
 plugins = [
   { name = "imbi-plugin-aws", git = "https://github.com/AWeber-Imbi/imbi-plugin-aws.git?rev=main" },
-  { name = "imbi-plugin-github", git = "https://github.com/AWeber-Imbi/imbi-plugin-github.git?rev=main" },
+  { name = "imbi-plugin-github", git = "https://github.com/AWeber-Imbi/imbi-plugin-github.git?rev=feature%2Frelease-train-ci-status" },
   { name = "imbi-plugin-logzio", git = "https://github.com/AWeber-Imbi/imbi-plugin-logzio.git?rev=main" },
   { name = "imbi-plugin-oidc", git = "https://github.com/AWeber-Imbi/imbi-plugin-oidc.git?rev=main" },
 ]
 
 [[package]]
 name = "imbi-common"
-version = "0.8.0"
-source = { git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=feature%2Fdeployment-event-run-url#e6e780e26db9c19d3bb76d12cc8d3f12db2aec9b" }
+version = "0.8.1"
+source = { git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=feature%2Frelease-train-ci-status#5377ce21c8060d1e9806f9ee4f77d8b3c58fdc65" }
 dependencies = [
   { name = "cryptography" },
   { name = "jsonschema-models" },
@@ -1083,7 +1083,7 @@ dependencies = [
 [[package]]
 name = "imbi-plugin-github"
 version = "0.1.0"
-source = { git = "https://github.com/AWeber-Imbi/imbi-plugin-github.git?rev=main#b9e3dd02e876b123516be65d2d92d53d0dd48360" }
+source = { git = "https://github.com/AWeber-Imbi/imbi-plugin-github.git?rev=feature%2Frelease-train-ci-status#8aee0b0f2d8480aed33456c5729ccc1c3c29cfb4" }
 dependencies = [
   { name = "httpx" },
   { name = "imbi-common" },

--- a/uv.lock
+++ b/uv.lock
@@ -987,7 +987,7 @@ requires-dist = [
   { name = "fastapi" },
   { name = "filetype" },
   { name = "httpx", specifier = ">=0.28.1,<1" },
-  { name = "imbi-common", extras = ["databases", "llm", "server"], git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=feature%2Frelease-train-ci-status" },
+  { name = "imbi-common", extras = ["databases", "llm", "server"], git = "https://github.com/AWeber-Imbi/imbi-common.git?tag=v0.8.2" },
   { name = "jinja2" },
   { name = "jsonpatch", specifier = ">=1.33" },
   { name = "nanoid", specifier = ">=2.0.0" },
@@ -1032,15 +1032,15 @@ docs = [
 ]
 plugins = [
   { name = "imbi-plugin-aws", git = "https://github.com/AWeber-Imbi/imbi-plugin-aws.git?rev=main" },
-  { name = "imbi-plugin-github", git = "https://github.com/AWeber-Imbi/imbi-plugin-github.git?rev=feature%2Frelease-train-ci-status" },
+  { name = "imbi-plugin-github", git = "https://github.com/AWeber-Imbi/imbi-plugin-github.git?rev=main" },
   { name = "imbi-plugin-logzio", git = "https://github.com/AWeber-Imbi/imbi-plugin-logzio.git?rev=main" },
   { name = "imbi-plugin-oidc", git = "https://github.com/AWeber-Imbi/imbi-plugin-oidc.git?rev=main" },
 ]
 
 [[package]]
 name = "imbi-common"
-version = "0.8.1"
-source = { git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=feature%2Frelease-train-ci-status#5377ce21c8060d1e9806f9ee4f77d8b3c58fdc65" }
+version = "0.8.2"
+source = { git = "https://github.com/AWeber-Imbi/imbi-common.git?tag=v0.8.2#a2875a767d862f863f48488aea26f69082ca3868" }
 dependencies = [
   { name = "cryptography" },
   { name = "jsonschema-models" },
@@ -1083,7 +1083,7 @@ dependencies = [
 [[package]]
 name = "imbi-plugin-github"
 version = "0.1.0"
-source = { git = "https://github.com/AWeber-Imbi/imbi-plugin-github.git?rev=feature%2Frelease-train-ci-status#8aee0b0f2d8480aed33456c5729ccc1c3c29cfb4" }
+source = { git = "https://github.com/AWeber-Imbi/imbi-plugin-github.git?rev=main#7fd35e36878958a4d4d47f2eea58e55295fb215e" }
 dependencies = [
   { name = "httpx" },
   { name = "imbi-common" },


### PR DESCRIPTION
## Summary

Extends `GET /releases/current` with a deployment-plugin hydration pass that fills two gaps in the read path:

1. **Live workflow run status** for any latest `DeploymentEvent` whose `status` is `in_progress` and that carries an `external_run_id`. When the plugin reports a terminal status we update the in-memory event AND append a fresh `DeploymentEvent` to the edge — the system self-heals on subsequent reads, so the train no longer stays stuck on "deploying…" after the toast watcher unmounts.
2. **Aggregate CI check-runs status** for each env's currently-deployed version, via the new `DeploymentPlugin.get_check_status` method. Surfaced as `CurrentReleaseEnvironment.ci_status` so the UI can render a green/red dot per chip.

The response also gains `external_run_url` so the UI can deep-link to the workflow run from the train chip.

## Why

Phase 3 item 4 of the deployments rollout. Items 1-3 (status polling, audit log, run-URL plumbing) plumbed `external_run_id` end-to-end but the read path was still snapshot-only. This closes the loop so a hard reload reflects current state without a watcher.

## Notes

- Plugin resolution failures (no plugin bound, no creds, etc.) and per-call failures are tolerated silently — the train must keep rendering even if hydration hiccups.
- Persistence of terminal events is best-effort: a write failure logs but does not fail the read.
- Temporarily rev-pins `imbi-common` to its `feature/release-train-ci-status` branch and `imbi-plugin-github` to its matching branch. Both reset to main once the upstream PRs merge.
- This PR is blocked on [imbi-common#87](https://github.com/AWeber-Imbi/imbi-common/pull/87) and [imbi-plugin-github#5](https://github.com/AWeber-Imbi/imbi-plugin-github/pull/5).

## Test plan

- [x] 4 new `CurrentReleasesHydrationTestCase` tests covering the no-plugin, in-flight→terminal, unknown-CI, and plugin-failure paths.
- [x] `pytest tests/endpoints/test_releases.py` — 32 passing.
- [x] Full suite `pytest --no-cov` — 1456 passing.
- [x] `ruff check`, `mypy`, `basedpyright` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)