### PR TITLE
Fix role permission resolver when role has no ancestors

### DIFF
--- a/src/imbi_api/auth/permissions.py
+++ b/src/imbi_api/auth/permissions.py
@@ -104,13 +104,19 @@ async def load_principal_permissions(
         raise ValueError(
             f'Unsupported principal selector: ({label!r}, {match_prop!r})'
         )
+    # Apache AGE does not honor the zero-hop case in variable-length
+    # paths (``*0..``), so the start role itself would be excluded
+    # from the traversal. Collect ancestors with ``*1..`` then union
+    # the start role back in.
     query = (
         f'MATCH (p:{label} {{{{{match_prop}: {{value}}}}}})'
         '-[m:MEMBER_OF]->(o:Organization) '
         'MATCH (r:Role {{slug: m.role}}) '
-        'OPTIONAL MATCH (r)-[:INHERITS_FROM*0..]->(parent:Role) '
-        'WITH DISTINCT parent '
-        'OPTIONAL MATCH (parent)-[:GRANTS]->(perm:Permission) '
+        'OPTIONAL MATCH (r)-[:INHERITS_FROM*1..]->(ancestor:Role) '
+        'WITH r, collect(DISTINCT ancestor) AS ancestors '
+        'UNWIND ancestors + [r] AS role '
+        'WITH DISTINCT role '
+        'OPTIONAL MATCH (role)-[:GRANTS]->(perm:Permission) '
         'RETURN collect(DISTINCT perm.name)'
     )
     records = await db.execute(

--- a/tests/auth/test_permissions.py
+++ b/tests/auth/test_permissions.py
@@ -102,6 +102,28 @@ class OrgMembershipPermissionTestCase(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(perms, set())
 
+    async def test_query_does_not_use_zero_hop_variable_length(
+        self,
+    ) -> None:
+        """Guard against regressing to ``*0..``.
+
+        Apache AGE does not honor the zero-hop case in variable-length
+        paths, so the assigned role's own GRANTS would be silently
+        excluded. The query must collect ancestors with ``*1..`` and
+        union the start role back in.
+        """
+        mock_db = mock.AsyncMock()
+        mock_db.execute.return_value = []
+
+        await permissions.load_principal_permissions(
+            mock_db, 'User', 'email', 'someone@example.com'
+        )
+
+        query = mock_db.execute.call_args.args[0]
+        self.assertNotIn('*0..', query)
+        self.assertIn('*1..', query)
+        self.assertIn('ancestors + [r]', query)
+
 
 class ResourceLevelPermissionTestCase(
     unittest.IsolatedAsyncioTestCase,


### PR DESCRIPTION
## Summary
- Apache AGE does not honor the zero-hop case in variable-length paths (`*0..`).
- `load_principal_permissions` used `OPTIONAL MATCH (r)-[:INHERITS_FROM*0..]->(parent:Role)` to include the user's own role plus any ancestors. Because AGE returned `[]` for that pattern when the role had no outbound `INHERITS_FROM` edges, the role itself was excluded and **no** GRANTS were collected.
- Effect in production: users mapped to a role with no inheritance got `permissions = set()` and were 403'd on every endpoint, including `/api/organizations/` and `/api/users/<email>`, despite the role having the appropriate GRANTS.

## Solution
- Collect ancestors with `*1..` and union the start role back in, so the role's direct GRANTS are always considered.
- Added a regression-guard unit test asserting the query string no longer contains `*0..` and does include the ancestors-plus-self union.

## Verified
- All 14 tests in `tests/auth/test_permissions.py` pass.
- Manually verified against an AGE graph that the new pattern returns the role's GRANTS when no `INHERITS_FROM` edges exist (the failure mode the previous query exhibited).

## Test plan
- [ ] CI green
- [ ] After deploy, a user with a `role: 'default'` membership (whose `default` Role has GRANTS but no INHERITS_FROM ancestors) can call `/api/organizations/` and `/api/users/...` without 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)