### PR TITLE
Add project archive/unarchive endpoints

### DIFF
--- a/src/imbi_api/endpoints/projects.py
+++ b/src/imbi_api/endpoints/projects.py
@@ -135,6 +135,8 @@ class ProjectResponse(pydantic.BaseModel):
     icon: pydantic.HttpUrl | str | None = None
     created_at: datetime.datetime | None = None
     updated_at: datetime.datetime | None = None
+    archived: bool = False
+    archived_at: datetime.datetime | None = None
     team: models.Team
     project_types: list[models.ProjectType] = []
     environments: list[EnvironmentRef] = []
@@ -323,6 +325,8 @@ _RESERVED_FIELDS = frozenset(
         'environments',
         'created_at',
         'updated_at',
+        'archived',
+        'archived_at',
     }
 )
 
@@ -653,17 +657,28 @@ async def list_projects(
         ),
     ],
     project_type: str | None = None,
+    include_archived: bool = False,
 ) -> list[ProjectResponse]:
-    """List all projects, optionally filtered by type."""
+    """List projects in the organization.
+
+    By default archived projects are excluded.  Pass
+    ``include_archived=true`` to include them.
+    """
     type_filter: typing.LiteralString = (
         'MATCH (p)-[:TYPE]->(filter_pt:ProjectType {{slug: {project_type}}})'
         if project_type
         else ''
     )
+    archived_filter: typing.LiteralString = (
+        '' if include_archived else 'WHERE coalesce(p.archived, false) = false'
+    )
     query: typing.LiteralString = (
         """
     MATCH (p:Project)-[:OWNED_BY]->(:Team)
           -[:BELONGS_TO]->(o:Organization {{slug: {org_slug}}})
+    """
+        + archived_filter
+        + """
     WITH DISTINCT p, o
     """
         + type_filter
@@ -1595,6 +1610,90 @@ async def patch_project(
         patched,
     )
     return response
+
+
+async def _set_archived_state(
+    org_slug: str,
+    project_id: str,
+    archived: bool,
+    request: fastapi.Request,
+    db: graph.Pool,
+) -> ProjectResponse:
+    """Toggle archived state on a project and return the updated entity."""
+    now = datetime.datetime.now(datetime.UTC).isoformat()
+    archived_at: str | None = now if archived else None
+    query: typing.LiteralString = (
+        """
+    MATCH (p:Project {{id: {project_id}}})
+          -[:OWNED_BY]->(:Team)
+          -[:BELONGS_TO]->(o:Organization {{slug: {org_slug}}})
+    SET p.archived = {archived},
+        p.archived_at = {archived_at},
+        p.updated_at = {updated_at}
+    WITH DISTINCT p, o
+    """
+        + _RETURN_FRAGMENT
+    )
+    records = await db.execute(
+        query,
+        {
+            'project_id': project_id,
+            'org_slug': org_slug,
+            'archived': archived,
+            'archived_at': archived_at,
+            'updated_at': now,
+        },
+        ['project', 'outbound_count', 'inbound_count'],
+    )
+    if not records:
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail=f'Project {project_id!r} not found',
+        )
+    project_data = graph.parse_agtype(records[0]['project'])
+    _flatten_edge_props(project_data)
+    _attach_project_relationships(
+        project_data,
+        org_slug,
+        request,
+        graph.parse_agtype(records[0]['outbound_count']),
+        graph.parse_agtype(records[0]['inbound_count']),
+    )
+    return ProjectResponse.model_validate(project_data)
+
+
+@projects_router.post('/{project_id}/archive')
+async def archive_project(
+    org_slug: str,
+    project_id: str,
+    request: fastapi.Request,
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('project:write'),
+        ),
+    ],
+) -> ProjectResponse:
+    """Archive a project (soft-hide from default listings)."""
+    return await _set_archived_state(org_slug, project_id, True, request, db)
+
+
+@projects_router.post('/{project_id}/unarchive')
+async def unarchive_project(
+    org_slug: str,
+    project_id: str,
+    request: fastapi.Request,
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('project:write'),
+        ),
+    ],
+) -> ProjectResponse:
+    """Restore an archived project to the active state."""
+    return await _set_archived_state(org_slug, project_id, False, request, db)
 
 
 @projects_router.delete('/{project_id}', status_code=204)

--- a/tests/endpoints/test_projects.py
+++ b/tests/endpoints/test_projects.py
@@ -730,6 +730,118 @@ class ProjectEndpointsTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 404)
         self.assertIn('not found', response.json()['detail'])
 
