### PR TITLE
Assign default role on first login

### DIFF
--- a/src/imbi_api/auth/membership.py
+++ b/src/imbi_api/auth/membership.py
@@ -1,0 +1,149 @@
+"""Auto-assignment of the default role on user login.
+
+When a user successfully authenticates but has no ``MEMBER_OF`` edge
+to any organization yet, they would otherwise receive an empty
+permission set and be 403'd everywhere.
+
+``ensure_user_membership`` resolves the role flagged with
+``is_default: true`` (seeded by :mod:`imbi_api.auth.seed`) and creates
+a ``MEMBER_OF {role: <slug>}`` edge to the target organization. The
+target is the sole ``Organization`` if there is exactly one; otherwise
+it falls back to the seeded ``slug='default'`` organization. If the
+target cannot be resolved unambiguously, the helper logs a warning
+and returns ``None`` so login still succeeds.
+"""
+
+import logging
+import typing
+
+from imbi_common import graph
+
+LOGGER = logging.getLogger(__name__)
+
+
+_DEFAULT_ROLE_QUERY: typing.LiteralString = (
+    'MATCH (r:Role {{is_default: true}}) RETURN r.slug AS slug LIMIT 1'
+)
+
+_TARGET_ORG_QUERY: typing.LiteralString = (
+    'MATCH (o:Organization) RETURN collect(o.slug) AS slugs'
+)
+
+_USER_HAS_MEMBERSHIP_QUERY: typing.LiteralString = (
+    'MATCH (u:User {{email: {email}}}) '
+    'OPTIONAL MATCH (u)-[m:MEMBER_OF]->() '
+    'RETURN count(m) AS edges'
+)
+
+_CREATE_MEMBERSHIP_QUERY: typing.LiteralString = (
+    'MATCH (u:User {{email: {email}}}), '
+    '(o:Organization {{slug: {org_slug}}}) '
+    'CREATE (u)-[:MEMBER_OF {{role: {role_slug}}}]->(o) '
+    'RETURN u.email AS email'
+)
+
+
+async def ensure_user_membership(
+    db: graph.Graph,
+    email: str,
+) -> str | None:
+    """Assign the default role to ``email`` if the user has no membership.
+
+    Args:
+        db: Graph database connection.
+        email: User email used to look up the ``User`` node.
+
+    Returns:
+        The role slug that was assigned, or ``None`` if the user
+        already had a membership, or if the default role / target
+        organization could not be resolved.
+    """
+    edges = await _count_memberships(db, email)
+    if edges is None or edges > 0:
+        return None
+
+    role_slug = await _resolve_default_role(db)
+    if role_slug is None:
+        LOGGER.warning(
+            'No Role with is_default=true; cannot auto-assign for %s',
+            email,
+        )
+        return None
+
+    org_slug = await _resolve_target_org(db)
+    if org_slug is None:
+        LOGGER.warning(
+            'No unambiguous target Organization for default role '
+            'assignment of %s',
+            email,
+        )
+        return None
+
+    created = await _create_membership(db, email, org_slug, role_slug)
+    if created:
+        LOGGER.info(
+            'Assigned default role %r in organization %r to %s',
+            role_slug,
+            org_slug,
+            email,
+        )
+        return role_slug
+    return None
+
+
+async def _count_memberships(
+    db: graph.Graph,
+    email: str,
+) -> int | None:
+    records = await db.execute(
+        _USER_HAS_MEMBERSHIP_QUERY,
+        {'email': email},
+        columns=['edges'],
+    )
+    if not records:
+        return None
+    raw = graph.parse_agtype(records[0].get('edges'))
+    if raw is None:
+        return None
+    return int(raw)
+
+
+async def _resolve_default_role(db: graph.Graph) -> str | None:
+    records = await db.execute(_DEFAULT_ROLE_QUERY, columns=['slug'])
+    if not records:
+        return None
+    raw = graph.parse_agtype(records[0].get('slug'))
+    return raw if isinstance(raw, str) else None
+
+
+async def _resolve_target_org(db: graph.Graph) -> str | None:
+    records = await db.execute(_TARGET_ORG_QUERY, columns=['slugs'])
+    if not records:
+        return None
+    raw: typing.Any = graph.parse_agtype(records[0].get('slugs'))
+    if not isinstance(raw, list):
+        return None
+    slugs: list[str] = [
+        item
+        for item in typing.cast(list[str | typing.Any], raw)
+        if isinstance(item, str)
+    ]
+    if len(slugs) == 1:
+        return slugs[0]
+    if 'default' in slugs:
+        return 'default'
+    return None
+
+
+async def _create_membership(
+    db: graph.Graph,
+    email: str,
+    org_slug: str,
+    role_slug: str,
+) -> bool:
+    records = await db.execute(
+        _CREATE_MEMBERSHIP_QUERY,
+        {'email': email, 'org_slug': org_slug, 'role_slug': role_slug},
+        columns=['email'],
+    )
+    return bool(records)

