### PR TITLE
Fix DatatypeMismatch 500 on GET /users/{email}/activity

### DIFF
--- a/src/imbi_api/endpoints/user_activity.py
+++ b/src/imbi_api/endpoints/user_activity.py
@@ -908,6 +908,35 @@ _LABEL_TO_TYPE: dict[str, str] = {
     'conversation': 'Conversation',
 }
 
+# AGE requires the SQL ``AS (...)`` column list to match the Cypher
+# ``RETURN`` arity; otherwise psycopg raises ``DatatypeMismatch:
+# return row and column definition list do not match``.  Keep these
+# lists aligned with the ``RETURN`` clauses in
+# ``_GRAPH_ACTIVITY_QUERIES`` above.
+_GRAPH_ACTIVITY_COLUMNS: dict[str, list[str]] = {
+    'document': [
+        'id',
+        'ts',
+        'title',
+        'created_by',
+        'updated_by',
+        'project_id',
+        'project_slug',
+        'project_name',
+    ],
+    'release': [
+        'id',
+        'ts',
+        'version',
+        'title',
+        'project_id',
+        'project_slug',
+        'project_name',
+    ],
+    'upload': ['id', 'ts', 'filename'],
+    'conversation': ['id', 'ts', 'title'],
+}
+
 
 async def _graph_activity(
     db: graph.Graph,
@@ -925,6 +954,7 @@ async def _graph_activity(
             'before': before.isoformat(),
             'row_limit': limit,
         },
+        _GRAPH_ACTIVITY_COLUMNS[label],
     )
     out: list[ActivityRecord] = []
     for row in rows:

--- a/tests/endpoints/test_user_activity.py
+++ b/tests/endpoints/test_user_activity.py
@@ -408,6 +408,88 @@ class ActivityFeedTests(_Base):
         self.assertNotIn('rel="next"', link)
 
 
+class GraphActivityColumnsTests(unittest.TestCase):
+    """Cypher RETURN arity must match ``_GRAPH_ACTIVITY_COLUMNS``.
+
+    AGE requires the SQL ``AS (...)`` column list passed to ``cypher()``
+    to match the number of ``RETURN`` expressions, otherwise psycopg
+    raises ``DatatypeMismatch: return row and column definition list do
+    not match`` — which is what surfaced as a 500 on the
+    ``GET /users/{email}/activity`` endpoint.
+    """
+
+    @staticmethod
+    def _return_arity(template: str) -> int:
+        """Count comma-separated aliases in the Cypher RETURN clause."""
+        import re
+
+        upper = template.upper()
+        start = upper.index('RETURN')
+        tail = template[start + len('RETURN') :]
+        tail_upper = tail.upper()
+        stop = len(tail)
+        for kw in (' ORDER BY ', ' LIMIT ', ' WITH ', ' UNION '):
+            idx = tail_upper.find(kw)
+            if idx != -1 and idx < stop:
+                stop = idx
+        clause = tail[:stop]
+        flat = re.sub(r'\s+', ' ', clause).strip()
+        return len([p for p in flat.split(',') if p.strip()])
+
+    def test_columns_match_return_arity(self) -> None:
+        for label, template in user_activity._GRAPH_ACTIVITY_QUERIES.items():
+            with self.subTest(label=label):
+                arity = self._return_arity(template)
+                self.assertEqual(
+                    len(user_activity._GRAPH_ACTIVITY_COLUMNS[label]),
+                    arity,
+                    f'columns for {label!r} must match RETURN arity',
+                )
+
+
+class GraphActivityExecuteTests(_Base):
+    """``_graph_activity`` must pass a columns list matching the query."""
+
+    def test_execute_columns_match_per_label(self) -> None:
+        """Regression for the 500 on /users/{email}/activity.
+
+        AGE's ``cypher()`` wrapper requires an ``AS (...)`` column list
+        whose arity matches the Cypher ``RETURN`` clause; the bug was
+        that ``_graph_activity`` omitted the ``columns`` argument
+        entirely, so psycopg attempted a single-column unpack of an
+        N-column row and raised ``DatatypeMismatch``.
+        """
+        self._execute_returns(
+            [
+                [{'id': 'u1'}],  # _ensure_user_exists
+                [{'conn_subjects': [], 'oauth_subjects': []}],  # subjects
+                [],  # documents
+                [],  # releases
+                [],  # uploads
+                [],  # conversations
+            ]
+        )
+        self.mock_query.side_effect = [[], []]  # opslog, events
+        resp = self.client.get('/users/alice@example.com/activity')
+        self.assertEqual(resp.status_code, 200, resp.text)
+
+        # First two execute calls are _ensure_user_exists + subjects; the
+        # next four are the graph-activity legs in registration order.
+        graph_calls = self.mock_db.execute.await_args_list[2:6]
+        for call, label in zip(
+            graph_calls,
+            ('document', 'release', 'upload', 'conversation'),
+            strict=True,
+        ):
+            with self.subTest(label=label):
+                self.assertGreaterEqual(len(call.args), 3, call)
+                columns = call.args[2]
+                self.assertEqual(
+                    columns,
+                    user_activity._GRAPH_ACTIVITY_COLUMNS[label],
+                )
+
+
 class PermissionTests(unittest.TestCase):
     """Endpoints must require user:read."""
 


