### PR TITLE
Persist plugin_slug on operations_log audit writes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
   "fastapi",
   "filetype",
   "httpx>=0.28.1,<1",
-  "imbi-common[databases,llm,server]>=0.8.5",
+  "imbi-common[databases,llm,server]>=0.10.1",
   "jinja2",
   "jsonpatch>=1.33",
   "nanoid>=2.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
   "fastapi",
   "filetype",
   "httpx>=0.28.1,<1",
-  "imbi-common[databases,llm,server]>=0.10.1",
+  "imbi-common[databases,llm,server]>=0.10.2",
   "jinja2",
   "jsonpatch>=1.33",
   "nanoid>=2.0.0",

--- a/src/imbi_api/endpoints/project_configuration.py
+++ b/src/imbi_api/endpoints/project_configuration.py
@@ -398,6 +398,7 @@ async def _write_audit(
         environment_slug=environment_slug,
         entry_type='Configured',
         description=description,
+        plugin_slug=plugin_slug,
     )
     row = entry.model_dump(by_alias=True, mode='python')
     row['is_deleted'] = 1 if entry.is_deleted else 0

--- a/src/imbi_api/endpoints/project_deployments.py
+++ b/src/imbi_api/endpoints/project_deployments.py
@@ -305,6 +305,7 @@ async def _record_deployment_audit(
         description=description,
         link=run_url,
         version=version,
+        plugin_slug=plugin_slug,
     )
     row = entry.model_dump(by_alias=True, mode='python')
     row['is_deleted'] = 1 if entry.is_deleted else 0