--- a/src/imbi_api/auth/membership.py
+++ b/src/imbi_api/auth/membership.py
@@ -35,10 +35,16 @@ _USER_HAS_MEMBERSHIP_QUERY: typing.LiteralString = (
     'RETURN count(m) AS edges'
 )
 
+# MERGE rather than CREATE so two concurrent logins for the same
+# previously-unassigned user cannot leave behind duplicate MEMBER_OF
+# edges. ``role_slug`` is part of the merge pattern, so this is
+# idempotent only for the same role value — fine here because the
+# caller invokes this helper only when the user has zero memberships
+# of any kind.
 _CREATE_MEMBERSHIP_QUERY: typing.LiteralString = (
     'MATCH (u:User {{email: {email}}}), '
     '(o:Organization {{slug: {org_slug}}}) '
-    'CREATE (u)-[:MEMBER_OF {{role: {role_slug}}}]->(o) '
+    'MERGE (u)-[:MEMBER_OF {{role: {role_slug}}}]->(o) '
     'RETURN u.email AS email'
 )
 

--- a/src/imbi_api/auth/seed.py
+++ b/src/imbi_api/auth/seed.py
@@ -386,14 +386,20 @@ STANDARD_PERMISSIONS: list[tuple[str, str, str, str]] = [
     ),
 ]
 
-# Default role definitions
-DEFAULT_ROLES: list[tuple[str, str, str, int, list[str]]] = [
+# Default role definitions.
+#
+# The 6th tuple element marks the role auto-assigned to newly-logging-in
+# users that have no organization membership yet (see
+# ``imbi_api.auth.membership.ensure_user_membership``). Exactly one
+# entry should set this to True; ``bootstrap_auth_system`` enforces it.
+DEFAULT_ROLES: list[tuple[str, str, str, int, list[str], bool]] = [
     (
         'admin',
         'Administrator',
         'Full system access with all permissions',
         1000,
         [perm[0] for perm in STANDARD_PERMISSIONS],  # All permissions
+        False,
     ),
     (
         'developer',
@@ -431,6 +437,33 @@ DEFAULT_ROLES: list[tuple[str, str, str, int, list[str]]] = [
             'document_template:read',
             'me:identities:manage',
         ],
+        False,
+    ),
+    (
+        'default',
+        'Default',
+        'Baseline access granted automatically on first login',
+        150,
+        [
+            'blueprint:read',
+            'document:read',
+            'document_template:read',
+            'environment:read',
+            'link_definition:read',
+            'me:identities:manage',
+            'operations_log:read',
+            'organization:read',
+            'project:read',
+            'project_type:read',
+            'role:read',
+            'tag:read',
+            'team:read',
+            'third_party_service:read',
+            'upload:read',
+            'user:read',
+            'webhook:read',
+        ],
+        True,
     ),
     (
         'readonly',
@@ -456,8 +489,18 @@ DEFAULT_ROLES: list[tuple[str, str, str, int, list[str]]] = [
             'document_template:read',
             'me:identities:manage',
         ],
+        False,
     ),
 ]
+
+# Invariant: exactly one seeded role is the auto-assignment target so
+# ``ensure_user_membership`` can resolve it unambiguously. Enforced at
+# module import time so a misconfigured DEFAULT_ROLES table fails fast
+# rather than producing silent permission gaps in production.
+if sum(role[5] for role in DEFAULT_ROLES) != 1:
+    raise RuntimeError(
+        'Exactly one DEFAULT_ROLES entry must set is_default=True'
+    )
 
 
 async def seed_permissions(db: graph.Graph) -> int:
@@ -513,15 +556,18 @@ async def seed_default_roles(db: graph.Graph) -> int:
         description,
         priority,
         permission_names,
+        is_default,
     ) in enumerate(DEFAULT_ROLES):
         role_maps.append(
             f'{{{{slug: {{r_s_{i}}}, name: {{r_n_{i}}},'
-            f' description: {{r_d_{i}}}, priority: {{r_p_{i}}}}}}}'
+            f' description: {{r_d_{i}}}, priority: {{r_p_{i}}},'
+            f' is_default: {{r_dflt_{i}}}}}}}'
         )
         params[f'r_s_{i}'] = slug
         params[f'r_n_{i}'] = name
         params[f'r_d_{i}'] = description
         params[f'r_p_{i}'] = priority
