### PR TITLE
Add Stoplight docs endpoint

### DIFF
--- a/src/imbi_api/app.py
+++ b/src/imbi_api/app.py
@@ -27,7 +27,7 @@ def create_app() -> fastapi.FastAPI:
             lifespans.identity_refresh_hook,
         ),
         version=version,
-        redoc_url='/docs',
+        redoc_url=None,
         docs_url=None,
         license_info={
             'name': 'BSD 3-Clause',
@@ -70,6 +70,7 @@ def create_app() -> fastapi.FastAPI:
     # Phase 5: Setup rate limiting middleware
     rate_limit.setup_rate_limiting(app)
 
+    app.add_route('/docs', openapi.stoplights_html, include_in_schema=False)
     for router in endpoints.prefixed_routers:
         app.include_router(router, prefix=server_config.api_prefix)
     for router in endpoints.unprefixed_routers:

--- a/src/imbi_api/openapi.py
+++ b/src/imbi_api/openapi.py
@@ -22,11 +22,15 @@ import typing
 import fastapi.openapi.utils
 import imbi_common.blueprints
 import pydantic
+import starlette.responses
 from imbi_common import graph
 
 from imbi_api import models as imbi_models
 
 LOGGER = logging.getLogger(__name__)
+
+# Constant for where to fetch the UI script from
+_STOPLIGHT_ELEMENTS_URL = 'https://unpkg.com/@stoplight/elements'
 
 # Cache for blueprint-enhanced write models
 _blueprint_models: dict[str, type[pydantic.BaseModel]] = {}
@@ -407,3 +411,25 @@ def clear_schema_cache() -> None:
     global _schema_cache
     _schema_cache = None
     LOGGER.debug('Cleared OpenAPI schema cache')
+
+
+async def stoplights_html(
+    req: fastapi.Request,
+) -> starlette.responses.HTMLResponse:
+    """Expose the API using Stoplight Elements.
+
+    https://docs.stoplight.io/docs/elements/a71d7fcfefcd6-elements-in-html
+    """
+    app = typing.cast(fastapi.FastAPI, req.app)
+    openapi_url = req.scope.get('root_path', '').removesuffix('/')
+    openapi_url += app.openapi_url
+    elements_url = _STOPLIGHT_ELEMENTS_URL.removesuffix('/')
+    return starlette.responses.HTMLResponse(
+        f'<title>{app.title}</title>'
+        f'<script src="{elements_url}/web-components.min.js"></script>'
+        f'<link rel="stylesheet" href="{elements_url}/styles.min.css">'
+        '</head><body>'
+        '<noscript>Stoplights documentation requires JavaScript</noscript>'
+        f'<elements-api apiDescriptionUrl="{openapi_url}" router="hash" />'
+        '</body></html>'
+    )

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -3,6 +3,7 @@
 import unittest
 import unittest.mock
 
+import fastapi
 import imbi_common.blueprints
 import imbi_common.models
 import pydantic
@@ -388,3 +389,33 @@ class ClearSchemaCacheTestCase(unittest.TestCase):
         openapi.clear_schema_cache()
 
         self.assertIsNone(openapi._schema_cache)
+
+
+class StoplightsHtmlTestCase(unittest.IsolatedAsyncioTestCase):
+    """Test cases for stoplights_html."""
+
+    async def test_injects_title_and_root_path(self) -> None:
+        """Test templated title and root path are injected."""
+        app = fastapi.FastAPI(
+            title='Imbi API Docs',
+            version='1.0.0',
+            root_path='/imbi',
+        )
+        request = fastapi.Request(
+            {
+                'type': 'http',
+                'app': app,
+                'root_path': '/imbi/',
+                'path': '/docs',
+                'headers': [],
+            }
+        )
+
+        response = await openapi.stoplights_html(request)
+        content = response.body.decode()
+
+        self.assertIn('<title>Imbi API Docs</title>', content)
+        self.assertIn(
+            'apiDescriptionUrl="/imbi/openapi.json"',
+            content,
+        )


### PR DESCRIPTION
## Summary
- replace the default `/docs` ReDoc page with a Stoplight Elements page
- serve the Stoplight HTML shell from a dedicated route in the FastAPI app
- add tests covering the generated title and root-path aware OpenAPI URL
