### PR TITLE
Harden auth-provider write & lookup paths

### DIFF
--- a/src/imbi_api/auth/login_providers.py
+++ b/src/imbi_api/auth/login_providers.py
@@ -246,6 +246,19 @@ async def get_login_app(db: graph.Graph, slug: str) -> LoginApp | None:
     records = await db.execute(_GET_QUERY, {'slug': slug}, ['app', 'service'])
     if not records:
         return None
+    if len(records) > 1:
+        # AWeber-Imbi/imbi-api#254: ServiceApplication.slug is only
+        # unique within a parent service, but login resolution keys on
+        # slug alone. The write path now blocks new collisions; this
+        # branch catches pre-existing ones. Refuse to pick one
+        # arbitrarily — that would silently route through whichever IdP
+        # the graph happened to return first.
+        LOGGER.error(
+            'Multiple login-eligible ServiceApplications share slug %r; '
+            'refusing to resolve. Reconcile the duplicates manually.',
+            slug,
+        )
+        return None
     app = graph.parse_agtype(records[0]['app'])
     svc = graph.parse_agtype(records[0].get('service'))
     if not app.get('oauth_app_type'):

--- a/src/imbi_api/domain/models.py
+++ b/src/imbi_api/domain/models.py
@@ -88,9 +88,17 @@ class User(models.GraphModel):
 
 
 class OAuthIdentity(models.GraphModel):
-    """OAuth provider identity linked to a user."""
+    """OAuth provider identity linked to a user.
 
-    provider: typing.Literal['google', 'github', 'oidc']
+    Keyed by ``(provider_slug, provider_user_id)`` so two configured
+    IdPs of the same ``oauth_app_type`` (e.g. two OIDC issuers or two
+    GHE instances) cannot collide on ``provider_user_id`` when their
+    ``sub`` values happen to overlap. ``provider_slug`` is the
+    ``ServiceApplication.slug`` of the row that minted the identity.
+    See AWeber-Imbi/imbi-api#255.
+    """
+
+    provider_slug: str
     provider_user_id: str
     email: pydantic.EmailStr
     display_name: str

--- a/src/imbi_api/endpoints/auth.py
+++ b/src/imbi_api/endpoints/auth.py
@@ -901,10 +901,10 @@ async def oauth_callback(
         )
 
         # Get associated user — fetch via graph query keyed on the
-        # OAuthIdentity's oauth_app_type (stored in `provider`).
+        # OAuthIdentity's ServiceApplication slug (#255).
         user_q: typing.LiteralString = """
         MATCH (oi:OAuthIdentity {{
-            provider: {provider},
+            provider_slug: {provider_slug},
             provider_user_id: {provider_user_id}
         }})-[:OAUTH_IDENTITY]->(u:User)
         RETURN u
@@ -912,7 +912,7 @@ async def oauth_callback(
         user_records = await db.execute(
             user_q,
             {
-                'provider': oauth_identity.provider,
+                'provider_slug': oauth_identity.provider_slug,
                 'provider_user_id': profile['id'],
             },
             ['u'],
@@ -945,14 +945,14 @@ async def oauth_callback(
         # loaded via db.match the edge isn't populated.
         oauth_identity.last_used = now
         update_last_used: typing.LiteralString = (
-            'MATCH (oi:OAuthIdentity {{provider: {provider},'
+            'MATCH (oi:OAuthIdentity {{provider_slug: {provider_slug},'
             ' provider_user_id: {provider_user_id}}})'
             ' SET oi.last_used = {last_used}'
         )
         await db.execute(
             update_last_used,
             {
-                'provider': oauth_identity.provider,
+                'provider_slug': oauth_identity.provider_slug,
                 'provider_user_id': oauth_identity.provider_user_id,
                 'last_used': now.isoformat(),
             },
@@ -1150,11 +1150,13 @@ async def find_or_create_oauth_identity(
                 f' domains: ' + ', '.join(app.allowed_domains)
             )
 
-    # OAuthIdentity.provider stores the oauth_app_type, not the slug.
+    # OAuthIdentity is keyed on ``provider_slug`` (#255): two configured
+    # IdPs of the same ``oauth_app_type`` would otherwise collide on
+    # ``provider_user_id`` when their ``sub`` values overlap.
     identity_results = await db.match(
         models.OAuthIdentity,
         {
-            'provider': oauth_app_type,
+            'provider_slug': provider,
             'provider_user_id': profile['id'],
         },
     )
@@ -1175,7 +1177,7 @@ async def find_or_create_oauth_identity(
             datetime.UTC
         ) + datetime.timedelta(seconds=token_response.get('expires_in', 3600))
         update_tokens_query: typing.LiteralString = (
-            'MATCH (oi:OAuthIdentity {{provider: {provider},'
+            'MATCH (oi:OAuthIdentity {{provider_slug: {provider_slug},'
             ' provider_user_id: {provider_user_id}}})'
             ' SET oi.access_token = {access_token},'
             ' oi.refresh_token = {refresh_token},'
@@ -1184,7 +1186,7 @@ async def find_or_create_oauth_identity(
         await db.execute(
             update_tokens_query,
             {
-                'provider': oauth_app_type,
+                'provider_slug': provider,
                 'provider_user_id': profile['id'],
                 'access_token': identity.access_token,
                 'refresh_token': identity.refresh_token,
@@ -1252,14 +1254,8 @@ async def find_or_create_oauth_identity(
 
     # Create OAuth identity (Phase 5: with encrypted tokens)
     now = datetime.datetime.now(datetime.UTC)
-    # ``oauth_app_type`` is one of the legacy literals here — the
-    # identity-plugin path branched out in ``oauth_callback`` before
-    # reaching ``find_or_create_oauth_identity``.
-    legacy_provider = typing.cast(
-        typing.Literal['google', 'github', 'oidc'], oauth_app_type
-    )
     identity = models.OAuthIdentity(
-        provider=legacy_provider,
+        provider_slug=provider,
         provider_user_id=profile['id'],
         email=profile['email'],
         display_name=profile['name'],
@@ -1287,7 +1283,7 @@ async def find_or_create_oauth_identity(
     # Create relationship via Cypher
     rel_query: typing.LiteralString = """
     MATCH (oi:OAuthIdentity {{
-        provider: {provider},
+        provider_slug: {provider_slug},
         provider_user_id: {provider_user_id}
     }})
     MATCH (u:User {{email: {email}}})
