### PR TITLE
Add OIDC token-refresh resilience to identity hydration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -223,8 +223,8 @@ url = "https://pypi.org/simple"
 default = true
 
 [tool.uv.sources]
-imbi-common = { git = "https://github.com/AWeber-Imbi/imbi-common.git", rev = "feature/oidc-refresh-resilience" }
-imbi-plugin-aws = { git = "https://github.com/AWeber-Imbi/imbi-plugin-aws.git", rev = "feature/oidc-refresh-resilience" }
-imbi-plugin-github = { git = "https://github.com/AWeber-Imbi/imbi-plugin-github.git", rev = "feature/oidc-refresh-resilience" }
+imbi-common = { git = "https://github.com/AWeber-Imbi/imbi-common.git", rev = "main" }
+imbi-plugin-aws = { git = "https://github.com/AWeber-Imbi/imbi-plugin-aws.git", rev = "main" }
+imbi-plugin-github = { git = "https://github.com/AWeber-Imbi/imbi-plugin-github.git", rev = "main" }
 imbi-plugin-logzio = { git = "https://github.com/AWeber-Imbi/imbi-plugin-logzio.git", rev = "main" }
 imbi-plugin-oidc = { git = "https://github.com/AWeber-Imbi/imbi-plugin-oidc.git", rev = "main" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -223,8 +223,8 @@ url = "https://pypi.org/simple"
 default = true
 
 [tool.uv.sources]
-imbi-common = { git = "https://github.com/AWeber-Imbi/imbi-common.git", tag = "v0.8.2" }
-imbi-plugin-aws = { git = "https://github.com/AWeber-Imbi/imbi-plugin-aws.git", rev = "main" }
-imbi-plugin-github = { git = "https://github.com/AWeber-Imbi/imbi-plugin-github.git", rev = "main" }
+imbi-common = { git = "https://github.com/AWeber-Imbi/imbi-common.git", rev = "feature/oidc-refresh-resilience" }
+imbi-plugin-aws = { git = "https://github.com/AWeber-Imbi/imbi-plugin-aws.git", rev = "feature/oidc-refresh-resilience" }
+imbi-plugin-github = { git = "https://github.com/AWeber-Imbi/imbi-plugin-github.git", rev = "feature/oidc-refresh-resilience" }
 imbi-plugin-logzio = { git = "https://github.com/AWeber-Imbi/imbi-plugin-logzio.git", rev = "main" }
 imbi-plugin-oidc = { git = "https://github.com/AWeber-Imbi/imbi-plugin-oidc.git", rev = "main" }

--- a/src/imbi_api/endpoints/project_configuration.py
+++ b/src/imbi_api/endpoints/project_configuration.py
@@ -22,7 +22,7 @@ from imbi_common.plugins.errors import (
 from imbi_api.auth import permissions
 from imbi_api.domain import models
 from imbi_api.endpoints._helpers import lookup_project_slugs
-from imbi_api.identity.host_integration import attach_identity
+from imbi_api.identity.host_integration import call_with_identity_retry
 from imbi_api.plugins import call_with_timeout
 from imbi_api.plugins.credentials import get_plugin_credentials
 from imbi_api.plugins.resolution import resolve_plugin
@@ -108,7 +108,6 @@ async def get_configuration(
         environment=environment,
         assignment_options=resolved.options,
     )
-    ctx = await attach_identity(db, ctx, resolved, auth)
     try:
         credentials = await get_plugin_credentials(
             db, resolved.plugin_id, resolved.entry
@@ -137,7 +136,13 @@ async def get_configuration(
             LOGGER.debug('Cache read failed', exc_info=True)
 
     handler = typing.cast(ConfigurationPlugin, resolved.entry.handler_cls())
-    keys = await call_with_timeout(handler.list_keys(ctx, credentials))
+
+    async def _list_keys(c: PluginContext) -> typing.Any:
+        return await call_with_timeout(handler.list_keys(c, credentials))
+
+    keys = await call_with_identity_retry(
+        db, ctx, resolved, auth, fn=_list_keys
+    )
 
     result = [
         models.ConfigKeyResponse(
@@ -186,7 +191,6 @@ async def fetch_values(
         environment=environment,
         assignment_options=resolved.options,
     )
-    ctx = await attach_identity(db, ctx, resolved, auth)
     try:
         credentials = await get_plugin_credentials(
             db, resolved.plugin_id, resolved.entry
@@ -199,8 +203,14 @@ async def fetch_values(
 
     keys: list[str] | None = body.get('keys')
     handler = typing.cast(ConfigurationPlugin, resolved.entry.handler_cls())
-    values = await call_with_timeout(
-        handler.get_values(ctx, credentials, keys)
+
+    async def _get_values(c: PluginContext) -> typing.Any:
+        return await call_with_timeout(
+            handler.get_values(c, credentials, keys)
+        )
+
+    values = await call_with_identity_retry(
+        db, ctx, resolved, auth, fn=_get_values
     )
 
     return [
@@ -242,7 +252,6 @@ async def set_configuration_value(
         environment=environment,
         assignment_options=resolved.options,
     )
-    ctx = await attach_identity(db, ctx, resolved, auth)
     try:
         credentials = await get_plugin_credentials(
             db, resolved.plugin_id, resolved.entry
@@ -254,8 +263,14 @@ async def set_configuration_value(
         ) from exc
 
     handler = typing.cast(ConfigurationPlugin, resolved.entry.handler_cls())
-    result_key = await call_with_timeout(
-        handler.set_value(ctx, credentials, key, body)
+
+    async def _set_value(c: PluginContext) -> typing.Any:
+        return await call_with_timeout(
+            handler.set_value(c, credentials, key, body)
+        )
+
+    result_key = await call_with_identity_retry(
+        db, ctx, resolved, auth, fn=_set_value
     )
 
     await _invalidate_cache(resolved.plugin_id, project_id)
@@ -305,7 +320,6 @@ async def delete_configuration_key(
         environment=environment,
         assignment_options=resolved.options,
     )
-    ctx = await attach_identity(db, ctx, resolved, auth)
     try:
         credentials = await get_plugin_credentials(
             db, resolved.plugin_id, resolved.entry
@@ -317,7 +331,11 @@ async def delete_configuration_key(
         ) from exc
 
     handler = typing.cast(ConfigurationPlugin, resolved.entry.handler_cls())
-    await call_with_timeout(handler.delete_key(ctx, credentials, key))
+
+    async def _delete_key(c: PluginContext) -> None:
+        await call_with_timeout(handler.delete_key(c, credentials, key))
+
+    await call_with_identity_retry(db, ctx, resolved, auth, fn=_delete_key)
 
     await _invalidate_cache(resolved.plugin_id, project_id)
     project_slug = await _lookup_project_slug(db, project_id)

--- a/src/imbi_api/endpoints/project_deployments.py
+++ b/src/imbi_api/endpoints/project_deployments.py
@@ -34,7 +34,10 @@ from imbi_common.plugins.errors import PluginCredentialsMissing
 from imbi_api.auth import permissions
 from imbi_api.endpoints._helpers import lookup_project_slugs
 from imbi_api.endpoints.releases import append_deployment_event
-from imbi_api.identity.host_integration import attach_identity
+from imbi_api.identity.host_integration import (
+    attach_identity,
+    call_with_identity_retry,
+)
 from imbi_api.llm.dependencies import InjectAnthropicClient
 from imbi_api.plugins import call_with_timeout
 from imbi_api.plugins.credentials import get_plugin_credentials
@@ -233,6 +236,22 @@ async def _resolve_and_context(
 def _handler(resolved: ResolvedPlugin) -> DeploymentPlugin:
     """Instantiate and type-narrow the plugin handler."""
     return typing.cast(DeploymentPlugin, resolved.entry.handler_cls())
+
+
+def _resolve_credentials(
+    ctx: PluginContext, fallback: dict[str, str]
+) -> dict[str, str]:
+    """Pick the deployment-call credentials for ``ctx``.
+
+    Prefers the per-user identity's bearer token (so the API call is
+    attributed to the human and refreshes apply) and falls back to the
+    service-account PAT bound to the plugin instance.  Recomputed
+    inside :func:`call_with_identity_retry`'s closure so a refreshed
+    identity surfaces the new access token on retry.
+    """
+    if ctx.identity is not None and ctx.identity.access_token:
+        return {'access_token': ctx.identity.access_token}
+    return fallback
 
 
 async def _record_deployment_audit(
@@ -483,13 +502,19 @@ async def _handle_deploy(
         environment=body.environment,
     )
     handler = _handler(resolved)
-    run = await call_with_timeout(
-        handler.trigger_deployment(
-            ctx,
-            credentials,
-            ref_or_sha=body.committish,
-            inputs=body.inputs,
+
+    async def _trigger(c: PluginContext) -> DeploymentRun:
+        return await call_with_timeout(
+            handler.trigger_deployment(
+                c,
+                _resolve_credentials(c, credentials),
+                ref_or_sha=body.committish,
+                inputs=body.inputs,
+            )
         )
+
+    run = await call_with_identity_retry(
+        db, ctx, resolved, auth, fn=_trigger, attached=True
     )
     LOGGER.info(
         'Deployment triggered: project=%s env=%s ref=%s plugin=%s '
@@ -559,15 +584,21 @@ async def _handle_promote(
 
     # 1. Cut the annotated tag at the chosen build commit.
     tag_message = body.release_name or body.tag
-    try:
-        await call_with_timeout(
+
+    async def _create_tag(c: PluginContext) -> typing.Any:
+        return await call_with_timeout(
             handler.create_tag(
-                ctx,
-                credentials,
+                c,
+                _resolve_credentials(c, credentials),
                 sha=body.from_committish,
                 tag=body.tag,
                 message=tag_message,
             )
+        )
+
+    try:
+        await call_with_identity_retry(
+            db, ctx, resolved, auth, fn=_create_tag, attached=True
         )
     except NotImplementedError as exc:
         raise fastapi.HTTPException(
@@ -580,16 +611,22 @@ async def _handle_promote(
 
     # 2. Create the release on the remote.
     release_info = None
-    try:
-        release_info = await call_with_timeout(
+
+    async def _create_release(c: PluginContext) -> typing.Any:
+        return await call_with_timeout(
             handler.create_release(
-                ctx,
-                credentials,
+                c,
+                _resolve_credentials(c, credentials),
                 tag=body.tag,
                 name=body.release_name or body.tag,
                 body_markdown=body.release_notes_markdown,
                 prerelease=body.prerelease,
             )
+        )
+
+    try:
+        release_info = await call_with_identity_retry(
+            db, ctx, resolved, auth, fn=_create_release, attached=True
         )
     except NotImplementedError:
         LOGGER.info(
@@ -604,13 +641,18 @@ async def _handle_promote(
     # 3. Dispatch the workflow against the new tag.  We do this before
     #    upserting the Release node so a trigger failure doesn't leave
     #    a Release in the graph with no associated deployment run.
-    run = await call_with_timeout(
-        handler.trigger_deployment(
-            ctx,
-            credentials,
-            ref_or_sha=body.tag,
-            inputs=None,
+    async def _trigger(c: PluginContext) -> DeploymentRun:
+        return await call_with_timeout(
+            handler.trigger_deployment(
+                c,
+                _resolve_credentials(c, credentials),
+                ref_or_sha=body.tag,
+                inputs=None,
+            )
         )
+
+    run = await call_with_identity_retry(
+        db, ctx, resolved, auth, fn=_trigger, attached=True
     )
 
     # 4. Upsert the Release node so future deploys of the same tag

--- a/src/imbi_api/identity/host_integration.py
+++ b/src/imbi_api/identity/host_integration.py
@@ -18,12 +18,14 @@ duplicating the try/except + actor stamping + 401 mapping seven times.
 
 from __future__ import annotations
 
+import collections.abc
 import logging
 import typing
 
 import fastapi
 from imbi_common import graph
 from imbi_common.plugins.base import PluginContext
+from imbi_common.plugins.errors import PluginAuthenticationFailed
 
 from imbi_api.auth import permissions
 from imbi_api.identity import errors as identity_errors
@@ -31,6 +33,8 @@ from imbi_api.identity import resolution as identity_resolution
 from imbi_api.plugins.resolution import ResolvedPlugin
 
 LOGGER = logging.getLogger(__name__)
+
+T = typing.TypeVar('T')
 
 
 async def attach_identity(
@@ -72,6 +76,80 @@ async def attach_identity(
         )
     except identity_errors.IdentityRequiredError as exc:
         raise _identity_required_response(exc) from exc
+
+
+async def call_with_identity_retry(
+    db: graph.Graph,
+    ctx: PluginContext,
+    resolved: ResolvedPlugin,
+    auth: permissions.AuthContext,
+    *,
+    fn: collections.abc.Callable[
+        [PluginContext], collections.abc.Awaitable[T]
+    ],
+    identity_options: dict[str, typing.Any] | None = None,
+    attached: bool = False,
+) -> T:
+    """Invoke ``fn`` with hydrated identity, retrying once on 401.
+
+    Combines :func:`attach_identity` with an automatic refresh-and-retry
+    on :class:`PluginAuthenticationFailed`: when a data plugin's API
+    call comes back as 401 (token expired between the sweeper's last
+    refresh and now), the host calls
+    :func:`flows.refresh_connection`, re-hydrates the context, and
+    retries the call once.  A second 401 — or a refresh failure —
+    surfaces as the canonical ``identity_required`` 401 so the UI can
+    prompt the user to reconnect.
+
+    Wrap each plugin call site that may legitimately encounter token
+    expiry mid-flight (configuration reads/writes, deployments,
+    interactive log queries).  Background sweeps and one-shot CLI
+    paths can still call :func:`attach_identity` directly when retry
+    is undesirable.
+
+    Pass ``attached=True`` when the caller has already invoked
+    :func:`attach_identity` on ``ctx`` (e.g. shared resolve helpers
+    that hydrate up-front for read paths) — saves an avoidable
+    ``hydrate_identity`` round-trip on the happy path.  The retry
+    branch always re-attaches regardless.
+    """
+    if not attached:
+        ctx = await attach_identity(
+            db, ctx, resolved, auth, identity_options=identity_options
+        )
+    try:
+        return await fn(ctx)
+    except PluginAuthenticationFailed as exc:
+        plugin_id = resolved.identity_plugin_id
+        if not plugin_id or auth.user is None:
+            raise
+        LOGGER.info(
+            'Plugin %s returned 401 for user %s; refreshing identity '
+            'and retrying once: %s',
+            plugin_id,
+            auth.user.id,
+            exc,
+        )
+        from imbi_api.identity import flows
+
+        try:
+            await flows.refresh_connection(
+                db,
+                plugin_id=plugin_id,
+                actor_user_id=auth.user.id,
+            )
+        except identity_errors.IdentityRefreshFailed as refresh_exc:
+            raise _identity_required_response(
+                identity_errors.IdentityRequiredError(
+                    plugin_id=plugin_id,
+                    start_url=f'/me/identities/{plugin_id}/start',
+                )
+            ) from refresh_exc
+
+        ctx = await attach_identity(
+            db, ctx, resolved, auth, identity_options=identity_options
+        )
+        return await fn(ctx)
 
 
 def _identity_required_response(

--- a/src/imbi_api/identity/resolution.py
+++ b/src/imbi_api/identity/resolution.py
@@ -15,9 +15,16 @@ from imbi_common.plugins.registry import get_plugin
 
 from imbi_api.identity import errors as identity_errors
 from imbi_api.identity import repository
+from imbi_api.identity.models import IdentityCredentialsInternal
 from imbi_api.plugins import parse_options
 
 LOGGER = logging.getLogger(__name__)
+
+# Refresh proactively when the access token expires within this many
+# seconds.  Smaller than the sweeper's 5-minute lookahead so the two
+# layers don't fight; this hook only catches the race between sweeper
+# ticks.
+_PROACTIVE_REFRESH_WINDOW_SECONDS = 60
 
 
 def _start_url_for(plugin_id: str) -> str:
@@ -53,6 +60,9 @@ async def hydrate_identity(
             plugin_id=identity_plugin_id,
             start_url=_start_url_for(identity_plugin_id),
         )
+
+    if _should_refresh(connection):
+        connection = await _refresh_and_reload(db, identity_plugin_id, user_id)
 
     # Look up the identity plugin's slug + handler so we can call
     # ``materialize`` for plugins that exchange the IdP token (AWS IAM IC).
@@ -135,3 +145,59 @@ def is_active(connection_expires_at: datetime.datetime | None) -> bool:
     if connection_expires_at is None:
         return True
     return connection_expires_at > datetime.datetime.now(datetime.UTC)
+
+
+def _should_refresh(connection: IdentityCredentialsInternal) -> bool:
+    """True when ``connection`` should be refreshed before hydration.
+
+    Connections without a refresh token are skipped — the sweeper
+    would have flipped them to ``expired`` if it could have refreshed
+    them.
+    """
+    if not connection.refresh_token:
+        return False
+    if connection.expires_at is None:
+        return False
+    horizon = datetime.datetime.now(datetime.UTC) + datetime.timedelta(
+        seconds=_PROACTIVE_REFRESH_WINDOW_SECONDS
+    )
+    return connection.expires_at <= horizon
+
+
+async def _refresh_and_reload(
+    db: graph.Graph,
+    plugin_id: str,
+    user_id: str,
+) -> IdentityCredentialsInternal:
+    """Force-refresh the actor's connection and re-load it.
+
+    On refresh failure the underlying flow marks the connection
+    ``status='expired'``; we surface :class:`IdentityRequiredError`
+    so the request gets the same 401 as a missing connection.
+    """
+    from imbi_api.identity import flows
+
+    try:
+        await flows.refresh_connection(
+            db, plugin_id=plugin_id, actor_user_id=user_id
+        )
+    except identity_errors.IdentityRefreshFailed as exc:
+        LOGGER.info(
+            'Proactive refresh failed plugin_id=%s user_id=%s: %s; '
+            'returning IdentityRequired to caller',
+            plugin_id,
+            user_id,
+            exc,
+        )
+        raise identity_errors.IdentityRequiredError(
+            plugin_id=plugin_id,
+            start_url=_start_url_for(plugin_id),
+        ) from exc
+
+    refreshed = await repository.load_connection(db, plugin_id, user_id)
+    if refreshed is None or refreshed.status != 'active':
+        raise identity_errors.IdentityRequiredError(
+            plugin_id=plugin_id,
+            start_url=_start_url_for(plugin_id),
+        )
+    return refreshed

--- a/tests/identity/test_host_integration.py
+++ b/tests/identity/test_host_integration.py
@@ -9,6 +9,7 @@ from imbi_common.plugins.base import (
     IdentityCredentials,
     PluginContext,
 )
+from imbi_common.plugins.errors import PluginAuthenticationFailed
 
 from imbi_api.identity import errors as identity_errors
 from imbi_api.identity import host_integration
@@ -106,3 +107,148 @@ class AttachIdentityTestCase(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(detail['error'], 'identity_required')
         self.assertEqual(detail['plugin_id'], 'plug-1')
         self.assertEqual(detail['start_url'], '/me/identities/plug-1/start')
+
+
+class CallWithIdentityRetryTestCase(unittest.IsolatedAsyncioTestCase):
+    """Verify the retry-on-401 wrapper around plugin invocations."""
+
+    async def test_returns_value_on_first_call(self) -> None:
+        db = mock.AsyncMock()
+        ctx = _ctx().model_copy(
+            update={
+                'actor_user_id': 'user-1',
+                'identity': IdentityCredentials(access_token='at'),
+            }
+        )
+        with mock.patch.object(
+            host_integration,
+            'attach_identity',
+            new=mock.AsyncMock(return_value=ctx),
+        ) as attach:
+            fn = mock.AsyncMock(return_value='result')
+            value = await host_integration.call_with_identity_retry(
+                db, _ctx(), _resolved('plug-1'), _auth('user-1'), fn=fn
+            )
+        self.assertEqual(value, 'result')
+        attach.assert_awaited_once()
+        fn.assert_awaited_once_with(ctx)
+
+    async def test_no_identity_plugin_does_not_retry(self) -> None:
+        db = mock.AsyncMock()
+        ctx = _ctx().model_copy(update={'actor_user_id': 'user-1'})
+        with mock.patch.object(
+            host_integration,
+            'attach_identity',
+            new=mock.AsyncMock(return_value=ctx),
+        ):
+            fn = mock.AsyncMock(side_effect=PluginAuthenticationFailed('401'))
+            with self.assertRaises(PluginAuthenticationFailed):
+                await host_integration.call_with_identity_retry(
+                    db, _ctx(), _resolved(None), _auth('user-1'), fn=fn
+                )
+        # Called exactly once, no retry.
+        fn.assert_awaited_once()
+
+    async def test_retries_after_refresh_on_401(self) -> None:
+        db = mock.AsyncMock()
+        first_ctx = _ctx().model_copy(
+            update={
+                'actor_user_id': 'user-1',
+                'identity': IdentityCredentials(access_token='old'),
+            }
+        )
+        second_ctx = _ctx().model_copy(
+            update={
+                'actor_user_id': 'user-1',
+                'identity': IdentityCredentials(access_token='new'),
+            }
+        )
+        from imbi_api.identity import flows
+
+        attach = mock.AsyncMock(side_effect=[first_ctx, second_ctx])
+        fn_call_count = {'n': 0}
+
+        async def fn(ctx: PluginContext) -> str:
+            fn_call_count['n'] += 1
+            if fn_call_count['n'] == 1:
+                raise PluginAuthenticationFailed('401')
+            return f'ok:{ctx.identity.access_token}'
+
+        with (
+            mock.patch.object(host_integration, 'attach_identity', attach),
+            mock.patch.object(
+                flows,
+                'refresh_connection',
+                new=mock.AsyncMock(return_value=mock.MagicMock()),
+            ) as refresh,
+        ):
+            value = await host_integration.call_with_identity_retry(
+                db, _ctx(), _resolved('plug-1'), _auth('user-1'), fn=fn
+            )
+        self.assertEqual(value, 'ok:new')
+        refresh.assert_awaited_once()
+        self.assertEqual(attach.await_count, 2)
+        self.assertEqual(fn_call_count['n'], 2)
+
+    async def test_refresh_failure_maps_to_401(self) -> None:
+        db = mock.AsyncMock()
+        ctx = _ctx().model_copy(
+            update={
+                'actor_user_id': 'user-1',
+                'identity': IdentityCredentials(access_token='old'),
+            }
+        )
+        from imbi_api.identity import flows
+
+        with (
+            mock.patch.object(
+                host_integration,
+                'attach_identity',
+                new=mock.AsyncMock(return_value=ctx),
+            ),
+            mock.patch.object(
+                flows,
+                'refresh_connection',
+                new=mock.AsyncMock(
+                    side_effect=identity_errors.IdentityRefreshFailed('nope')
+                ),
+            ),
+        ):
+            fn = mock.AsyncMock(side_effect=PluginAuthenticationFailed('401'))
+            with self.assertRaises(fastapi.HTTPException) as cm:
+                await host_integration.call_with_identity_retry(
+                    db, _ctx(), _resolved('plug-1'), _auth('user-1'), fn=fn
+                )
+        self.assertEqual(cm.exception.status_code, 401)
+        detail = typing.cast('dict[str, typing.Any]', cm.exception.detail)
+        self.assertEqual(detail['error'], 'identity_required')
+        self.assertEqual(detail['plugin_id'], 'plug-1')
+
+    async def test_second_401_propagates(self) -> None:
+        db = mock.AsyncMock()
+        ctx = _ctx().model_copy(
+            update={
+                'actor_user_id': 'user-1',
+                'identity': IdentityCredentials(access_token='at'),
+            }
+        )
+        from imbi_api.identity import flows
+
+        with (
+            mock.patch.object(
+                host_integration,
+                'attach_identity',
+                new=mock.AsyncMock(return_value=ctx),
+            ),
+            mock.patch.object(
+                flows,
+                'refresh_connection',
+                new=mock.AsyncMock(return_value=mock.MagicMock()),
+            ),
+        ):
+            fn = mock.AsyncMock(side_effect=PluginAuthenticationFailed('401'))
+            with self.assertRaises(PluginAuthenticationFailed):
+                await host_integration.call_with_identity_retry(
+                    db, _ctx(), _resolved('plug-1'), _auth('user-1'), fn=fn
+                )
+        self.assertEqual(fn.await_count, 2)

--- a/tests/identity/test_resolution.py
+++ b/tests/identity/test_resolution.py
@@ -73,6 +73,8 @@ class HydrateIdentityTestCase(unittest.IsolatedAsyncioTestCase):
     async def test_inactive_connection_raises_identity_required(self) -> None:
         connection = mock.MagicMock()
         connection.status = 'expired'
+        connection.expires_at = None
+        connection.refresh_token = None
         with mock.patch.object(
             resolution.repository,
             'load_connection',
@@ -86,6 +88,8 @@ class HydrateIdentityTestCase(unittest.IsolatedAsyncioTestCase):
     async def test_missing_plugin_slug_raises_identity_required(self) -> None:
         connection = mock.MagicMock()
         connection.status = 'active'
+        connection.expires_at = None
+        connection.refresh_token = None
         with (
             mock.patch.object(
                 resolution.repository,
@@ -106,6 +110,8 @@ class HydrateIdentityTestCase(unittest.IsolatedAsyncioTestCase):
     async def test_plugin_not_found_raises_identity_required(self) -> None:
         connection = mock.MagicMock()
         connection.status = 'active'
+        connection.expires_at = None
+        connection.refresh_token = None
         with (
             mock.patch.object(
                 resolution.repository,
@@ -131,6 +137,8 @@ class HydrateIdentityTestCase(unittest.IsolatedAsyncioTestCase):
     async def test_handler_not_identity_plugin_raises(self) -> None:
         connection = mock.MagicMock()
         connection.status = 'active'
+        connection.expires_at = None
+        connection.refresh_token = None
 
         # Handler that is *not* an IdentityPlugin instance.
         non_identity_handler = mock.MagicMock()
@@ -151,6 +159,139 @@ class HydrateIdentityTestCase(unittest.IsolatedAsyncioTestCase):
                 resolution,
                 'get_plugin',
                 return_value=entry,
+            ),
+        ):
+            with self.assertRaises(identity_errors.IdentityRequiredError):
+                await resolution.hydrate_identity(
+                    self.db, self.ctx, 'plugin-1'
+                )
+
+    async def test_proactive_refresh_when_near_expiry(self) -> None:
+        # expires_at is 10 seconds from now → inside the 60s window.
+        connection = mock.MagicMock()
+        connection.status = 'active'
+        connection.access_token = 'old-access'
+        connection.refresh_token = 'refresh'
+        connection.expires_at = datetime.datetime.now(
+            datetime.UTC
+        ) + datetime.timedelta(seconds=10)
+        connection.scopes = []
+
+        refreshed = mock.MagicMock()
+        refreshed.status = 'active'
+        refreshed.access_token = 'new-access'
+        refreshed.refresh_token = 'refresh-2'
+        refreshed.expires_at = datetime.datetime.now(
+            datetime.UTC
+        ) + datetime.timedelta(hours=1)
+        refreshed.scopes = []
+
+        load = mock.AsyncMock(side_effect=[connection, refreshed])
+        materialized = mock.MagicMock(name='materialized')
+        handler = mock.MagicMock(spec=resolution.IdentityPlugin)
+        handler.materialize = mock.AsyncMock(return_value=materialized)
+        entry = mock.MagicMock()
+        entry.handler_cls = mock.MagicMock(return_value=handler)
+
+        # Patch the lazy import target inside imbi_api.identity.flows.
+        from imbi_api.identity import flows
+
+        with (
+            mock.patch.object(resolution.repository, 'load_connection', load),
+            mock.patch.object(
+                resolution,
+                '_plugin_slug',
+                new=mock.AsyncMock(return_value='oidc'),
+            ),
+            mock.patch.object(
+                resolution,
+                'load_plugin_options',
+                new=mock.AsyncMock(return_value={}),
+            ),
+            mock.patch.object(resolution, 'get_plugin', return_value=entry),
+            mock.patch.object(
+                flows,
+                'refresh_connection',
+                new=mock.AsyncMock(return_value=mock.MagicMock()),
+            ) as refresh_mock,
+        ):
+            await resolution.hydrate_identity(self.db, self.ctx, 'plugin-1')
+
+        refresh_mock.assert_awaited_once()
+        # The materialized credentials should derive from the refreshed
+        # connection (post-refresh access token), not the stale one.
+        base_credentials = handler.materialize.await_args[0][2]
+        self.assertEqual(base_credentials.access_token, 'new-access')
+
+    async def test_no_proactive_refresh_when_far_from_expiry(self) -> None:
+        connection = mock.MagicMock()
+        connection.status = 'active'
+        connection.access_token = 'access'
+        connection.refresh_token = 'refresh'
+        connection.expires_at = datetime.datetime.now(
+            datetime.UTC
+        ) + datetime.timedelta(hours=1)
+        connection.scopes = []
+
+        materialized = mock.MagicMock(name='materialized')
+        handler = mock.MagicMock(spec=resolution.IdentityPlugin)
+        handler.materialize = mock.AsyncMock(return_value=materialized)
+        entry = mock.MagicMock()
+        entry.handler_cls = mock.MagicMock(return_value=handler)
+
+        from imbi_api.identity import flows
+
+        with (
+            mock.patch.object(
+                resolution.repository,
+                'load_connection',
+                new=mock.AsyncMock(return_value=connection),
+            ),
+            mock.patch.object(
+                resolution,
+                '_plugin_slug',
+                new=mock.AsyncMock(return_value='oidc'),
+            ),
+            mock.patch.object(
+                resolution,
+                'load_plugin_options',
+                new=mock.AsyncMock(return_value={}),
+            ),
+            mock.patch.object(resolution, 'get_plugin', return_value=entry),
+            mock.patch.object(
+                flows,
+                'refresh_connection',
+                new=mock.AsyncMock(),
+            ) as refresh_mock,
+        ):
+            await resolution.hydrate_identity(self.db, self.ctx, 'plugin-1')
+
+        refresh_mock.assert_not_awaited()
+
+    async def test_proactive_refresh_failure_maps_to_identity_required(
+        self,
+    ) -> None:
+        connection = mock.MagicMock()
+        connection.status = 'active'
+        connection.refresh_token = 'refresh'
+        connection.expires_at = datetime.datetime.now(
+            datetime.UTC
+        ) - datetime.timedelta(seconds=5)
+
+        from imbi_api.identity import flows
+
+        with (
+            mock.patch.object(
+                resolution.repository,
+                'load_connection',
+                new=mock.AsyncMock(return_value=connection),
+            ),
+            mock.patch.object(
+                flows,
+                'refresh_connection',
+                new=mock.AsyncMock(
+                    side_effect=identity_errors.IdentityRefreshFailed('nope')
+                ),
             ),
         ):
             with self.assertRaises(identity_errors.IdentityRequiredError):

--- a/uv.lock
+++ b/uv.lock
@@ -987,7 +987,7 @@ requires-dist = [
   { name = "fastapi" },
   { name = "filetype" },
   { name = "httpx", specifier = ">=0.28.1,<1" },
-  { name = "imbi-common", extras = ["databases", "llm", "server"], git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=feature%2Foidc-refresh-resilience" },
+  { name = "imbi-common", extras = ["databases", "llm", "server"], git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=main" },
   { name = "jinja2" },
   { name = "jsonpatch", specifier = ">=1.33" },
   { name = "nanoid", specifier = ">=2.0.0" },
@@ -1031,8 +1031,8 @@ docs = [
   { name = "mkdocstrings-python-xref", specifier = ">=1.6,<2" },
 ]
 plugins = [
-  { name = "imbi-plugin-aws", git = "https://github.com/AWeber-Imbi/imbi-plugin-aws.git?rev=feature%2Foidc-refresh-resilience" },
-  { name = "imbi-plugin-github", git = "https://github.com/AWeber-Imbi/imbi-plugin-github.git?rev=feature%2Foidc-refresh-resilience" },
+  { name = "imbi-plugin-aws", git = "https://github.com/AWeber-Imbi/imbi-plugin-aws.git?rev=main" },
+  { name = "imbi-plugin-github", git = "https://github.com/AWeber-Imbi/imbi-plugin-github.git?rev=main" },
   { name = "imbi-plugin-logzio", git = "https://github.com/AWeber-Imbi/imbi-plugin-logzio.git?rev=main" },
   { name = "imbi-plugin-oidc", git = "https://github.com/AWeber-Imbi/imbi-plugin-oidc.git?rev=main" },
 ]
@@ -1040,7 +1040,7 @@ plugins = [
 [[package]]
 name = "imbi-common"
 version = "0.8.2"
-source = { git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=feature%2Foidc-refresh-resilience#f1370d51231e9facc7825c1c478d6c0916f8b1c6" }
+source = { git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=main#a3475e2bac6bdc234f2a250d6393d0e9b5c9a032" }
 dependencies = [
   { name = "cryptography" },
   { name = "jsonschema-models" },
@@ -1073,7 +1073,7 @@ server = [
 [[package]]
 name = "imbi-plugin-aws"
 version = "0.1.0"
-source = { git = "https://github.com/AWeber-Imbi/imbi-plugin-aws.git?rev=feature%2Foidc-refresh-resilience#da7868e33875faed3465a99ed29bcbd73b03398b" }
+source = { git = "https://github.com/AWeber-Imbi/imbi-plugin-aws.git?rev=main#dc4eab42b9fcc9fb4aabc50602731e88b1af7d9d" }
 dependencies = [
   { name = "httpx" },
   { name = "imbi-common" },
@@ -1083,7 +1083,7 @@ dependencies = [
 [[package]]
 name = "imbi-plugin-github"
 version = "0.1.0"
-source = { git = "https://github.com/AWeber-Imbi/imbi-plugin-github.git?rev=feature%2Foidc-refresh-resilience#3791e4487daaacfb5ac3ccd62446d49460d4c17f" }
+source = { git = "https://github.com/AWeber-Imbi/imbi-plugin-github.git?rev=main#5568863e28a147f57d754e1da9e25ae47b092f22" }
 dependencies = [
   { name = "httpx" },
   { name = "imbi-common" },

--- a/uv.lock
+++ b/uv.lock
@@ -987,7 +987,7 @@ requires-dist = [
   { name = "fastapi" },
   { name = "filetype" },
   { name = "httpx", specifier = ">=0.28.1,<1" },
-  { name = "imbi-common", extras = ["databases", "llm", "server"], git = "https://github.com/AWeber-Imbi/imbi-common.git?tag=v0.8.2" },
+  { name = "imbi-common", extras = ["databases", "llm", "server"], git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=feature%2Foidc-refresh-resilience" },
   { name = "jinja2" },
   { name = "jsonpatch", specifier = ">=1.33" },
   { name = "nanoid", specifier = ">=2.0.0" },
@@ -1031,8 +1031,8 @@ docs = [
   { name = "mkdocstrings-python-xref", specifier = ">=1.6,<2" },
 ]
 plugins = [
-  { name = "imbi-plugin-aws", git = "https://github.com/AWeber-Imbi/imbi-plugin-aws.git?rev=main" },
-  { name = "imbi-plugin-github", git = "https://github.com/AWeber-Imbi/imbi-plugin-github.git?rev=main" },
+  { name = "imbi-plugin-aws", git = "https://github.com/AWeber-Imbi/imbi-plugin-aws.git?rev=feature%2Foidc-refresh-resilience" },
+  { name = "imbi-plugin-github", git = "https://github.com/AWeber-Imbi/imbi-plugin-github.git?rev=feature%2Foidc-refresh-resilience" },
   { name = "imbi-plugin-logzio", git = "https://github.com/AWeber-Imbi/imbi-plugin-logzio.git?rev=main" },
   { name = "imbi-plugin-oidc", git = "https://github.com/AWeber-Imbi/imbi-plugin-oidc.git?rev=main" },
 ]
@@ -1040,7 +1040,7 @@ plugins = [
 [[package]]
 name = "imbi-common"
 version = "0.8.2"
-source = { git = "https://github.com/AWeber-Imbi/imbi-common.git?tag=v0.8.2#a2875a767d862f863f48488aea26f69082ca3868" }
+source = { git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=feature%2Foidc-refresh-resilience#f1370d51231e9facc7825c1c478d6c0916f8b1c6" }
 dependencies = [
   { name = "cryptography" },
   { name = "jsonschema-models" },
@@ -1073,7 +1073,7 @@ server = [
 [[package]]
 name = "imbi-plugin-aws"
 version = "0.1.0"
-source = { git = "https://github.com/AWeber-Imbi/imbi-plugin-aws.git?rev=main#009bf0cb9210be77d935aff38c69a01025bdc4f8" }
+source = { git = "https://github.com/AWeber-Imbi/imbi-plugin-aws.git?rev=feature%2Foidc-refresh-resilience#da7868e33875faed3465a99ed29bcbd73b03398b" }
 dependencies = [
   { name = "httpx" },
   { name = "imbi-common" },
@@ -1083,7 +1083,7 @@ dependencies = [
 [[package]]
 name = "imbi-plugin-github"
 version = "0.1.0"
-source = { git = "https://github.com/AWeber-Imbi/imbi-plugin-github.git?rev=main#7fd35e36878958a4d4d47f2eea58e55295fb215e" }
+source = { git = "https://github.com/AWeber-Imbi/imbi-plugin-github.git?rev=feature%2Foidc-refresh-resilience#3791e4487daaacfb5ac3ccd62446d49460d4c17f" }
 dependencies = [
   { name = "httpx" },
   { name = "imbi-common" },


### PR DESCRIPTION
## Summary

Three layers of defense against access tokens that expire between the sweeper's last refresh and a user request.

### 1. Proactive refresh in `hydrate_identity`

`identity/resolution.py` — when the connection's `expires_at` is within 60 seconds of now AND a refresh token is present, refresh proactively before materializing credentials. Smaller window than the sweeper's 5-minute lookahead so the two layers don't fight; this hook only catches the race between sweeper ticks.

### 2. `call_with_identity_retry` helper

`identity/host_integration.py` — wraps a plugin call: on `PluginAuthenticationFailed`, calls `flows.refresh_connection`, re-hydrates ctx, and retries the closure once. A second 401 or a refresh failure surfaces as the canonical `identity_required` 401 so the UI can prompt the user to reconnect.

Pass `attached=True` when the caller has already invoked `attach_identity` (e.g. a shared resolve helper that hydrates up-front for read paths) to skip the redundant first hydration.

### 3. Endpoint retrofits

- `endpoints/project_configuration.py` — all 4 plugin call sites (`list_keys`, `get_values`, `set_value`, `delete_key`)
- `endpoints/project_deployments.py` — `_handle_deploy.trigger_deployment` and `_handle_promote.create_tag` / `create_release` / `trigger_deployment` (4 sites). Each closure recomputes credentials per attempt via `_resolve_credentials(ctx, fallback)` so a refreshed identity's new access token is used on retry.

Read-only deployment endpoints (refs/commits/compare/runs/promotion-options/draft-release-notes) still use the existing `_resolve_and_context` path; they benefit from the proactive refresh in `hydrate_identity` but skip the 401-retry overhead.

## Why

Found two production identity connections in `status='expired'` with refresh tokens that AWS/GitHub were rejecting. Combined with the AWS scope-tracking fix in imbi-plugin-aws#10, this should stop users from being silently kicked out of OIDC connections mid-session.

End-to-end behavior now:
1. Steady state — sweeper refreshes 5 min before expiry every 60s.
2. Cold call near expiry — `hydrate_identity` proactively refreshes if within 60s.
3. Mid-flight 401 on writes — retry helper refreshes and retries once.
4. AWS connections with stale cached client — auto-detected and re-registered with `sso:account:access` on next connect.

## Dependencies

- AWeber-Imbi/imbi-common#88 — `PluginAuthenticationFailed` error
- AWeber-Imbi/imbi-plugin-aws#10 — AWS 401 detection + scope tracking
- AWeber-Imbi/imbi-plugin-github#8 — GitHub 401 detection

`pyproject.toml` is temporarily pinned to `feature/oidc-refresh-resilience` of all three; **reset to released refs (tag for imbi-common, main rev for plugins) before merging** (matches the existing `Reset imbi-common + imbi-plugin-github to released refs` pattern).

## Test plan

- [x] Three new tests in `tests/identity/test_resolution.py` cover proactive refresh near expiry, no-refresh far from expiry, refresh-failure-maps-to-401
- [x] Five new tests in `tests/identity/test_host_integration.py` cover the retry helper end-to-end
- [x] Full test suite passes (935 endpoint + identity tests)