+        params[f'r_dflt_{i}'] = is_default
         for j, perm_name in enumerate(permission_names):
             grant_maps.append(
                 f'{{{{slug: {{r_s_{i}}}, perm: {{g_{i}_{j}}}}}}}'
@@ -536,6 +582,7 @@ async def seed_default_roles(db: graph.Graph) -> int:
         'SET r.name = role.name, '
         'r.description = role.description, '
         'r.priority = role.priority, '
+        'r.is_default = role.is_default, '
         'r.is_system = true '
         'WITH sum(CASE WHEN existing IS NULL THEN 1 ELSE 0 END) '
         'AS created '

--- a/src/imbi_api/auth/tokens.py
+++ b/src/imbi_api/auth/tokens.py
@@ -16,6 +16,7 @@ from imbi_common import graph
 from imbi_common.auth import core
 
 from imbi_api import settings
+from imbi_api.auth import membership
 
 LOGGER = logging.getLogger(__name__)
 
@@ -173,6 +174,17 @@ async def issue_token_pair(
             'issue_token_pair: no %s principal matched', principal_type
         )
         raise PrincipalNotFoundError(f'No {principal_type} found')
+
+    # Assign the seeded default role to users that have no organization
+    # membership yet. Best-effort: any failure here must not block
+    # token issuance, since the tokens have already been persisted.
+    if principal_type == 'user':
+        try:
+            await membership.ensure_user_membership(db, principal_id)
+        except Exception:
+            LOGGER.exception(
+                'ensure_user_membership failed during token issuance'
+            )
 
     return (
         access_token,

--- a/tests/auth/test_membership.py
+++ b/tests/auth/test_membership.py
@@ -1,0 +1,155 @@
+"""Tests for default-role auto-assignment on login."""
+
+import unittest
+from unittest import mock
+
+from imbi_api.auth import membership
+
+
+def _agtype_passthrough(value):
+    return value
+
+
+class EnsureUserMembershipTestCase(unittest.IsolatedAsyncioTestCase):
+    """Cover the decision branches of ensure_user_membership."""
+
+    async def test_assigns_when_no_membership_and_sole_org(self) -> None:
+        """User with no MEMBER_OF gets default role in the sole org."""
+        mock_db = mock.AsyncMock()
+        mock_db.execute.side_effect = [
+            [{'edges': 0}],
+            [{'slug': 'default'}],
+            [{'slugs': ['aweber']}],
+            [{'email': 'u@example.com'}],
+        ]
+
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=_agtype_passthrough,
+        ):
+            result = await membership.ensure_user_membership(
+                mock_db, 'u@example.com'
+            )
+
+        self.assertEqual(result, 'default')
+        # Verify the CREATE call used the sole org slug + default role
+        create_args = mock_db.execute.await_args_list[-1].args
+        self.assertEqual(
+            create_args[1],
+            {
+                'email': 'u@example.com',
+                'org_slug': 'aweber',
+                'role_slug': 'default',
+            },
+        )
+
+    async def test_prefers_default_org_when_multiple(self) -> None:
+        """With multiple orgs, the slug='default' org is chosen."""
+        mock_db = mock.AsyncMock()
+        mock_db.execute.side_effect = [
+            [{'edges': 0}],
+            [{'slug': 'default'}],
+            [{'slugs': ['aweber', 'default', 'other']}],
+            [{'email': 'u@example.com'}],
+        ]
+
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=_agtype_passthrough,
+        ):
+            result = await membership.ensure_user_membership(
+                mock_db, 'u@example.com'
+            )
+
+        self.assertEqual(result, 'default')
+        create_args = mock_db.execute.await_args_list[-1].args
+        self.assertEqual(create_args[1]['org_slug'], 'default')
+
+    async def test_skips_when_user_already_has_membership(self) -> None:
+        """User with any MEMBER_OF edge is left alone."""
+        mock_db = mock.AsyncMock()
+        mock_db.execute.side_effect = [[{'edges': 1}]]
+
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=_agtype_passthrough,
+        ):
+            result = await membership.ensure_user_membership(
+                mock_db, 'u@example.com'
+            )
+
+        self.assertIsNone(result)
+        self.assertEqual(mock_db.execute.await_count, 1)
+
+    async def test_skips_when_no_default_role(self) -> None:
+        """No is_default role -> no assignment, no exception."""
+        mock_db = mock.AsyncMock()
+        mock_db.execute.side_effect = [
+            [{'edges': 0}],
+            [],  # no default role row
+        ]
+
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=_agtype_passthrough,
+        ):
+            result = await membership.ensure_user_membership(
+                mock_db, 'u@example.com'
+            )
+
+        self.assertIsNone(result)
+
+    async def test_skips_when_multiple_orgs_and_no_default(self) -> None:
+        """Ambiguous orgs (>1 and none named 'default') -> skip."""
+        mock_db = mock.AsyncMock()
+        mock_db.execute.side_effect = [
+            [{'edges': 0}],
+            [{'slug': 'default'}],
+            [{'slugs': ['orgA', 'orgB']}],
+        ]
+
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=_agtype_passthrough,
+        ):
+            result = await membership.ensure_user_membership(
+                mock_db, 'u@example.com'
+            )
+
+        self.assertIsNone(result)
+        # The CREATE call must not have run
+        self.assertEqual(mock_db.execute.await_count, 3)
+
+    async def test_skips_when_no_orgs(self) -> None:
+        """No organizations at all -> skip."""
+        mock_db = mock.AsyncMock()
+        mock_db.execute.side_effect = [
+            [{'edges': 0}],
+            [{'slug': 'default'}],
+            [{'slugs': []}],
+        ]
+
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=_agtype_passthrough,
+        ):
+            result = await membership.ensure_user_membership(
+                mock_db, 'u@example.com'
+            )
+
+        self.assertIsNone(result)
+
+    async def test_skips_when_user_node_missing(self) -> None:
+        """Membership-count query empty -> skip without error."""
+        mock_db = mock.AsyncMock()
+        mock_db.execute.side_effect = [[]]
+
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=_agtype_passthrough,
+        ):
+            result = await membership.ensure_user_membership(
+                mock_db, 'u@example.com'
+            )
+
+        self.assertIsNone(result)

