### PR TITLE
Release 2.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "imbi-api"
-version = "2.0.7"
+version = "2.1.0"
 description = "Imbi is a DevOps Service Management Platform designed to provide an efficient way to manage a large environment that contains many services and applications."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/uv.lock
+++ b/uv.lock
@@ -6,9 +6,6 @@ resolution-markers = [
   "python_full_version < '3.15'",
 ]
 
-[options]
-prerelease-mode = "allow"
-
 [[package]]
 name = "aioboto3"
 version = "15.5.0"
@@ -954,7 +951,7 @@ wheels = [
 
 [[package]]
 name = "imbi-api"
-version = "2.0.7"
+version = "2.1.0"
 source = { editable = "." }
 dependencies = [
   { name = "aioboto3" },


### PR DESCRIPTION
## Summary

Release 2.1.0. Aligns with the Imbi v2 platform version family (api/ui/common all at 2.1.0).

## What's Changed Since 2.0.7

- Dispatch lifecycle plugins on project archive / unarchive (#299)
- Resolve DEPLOYS_VIA per env in `_handle_promote`; failures become warnings (#297)
- Persist plugin_slug on operations_log audit writes (#298)
- Harden auth-provider write & lookup paths (#295)
- Add plugin_slug to OperationLogResponse (#296)
- Persist surrogate id on ThirdPartyService and ServiceApplication nodes (#293)
- Fix DatatypeMismatch 500 on GET /users/{email}/activity (#294)
- Add project archive/unarchive endpoints (#292)

## Test plan

- [x] `uv lock` regenerated cleanly
- [ ] CI passes
- [ ] Tag 2.1.0 after merge