+    # -- Archive -------------------------------------------------------
+
+    def test_archive_success(self) -> None:
+        """Archiving a project marks it archived and returns it."""
+        archived = self._project_data(
+            archived=True,
+            archived_at='2026-05-11T20:00:00Z',
+        )
+        self.mock_db.execute.return_value = [
+            {
+                'project': archived,
+                'outbound_count': 0,
+                'inbound_count': 0,
+            },
+        ]
+
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            response = self.client.post(
+                f'/organizations/engineering/projects/{PROJECT_ID}/archive',
+            )
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertTrue(data['archived'])
+        self.assertEqual(data['archived_at'], '2026-05-11T20:00:00Z')
+        call_kwargs = self.mock_db.execute.call_args
+        self.assertIs(call_kwargs.args[1]['archived'], True)
+        self.assertIsNotNone(call_kwargs.args[1]['archived_at'])
+
+    def test_archive_not_found(self) -> None:
+        """Archiving a missing project returns 404."""
+        self.mock_db.execute.return_value = []
+
+        response = self.client.post(
+            '/organizations/engineering/projects/nonexistent/archive',
+        )
+
+        self.assertEqual(response.status_code, 404)
+        self.assertIn('not found', response.json()['detail'])
+
+    def test_unarchive_success(self) -> None:
+        """Unarchiving a project clears archived state."""
+        restored = self._project_data(
+            archived=False,
+            archived_at=None,
+        )
+        self.mock_db.execute.return_value = [
+            {
+                'project': restored,
+                'outbound_count': 0,
+                'inbound_count': 0,
+            },
+        ]
+
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            response = self.client.post(
+                f'/organizations/engineering/projects/{PROJECT_ID}/unarchive',
+            )
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertFalse(data['archived'])
+        self.assertIsNone(data['archived_at'])
+        call_kwargs = self.mock_db.execute.call_args
+        self.assertIs(call_kwargs.args[1]['archived'], False)
+        self.assertIsNone(call_kwargs.args[1]['archived_at'])
+
+    def test_unarchive_not_found(self) -> None:
+        """Unarchiving a missing project returns 404."""
+        self.mock_db.execute.return_value = []
+
+        response = self.client.post(
+            '/organizations/engineering/projects/nonexistent/unarchive',
+        )
+
+        self.assertEqual(response.status_code, 404)
+        self.assertIn('not found', response.json()['detail'])
+
+    def test_list_excludes_archived_by_default(self) -> None:
+        """List query filters out archived projects by default."""
+        self.mock_db.execute.return_value = []
+
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            self.client.get('/organizations/engineering/projects/')
+
+        query = self.mock_db.execute.call_args.args[0]
+        self.assertIn('coalesce(p.archived, false) = false', query)
+
+    def test_list_include_archived(self) -> None:
+        """``include_archived=true`` drops the archive filter."""
+        self.mock_db.execute.return_value = []
+
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            self.client.get(
+                '/organizations/engineering/projects/?include_archived=true',
+            )
+
+        query = self.mock_db.execute.call_args.args[0]
+        self.assertNotIn('coalesce(p.archived, false)', query)
+
 
 class _RelationshipsTestBase(unittest.TestCase):
     """Shared setup for relationship endpoint tests."""


### PR DESCRIPTION
## Summary
- Adds `POST /api/organizations/{org}/projects/{id}/archive` and `/unarchive`. Both require `project:write` and return the updated `ProjectResponse`.
- `ProjectResponse` exposes `archived` (default `false`) and `archived_at`.
- `GET /api/organizations/{org}/projects/` now hides archived projects by default; opt in with `?include_archived=true`. Filter uses `coalesce(p.archived, false)` so existing nodes (no archived property) remain visible.
- `archived`/`archived_at` added to `_RESERVED_FIELDS` so JSON Patch on `/{project_id}` cannot mutate them — archive state changes go only through the dedicated endpoints.

## Test plan
- [x] `just lint` clean (ruff, mypy, basedpyright)
- [x] `just test tests/endpoints/test_projects.py` — 40 passed (new tests: archive success/404, unarchive success/404, list excludes archived by default, list with `include_archived=true` drops filter)
- [ ] Smoke against a live API: archive a project, confirm it disappears from the default list and reappears with `?include_archived=true`; unarchive and confirm it returns to the default list.