### PR TITLE
Persist surrogate id on ThirdPartyService and ServiceApplication nodes

### DIFF
--- a/src/imbi_api/endpoints/auth_providers.py
+++ b/src/imbi_api/endpoints/auth_providers.py
@@ -13,6 +13,7 @@ import logging
 import typing
 
 import fastapi
+import nanoid
 import psycopg
 import pydantic
 from imbi_common import graph
@@ -42,7 +43,7 @@ def _parse_json_field(value: typing.Any, default: typing.Any) -> typing.Any:
     if isinstance(value, str):
         try:
             return json.loads(value)
-        except (json.JSONDecodeError, TypeError):
+        except json.JSONDecodeError, TypeError:
             return default
     return value
 
@@ -385,6 +386,7 @@ async def create_auth_provider(
     # the OAuth app type so admins viewing the third-party-services
     # screen can recognize it.
     create_props: dict[str, typing.Any] = {
+        'id': nanoid.generate(),
         'slug': resolved_slug,
         'name': resolved_name,
         'description': data.description,
@@ -439,7 +441,8 @@ async def create_auth_provider(
         'MATCH (o:Organization {{slug: {org_slug}}})'
         ' MERGE (s:ThirdPartyService {{slug: {svc_slug}}})'
         ' -[:BELONGS_TO]->(o)'
-        ' SET s.name = COALESCE(s.name, {svc_name}),'
+        ' SET s.id = COALESCE(s.id, {svc_id}),'
+        ' s.name = COALESCE(s.name, {svc_name}),'
         ' s.vendor = COALESCE(s.vendor, {svc_vendor}),'
         " s.status = COALESCE(s.status, 'active'),"
         " s.identifiers = COALESCE(s.identifiers, '{{}}'),"
@@ -455,6 +458,7 @@ async def create_auth_provider(
             create_query,
             {
                 'svc_slug': resolved_service_slug,
+                'svc_id': nanoid.generate(),
                 'svc_name': service_label,
                 'svc_vendor': _OAUTH_APP_TYPE_LABELS[data.oauth_app_type],
                 'org_slug': resolved_org_slug,

--- a/src/imbi_api/endpoints/third_party_services.py
+++ b/src/imbi_api/endpoints/third_party_services.py
@@ -6,6 +6,7 @@ import logging
 import typing
 
 import fastapi
+import nanoid
 import psycopg
 import pydantic
 from imbi_common import graph
@@ -62,7 +63,7 @@ def _deserialize_json_fields(
         if isinstance(val, str):
             try:
                 obj[key] = json.loads(val)
-            except (json.JSONDecodeError, TypeError):
+            except json.JSONDecodeError, TypeError:
                 obj[key] = default
         elif val is None:
             obj[key] = default
@@ -137,6 +138,7 @@ async def create_third_party_service(
 
     """
     props = {
+        'id': nanoid.generate(),
         'name': data.name,
         'slug': data.slug,
         'description': data.description,
@@ -616,6 +618,7 @@ async def create_service_application(
     # Encrypt secrets
     encryptor = encryption.TokenEncryption.get_instance()
     props = data.model_dump(mode='json')
+    props['id'] = nanoid.generate()
     props['client_secret'] = encryptor.encrypt(data.client_secret)
     if props.get('webhook_secret') is not None:
         props['webhook_secret'] = encryptor.encrypt(
@@ -1071,7 +1074,7 @@ async def delete_service_application(
     if 'auth_providers:write' not in auth.permissions:
         try:
             existing = await _fetch_application(db, org_slug, slug, app_slug)
-        except (fastapi.HTTPException, KeyError):
+        except fastapi.HTTPException, KeyError:
             existing = None
         if existing and existing.get('usage') in ('login', 'both'):
             raise fastapi.HTTPException(

--- a/src/imbi_api/entrypoint.py
+++ b/src/imbi_api/entrypoint.py
@@ -2,6 +2,7 @@ import asyncio
 import datetime
 import getpass
 
+import nanoid
 import typer
 from imbi_common import clickhouse, graph, server
 
@@ -11,6 +12,108 @@ from imbi_api.auth import seed
 
 main = typer.Typer(no_args_is_help=True)
 main.command('serve')(server.bind_entrypoint('imbi_api.app:create_app'))
+
+
+@main.command('backfill-node-ids')
+def backfill_node_ids() -> None:
+    """Backfill ``id`` on graph nodes that were created without one.
+
+    Idempotent: only assigns ``id`` where it is currently NULL. Run once
+    against staging/production after deploying the create-path fix from
+    issue #291. Safe to re-run.
+    """
+    asyncio.run(_backfill_node_ids_async())
+
+
+async def _backfill_node_ids_async() -> None:
+    db = graph.Graph()
+    try:
+        await db.open()
+    except Exception as e:
+        typer.echo(f'✗ Failed to connect to PostgreSQL: {e}', err=True)
+        raise typer.Exit(code=1) from e
+
+    try:
+        tps_count = await _backfill_tps_ids(db)
+        typer.echo(
+            f'  ✓ ThirdPartyService: assigned id to {tps_count} node(s)'
+        )
+        app_count = await _backfill_service_application_ids(db)
+        typer.echo(
+            f'  ✓ ServiceApplication: assigned id to {app_count} node(s)'
+        )
+    finally:
+        await db.close()
+
+
+async def _backfill_tps_ids(db: graph.Graph) -> int:
+    """Assign a fresh nanoid to every ``ThirdPartyService`` missing one."""
+    query = (
+        'MATCH (s:ThirdPartyService)-[:BELONGS_TO]->(o:Organization)'
+        ' WHERE s.id IS NULL'
+        ' RETURN o.slug AS org_slug, s.slug AS slug'
+    )
+    records = await db.execute(query, {}, ['org_slug', 'slug'])
+    count = 0
+    for record in records:
+        org_slug = graph.parse_agtype(record['org_slug'])
+        slug = graph.parse_agtype(record['slug'])
+        update_query = (
+            'MATCH (s:ThirdPartyService {{slug: {slug}}})'
+            ' -[:BELONGS_TO]->(o:Organization {{slug: {org_slug}}})'
+            ' WHERE s.id IS NULL'
+            ' SET s.id = {new_id}'
+            ' RETURN s.id AS id'
+        )
+        await db.execute(
+            update_query,
+            {
+                'slug': slug,
+                'org_slug': org_slug,
+                'new_id': nanoid.generate(),
+            },
+            ['id'],
+        )
+        count += 1
+    return count
+
+
+async def _backfill_service_application_ids(db: graph.Graph) -> int:
+    """Assign a fresh nanoid to every ``ServiceApplication`` missing one."""
+    query = (
+        'MATCH (a:ServiceApplication)-[:REGISTERED_IN]'
+        '->(s:ThirdPartyService)-[:BELONGS_TO]->(o:Organization)'
+        ' WHERE a.id IS NULL'
+        ' RETURN o.slug AS org_slug,'
+        ' s.slug AS svc_slug, a.slug AS app_slug'
+    )
+    records = await db.execute(query, {}, ['org_slug', 'svc_slug', 'app_slug'])
+    count = 0
+    for record in records:
+        org_slug = graph.parse_agtype(record['org_slug'])
+        svc_slug = graph.parse_agtype(record['svc_slug'])
+        app_slug = graph.parse_agtype(record['app_slug'])
+        update_query = (
+            'MATCH (a:ServiceApplication {{slug: {app_slug}}})'
+            ' -[:REGISTERED_IN]->'
+            '(s:ThirdPartyService {{slug: {svc_slug}}})'
+            ' -[:BELONGS_TO]->(o:Organization {{slug: {org_slug}}})'
+            ' WHERE a.id IS NULL'
+            ' SET a.id = {new_id}'
+            ' RETURN a.id AS id'
+        )
+        await db.execute(
+            update_query,
+            {
+                'app_slug': app_slug,
+                'svc_slug': svc_slug,
+                'org_slug': org_slug,
+                'new_id': nanoid.generate(),
+            },
+            ['id'],
+        )
+        count += 1
+    return count
 
 
 @main.command()

--- a/src/imbi_api/entrypoint.py
+++ b/src/imbi_api/entrypoint.py
@@ -65,7 +65,7 @@ async def _backfill_tps_ids(db: graph.Graph) -> int:
             ' SET s.id = {new_id}'
             ' RETURN s.id AS id'
         )
-        await db.execute(
+        updated = await db.execute(
             update_query,
             {
                 'slug': slug,
@@ -74,7 +74,8 @@ async def _backfill_tps_ids(db: graph.Graph) -> int:
             },
             ['id'],
         )
-        count += 1
+        if updated:
+            count += 1
     return count
 
 
@@ -102,7 +103,7 @@ async def _backfill_service_application_ids(db: graph.Graph) -> int:
             ' SET a.id = {new_id}'
             ' RETURN a.id AS id'
         )
-        await db.execute(
+        updated = await db.execute(
             update_query,
             {
                 'app_slug': app_slug,
@@ -112,7 +113,8 @@ async def _backfill_service_application_ids(db: graph.Graph) -> int:
             },
             ['id'],
         )
-        count += 1
+        if updated:
+            count += 1
     return count
 
 

--- a/tests/endpoints/test_auth_providers.py
+++ b/tests/endpoints/test_auth_providers.py
@@ -248,6 +248,44 @@ class AuthProvidersEndpointTestCase(unittest.TestCase):
             )
         self.assertEqual(response.status_code, 201)
 
+    def test_create_persists_ids(self) -> None:
+        """CREATE supplies non-empty ids for both the synthetic
+        ThirdPartyService and the new ServiceApplication (#291)."""
+        new = _row('google', usage='login')
+        self.db.execute.side_effect = [
+            [],  # _FETCH_BY_SLUG initial check
+            [new],  # CREATE
+        ]
+        with (
+            _patch_encryptor(),
+            mock.patch(
+                'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+            ),
+        ):
+            response = self.client.post(
+                '/admin/auth-providers',
+                json={
+                    'org_slug': 'eng',
+                    'third_party_service_slug': 'svc',
+                    'slug': 'google',
+                    'name': 'Google',
+                    'oauth_app_type': 'google',
+                    'client_id': 'cid',
+                    'client_secret': 'shh',
+                },
+            )
+        self.assertEqual(response.status_code, 201)
+        create_call = self.db.execute.call_args_list[1]
+        params = create_call.args[1]
+        # ServiceApplication id (carried as ``id`` via create_props).
+        self.assertIn('id', params)
+        self.assertIsInstance(params['id'], str)
+        self.assertTrue(params['id'])
+        # Synthetic ThirdPartyService id (carried as ``svc_id``).
+        self.assertIn('svc_id', params)
+        self.assertIsInstance(params['svc_id'], str)
+        self.assertTrue(params['svc_id'])
+
     def test_create_promotes_existing_row(self) -> None:
         # Existing row → promote path: fetch returns row, SET, re-fetch.
         existing = _row('google', usage='integration')

--- a/tests/endpoints/test_third_party_services.py
+++ b/tests/endpoints/test_third_party_services.py
@@ -50,8 +50,8 @@ class ThirdPartyServiceEndpointsTestCase(unittest.TestCase):
         )
 
         self.mock_db = mock.AsyncMock(spec=graph.Graph)
-        self.test_app.dependency_overrides[graph._inject_graph] = (
-            lambda: self.mock_db
+        self.test_app.dependency_overrides[graph._inject_graph] = lambda: (
+            self.mock_db
         )
 
         self.client = testclient.TestClient(self.test_app)
@@ -119,6 +119,30 @@ class ThirdPartyServiceEndpointsTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 201)
         data = response.json()
         self.assertEqual(data['team']['slug'], 'backend')
+
+    def test_create_persists_id(self) -> None:
+        """The CREATE query must carry a non-empty surrogate id (#291)."""
+        self.mock_db.execute.return_value = [{'service': self.service_data}]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            response = self.client.post(
+                '/organizations/engineering/third-party-services/',
+                json={
+                    'name': 'Stripe',
+                    'slug': 'stripe',
+                    'vendor': 'Stripe Inc',
+                },
+            )
+
+        self.assertEqual(response.status_code, 201)
+        params = self.mock_db.execute.call_args.args[1]
+        self.assertIn('id', params)
+        self.assertIsInstance(params['id'], str)
+        self.assertTrue(params['id'])
+        query = self.mock_db.execute.call_args.args[0]
+        self.assertIn('id', query)
 
     def test_create_missing_vendor(self) -> None:
         response = self.client.post(
@@ -508,8 +532,8 @@ class ServiceWebhooksEndpointsTestCase(unittest.TestCase):
         )
 
         self.mock_db = mock.AsyncMock(spec=graph.Graph)
-        self.test_app.dependency_overrides[graph._inject_graph] = (
-            lambda: self.mock_db
+        self.test_app.dependency_overrides[graph._inject_graph] = lambda: (
+            self.mock_db
         )
 
         self.client = testclient.TestClient(self.test_app)
@@ -798,8 +822,8 @@ class ServiceApplicationEndpointsTestCase(unittest.TestCase):
         )
 
         self.mock_db = mock.AsyncMock(spec=graph.Graph)
-        self.test_app.dependency_overrides[graph._inject_graph] = (
-            lambda: self.mock_db
+        self.test_app.dependency_overrides[graph._inject_graph] = lambda: (
+            self.mock_db
         )
 
         self.client = testclient.TestClient(self.test_app)
@@ -932,6 +956,37 @@ class ServiceApplicationEndpointsTestCase(unittest.TestCase):
         data = response.json()
         self.assertEqual(data['slug'], 'my-app')
         self.assertNotIn('client_secret', data)
+
+    def test_create_application_persists_id(self) -> None:
+        """The CREATE query must carry a non-empty surrogate id (#291)."""
+        self.mock_db.execute.side_effect = [
+            [{'cnt': 0}],
+            [{'app': self.app_data}],
+        ]
+
+        with (
+            self._patch_encryption(),
+            mock.patch(
+                'imbi_common.graph.parse_agtype',
+                side_effect=lambda x: x,
+            ),
+        ):
+            response = self.client.post(
+                '/organizations/engineering'
+                '/third-party-services/stripe'
+                '/applications/',
+                json=self.app_create_json,
+            )
+
+        self.assertEqual(response.status_code, 201)
+        # Second execute call is the CREATE; first is the duplicate check.
+        create_call = self.mock_db.execute.call_args_list[1]
+        params = create_call.args[1]
+        self.assertIn('id', params)
+        self.assertIsInstance(params['id'], str)
+        self.assertTrue(params['id'])
+        query = create_call.args[0]
+        self.assertIn('id', query)
 
     def test_create_application_duplicate(self) -> None:
         self.mock_db.execute.return_value = [{'cnt': 1}]

--- a/tests/test_entrypoint.py
+++ b/tests/test_entrypoint.py
@@ -343,6 +343,31 @@ class BackfillNodeIdsTestCase(unittest.TestCase):
         self.assertTrue(sa_set_params['new_id'])
         self.assertEqual(sa_set_params['app_slug'], 'my-app')
 
+    def test_backfill_skips_updates_that_match_no_rows(self) -> None:
+        """When SET ... WHERE id IS NULL matches nothing, don't count it."""
+        self.mock_graph.execute.side_effect = [
+            # First SELECT: TPS missing id.
+            [{'org_slug': 'eng', 'slug': 'stripe'}],
+            # SET on the TPS returns no rows (e.g. concurrent backfill).
+            [],
+            # Second SELECT: ServiceApplication missing id.
+            [
+                {
+                    'org_slug': 'eng',
+                    'svc_slug': 'stripe',
+                    'app_slug': 'my-app',
+                }
+            ],
+            # SET on the ServiceApplication returns no rows.
+            [],
+        ]
+
+        result = self.runner.invoke(entrypoint.main, ['backfill-node-ids'])
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn('ThirdPartyService: assigned id to 0', result.output)
+        self.assertIn('ServiceApplication: assigned id to 0', result.output)
+
     def test_backfill_graph_connection_failure(self) -> None:
         """When the graph pool fails to open, exit non-zero."""
         self.mock_graph.open.side_effect = ConnectionError('refused')

--- a/tests/test_entrypoint.py
+++ b/tests/test_entrypoint.py
@@ -263,3 +263,93 @@ class SetupTestCase(unittest.TestCase):
         self.assertIn('Failed to set up ClickHouse schema', result.output)
         self.mock_graph.close.assert_awaited_once()
         self.mock_ch_close.assert_awaited_once()
+
+
+class BackfillNodeIdsTestCase(unittest.TestCase):
+    """Test cases for the ``backfill-node-ids`` command (#291).
+
+    Uses regular TestCase because the command calls asyncio.run() which
+    creates its own event loop.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.runner = typer.testing.CliRunner()
+
+        self.mock_graph = mock.MagicMock()
+        self.mock_graph.open = mock.AsyncMock()
+        self.mock_graph.close = mock.AsyncMock()
+        self.mock_graph.execute = mock.AsyncMock(return_value=[])
+        self.enterContext(
+            mock.patch.object(
+                entrypoint.graph,
+                'Graph',
+                return_value=self.mock_graph,
+            )
+        )
+        self.enterContext(
+            mock.patch.object(
+                entrypoint.graph,
+                'parse_agtype',
+                side_effect=lambda v: v,
+            )
+        )
+
+    def test_backfill_empty_database(self) -> None:
+        """No rows missing id → no SET queries are emitted."""
+        result = self.runner.invoke(entrypoint.main, ['backfill-node-ids'])
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn('ThirdPartyService: assigned id to 0', result.output)
+        self.assertIn('ServiceApplication: assigned id to 0', result.output)
+        # Only the two SELECTs (one per label); no UPDATEs.
+        self.assertEqual(self.mock_graph.execute.await_count, 2)
+        self.mock_graph.close.assert_awaited_once()
+
+    def test_backfill_assigns_ids(self) -> None:
+        """Each missing-id row triggers a SET query with a nanoid."""
+        self.mock_graph.execute.side_effect = [
+            # First SELECT: TPS missing id.
+            [{'org_slug': 'eng', 'slug': 'stripe'}],
+            # SET on the TPS.
+            [{'id': 'generated'}],
+            # Second SELECT: ServiceApplication missing id.
+            [
+                {
+                    'org_slug': 'eng',
+                    'svc_slug': 'stripe',
+                    'app_slug': 'my-app',
+                }
+            ],
+            # SET on the ServiceApplication.
+            [{'id': 'generated'}],
+        ]
+
+        result = self.runner.invoke(entrypoint.main, ['backfill-node-ids'])
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn('ThirdPartyService: assigned id to 1', result.output)
+        self.assertIn('ServiceApplication: assigned id to 1', result.output)
+        self.assertEqual(self.mock_graph.execute.await_count, 4)
+        # Verify the TPS SET carries a fresh id.
+        tps_set_params = self.mock_graph.execute.await_args_list[1].args[1]
+        self.assertIn('new_id', tps_set_params)
+        self.assertTrue(tps_set_params['new_id'])
+        self.assertEqual(tps_set_params['slug'], 'stripe')
+        self.assertEqual(tps_set_params['org_slug'], 'eng')
+        # Verify the SA SET carries a fresh id.
+        sa_set_params = self.mock_graph.execute.await_args_list[3].args[1]
+        self.assertIn('new_id', sa_set_params)
+        self.assertTrue(sa_set_params['new_id'])
+        self.assertEqual(sa_set_params['app_slug'], 'my-app')
+
+    def test_backfill_graph_connection_failure(self) -> None:
+        """When the graph pool fails to open, exit non-zero."""
+        self.mock_graph.open.side_effect = ConnectionError('refused')
+
+        result = self.runner.invoke(entrypoint.main, ['backfill-node-ids'])
+
+        self.assertEqual(result.exit_code, 1)
+        self.assertIn('Failed to connect to PostgreSQL', result.output)
+        # Should not have attempted any queries.
+        self.mock_graph.execute.assert_not_awaited()


### PR DESCRIPTION
## Summary

Fixes #291.

- `ThirdPartyService` / `ServiceApplication` create paths now stamp a `nanoid.generate()` `id` into the property map, so AGE nodes carry the surrogate key declared by `GraphModel`.
- Adds an idempotent `imbi-api backfill-node-ids` Typer command to repair rows persisted before this fix.

## Problem

`ThirdPartyService` and `ServiceApplication` inherit `id: str = pydantic.Field(default_factory=nanoid.generate)` from `GraphModel`, but the relevant endpoints built their Cypher `CREATE` directly from a `*Create` DTO (which has no `id` field) and never called `nanoid.generate()`. The pydantic default factory only fires when the model is *instantiated*, and that never happened on the write path — so the resulting AGE node had no `id` property.

`imbi-gateway`'s webhook notification handler relies on the `id` contract:

```python
records = await db.execute(
    'MATCH (p:Project)-[:EXISTS_IN {identifier: ...}]->'
    '(tps:ThirdPartyService {id: {tps_id}}) ...',
    {'tps_id': str(service['id'])},
)
```

Every webhook that passed filtering crashed with `KeyError: 'id'` because the projected `tps{.*}` dict did not contain it.

## Solution

Generate the surrogate id wherever Cypher `CREATE` is built directly from a DTO:

| Endpoint | Change |
| -- | -- |
| `endpoints/third_party_services.py::create_third_party_service` | Adds `'id': nanoid.generate()` to `props` |
| `endpoints/third_party_services.py::create_service_application` | Sets `props['id'] = nanoid.generate()` after `data.model_dump()` |
| `endpoints/auth_providers.py::create_auth_provider` | Stamps both the new `ServiceApplication` (`create_props['id']`) and the synthetic `ThirdPartyService` `MERGE` (`SET s.id = COALESCE(s.id, {svc_id})`) |

The synthetic `ThirdPartyService` `MERGE` uses `COALESCE` so existing rows keep whatever id they already have — same pattern used for `name`, `vendor`, `status`, etc.

A new `imbi-api backfill-node-ids` Typer command repairs existing rows by assigning a fresh nanoid to every `ThirdPartyService` and `ServiceApplication` with a null `id`. It is idempotent (only `NULL` ids are touched) so it can be run safely against staging and production, and re-run.

## Audit scope

I audited every endpoint that builds a Cypher `CREATE` from a `props` map. Only the files above were affected — peer create endpoints (`teams.py`, `environments.py`, `project_types.py`, `link_definitions.py`, `project_plugins.py`, `service_plugins.py`, `projects.py`, `webhooks.py`, `plugin_entities.py`, `releases.py`, `documents.py`, `tags.py`, `project_deployments.py`, `document_templates.py`, `project_configuration.py`) either instantiate the full Node model (so `default_factory=nanoid.generate` fires during `model_dump`) or explicitly call `nanoid.generate()` already.

## Test plan

- [ ] CI: `just lint` and `just test` pass on Python 3.14.
- [ ] New `test_create_persists_id` (TPS endpoint) confirms the CREATE params include a non-empty `id` and the query references `id`.
- [ ] New `test_create_application_persists_id` (ServiceApplication endpoint) does the same for the app CREATE.
- [ ] New `test_create_persists_ids` (auth providers) confirms both `id` (ServiceApplication) and `svc_id` (synthetic ThirdPartyService) are non-empty.
- [ ] New `BackfillNodeIdsTestCase` exercises the empty-DB, populated-DB, and graph-failure paths of `imbi-api backfill-node-ids`.
- [ ] Manual: after merge, run `imbi-api backfill-node-ids` against staging, then re-run to confirm idempotency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)