### PR TITLE
Quiet /status with imbi_common access-log middleware

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
   "fastapi",
   "filetype",
   "httpx>=0.28.1,<1",
-  "imbi-common[databases,llm,server]>=0.8.4",
+  "imbi-common[databases,llm,server]>=0.8.5",
   "jinja2",
   "jsonpatch>=1.33",
   "nanoid>=2.0.0",

--- a/src/imbi_api/app.py
+++ b/src/imbi_api/app.py
@@ -3,7 +3,7 @@ import logging
 import fastapi
 from fastapi import responses
 from fastapi.middleware import cors
-from imbi_common import graph, lifespan, valkey
+from imbi_common import access_log, graph, lifespan, valkey
 from imbi_common.plugins.errors import PluginCredentialsMissing
 from uvicorn.middleware import proxy_headers
 
@@ -36,6 +36,13 @@ def create_app() -> fastapi.FastAPI:
     )
 
     server_config = settings.ServerConfig()
+    # Quiet both the unprefixed and ``/api``-prefixed status route
+    # because the served path depends on IMBI_API_URL at startup;
+    # listing both keeps the middleware deployment-agnostic.
+    app.add_middleware(
+        access_log.AccessLogMiddleware,
+        quiet_paths={'/status', '/api/status'},
+    )
     app.add_middleware(
         cors.CORSMiddleware,
         allow_origins=server_config.cors_allowed_origins,

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,8 +1,10 @@
 import os
+import typing
 import unittest
 import unittest.mock
 
 import fastapi
+from imbi_common import access_log
 
 from imbi_api import app, settings, version
 
@@ -37,6 +39,26 @@ class CreateAppTestCase(unittest.TestCase):
         """Test that the app has a lifespan context manager configured."""
         application = app.create_app()
         self.assertIsNotNone(application.router.lifespan_context)
+
+    def test_access_log_middleware_quiets_status_routes(self) -> None:
+        """``/status`` and ``/api/status`` are silenced on success."""
+        application = app.create_app()
+        access_log_mw = next(
+            (
+                mw
+                for mw in application.user_middleware
+                if mw.cls is access_log.AccessLogMiddleware
+            ),
+            None,
+        )
+        self.assertIsNotNone(
+            access_log_mw, 'AccessLogMiddleware was not installed'
+        )
+        assert access_log_mw is not None  # narrow for basedpyright
+        quiet_paths = typing.cast(
+            'set[str]', access_log_mw.kwargs['quiet_paths']
+        )
+        self.assertEqual(set(quiet_paths), {'/status', '/api/status'})
 
 
 class ApiPrefixTestCase(unittest.TestCase):

--- a/uv.lock
+++ b/uv.lock
@@ -6,9 +6,6 @@ resolution-markers = [
   "python_full_version < '3.15'",
 ]
 
-[options]
-prerelease-mode = "allow"
-
 [[package]]
 name = "aioboto3"
 version = "15.5.0"
@@ -1028,7 +1025,7 @@ requires-dist = [
   { name = "fastapi" },
   { name = "filetype" },
   { name = "httpx", specifier = ">=0.28.1,<1" },
-  { name = "imbi-common", extras = ["databases", "llm", "server"], specifier = ">=0.8.4" },
+  { name = "imbi-common", extras = ["databases", "llm", "server"], specifier = ">=0.8.5" },
   { name = "jinja2" },
   { name = "jsonpatch", specifier = ">=1.33" },
   { name = "nanoid", specifier = ">=2.0.0" },
@@ -1080,7 +1077,7 @@ plugins = [
 
 [[package]]
 name = "imbi-common"
-version = "0.8.4"
+version = "0.8.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
   { name = "cryptography" },
@@ -1094,9 +1091,9 @@ dependencies = [
   { name = "python-slugify" },
   { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/94/20/6b8de053fc25fa7b4905bd3b0e1ebd33fcf909f2f0e5a61cee4e2c29c824/imbi_common-0.8.4.tar.gz", hash = "sha256:549b1cf7eded303af16f17feac2bb1b9c10f8178016de742d78b629f1f1cb7b5", size = 245922, upload-time = "2026-05-10T19:34:17.874Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/1b/38e8b30ad0653f3cb8c2a73e48ddf0cbd81362d36fe6eef8c61dfd8e32d5/imbi_common-0.8.5.tar.gz", hash = "sha256:e3dff51d5d2fe01b66072e3c34317db04844a406a3745d4481bc2083b15a594a", size = 248174, upload-time = "2026-05-11T20:01:06.769Z" }
 wheels = [
-  { url = "https://files.pythonhosted.org/packages/ba/d5/746fd775d7f2cd093242a23b0c89bb74b83a6e7deb8f014c3bbb060653bd/imbi_common-0.8.4-py3-none-any.whl", hash = "sha256:8761545ab87a92b8ede814e2d6b139c70fdd4a8ea0269394128abc5fac381df1", size = 71887, upload-time = "2026-05-10T19:34:16.565Z" },
+  { url = "https://files.pythonhosted.org/packages/07/90/a95857698075fd59d5195d2de58910ddb9ce5802b29aec25a7dc585b9ac4/imbi_common-0.8.5-py3-none-any.whl", hash = "sha256:fc07e909369a6754e103a876252f0bc5696652c38e982227f7e38ab0f9a4f4fe", size = 73294, upload-time = "2026-05-11T20:01:05.51Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

Installs ``imbi_common.access_log.AccessLogMiddleware`` (new in
``imbi-common`` 0.8.5) so the high-frequency status endpoint
stops dominating the access log without hiding misconfiguration
failures.

## Problem

A health-check polling ``/api/status`` (or ``/status`` in the
no-prefix deployment) emits dozens of identical ``200`` access
records per minute. They drown out anything else worth looking
at, but simply silencing the route would also hide the case
where the status endpoint returns ``404`` because it isn't wired
up correctly.

## Solution

* Bump ``imbi-common[databases,llm,server]`` from ``>=0.8.4`` to
  ``>=0.8.5`` (via ``uv add``).
* In ``create_app`` install ``AccessLogMiddleware`` with
  ``quiet_paths={'/status', '/api/status'}``. Listing both forms
  keeps the wiring deployment-agnostic because the served path
  depends on ``IMBI_API_URL`` at startup.
* The middleware only suppresses access records when the
  response status is ``2xx``, so a ``404``/``500`` on the
  status endpoint still appears in the log.

## Test plan

- [x] ``just lint`` clean (ruff, tombi, mypy, basedpyright)
- [x] ``just test tests/test_app.py`` -- 9 pass, including new
      ``test_access_log_middleware_quiets_status_routes``
- [ ] Hit ``/status`` (or ``/api/status``) in a running ``just
      serve`` and confirm it no longer appears in the console
      access log; force a 404 on the same path and confirm it
      *does* appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)