### PR TITLE
Rename IMBI_API_ENVIRONMENT to ENVIRONMENT

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -51,7 +51,7 @@ export NEO4J_PASSWORD="your-neo4j-password"
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `IMBI_API_ENVIRONMENT` | `development` | Environment name (development, staging, production) |
+| `ENVIRONMENT` | `development` | Environment name (development, staging, production). Unprefixed so it picks up whatever the deploy target already exports. |
 | `IMBI_API_HOST` | `localhost` | Server bind address |
 | `IMBI_API_PORT` | `8000` | Server bind port |
 | `IMBI_API_CORS_ALLOWED_ORIGINS` | `[]` | JSON array of allowed CORS origins |
@@ -238,7 +238,7 @@ For development, use environment variables or a `.env` file:
 
 ```bash
 # Application
-IMBI_API_ENVIRONMENT=development
+ENVIRONMENT=development
 IMBI_API_HOST=localhost
 IMBI_API_PORT=8000
 IMBI_LOG_LEVEL=INFO

--- a/src/imbi_api/settings.py
+++ b/src/imbi_api/settings.py
@@ -158,7 +158,7 @@ class Email(pydantic_settings.BaseSettings):
     @pydantic.model_validator(mode='after')
     def configure_mailpit_defaults(self) -> Email:
         """Auto-configure for Mailpit in development."""
-        if os.getenv('IMBI_API_ENVIRONMENT', 'development') != 'development':
+        if os.getenv('ENVIRONMENT', 'development') != 'development':
             return self
         if self.smtp_host == 'localhost' and self.smtp_port == 587:
             mailpit_port = os.getenv('MAILPIT_SMTP_PORT')

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -57,7 +57,7 @@ class EmailSettingsTestCase(unittest.TestCase):
         import os
 
         # Set environment variables for Mailpit detection
-        os.environ['IMBI_API_ENVIRONMENT'] = 'development'
+        os.environ['ENVIRONMENT'] = 'development'
         os.environ['MAILPIT_SMTP_PORT'] = '1025'
 
         try:
@@ -68,14 +68,14 @@ class EmailSettingsTestCase(unittest.TestCase):
             self.assertFalse(email.smtp_use_tls)
         finally:
             # Clean up environment variables
-            os.environ.pop('IMBI_API_ENVIRONMENT', None)
+            os.environ.pop('ENVIRONMENT', None)
             os.environ.pop('MAILPIT_SMTP_PORT', None)
 
     def test_mailpit_detection_with_explicit_tls(self) -> None:
         """Test that explicit TLS setting is not overridden."""
         import os
 
-        os.environ['IMBI_API_ENVIRONMENT'] = 'development'
+        os.environ['ENVIRONMENT'] = 'development'
         os.environ['MAILPIT_SMTP_PORT'] = '1025'
         os.environ['IMBI_EMAIL_SMTP_USE_TLS'] = 'true'
 
@@ -88,7 +88,7 @@ class EmailSettingsTestCase(unittest.TestCase):
             self.assertEqual(email.smtp_port, 1025)
             self.assertTrue(email.smtp_use_tls)
         finally:
-            os.environ.pop('IMBI_API_ENVIRONMENT', None)
+            os.environ.pop('ENVIRONMENT', None)
             os.environ.pop('MAILPIT_SMTP_PORT', None)
             os.environ.pop('IMBI_EMAIL_SMTP_USE_TLS', None)
 
@@ -96,7 +96,7 @@ class EmailSettingsTestCase(unittest.TestCase):
         """Test that Mailpit detection is skipped in production."""
         import os
 
-        os.environ['IMBI_API_ENVIRONMENT'] = 'production'
+        os.environ['ENVIRONMENT'] = 'production'
         os.environ['MAILPIT_SMTP_PORT'] = '1025'
 
         try:
@@ -108,14 +108,14 @@ class EmailSettingsTestCase(unittest.TestCase):
             self.assertEqual(email.smtp_port, 587)
             self.assertTrue(email.smtp_use_tls)
         finally:
-            os.environ.pop('IMBI_API_ENVIRONMENT', None)
+            os.environ.pop('ENVIRONMENT', None)
             os.environ.pop('MAILPIT_SMTP_PORT', None)
 
     def test_no_mailpit_detection_non_localhost(self) -> None:
         """Test that Mailpit detection only applies to localhost."""
         import os
 
-        os.environ['IMBI_API_ENVIRONMENT'] = 'development'
+        os.environ['ENVIRONMENT'] = 'development'
         os.environ['MAILPIT_SMTP_PORT'] = '1025'
 
         try:
@@ -129,14 +129,14 @@ class EmailSettingsTestCase(unittest.TestCase):
             self.assertEqual(email.smtp_port, 587)
             self.assertTrue(email.smtp_use_tls)
         finally:
-            os.environ.pop('IMBI_API_ENVIRONMENT', None)
+            os.environ.pop('ENVIRONMENT', None)
             os.environ.pop('MAILPIT_SMTP_PORT', None)
 
     def test_no_mailpit_detection_different_port(self) -> None:
         """Test that Mailpit detection only applies to default port."""
         import os
 
-        os.environ['IMBI_API_ENVIRONMENT'] = 'development'
+        os.environ['ENVIRONMENT'] = 'development'
         os.environ['MAILPIT_SMTP_PORT'] = '1025'
 
         try:
@@ -145,7 +145,7 @@ class EmailSettingsTestCase(unittest.TestCase):
             # Should not detect Mailpit for non-default port
             self.assertEqual(email.smtp_port, 2525)
         finally:
-            os.environ.pop('IMBI_API_ENVIRONMENT', None)
+            os.environ.pop('ENVIRONMENT', None)
             os.environ.pop('MAILPIT_SMTP_PORT', None)
 
 


### PR DESCRIPTION
## Summary

The Mailpit auto-config short-circuit in ``Email`` is the only live reader of this env var, and it's read via ``os.getenv`` (not Pydantic Settings), so the ``IMBI_API_`` prefix never bought anything. Renaming to the unprefixed ``ENVIRONMENT`` lets the deploy target's existing convention (Vercel, AWS task defs, GitHub Actions, etc. already export this) drive the dev/prod split without an extra knob.

- ``src/imbi_api/settings.py`` — ``os.getenv('ENVIRONMENT', ...)``.
- ``tests/test_settings.py`` — 10 occurrences renamed.
- ``docs/configuration.md`` — table row + ``.env`` example updated; added a one-liner noting the unprefixed name is intentional.

The matching ``compose.yml`` change lives in the orchestrator repo.

## Test plan

- [x] ``uv run pytest tests/test_settings.py`` — 18/18 pass
- [ ] CI green
- [ ] Smoke: confirm Mailpit auto-config still kicks in when ``ENVIRONMENT=development`` and stays disabled in ``production``

🤖 Generated with [Claude Code](https://claude.com/claude-code)