--- a/tests/endpoints/test_project_configuration.py
+++ b/tests/endpoints/test_project_configuration.py
@@ -232,7 +232,7 @@ class ProjectConfigurationEndpointTestCase(unittest.TestCase):
         try:
             rows: list[dict[str, typing.Any]] = await ch.query(
                 'SELECT id, project_id, project_slug, environment_slug,'
-                ' entry_type, description, recorded_by'
+                ' entry_type, description, recorded_by, plugin_slug'
                 ' FROM operations_log FINAL'
                 ' WHERE project_id = {pid:String}'
                 '   AND recorded_at >= {after:DateTime64(3)}'

--- a/tests/endpoints/test_project_configuration.py
+++ b/tests/endpoints/test_project_configuration.py
@@ -162,8 +162,8 @@ class ProjectConfigurationEndpointTestCase(unittest.TestCase):
         # Default: project-slug lookup returns no rows → audit writes
         # use empty project_slug. Tests that care can override.
         self.mock_db.execute.return_value = []
-        self.test_app.dependency_overrides[graph._inject_graph] = (
-            lambda: self.mock_db
+        self.test_app.dependency_overrides[graph._inject_graph] = lambda: (
+            self.mock_db
         )
 
         self.plugin_id = f'p-{_short_id()}'
@@ -477,6 +477,7 @@ class ProjectConfigurationEndpointTestCase(unittest.TestCase):
         self.assertEqual(row['environment_slug'], 'production')
         self.assertEqual(row['entry_type'], 'Configured')
         self.assertEqual(row['recorded_by'], 'admin@example.com')
+        self.assertEqual(row['plugin_slug'], 'ssm')
         description = json.loads(row['description'])
         self.assertEqual(description['action'], 'set_value')
         self.assertEqual(description['plugin_slug'], 'ssm')

--- a/tests/endpoints/test_project_deployments.py
+++ b/tests/endpoints/test_project_deployments.py
@@ -708,6 +708,7 @@ class ProjectDeploymentsTestCase(unittest.TestCase):
         self.assertEqual(row['environment_slug'], 'testing')
         self.assertEqual(row['link'], 'https://gh/runs/42')
         self.assertEqual(row['version'], 'main')
+        self.assertEqual(row['plugin_slug'], 'github-deployment')
 
     def test_promote_writes_operations_log_audit(self) -> None:
         self.mocks['append_deployment_event'].return_value = mock.Mock()
@@ -732,6 +733,7 @@ class ProjectDeploymentsTestCase(unittest.TestCase):
         self.assertEqual(row['entry_type'], 'Deployed')
         self.assertEqual(row['environment_slug'], 'staging')
         self.assertEqual(row['version'], 'v6.4.0')
+        self.assertEqual(row['plugin_slug'], 'github-deployment')
 
 
 class FallbackNotesTestCase(unittest.TestCase):

--- a/uv.lock
+++ b/uv.lock
@@ -951,7 +951,7 @@ wheels = [
 
 [[package]]
 name = "imbi-api"
-version = "2.0.1"
+version = "2.0.7"
 source = { editable = "." }
 dependencies = [
   { name = "aioboto3" },
@@ -1025,7 +1025,7 @@ requires-dist = [
   { name = "fastapi" },
   { name = "filetype" },
   { name = "httpx", specifier = ">=0.28.1,<1" },
-  { name = "imbi-common", extras = ["databases", "llm", "server"], specifier = ">=0.8.5" },
+  { name = "imbi-common", extras = ["databases", "llm", "server"], specifier = ">=0.10.1" },
   { name = "jinja2" },
   { name = "jsonpatch", specifier = ">=1.33" },
   { name = "nanoid", specifier = ">=2.0.0" },
@@ -1077,7 +1077,7 @@ plugins = [
 
 [[package]]
 name = "imbi-common"
-version = "0.8.5"
+version = "0.10.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
   { name = "cryptography" },
@@ -1091,9 +1091,9 @@ dependencies = [
   { name = "python-slugify" },
   { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/43/1b/38e8b30ad0653f3cb8c2a73e48ddf0cbd81362d36fe6eef8c61dfd8e32d5/imbi_common-0.8.5.tar.gz", hash = "sha256:e3dff51d5d2fe01b66072e3c34317db04844a406a3745d4481bc2083b15a594a", size = 248174, upload-time = "2026-05-11T20:01:06.769Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/19/bf584f52cc7558c6ce4c6f6afb0b8ce712673f97dac057a8eb28f49c317a/imbi_common-0.10.1.tar.gz", hash = "sha256:abf8aae5e729f2ad37d2db4afba16ca16e534070e1228c25dce553c3852fde62", size = 250550, upload-time = "2026-05-12T16:26:40.198Z" }
 wheels = [
-  { url = "https://files.pythonhosted.org/packages/07/90/a95857698075fd59d5195d2de58910ddb9ce5802b29aec25a7dc585b9ac4/imbi_common-0.8.5-py3-none-any.whl", hash = "sha256:fc07e909369a6754e103a876252f0bc5696652c38e982227f7e38ab0f9a4f4fe", size = 73294, upload-time = "2026-05-11T20:01:05.51Z" },
+  { url = "https://files.pythonhosted.org/packages/ec/a6/3a743dd38166d9f4813b994fa06c96fb04a98b862e597f41ba49d737bdf5/imbi_common-0.10.1-py3-none-any.whl", hash = "sha256:f40f4417fe9b39accd612a8098e235dbb2200bd7e86fc6a1dc220ffdbed0290b", size = 74888, upload-time = "2026-05-12T16:26:38.45Z" },
 ]
 
 [package.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -1025,7 +1025,7 @@ requires-dist = [
   { name = "fastapi" },
   { name = "filetype" },
   { name = "httpx", specifier = ">=0.28.1,<1" },
-  { name = "imbi-common", extras = ["databases", "llm", "server"], specifier = ">=0.10.1" },
+  { name = "imbi-common", extras = ["databases", "llm", "server"], specifier = ">=0.10.2" },
   { name = "jinja2" },
   { name = "jsonpatch", specifier = ">=1.33" },
   { name = "nanoid", specifier = ">=2.0.0" },
@@ -1077,7 +1077,7 @@ plugins = [
 
 [[package]]
 name = "imbi-common"
-version = "0.10.1"
+version = "0.10.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
   { name = "cryptography" },
@@ -1091,9 +1091,9 @@ dependencies = [
   { name = "python-slugify" },
   { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/58/19/bf584f52cc7558c6ce4c6f6afb0b8ce712673f97dac057a8eb28f49c317a/imbi_common-0.10.1.tar.gz", hash = "sha256:abf8aae5e729f2ad37d2db4afba16ca16e534070e1228c25dce553c3852fde62", size = 250550, upload-time = "2026-05-12T16:26:40.198Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/83/c2/e0bad0b396e108b4e2596830a026194783d738f19252978230dd2cd92b6c/imbi_common-0.10.2.tar.gz", hash = "sha256:8c8a1c06b6a6abf0bc42043a752cf0a2c5f3b8855889749be46adf073a913e00", size = 250551, upload-time = "2026-05-12T17:13:21.595Z" }
 wheels = [
-  { url = "https://files.pythonhosted.org/packages/ec/a6/3a743dd38166d9f4813b994fa06c96fb04a98b862e597f41ba49d737bdf5/imbi_common-0.10.1-py3-none-any.whl", hash = "sha256:f40f4417fe9b39accd612a8098e235dbb2200bd7e86fc6a1dc220ffdbed0290b", size = 74888, upload-time = "2026-05-12T16:26:38.45Z" },
+  { url = "https://files.pythonhosted.org/packages/f8/0b/60cd67909bb2def3f336357215e93407b1576f87b150f985e79985d5230b/imbi_common-0.10.2-py3-none-any.whl", hash = "sha256:0d8c69ba678f9e9cdd0027984b707ed16f8aeeefdf36c884825c6dfe339543d7", size = 74881, upload-time = "2026-05-12T17:13:20.1Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary
- Pass ``plugin_slug`` through to ``common_models.OperationLog`` in ``project_configuration._write_audit`` and ``project_deployments._record_deployment_audit`` so the dedicated ``operations_log.plugin_slug`` column carries plugin attribution.
- Extend existing audit-write tests to assert the row's ``plugin_slug`` matches the resolved plugin.
- Bump ``imbi-common`` floor to ``>=0.10.1``.

## Problem
0.10.0 added the ``plugin_slug LowCardinality(String) DEFAULT ''`` column on the ``operations_log`` ClickHouse table, and PR #296 exposed it on the read-side ``OperationLogResponse``. Both internal writers already accepted a ``plugin_slug`` argument and stuffed it into the JSON ``description`` payload, but never on the model — so every row inserted today gets the column default (``''``) regardless of the resolved plugin. For example, an SSM-driven config change wrote the slug into the description JSON but the dedicated column stayed empty, defeating any future UI/analytics that pivot on ``plugin_slug``.

Plugins themselves don't write to ClickHouse directly; configuration and deployment writes are orchestrated by the API and the ``resolve_plugin(...)`` call already provides ``plugin_slug`` on the resolved entry. So this is entirely a write-path plumbing fix in the API layer.

## Solution
- Add ``plugin_slug=plugin_slug`` to both ``OperationLog(...)`` constructors. The argument was already in scope.
- Update both ``test_*_writes_operations_log_audit`` and ``test_set_configuration_value`` to assert the resolved plugin slug ends up on the row.

## Dependency
Requires imbi-common ``0.10.1`` (https://github.com/AWeber-Imbi/imbi-common/pull/97), which adds the ``plugin_slug`` field to the Pydantic ``OperationLog`` model. Without that release the keyword is silently dropped by ``extra='ignore'`` and these changes are a no-op. **Merge-blocked on the imbi-common release.**

## Test plan
- [x] ``ruff check`` / ``ruff format`` clean.
- [x] ``mypy`` clean (against local editable imbi-common 0.10.1).
- [x] ``ProjectDeploymentsTestCase.test_deploy_writes_operations_log_audit`` and ``test_promote_writes_operations_log_audit`` pass.
- [ ] ``ProjectConfigurationEndpointTestCase.test_set_configuration_value`` runs in CI once imbi-common 0.10.1 is published. *(Locally blocked by a separate pre-existing schema typo — ``CREATE TABLE ... operations_log ON (`` in ``imbi-common/src/imbi_common/clickhouse/schemata.toml`` — that prevents the schema from refreshing on a single-node ClickHouse. Worth tracking separately.)*

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>