@@ -1296,7 +1292,7 @@ async def find_or_create_oauth_identity(
     await db.execute(
         rel_query,
         {
-            'provider': oauth_app_type,
+            'provider_slug': provider,
             'provider_user_id': profile['id'],
             'email': user.email,
         },

--- a/src/imbi_api/endpoints/third_party_services.py
+++ b/src/imbi_api/endpoints/third_party_services.py
@@ -568,6 +568,54 @@ async def list_service_applications(
     return apps
 
 
+async def _ensure_login_slug_unique(
+    db: graph.Graph,
+    app_slug: str,
+    *,
+    exclude_org_slug: str | None = None,
+    exclude_service_slug: str | None = None,
+    exclude_app_slug: str | None = None,
+) -> None:
+    """Reject if another login-eligible ServiceApplication shares this slug.
+
+    ``ServiceApplication.slug`` is only unique within a parent service, but
+    login providers are resolved by slug alone in the OAuth start/callback
+    flow (``auth/login_providers.get_login_app``). Two ``usage IN ('login',
+    'both')`` rows under different parents would let one tenant clobber
+    another's login route. Enforce instance-wide uniqueness on the write
+    path. See AWeber-Imbi/imbi-api#254.
+
+    The optional ``exclude_*`` triple carves out the row being written so a
+    patch on the row itself does not collide with itself.
+    """
+    query: typing.LiteralString = (
+        'MATCH (a:ServiceApplication {{slug: {app_slug}}})'
+        '      -[:REGISTERED_IN]->(s:ThirdPartyService)'
+        '      -[:BELONGS_TO]->(o:Organization)'
+        " WHERE a.usage IN ['login', 'both']"
+        ' RETURN s.slug AS svc_slug, o.slug AS org_slug'
+    )
+    records = await db.execute(
+        query, {'app_slug': app_slug}, ['svc_slug', 'org_slug']
+    )
+    for record in records:
+        svc_slug = graph.parse_agtype(record['svc_slug'])
+        org_slug = graph.parse_agtype(record['org_slug'])
+        if (
+            org_slug == exclude_org_slug
+            and svc_slug == exclude_service_slug
+            and app_slug == exclude_app_slug
+        ):
+            continue
+        raise fastapi.HTTPException(
+            status_code=409,
+            detail=(
+                f'A login auth provider with slug {app_slug!r} already '
+                f'exists under {org_slug!r}/{svc_slug!r}'
+            ),
+        )
+
+
 @third_party_services_router.post(
     '/{slug}/applications/',
     status_code=201,
@@ -612,6 +660,9 @@ async def create_service_application(
                 f'Application {data.slug!r} already exists in service {slug!r}'
             ),
         )
+
+    if data.usage in ('login', 'both'):
+        await _ensure_login_slug_unique(db, data.slug)
 
     # Encrypt secrets
     encryptor = encryption.TokenEncryption.get_instance()
@@ -1000,6 +1051,15 @@ async def patch_service_application(
         new_usage=validated.usage,
     )
 
+    if validated.usage in ('login', 'both'):
+        await _ensure_login_slug_unique(
+            db,
+            validated.slug,
+            exclude_org_slug=org_slug,
+            exclude_service_slug=slug,
+            exclude_app_slug=app_slug,
+        )
+
     props = validated.model_dump(mode='json')
 
     graph_props = _serialize_json_fields(props, _APP_JSON_FIELDS)
@@ -1071,7 +1131,7 @@ async def delete_service_application(
     if 'auth_providers:write' not in auth.permissions:
         try:
             existing = await _fetch_application(db, org_slug, slug, app_slug)
-        except (fastapi.HTTPException, KeyError):
+        except fastapi.HTTPException:
             existing = None
         if existing and existing.get('usage') in ('login', 'both'):
             raise fastapi.HTTPException(

--- a/src/imbi_api/entrypoint.py
+++ b/src/imbi_api/entrypoint.py
@@ -1,6 +1,7 @@
 import asyncio
 import datetime
 import getpass
+import typing
 
 import typer
 from imbi_common import clickhouse, graph, server
@@ -148,6 +149,134 @@ async def _setup_async() -> None:
     finally:
         await db.close()
         await clickhouse.aclose()
+
+
+@main.command(name='migrate-oauth-identity')
+def migrate_oauth_identity() -> None:
+    """Backfill ``OAuthIdentity.provider_slug`` from the parent slug.
+
+    One-shot, idempotent migration introduced with AWeber-Imbi/imbi-api#255.
+    OAuth identities are now keyed on
+    ``(provider_slug, provider_user_id)`` instead of
+    ``(provider_type, provider_user_id)``. This walks every
+    ``OAuthIdentity`` node that still carries the legacy ``provider``
+    field and rewrites it to ``provider_slug`` by joining on the
+    ``ServiceApplication`` whose ``oauth_app_type`` matches the legacy
+    value.
+
+    Safe to re-run: rows already carrying ``provider_slug`` are left
+    untouched. The legacy unique index on ``(provider, provider_user_id)``
+    is dropped after the rewrite.
+    """
+    asyncio.run(_migrate_oauth_identity_async())
+
+
+async def _migrate_oauth_identity_async() -> None:
+    """Async body of ``migrate-oauth-identity``."""
+    db = graph.Graph()
+    try:
+        await db.open()
+    except Exception as e:
+        typer.echo(f'✗ Failed to connect to PostgreSQL: {e}', err=True)
+        raise typer.Exit(code=1) from e
+
+    try:
+        legacy_query = (
+            'MATCH (oi:OAuthIdentity) '
+            'WHERE oi.provider IS NOT NULL AND oi.provider_slug IS NULL '
+            'RETURN oi.provider AS provider, '
+            'oi.provider_user_id AS provider_user_id'
+        )
+        legacy_records = await db.execute(
+            legacy_query, columns=['provider', 'provider_user_id']
+        )
+        if not legacy_records:
+            typer.echo('No legacy OAuthIdentity rows found — nothing to do.')
+        else:
+            typer.echo(
+                f'Found {len(legacy_records)} legacy OAuthIdentity row(s)'
+            )
+            migrated, skipped = await _backfill_provider_slugs(
+                db, legacy_records
+            )
+            typer.echo(f'Migrated {migrated} row(s); skipped {skipped} row(s)')
+            if skipped:
+                typer.echo(
+                    'Skipped rows were left untouched. Re-run after '
+                    'configuring the missing ServiceApplications.',
+                    err=True,
+                )
+
+        # Drop the legacy unique index. ``IF EXISTS`` keeps re-runs idempotent
+        # once the new ``(provider_slug, provider_user_id)`` index has
+        # replaced it via the next initializer pass.
+        await db.execute(
+            'DROP INDEX IF EXISTS '
+            'imbi.oauthidentity_provider_provider_user_id_unique_idx'
+        )
+        typer.echo('✓ Migration complete')
+    finally:
+        await db.close()
+
+
+async def _backfill_provider_slugs(
+    db: graph.Graph,
+    legacy_records: list[dict[str, typing.Any]],
+) -> tuple[int, int]:
+    """Rewrite ``OAuthIdentity.provider`` to ``provider_slug``.
+
+    Returns ``(migrated, skipped)`` counts.
+    """
+    migrated = 0
+    skipped = 0
+    for record in legacy_records:
+        legacy_provider = graph.parse_agtype(record['provider'])
+        provider_user_id = graph.parse_agtype(record['provider_user_id'])
+        slug_records = await db.execute(
+            'MATCH (a:ServiceApplication) '
+            'WHERE a.oauth_app_type = {oauth_app_type} '
+            "AND a.usage IN ['login', 'both'] "
+            'RETURN a.slug AS slug',
+            {'oauth_app_type': legacy_provider},
+            ['slug'],
+        )
+        if not slug_records:
+            typer.echo(
+                f'  ! No login ServiceApplication for oauth_app_type='
+                f'{legacy_provider!r}; '
+                f'provider_user_id={provider_user_id!r} left untouched',
+                err=True,
+            )
+            skipped += 1
+            continue
+        if len(slug_records) > 1:
+            typer.echo(
+                f'  ! Multiple login ServiceApplications for oauth_app_type='
+                f'{legacy_provider!r}; '
+                f'provider_user_id={provider_user_id!r} cannot be migrated '
+                f'unambiguously',
+                err=True,
+            )
+            skipped += 1
+            continue
+        new_slug = graph.parse_agtype(slug_records[0]['slug'])
+        await db.execute(
+            'MATCH (oi:OAuthIdentity {{provider: {legacy_provider}, '
+            'provider_user_id: {provider_user_id}}}) '
+            'SET oi.provider_slug = {new_slug} '
+            'REMOVE oi.provider',
+            {
+                'legacy_provider': legacy_provider,
+                'provider_user_id': provider_user_id,
+                'new_slug': new_slug,
+            },
+        )
+        typer.echo(
+            f'  ✓ provider_user_id={provider_user_id!r}: '
+            f'{legacy_provider!r} → {new_slug!r}'
+        )
+        migrated += 1
+    return migrated, skipped
 
 
 async def _check_admin_exists(db: graph.Graph) -> bool:

--- a/tests/auth/test_login_providers.py
+++ b/tests/auth/test_login_providers.py
@@ -148,6 +148,35 @@ class LoginProvidersRepoTestCase(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(row.oauth_app_type, 'google')
         self.assertEqual(row.token_endpoint, 'https://auth/token')
 
+    async def test_get_login_app_refuses_on_duplicate_slug(self) -> None:
+        """When two login rows share a slug, ``get_login_app`` returns None.
+
+        The write path now blocks new collisions, but pre-existing
+        duplicates can still exist in deployed instances. Picking one
+        arbitrarily would silently route through whichever IdP the
+        graph happened to return first. See AWeber-Imbi/imbi-api#254.
+        """
+        db = _FakeDB(
+            [
+                _row('google', oauth_app_type='google'),
+                _row('google', oauth_app_type='google', name='Other'),
+            ]
+        )
+        with (
+            mock.patch(
+                'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+            ),
+            self.assertLogs(
+                'imbi_api.auth.login_providers', level='ERROR'
+            ) as logs,
+        ):
+            row = await login_providers.get_login_app(db, 'google')  # type: ignore[arg-type]
+        self.assertIsNone(row)
+        self.assertTrue(
+            any('share slug' in m for m in logs.output),
+            f'Expected duplicate-slug error in logs, got {logs.output!r}',
+        )
+
     async def test_cache_invalidation(self) -> None:
         db = _FakeDB([_row('google')])
         with mock.patch(

--- a/tests/endpoints/test_auth.py
+++ b/tests/endpoints/test_auth.py
@@ -773,7 +773,7 @@ class OAuthCallbackSuccessTestCase(unittest.TestCase):
         )
 
         test_identity = models.OAuthIdentity(
-            provider='google',
+            provider_slug='google',
             provider_user_id='google-123',
             email='test@example.com',
             display_name='Test User',

--- a/tests/endpoints/test_third_party_services.py
+++ b/tests/endpoints/test_third_party_services.py
@@ -1043,6 +1043,69 @@ class ServiceApplicationEndpointsTestCase(unittest.TestCase):
         self.assertNotIn('private_key', data)
         self.assertNotIn('signing_secret', data)
 
+    def test_create_login_application_slug_collides_across_instance(
+        self,
+    ) -> None:
+        """A login app whose slug already names another login app — under a
+        different parent service — is rejected with 409.
+
+        Login providers are resolved by ``ServiceApplication.slug`` alone in
+        the OAuth start/callback flow, so cross-instance uniqueness must be
+        enforced at the write boundary. See AWeber-Imbi/imbi-api#254.
+        """
+        payload = {
+            **self.app_create_json,
+            'usage': 'login',
+            'oauth_app_type': 'google',
+        }
+        # 1) per-(org, svc) duplicate check → 0
+        # 2) cross-instance login-slug check → returns a colliding row
+        self.mock_db.execute.side_effect = [
+            [{'cnt': 0}],
+            [{'svc_slug': 'other-svc', 'org_slug': 'other-org'}],
+        ]
+        with (
+            self._patch_encryption(),
+            mock.patch(
+                'imbi_common.graph.parse_agtype',
+                side_effect=lambda x: x,
+            ),
+        ):
+            response = self.client.post(
+                '/organizations/engineering'
+                '/third-party-services/stripe'
+                '/applications/',
+                json=payload,
+            )
+        self.assertEqual(response.status_code, 409)
+        self.assertIn('login auth provider', response.json()['detail'])
+
+    def test_create_integration_application_skips_login_slug_check(
+        self,
+    ) -> None:
+        """An ``integration``-usage app does not run the cross-instance
+        login-slug check — that check only applies to login providers.
+        """
+        # Only the per-(org, svc) duplicate check + the create itself.
+        self.mock_db.execute.side_effect = [
+            [{'cnt': 0}],
+            [{'app': self.app_data}],
+        ]
+        with (
+            self._patch_encryption(),
+            mock.patch(
+                'imbi_common.graph.parse_agtype',
+                side_effect=lambda x: x,
+            ),
+        ):
+            response = self.client.post(
+                '/organizations/engineering'
+                '/third-party-services/stripe'
+                '/applications/',
+                json=self.app_create_json,
+            )
+        self.assertEqual(response.status_code, 201)
+
     # -- Get application --
 
     def test_get_application(self) -> None:
@@ -1153,6 +1216,10 @@ class ServiceApplicationEndpointsTestCase(unittest.TestCase):
     # -- Delete application --
 
     def test_delete_application(self) -> None:
+        # Grant auth_providers:write so the handler skips the login-gate
+        # pre-fetch and hits only the delete query — keeps this fixture
+        # minimal and matches the skip-prefetch branch in the handler.
+        self.auth_context.permissions.add('auth_providers:write')
         self.mock_db.execute.return_value = [{'deleted': 1}]
         response = self.client.delete(
             '/organizations/engineering'
@@ -1163,6 +1230,7 @@ class ServiceApplicationEndpointsTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 204)
 
     def test_delete_application_not_found(self) -> None:
+        self.auth_context.permissions.add('auth_providers:write')
         self.mock_db.execute.return_value = [{'deleted': 0}]
         response = self.client.delete(
             '/organizations/engineering'
@@ -1390,6 +1458,78 @@ class ServiceApplicationEndpointsTestCase(unittest.TestCase):
             )
         self.assertEqual(response.status_code, 403)
         self.assertIn('auth_providers:write', response.json()['detail'])
+
+    def test_patch_promotion_to_login_rejected_on_slug_collision(
+        self,
+    ) -> None:
+        """Promoting an integration app to a login provider while another
+        login app already owns the slug is rejected with 409.
+
+        See AWeber-Imbi/imbi-api#254 — login providers are resolved by
+        slug alone, so cross-instance uniqueness must be enforced.
+        """
+        self.auth_context.permissions.add('auth_providers:write')
+        existing = dict(self.app_data)
+        existing['usage'] = 'integration'
+        existing['oauth_app_type'] = 'google'
+        # 1) _fetch_application → returns the existing integration row
+        # 2) cross-instance login-slug check → finds a collision
+        self.mock_db.execute.side_effect = [
+            [{'app': existing}],
+            [{'svc_slug': 'other-svc', 'org_slug': 'other-org'}],
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            response = self.client.patch(
+                '/organizations/engineering'
+                '/third-party-services/stripe'
+                '/applications/my-app',
+                json=[
+                    {'op': 'replace', 'path': '/usage', 'value': 'login'},
+                ],
+            )
+        self.assertEqual(response.status_code, 409)
+        self.assertIn('login auth provider', response.json()['detail'])
+
+    def test_patch_login_app_self_excluded_from_collision_check(
+        self,
+    ) -> None:
+        """A PATCH on an existing login app does not collide with itself.
+
+        The cross-instance check carves out the triple (org, svc, app) of
+        the row being written, so re-saving the row succeeds.
+        """
+        self.auth_context.permissions.add('auth_providers:write')
+        existing = dict(self.app_data)
+        existing['usage'] = 'login'
+        existing['oauth_app_type'] = 'google'
+        # 1) _fetch_application → the existing login row
+        # 2) cross-instance check → returns only self (excluded)
+        # 3) update_query → returns the updated row
+        self.mock_db.execute.side_effect = [
+            [{'app': existing}],
+            [{'svc_slug': 'stripe', 'org_slug': 'engineering'}],
+            [{'app': existing}],
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            response = self.client.patch(
+                '/organizations/engineering'
+                '/third-party-services/stripe'
+                '/applications/my-app',
+                json=[
+                    {
+                        'op': 'replace',
+                        'path': '/name',
+                        'value': 'Renamed App',
+                    },
+                ],
+            )
+        self.assertEqual(response.status_code, 200)
 
     def test_patch_application_slug_conflict(self) -> None:
         """Slug rename that collides returns 409."""


### PR DESCRIPTION
## Summary

Three related fixes around login-eligible `ServiceApplication` rows and their `OAuthIdentity` children. The changes sit on overlapping files so they're bundled here; each closes a separate tracked issue.

Closes #257, #254, #255.

## #257 — Narrow `delete_service_application` exception catch

The login-gate pre-fetch caught `KeyError` along with `HTTPException`, which silently relabeled real graph-shape bugs as "no existing row." Drop `KeyError` from the catch. The two delete-application tests that hit that path now add `auth_providers:write` to skip the pre-fetch — matching the intentional skip-prefetch branch already documented in the handler.

## #254 — Login-provider slug uniqueness

`ServiceApplication.slug` is only unique within a parent service, but `auth/login_providers.get_login_app` resolves the OAuth start/callback flow by slug alone. Two `usage IN ('login','both')` rows under different parents would let one tenant clobber another's login route.

- Add `_ensure_login_slug_unique` and call it from `create_service_application` and the PATCH path on rows whose resulting usage is login-eligible.
- The `exclude_*` triple carves out the row being written so a self-patch doesn't collide with itself.
- Defensive read-side guard: `get_login_app` logs an error and returns `None` when multiple login rows share a slug, so any pre-existing duplicates fail closed instead of routing arbitrarily.

## #255 — Key `OAuthIdentity` on `provider_slug`

`OAuthIdentity` was keyed on `(provider_type, provider_user_id)`. With arbitrary OIDC issuers admin-configurable, two configured IdPs of the same `oauth_app_type` could collide on `provider_user_id` when their `sub` values overlap.

- Rename `OAuthIdentity.provider` → `provider_slug` (the parent `ServiceApplication.slug`).
- Update every Cypher match (oauth_callback user lookup, last_used bump, token rotation, identity create + relationship MERGE) to key on `provider_slug`.
- Add `imbi-api migrate-oauth-identity` Typer command: idempotent one-shot that joins each legacy `OAuthIdentity.provider` to the matching `ServiceApplication.slug` and drops the old `(provider, provider_user_id)` unique index.

Companion change: [AWeber-Imbi/imbi-common#95](https://github.com/AWeber-Imbi/imbi-common/pull/95) updates the unique vlabel index in `schemata.toml`.

## Operator notes

After merging both PRs and bumping `imbi-common`:

```
uv run imbi-api migrate-oauth-identity
```

Idempotent — safe to re-run. Reports per-row status and exits 0 when complete.

## Test plan

- [x] `just lint` clean (ruff, mypy, basedpyright)
- [x] Full `just test` suite: 1488 passed, 1 skipped
- [x] New tests for #254 (5) and the defensive read-side guard (1)
- [x] Existing OAuthIdentity test fixture updated to `provider_slug`
- [ ] On a v2 deployment: confirm `migrate-oauth-identity` runs cleanly against rows with the legacy `provider` field
- [ ] On a v2 deployment: confirm OAuth login round-trips via Google/GitHub after the rewrite