--- a/tests/auth/test_seed.py
+++ b/tests/auth/test_seed.py
@@ -89,7 +89,10 @@ class SeedDefaultRolesTestCase(unittest.IsolatedAsyncioTestCase):
     def test_default_roles_structure(self) -> None:
         """Verify default role definitions are well-formed."""
         role_slugs = {role[0] for role in seed.DEFAULT_ROLES}
-        self.assertEqual(role_slugs, {'admin', 'developer', 'readonly'})
+        self.assertEqual(
+            role_slugs,
+            {'admin', 'developer', 'default', 'readonly'},
+        )
 
         # Verify admin has all permissions
         admin_role = next(r for r in seed.DEFAULT_ROLES if r[0] == 'admin')
@@ -98,6 +101,16 @@ class SeedDefaultRolesTestCase(unittest.IsolatedAsyncioTestCase):
             len(admin_permissions),
             len(seed.STANDARD_PERMISSIONS),
         )
+
+    def test_exactly_one_role_is_default(self) -> None:
+        """Exactly one seeded role is the auto-assignment target."""
+        defaults = [r for r in seed.DEFAULT_ROLES if r[5]]
+        self.assertEqual(
+            len(defaults),
+            1,
+            'Exactly one DEFAULT_ROLES entry must set is_default=True',
+        )
+        self.assertEqual(defaults[0][0], 'default')
 
         # Verify developer has subset of permissions
         dev_role = next(r for r in seed.DEFAULT_ROLES if r[0] == 'developer')
