### PR TITLE
Add deployment tab + project context helpers for plugin assignments

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
   "fastapi",
   "filetype",
   "httpx>=0.28.1,<1",
-  "imbi-common[databases,llm,server]>=0.8.3",
+  "imbi-common[databases,llm,server]>=0.8.4",
   "jinja2",
   "jsonpatch>=1.33",
   "nanoid>=2.0.0",

--- a/src/imbi_api/domain/models.py
+++ b/src/imbi_api/domain/models.py
@@ -850,7 +850,7 @@ class PluginAssignmentCreate(pydantic.BaseModel):
     """Request model for assigning a plugin to a project-type or project."""
 
     plugin_id: str
-    tab: typing.Literal['configuration', 'logs']
+    tab: typing.Literal['configuration', 'logs', 'deployment']
     default: bool = False
     options: dict[str, typing.Any] = pydantic.Field(default_factory=dict)
     identity_plugin_id: str | None = None
@@ -862,7 +862,7 @@ class PluginAssignmentResponse(pydantic.BaseModel):
     plugin_id: str
     plugin_slug: str
     label: str
-    tab: typing.Literal['configuration', 'logs']
+    tab: typing.Literal['configuration', 'logs', 'deployment']
     default: bool
     options: dict[str, typing.Any] = {}
     source: typing.Literal['project', 'project_type', 'merged'] = (

--- a/src/imbi_api/endpoints/_helpers.py
+++ b/src/imbi_api/endpoints/_helpers.py
@@ -167,7 +167,8 @@ async def lookup_project_links(
             return {}
     if not isinstance(raw, dict):
         return {}
-    return {str(k): str(v) for k, v in raw.items() if v}
+    items = typing.cast('dict[object, object]', raw)
+    return {str(k): str(v) for k, v in items.items() if v}
 
 
 async def lookup_project_type_slugs(

--- a/src/imbi_api/endpoints/_helpers.py
+++ b/src/imbi_api/endpoints/_helpers.py
@@ -1,5 +1,6 @@
 """Shared helpers for endpoint handlers."""
 
+import json
 import logging
 import typing
 
@@ -130,6 +131,71 @@ async def lookup_project_slugs(
         str(slug_raw) if slug_raw else '',
         str(team_raw) if team_raw else None,
     )
+
+
+async def lookup_project_links(
+    db: graph.Graph,
+    project_id: str,
+) -> dict[str, str]:
+    """Return the project's external link map.
+
+    Returns ``{}`` on lookup failure or when no links are set. Plugins
+    use these as a side-channel for per-project state (e.g. resolving
+    a GitHub owner/repo from the ``github-repository`` link) so that
+    callers don't have to duplicate the data as assignment options.
+    """
+    query: typing.LiteralString = (
+        'MATCH (p:Project {{id: {project_id}}}) RETURN p.links AS links'
+    )
+    try:
+        records = await db.execute(
+            query, {'project_id': project_id}, ['links']
+        )
+    except Exception:  # noqa: BLE001
+        LOGGER.debug('Project links lookup failed', exc_info=True)
+        return {}
+    if not records:
+        return {}
+    raw = graph.parse_agtype(records[0].get('links'))
+    # ``links`` is persisted as a JSON-encoded string on the AGE node
+    # (not a property map), so ``parse_agtype`` returns ``str`` here —
+    # decode it once more to recover the dict.
+    if isinstance(raw, str):
+        try:
+            raw = json.loads(raw)
+        except (TypeError, ValueError):
+            return {}
+    if not isinstance(raw, dict):
+        return {}
+    return {str(k): str(v) for k, v in raw.items() if v}
+
+
+async def lookup_project_type_slugs(
+    db: graph.Graph,
+    project_id: str,
+) -> list[str]:
+    """Return slugs for every ProjectType the project is tagged with.
+
+    Returns ``[]`` on lookup failure or when the project has no type
+    edges. Plugins use this list as a side-channel for per-project
+    discovery (e.g. ``owner`` derivation when the project lacks an
+    explicit GitHub Repository link).
+    """
+    query: typing.LiteralString = (
+        'MATCH (p:Project {{id: {project_id}}})-[:TYPE]->(pt:ProjectType) '
+        'RETURN pt.slug AS slug'
+    )
+    try:
+        records = await db.execute(query, {'project_id': project_id}, ['slug'])
+    except Exception:  # noqa: BLE001
+        LOGGER.debug('Project type lookup failed', exc_info=True)
+        return []
+    slugs: list[str] = []
+    for row in records:
+        raw = graph.parse_agtype(row.get('slug'))
+        if isinstance(raw, str) and raw:
+            slugs.append(raw)
+    return slugs
 
 
 def extract_role_slug(

--- a/src/imbi_api/endpoints/project_deployments.py
+++ b/src/imbi_api/endpoints/project_deployments.py
@@ -32,7 +32,11 @@ from imbi_common.plugins.base import (
 from imbi_common.plugins.errors import PluginCredentialsMissing
 
 from imbi_api.auth import permissions
-from imbi_api.endpoints._helpers import lookup_project_slugs
+from imbi_api.endpoints._helpers import (
+    lookup_project_links,
+    lookup_project_slugs,
+    lookup_project_type_slugs,
+)
 from imbi_api.endpoints.releases import append_deployment_event
 from imbi_api.identity.host_integration import (
     attach_identity,
@@ -196,6 +200,8 @@ async def _resolve_and_context(
     """Common boilerplate: resolve plugin, attach identity, build creds."""
     resolved = await resolve_plugin(db, project_id, 'deployment', source)
     project_slug, team_slug = await lookup_project_slugs(db, project_id)
+    project_links = await lookup_project_links(db, project_id)
+    project_type_slugs = await lookup_project_type_slugs(db, project_id)
     ctx = PluginContext(
         project_id=project_id,
         project_slug=project_slug,
@@ -203,6 +209,8 @@ async def _resolve_and_context(
         team_slug=team_slug,
         environment=environment,
         assignment_options=resolved.options,
+        project_links=project_links,
+        project_type_slugs=project_type_slugs,
     )
     ctx = await attach_identity(db, ctx, resolved, auth)
 

--- a/src/imbi_api/endpoints/service_plugins.py
+++ b/src/imbi_api/endpoints/service_plugins.py
@@ -654,7 +654,7 @@ async def patch_service_plugin_configuration(
 
 class _AssignmentInput(pydantic.BaseModel):
     project_type_slug: str
-    tab: typing.Literal['configuration', 'logs']
+    tab: typing.Literal['configuration', 'logs', 'deployment']
     default: bool = False
     options: dict[str, typing.Any] = {}
     identity_plugin_id: str | None = None
@@ -663,7 +663,7 @@ class _AssignmentInput(pydantic.BaseModel):
 class _AssignmentRow(pydantic.BaseModel):
     project_type_slug: str
     project_type_name: str
-    tab: typing.Literal['configuration', 'logs']
+    tab: typing.Literal['configuration', 'logs', 'deployment']
     default: bool
     options: dict[str, typing.Any]
     identity_plugin_id: str | None = None

--- a/src/imbi_api/openapi.py
+++ b/src/imbi_api/openapi.py
@@ -425,11 +425,13 @@ async def stoplights_html(
     openapi_url += app.openapi_url
     elements_url = _STOPLIGHT_ELEMENTS_URL.removesuffix('/')
     return starlette.responses.HTMLResponse(
+        '<!DOCTYPE html><html><head>'
         f'<title>{app.title}</title>'
         f'<script src="{elements_url}/web-components.min.js"></script>'
         f'<link rel="stylesheet" href="{elements_url}/styles.min.css">'
         '</head><body>'
         '<noscript>Stoplights documentation requires JavaScript</noscript>'
-        f'<elements-api apiDescriptionUrl="{openapi_url}" router="hash" />'
+        f'<elements-api apiDescriptionUrl="{openapi_url}" router="hash">'
+        '</elements-api>'
         '</body></html>'
     )

--- a/src/imbi_api/plugins/assignments.py
+++ b/src/imbi_api/plugins/assignments.py
@@ -13,7 +13,7 @@ from imbi_api.plugins import parse_options
 
 class PluginAssignmentRow(typing.TypedDict):
     plugin_id: str
-    tab: typing.Literal['configuration', 'logs']
+    tab: typing.Literal['configuration', 'logs', 'deployment']
     default: bool
     options: dict[str, typing.Any]
     identity_plugin_id: typing.NotRequired[str | None]

--- a/uv.lock
+++ b/uv.lock
@@ -987,7 +987,7 @@ requires-dist = [
   { name = "fastapi" },
   { name = "filetype" },
   { name = "httpx", specifier = ">=0.28.1,<1" },
-  { name = "imbi-common", extras = ["databases", "llm", "server"], specifier = ">=0.8.3" },
+  { name = "imbi-common", extras = ["databases", "llm", "server"], specifier = ">=0.8.4" },
   { name = "jinja2" },
   { name = "jsonpatch", specifier = ">=1.33" },
   { name = "nanoid", specifier = ">=2.0.0" },
@@ -1039,7 +1039,7 @@ plugins = [
 
 [[package]]
 name = "imbi-common"
-version = "0.8.3"
+version = "0.8.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
   { name = "cryptography" },
@@ -1053,9 +1053,9 @@ dependencies = [
   { name = "python-slugify" },
   { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9c/5e/4bd8ffe146a88d245ee7254d7fd1fca10e55fb5f3fc45a206260f882a39f/imbi_common-0.8.3.tar.gz", hash = "sha256:d3ee611a5b1996ede7d266a693a4f359c7ac6600dc2f2dc1912380ea26f3bc10", size = 245708, upload-time = "2026-05-09T23:30:20.319Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/20/6b8de053fc25fa7b4905bd3b0e1ebd33fcf909f2f0e5a61cee4e2c29c824/imbi_common-0.8.4.tar.gz", hash = "sha256:549b1cf7eded303af16f17feac2bb1b9c10f8178016de742d78b629f1f1cb7b5", size = 245922, upload-time = "2026-05-10T19:34:17.874Z" }
 wheels = [
-  { url = "https://files.pythonhosted.org/packages/de/6b/38e785ec18ef80d6644fffe7648de5038e52ab1e806eff1ded19a47ecf00/imbi_common-0.8.3-py3-none-any.whl", hash = "sha256:c4ad388799422dc5f4f8e1d47ba4492ad7b3fefd2a293ea59187a151e53873ba", size = 71657, upload-time = "2026-05-09T23:30:18.522Z" },
+  { url = "https://files.pythonhosted.org/packages/ba/d5/746fd775d7f2cd093242a23b0c89bb74b83a6e7deb8f014c3bbb060653bd/imbi_common-0.8.4-py3-none-any.whl", hash = "sha256:8761545ab87a92b8ede814e2d6b139c70fdd4a8ea0269394128abc5fac381df1", size = 71887, upload-time = "2026-05-10T19:34:16.565Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

- Extends the ``PluginAssignment`` ``tab`` literal to include ``deployment`` (was ``configuration | logs`` only). Without this the UI's ``tab='deployment'`` payload was rejected, which is why the Promote affordance was disabled end-to-end.
- Adds ``lookup_project_links`` / ``lookup_project_type_slugs`` helpers and threads them into the ``project_deployments`` resolve path so the GitHub deployment plugin can derive owner/repo from project state instead of per-project options. ``links`` is JSON-encoded as a string in AGE; the helper ``json.loads`` decodes it after ``parse_agtype``.
- Fixes the Stoplights docs page HTML (missing doctype/html/head wrapper, self-closed ``<elements-api/>``).
- Requires ``imbi-common>=0.8.4`` for the new ``project_links`` / ``project_type_slugs`` fields on ``PluginContext``.

## Test plan

- [ ] CI green
- [ ] Manual: load a project's plugin assignments and confirm the ``deployment`` tab assignments now round-trip through the API
- [ ] Manual: trigger a deployment from the UI and confirm the resolved ``PluginContext`` carries ``project_links`` + ``project_type_slugs`` to the GitHub plugin (paired with imbi-plugin-github PR #10)
- [ ] Manual: open ``/docs`` and confirm the Stoplights page renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)