### PR DESCRIPTION
## Summary

Fixes a 500 on `GET /api/users/{email}/activity` caused by AGE returning multi-column rows that the wrapper SQL unpacked as a single column.

## Problem

`_graph_activity` in `src/imbi_api/endpoints/user_activity.py` invoked `db.execute(template, params)` without a `columns` argument:

```python
rows = await db.execute(
    template,
    {'email': email, 'before': before.isoformat(), 'row_limit': limit},
)
```

`graph.client.execute` defaults `columns` to `['n']` (the docstring: *"Defaults to ``['n']`` for single-column returns."*). For the document/release/upload/conversation queries the Cypher `RETURN` projects 8, 7, 3, and 3 expressions — so AGE rejected the mismatched `AS (...)` list:

```
psycopg.errors.DatatypeMismatch: return row and column definition list do not match
LINE 1: SELECT * FROM cypher('imbi', $$ ...
                      ^
```

Stack-trace from staging confirms it:

```
File "/app/lib/python3.14/site-packages/imbi_api/endpoints/user_activity.py", line 921, in _graph_activity
    rows = await db.execute(
File "/app/lib/python3.14/site-packages/imbi_common/graph/client.py", line 749, in _execute_on
    await cursor.execute(cypher_sql)
psycopg.errors.DatatypeMismatch: return row and column definition list do not match
```

Sibling helper `_graph_buckets` already passes its `columns=['ts']` correctly — `_graph_activity` was the outlier.

## Solution

- Define `_GRAPH_ACTIVITY_COLUMNS: dict[str, list[str]]` next to `_GRAPH_ACTIVITY_QUERIES`, with one list per label whose entries match the `AS <alias>` projections in the Cypher `RETURN` clause.
- Pass `_GRAPH_ACTIVITY_COLUMNS[label]` as the third positional argument to `db.execute`.

## Tests

Two regression tests in `tests/endpoints/test_user_activity.py`:

- `GraphActivityColumnsTests.test_columns_match_return_arity` — parses each query's `RETURN` clause and asserts its arity matches the columns list length, so future query edits can't silently drift.
- `GraphActivityExecuteTests.test_execute_columns_match_per_label` — drives the endpoint through the test client and asserts every graph leg call to `db.execute` carries the correct columns list.

Local run: `tests/endpoints/test_user_activity.py` — **23 passed, 8 subtests passed**.

## Test plan

- [ ] CI `just lint` and `just test` pass on Python 3.14.
- [ ] After merge & deploy, `GET /api/users/{email}/activity` returns 200 in staging.
- [ ] Manual smoke: a user with documents/releases/uploads/conversations sees them in the activity feed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)