@@ -185,7 +198,7 @@ class BootstrapAuthSystemTestCase(unittest.IsolatedAsyncioTestCase):
             ) as mock_perms,
             mock.patch(
                 'imbi_api.auth.seed.seed_default_roles',
-                return_value=3,
+                return_value=len(seed.DEFAULT_ROLES),
             ) as mock_roles,
         ):
             result = await seed.bootstrap_auth_system(mock_db)
@@ -199,7 +212,7 @@ class BootstrapAuthSystemTestCase(unittest.IsolatedAsyncioTestCase):
             result['permissions'],
             len(seed.STANDARD_PERMISSIONS),
         )
-        self.assertEqual(result['roles'], 3)
+        self.assertEqual(result['roles'], len(seed.DEFAULT_ROLES))
 
     async def test_bootstrap_auth_system_idempotent(self) -> None:
         """Bootstrap can be safely run multiple times."""

--- a/tests/endpoints/test_auth.py
+++ b/tests/endpoints/test_auth.py
@@ -727,8 +727,19 @@ class OAuthCallbackSuccessTestCase(unittest.TestCase):
 
         self.client = testclient.TestClient(self.test_app)
 
+        # Default-role auto-assignment is exercised separately in
+        # tests/auth/test_membership.py; patch it out here so its
+        # ``db.execute`` calls do not consume the tightly-sized
+        # ``side_effect`` lists each test below configures.
+        self._membership_patch = mock.patch(
+            'imbi_api.auth.tokens.membership.ensure_user_membership',
+            return_value=None,
+        )
+        self._membership_patch.start()
+
     def tearDown(self) -> None:
         """Reset settings singleton after tests."""
+        self._membership_patch.stop()
         settings._auth_settings = None
 
     @mock.patch.dict(


### PR DESCRIPTION
## Summary
- Adds an `is_default` flag on seeded `Role` nodes and a new seeded role `slug='default'` (priority 150) that carries a read-heavy baseline plus `me:identities:manage`. Exactly one seeded role is required to set `is_default=true`; enforced at module import.
- New `imbi_api.auth.membership.ensure_user_membership(db, email)` resolves the default role and a target organization (sole `Organization` if there is exactly one, else fall back to `slug='default'`, else log + skip) and creates a `MEMBER_OF {role: <slug>}` edge when the user has none.
- Wired into `tokens.issue_token_pair` for `principal_type='user'` so every successful access-token mint (password login, OAuth callback, identity-plugin login, refresh) is a self-healing checkpoint. Best-effort: failures inside the hook are caught and logged so a hiccup never fails an otherwise valid login.

## Why
- Without auto-assignment, a newly-provisioned user authenticates successfully but ends up with `permissions = set()` and is 403'd on every API call. We hit this in prod today.
- Putting the hook in the central token-issuance helper guarantees we cover **all** login paths from one place and gives subsequent logins a chance to recover from data drift, not just first-login.

## Notes for reviewers
- The OAuth callback success tests configured tight `db.execute.side_effect` lists. To keep them deterministic, `OAuthCallbackSuccessTestCase` now patches `ensure_user_membership` to a no-op for the duration of each test; behavior is covered separately in `tests/auth/test_membership.py`.
- The seeded `default` role's permissions are intentionally read-heavy (similar to `readonly` plus `me:identities:manage`) so auto-assignment is safe by default. Admins can grant elevated roles explicitly.
- For existing deployments whose default role is not seeded (e.g. AWeber prod, which currently has a hand-rolled `default` role), set the flag via Cypher:
  ```cypher
  MATCH (r:Role {slug: 'default'}) SET r.is_default = true;
  ```

## Test plan
- [x] `just lint`
- [x] `just test tests/auth/ tests/endpoints/test_auth.py` (221 passed)
- [ ] CI green
- [ ] After deploy, a new user can log in (password or OAuth) and immediately see `/api/organizations/` without 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)