### PR TITLE
Add plugin_slug to OperationLogResponse

### DIFF
--- a/src/imbi_api/endpoints/operations_log.py
+++ b/src/imbi_api/endpoints/operations_log.py
@@ -99,6 +99,7 @@ class OperationLogResponse(pydantic.BaseModel):
     notes: str | None = None
     ticket_slug: str | None = None
     version: str | None = None
+    plugin_slug: str = ''
 
 
 def _encode_cursor(occurred_at: datetime.datetime, entry_id: str) -> str:


### PR DESCRIPTION
## Summary
- Expose the existing ClickHouse `plugin_slug` column on `OperationLogResponse` so UI clients can render plugin attribution alongside operations log entries.
- Defaults to `''` to mirror the ClickHouse column default (`LowCardinality(String) DEFAULT ''`).

## Problem
The UI is adding client-side rendering for operations log entries that need to attribute a plugin to each row. The `plugin_slug` column already exists in the `operations_log` ClickHouse table and rows are selected via `SELECT *`, but the public Pydantic response model was stripping the field before it reached clients.

## Solution
Add `plugin_slug: str = ''` to `OperationLogResponse`. No query, ingestion, or migration changes are required — existing rows already round-trip the value (or the empty default) through ClickHouse.

## Test plan
- [ ] `just lint`
- [ ] `just test`