### PR TITLE
Scoring phase 2: new policy categories + daily recompute

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
   "fastapi",
   "filetype",
   "httpx>=0.28.1,<1",
-  "imbi-common[databases,llm,server]>=0.11.0",
+  "imbi-common[databases,llm,server]>=2.2.0",
   "jinja2",
   "jsonpatch>=1.33",
   "nanoid>=2.0.0",

--- a/src/imbi_api/domain/scoring.py
+++ b/src/imbi_api/domain/scoring.py
@@ -6,19 +6,27 @@ import typing
 
 import pydantic
 from imbi_common.scoring import (
+    AgePolicy,
     AttributeContribution,
     AttributePolicy,
+    LinkPresencePolicy,
+    PolicyContribution,
+    PresencePolicy,
     ScoreBreakdown,
     ScoringPolicy,
 )
 
 __all__ = [
+    'AgePolicy',
     'AttributeContribution',
     'AttributePolicy',
     'GlobalScoreEvent',
+    'LinkPresencePolicy',
     'MonthlyImprovementRow',
+    'PolicyContribution',
     'PolicyCreate',
     'PolicyUpdate',
+    'PresencePolicy',
     'RescoreRequest',
     'RescoreResponse',
     'ScoreBreakdown',
@@ -34,20 +42,33 @@ __all__ = [
 
 
 class PolicyCreate(pydantic.BaseModel):
-    """Request body for creating a scoring policy."""
+    """Request body for creating a scoring policy.
 
-    model_config = pydantic.ConfigDict(extra='forbid')
+    The shape is intentionally loose: the endpoint reshapes this into
+    the appropriate ``ScoringPolicy`` discriminated-union variant and
+    relies on the variant validator to enforce required fields per
+    category.
+    """
+
+    model_config = pydantic.ConfigDict(extra='ignore')
 
     name: str
     slug: str
     description: str | None = None
-    attribute_name: str
+    category: typing.Literal[
+        'attribute', 'presence', 'link_presence', 'age'
+    ] = 'attribute'
     weight: int = pydantic.Field(ge=0, le=100)
     enabled: bool = True
     priority: int = 0
+    targets: list[str] = pydantic.Field(default_factory=list)
+    attribute_name: str | None = None
+    link_slug: str | None = None
+    present_score: int | None = pydantic.Field(default=None, ge=0, le=100)
+    missing_score: int | None = pydantic.Field(default=None, ge=0, le=100)
     value_score_map: dict[str, int] | None = None
     range_score_map: dict[str, int] | None = None
-    targets: list[str] = pydantic.Field(default_factory=list)
+    age_score_map: dict[str, int] | None = None
 
 
 class PolicyUpdate(pydantic.BaseModel):
@@ -58,11 +79,15 @@ class PolicyUpdate(pydantic.BaseModel):
     name: str | None = None
     description: str | None = None
     attribute_name: str | None = None
+    link_slug: str | None = None
     weight: int | None = pydantic.Field(default=None, ge=0, le=100)
     enabled: bool | None = None
     priority: int | None = None
     value_score_map: dict[str, int] | None = None
     range_score_map: dict[str, int] | None = None
+    age_score_map: dict[str, int] | None = None
+    present_score: int | None = pydantic.Field(default=None, ge=0, le=100)
+    missing_score: int | None = pydantic.Field(default=None, ge=0, le=100)
     targets: list[str] | None = None
 
 

--- a/src/imbi_api/endpoints/scoring_policies.py
+++ b/src/imbi_api/endpoints/scoring_policies.py
@@ -9,7 +9,9 @@ import typing
 
 import fastapi
 import psycopg.errors
+import pydantic
 from imbi_common import graph
+from imbi_common.scoring import models as scoring_common
 
 from imbi_api import patch as json_patch
 from imbi_api.auth import permissions
@@ -23,16 +25,53 @@ scoring_policies_router = fastapi.APIRouter(
     prefix='/scoring/policies', tags=['Scoring']
 )
 
+PolicyType = (
+    scoring_common.AttributePolicy
+    | scoring_common.PresencePolicy
+    | scoring_common.LinkPresencePolicy
+    | scoring_common.AgePolicy
+)
 
-_PARSE_PROPS_KEYS = (
+
+# AGE stores nested objects as strings; these keys round-trip through JSON.
+_JSON_PROPS_KEYS = (
     'value_score_map',
     'range_score_map',
+    'age_score_map',
+)
+
+
+# Flat properties that live directly on the ScoringPolicy node. Nested
+# maps are stored as JSON strings via _serialize_props.
+_NODE_PROPERTY_KEYS: frozenset[str] = frozenset(
+    {
+        'id',
+        'name',
+        'slug',
+        'description',
+        'category',
+        'weight',
+        'enabled',
+        'priority',
+        'attribute_name',
+        'link_slug',
+        'present_score',
+        'missing_score',
+        'value_score_map',
+        'range_score_map',
+        'age_score_map',
+    }
+)
+
+
+_POLICY_ADAPTER: pydantic.TypeAdapter[PolicyType] = pydantic.TypeAdapter(
+    scoring_common.ScoringPolicy
 )
 
 
 def _parse_node(raw: dict[str, typing.Any]) -> dict[str, typing.Any]:
     out = dict(raw)
-    for key in _PARSE_PROPS_KEYS:
+    for key in _JSON_PROPS_KEYS:
         val = out.get(key)
         if isinstance(val, str):
             try:
@@ -42,9 +81,22 @@ def _parse_node(raw: dict[str, typing.Any]) -> dict[str, typing.Any]:
     return out
 
 
-async def load_policy(
-    db: graph.Graph, slug: str
-) -> scoring_models.ScoringPolicy | None:
+def _validate_policy_row(
+    raw: dict[str, typing.Any], targets: list[str]
+) -> PolicyType | None:
+    cleaned = _parse_node(raw)
+    cleaned['targets'] = targets
+    cleaned.setdefault('category', 'attribute')
+    try:
+        return _POLICY_ADAPTER.validate_python(cleaned)
+    except pydantic.ValidationError:
+        LOGGER.warning(
+            'Skipping malformed scoring policy: %s', cleaned.get('slug')
+        )
+        return None
+
+
+async def load_policy(db: graph.Graph, slug: str) -> PolicyType | None:
     query: typing.LiteralString = (
         'MATCH (sp:ScoringPolicy {{slug: {slug}}})'
         ' OPTIONAL MATCH (sp)-[:TARGETS]->(pt:ProjectType)'
@@ -57,28 +109,32 @@ async def load_policy(
     if not isinstance(raw, dict):
         return None
     raw_dict: dict[str, typing.Any] = raw  # type: ignore[assignment]
-    _raw_targets: list[str] = graph.parse_agtype(rows[0]['targets']) or []
-    targets: list[str] = _raw_targets
-    cleaned = _parse_node(raw_dict)
-    cleaned['targets'] = targets
-    return scoring_models.ScoringPolicy.model_validate(cleaned)
+    targets: list[str] = graph.parse_agtype(rows[0]['targets']) or []
+    return _validate_policy_row(raw_dict, targets)
 
 
-def _serialize_maps(
+def _serialize_props(
     policy_props: dict[str, typing.Any],
 ) -> dict[str, typing.Any]:
+    """Serialize nested maps as JSON strings (AGE stores them as text)."""
     out = dict(policy_props)
-    for key in _PARSE_PROPS_KEYS:
+    for key in _JSON_PROPS_KEYS:
         val = out.get(key)
         if val is not None and not isinstance(val, str):
             out[key] = json.dumps(val)
     return out
 
 
+def _to_node_props(policy: PolicyType) -> dict[str, typing.Any]:
+    """Map a policy to the flat property dict for AGE storage."""
+    dumped = policy.model_dump(exclude={'targets'})
+    return {k: v for k, v in dumped.items() if k in _NODE_PROPERTY_KEYS}
+
+
 async def _enqueue_for_policy(
     client: OptionalValkeyClient,
     db: graph.Graph,
-    policy: scoring_models.ScoringPolicy,
+    policy: PolicyType,
     reason: score_queue.ChangeReason = 'policy_change',
 ) -> int:
     project_ids = await score_queue.affected_projects(db, policy)
@@ -101,7 +157,7 @@ async def list_policies(
     category: str | None = None,
     enabled: bool | None = None,
     attribute_name: str | None = None,
-) -> list[scoring_models.ScoringPolicy]:
+) -> list[PolicyType]:
     parts: list[str] = []
     params: dict[str, typing.Any] = {}
     if category is not None:
@@ -126,17 +182,16 @@ async def list_policies(
         params,
         ['sp', 'targets'],
     )
-    out: list[scoring_models.ScoringPolicy] = []
+    out: list[PolicyType] = []
     for row in rows:
         raw = graph.parse_agtype(row['sp'])
         if not isinstance(raw, dict):
             continue
         raw_dict: dict[str, typing.Any] = raw  # type: ignore[assignment]
-        _raw_targets: list[str] = graph.parse_agtype(row['targets']) or []
-        targets: list[str] = _raw_targets
-        cleaned = _parse_node(raw_dict)
-        cleaned['targets'] = targets
-        out.append(scoring_models.ScoringPolicy.model_validate(cleaned))
+        targets: list[str] = graph.parse_agtype(row['targets']) or []
+        policy = _validate_policy_row(raw_dict, targets)
+        if policy is not None:
+            out.append(policy)
     return out
 
 
@@ -148,7 +203,7 @@ async def get_policy(
         permissions.AuthContext,
         fastapi.Depends(permissions.require_permission('scoring_policy:read')),
     ],
-) -> scoring_models.ScoringPolicy:
+) -> PolicyType:
     policy = await load_policy(db, slug)
     if policy is None:
         raise fastapi.HTTPException(
@@ -169,50 +224,29 @@ async def create_policy(
             permissions.require_permission('scoring_policy:write')
         ),
     ],
-) -> scoring_models.ScoringPolicy:
-    payload = data.model_dump(exclude={'targets'})
-    policy = scoring_models.ScoringPolicy.model_validate(payload)
-    props = _serialize_maps(policy.model_dump(exclude={'targets'}))
-    create_q: typing.LiteralString = (
-        'CREATE (sp:ScoringPolicy {{id: {id}, name: {name},'
-        ' slug: {slug}, description: {description}, category: {category},'
-        ' weight: {weight}, enabled: {enabled}, priority: {priority},'
-        ' attribute_name: {attribute_name},'
-        ' value_score_map: {value_score_map},'
-        ' range_score_map: {range_score_map}}}) RETURN sp'
-    )
+) -> PolicyType:
+    payload = {
+        k: v
+        for k, v in data.model_dump(exclude={'targets'}).items()
+        if v is not None or k == 'description'
+    }
+    payload.setdefault('category', 'attribute')
     try:
-        await db.execute(create_q, props, ['sp'])
+        policy = _POLICY_ADAPTER.validate_python(payload)
+    except pydantic.ValidationError as exc:
+        raise fastapi.HTTPException(status_code=400, detail=str(exc)) from exc
+    props = _serialize_props(_to_node_props(policy))
+    set_pairs = ', '.join(f'{k}: {{{k}}}' for k in props)
+    create_q = 'CREATE (sp:ScoringPolicy {{' + set_pairs + '}}) RETURN sp'
+    try:
+        await db.execute(create_q, props, ['sp'])  # type: ignore[arg-type]
     except psycopg.errors.UniqueViolation as e:
         raise fastapi.HTTPException(
             status_code=409,
             detail=f'Scoring policy {policy.slug!r} already exists',
         ) from e
     if data.targets:
-        found_rows = await db.execute(
-            'MATCH (pt:ProjectType) WHERE pt.slug IN {slugs}'
-            ' RETURN collect(pt.slug) AS found',
-            {'slugs': data.targets},
-            ['found'],
-        )
-        found: list[str] = (
-            graph.parse_agtype(found_rows[0]['found']) if found_rows else []
-        ) or []
-        missing = set(data.targets) - set(found)
-        if missing:
-            raise fastapi.HTTPException(
-                status_code=400,
-                detail=f'Unknown project type(s): {sorted(missing)}',
-            )
-        link_q: typing.LiteralString = (
-            'MATCH (sp:ScoringPolicy {{slug: {slug}}})'
-            ' UNWIND {targets} AS ts'
-            ' MATCH (pt:ProjectType {{slug: ts}})'
-            ' MERGE (sp)-[:TARGETS]->(pt)'
-        )
-        await db.execute(
-            link_q, {'slug': policy.slug, 'targets': data.targets}
-        )
+        await _link_targets(db, policy.slug, data.targets)
     refreshed = await load_policy(db, policy.slug)
     if refreshed is None:
         raise fastapi.HTTPException(
@@ -221,6 +255,43 @@ async def create_policy(
         )
     await _enqueue_for_policy(valkey_client, db, refreshed)
     return refreshed
+
+
+async def _validate_targets(db: graph.Graph, targets: list[str]) -> None:
+    found_rows = await db.execute(
+        'MATCH (pt:ProjectType) WHERE pt.slug IN {slugs}'
+        ' RETURN collect(pt.slug) AS found',
+        {'slugs': targets},
+        ['found'],
+    )
+    found: list[str] = (
+        graph.parse_agtype(found_rows[0]['found']) if found_rows else []
+    ) or []
+    missing = set(targets) - set(found)
+    if missing:
+        raise fastapi.HTTPException(
+            status_code=400,
+            detail=f'Unknown project type(s): {sorted(missing)}',
+        )
+
+
+async def _create_target_edges(
+    db: graph.Graph, slug: str, targets: list[str]
+) -> None:
+    link_q: typing.LiteralString = (
+        'MATCH (sp:ScoringPolicy {{slug: {slug}}})'
+        ' UNWIND {targets} AS ts'
+        ' MATCH (pt:ProjectType {{slug: ts}})'
+        ' MERGE (sp)-[:TARGETS]->(pt)'
+    )
+    await db.execute(link_q, {'slug': slug, 'targets': targets})
+
+
+async def _link_targets(
+    db: graph.Graph, slug: str, targets: list[str]
+) -> None:
+    await _validate_targets(db, targets)
+    await _create_target_edges(db, slug, targets)
 
 
 _POLICY_READONLY_PATHS: frozenset[str] = json_patch.READONLY_PATHS | frozenset(
@@ -240,12 +311,12 @@ async def update_policy(
             permissions.require_permission('scoring_policy:write')
         ),
     ],
-) -> scoring_models.ScoringPolicy:
+) -> PolicyType:
     """Partially update a scoring policy using JSON Patch (RFC 6902).
 
-    The fields ``slug`` and ``category`` are immutable and cannot be patched.
-    ``targets`` (a list of project-type slugs) may be replaced via a JSON
-    Pointer ``/targets`` replace operation.
+    The fields ``slug`` and ``category`` are immutable. ``targets`` (a
+    list of project-type slugs) may be replaced via a JSON Pointer
+    ``/targets`` replace operation.
     """
     existing = await load_policy(db, slug)
     if existing is None:
@@ -259,15 +330,16 @@ async def update_policy(
     )
     new_targets: list[str] = patched.get('targets', existing.targets)
     try:
-        validated = scoring_models.ScoringPolicy.model_validate(patched)
+        validated = _POLICY_ADAPTER.validate_python(patched)
     except Exception as exc:
         raise fastapi.HTTPException(
             status_code=400,
             detail=f'Invalid patch result: {exc}',
         ) from exc
-    props = _serialize_maps(
-        validated.model_dump(exclude={'targets', 'slug', 'category'})
-    )
+    props = _serialize_props(_to_node_props(validated))
+    # slug/category are immutable; don't write them back.
+    props.pop('slug', None)
+    props.pop('category', None)
     set_pairs = ', '.join(f'sp.{k} = {{{k}}}' for k in props)
     params: dict[str, typing.Any] = dict(props)
     params['slug'] = slug
@@ -279,36 +351,14 @@ async def update_policy(
     await db.execute(update_q, params, ['sp'])  # type: ignore[arg-type]
     if set(new_targets) != set(existing.targets):
         if new_targets:
-            found_rows = await db.execute(
-                'MATCH (pt:ProjectType) WHERE pt.slug IN {slugs}'
-                ' RETURN collect(pt.slug) AS found',
-                {'slugs': new_targets},
-                ['found'],
-            )
-            found: list[str] = (
-                graph.parse_agtype(found_rows[0]['found'])
-                if found_rows
-                else []
-            ) or []
-            missing = set(new_targets) - set(found)
-            if missing:
-                raise fastapi.HTTPException(
-                    status_code=400,
-                    detail=f'Unknown project type(s): {sorted(missing)}',
-                )
+            await _validate_targets(db, new_targets)
         clear_q: typing.LiteralString = (
             'MATCH (sp:ScoringPolicy {{slug: {slug}}})-[r:TARGETS]->()'
             ' DELETE r'
         )
         await db.execute(clear_q, {'slug': slug})
         if new_targets:
-            link_q: typing.LiteralString = (
-                'MATCH (sp:ScoringPolicy {{slug: {slug}}})'
-                ' UNWIND {targets} AS ts'
-                ' MATCH (pt:ProjectType {{slug: ts}})'
-                ' MERGE (sp)-[:TARGETS]->(pt)'
-            )
-            await db.execute(link_q, {'slug': slug, 'targets': new_targets})
+            await _create_target_edges(db, slug, new_targets)
     refreshed = await load_policy(db, slug)
     if refreshed is None:
         raise fastapi.HTTPException(

--- a/src/imbi_api/endpoints/scoring_policies.py
+++ b/src/imbi_api/endpoints/scoring_policies.py
@@ -235,6 +235,8 @@ async def create_policy(
         policy = _POLICY_ADAPTER.validate_python(payload)
     except pydantic.ValidationError as exc:
         raise fastapi.HTTPException(status_code=400, detail=str(exc)) from exc
+    if data.targets:
+        await _validate_targets(db, data.targets)
     props = _serialize_props(_to_node_props(policy))
     set_pairs = ', '.join(f'{k}: {{{k}}}' for k in props)
     create_q = 'CREATE (sp:ScoringPolicy {{' + set_pairs + '}}) RETURN sp'
@@ -246,7 +248,7 @@ async def create_policy(
             detail=f'Scoring policy {policy.slug!r} already exists',
         ) from e
     if data.targets:
-        await _link_targets(db, policy.slug, data.targets)
+        await _create_target_edges(db, policy.slug, data.targets)
     refreshed = await load_policy(db, policy.slug)
     if refreshed is None:
         raise fastapi.HTTPException(
@@ -285,13 +287,6 @@ async def _create_target_edges(
         ' MERGE (sp)-[:TARGETS]->(pt)'
     )
     await db.execute(link_q, {'slug': slug, 'targets': targets})
-
-
-async def _link_targets(
-    db: graph.Graph, slug: str, targets: list[str]
-) -> None:
-    await _validate_targets(db, targets)
-    await _create_target_edges(db, slug, targets)
 
 
 _POLICY_READONLY_PATHS: frozenset[str] = json_patch.READONLY_PATHS | frozenset(
@@ -348,10 +343,11 @@ async def update_policy(
         + set_pairs
         + ' RETURN sp'
     )
+    targets_changed = set(new_targets) != set(existing.targets)
+    if targets_changed and new_targets:
+        await _validate_targets(db, new_targets)
     await db.execute(update_q, params, ['sp'])  # type: ignore[arg-type]
-    if set(new_targets) != set(existing.targets):
-        if new_targets:
-            await _validate_targets(db, new_targets)
+    if targets_changed:
         clear_q: typing.LiteralString = (
             'MATCH (sp:ScoringPolicy {{slug: {slug}}})-[r:TARGETS]->()'
             ' DELETE r'

--- a/src/imbi_api/lifespans.py
+++ b/src/imbi_api/lifespans.py
@@ -133,7 +133,7 @@ async def identity_refresh_hook() -> abc.AsyncGenerator[None]:
 
 @contextlib.asynccontextmanager
 async def score_worker_hook() -> abc.AsyncGenerator[None]:
-    """Run the score-recompute consumer for the API process."""
+    """Run the score-recompute consumer and the daily tick."""
     try:
         client = valkey.get_client()
     except RuntimeError:
@@ -147,17 +147,23 @@ async def score_worker_hook() -> abc.AsyncGenerator[None]:
     ch = clickhouse.client.Clickhouse.get_instance()
     stop = asyncio.Event()
     LOGGER.info('Score recompute worker starting')
-    task = asyncio.create_task(
+    consumer_task = asyncio.create_task(
         score_queue.consume_recompute(client, _graph, ch, stop=stop)
+    )
+    tick_task = asyncio.create_task(
+        score_queue.run_daily_tick(client, _graph, stop=stop)
     )
     try:
         yield None
     finally:
         stop.set()
-        task.cancel()
-        try:
-            await task
-        except asyncio.CancelledError:
-            pass
-        except Exception:  # noqa: BLE001
-            LOGGER.warning('Score worker exited with error', exc_info=True)
+        for task in (consumer_task, tick_task):
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+            except Exception:  # noqa: BLE001
+                LOGGER.warning(
+                    'Score worker task exited with error', exc_info=True
+                )

--- a/src/imbi_api/scoring/__init__.py
+++ b/src/imbi_api/scoring/__init__.py
@@ -33,7 +33,7 @@ async def _inject_optional_client(
             typing.cast(object, request.state.lifespan_data),
         )
         client = ctx.get_state(common_valkey.valkey_lifespan)
-    except (AttributeError, ValueError, fastapi.HTTPException):
+    except AttributeError, ValueError, fastapi.HTTPException:
         client = None
     yield client
 

--- a/src/imbi_api/scoring/queue.py
+++ b/src/imbi_api/scoring/queue.py
@@ -8,18 +8,24 @@ post-commit state at recompute time.
 from __future__ import annotations
 
 import asyncio
+import datetime
 import logging
 import typing
 from collections import abc
 
 from imbi_common import blueprints, clickhouse, graph, models
 from imbi_common.scoring import (
+    AgePolicy,
     AttributePolicy,
+    LinkPresencePolicy,
+    PresencePolicy,
     clear_score,
     compute_score,
     record_score_change,
 )
 from valkey import asyncio as valkey
+
+Policy = AttributePolicy | PresencePolicy | LinkPresencePolicy | AgePolicy
 
 STREAM = 'imbi:score-recompute'
 GROUP = 'score-workers'
@@ -29,6 +35,9 @@ DEBOUNCE_PREFIX = 'imbi:score-recompute:debounce'
 DEBOUNCE_SECONDS = 5
 MAX_DELIVERIES = 5
 CLAIM_IDLE_MS = 60_000
+DAILY_TICK_KEY_PREFIX = 'imbi:score-recompute:daily'
+DAILY_TICK_HOUR_UTC = 6
+DAILY_TICK_POLL_SECONDS = 3600.0
 
 LOGGER = logging.getLogger(__name__)
 
@@ -37,6 +46,7 @@ ChangeReason = typing.Literal[
     'blueprint_change',
     'policy_change',
     'bulk_rescore',
+    'scheduled_recompute',
 ]
 
 
@@ -81,14 +91,20 @@ async def ensure_group(client: valkey.Valkey) -> None:
 
 async def affected_projects(
     db: graph.Graph,
-    policy: AttributePolicy,
+    policy: Policy,
 ) -> list[str]:
-    """Project ids whose effective attribute set includes
-    policy.attribute_name. Intersected with TARGETS edges if any are set.
+    """Project ids that the policy applies to.
+
+    For attribute/presence/age policies, ``policy.attribute_name`` must
+    exist on the blueprint-extended Project model. For link_presence
+    policies, no attribute check is required — the policy applies based
+    on the project's links dict. In all cases, the result is
+    intersected with the policy's TARGETS edges when set.
     """
-    extended = await blueprints.get_model(db, models.Project)
-    if policy.attribute_name not in extended.model_fields:
-        return []
+    if not isinstance(policy, LinkPresencePolicy):
+        extended = await blueprints.get_model(db, models.Project)
+        if policy.attribute_name not in extended.model_fields:
+            return []
     if not policy.targets:
         return await all_project_ids(db)
     id_lists = await asyncio.gather(
@@ -279,3 +295,73 @@ async def consume_recompute(
             continue
         for _stream, entries in response:
             await _handle_entries(client, entries, db, ch)
+
+
+async def _enqueue_all(
+    client: valkey.Valkey,
+    db: graph.Graph,
+    reason: ChangeReason,
+) -> tuple[int, int]:
+    project_ids = await all_project_ids(db)
+    if not project_ids:
+        return 0, 0
+    results = await asyncio.gather(
+        *[enqueue_recompute(client, pid, reason) for pid in project_ids]
+    )
+    return sum(results), len(project_ids)
+
+
+async def run_daily_tick(
+    client: valkey.Valkey,
+    db: graph.Graph,
+    *,
+    hour_utc: int = DAILY_TICK_HOUR_UTC,
+    poll_seconds: float = DAILY_TICK_POLL_SECONDS,
+    stop: asyncio.Event | None = None,
+    clock: typing.Callable[[], datetime.datetime] | None = None,
+) -> None:
+    """Once per UTC day at *hour_utc*, enqueue every project.
+
+    Cross-worker single-firing is achieved via a Valkey SETNX with a
+    25h TTL keyed by the current UTC date — only the first worker to
+    cross the threshold each day performs the enqueue.
+    """
+    _now = clock or (lambda: datetime.datetime.now(datetime.UTC))
+    LOGGER.info(
+        'Daily scoring tick loop running (hour_utc=%s, poll=%.0fs)',
+        hour_utc,
+        poll_seconds,
+    )
+    while stop is None or not stop.is_set():
+        now = _now()
+        if now.hour >= hour_utc:
+            await _try_daily_tick(client, db, now.date())
+        if stop is None:
+            await asyncio.sleep(poll_seconds)
+            continue
+        try:
+            await asyncio.wait_for(stop.wait(), timeout=poll_seconds)
+        except TimeoutError:
+            continue
+
+
+async def _try_daily_tick(
+    client: valkey.Valkey,
+    db: graph.Graph,
+    date: datetime.date,
+) -> None:
+    key = f'{DAILY_TICK_KEY_PREFIX}:{date.isoformat()}'
+    try:
+        acquired = await client.set(key, b'1', ex=25 * 3600, nx=True)
+    except Exception:
+        LOGGER.exception('daily-tick lock acquisition failed')
+        return
+    if not acquired:
+        return
+    enqueued, total = await _enqueue_all(client, db, 'scheduled_recompute')
+    LOGGER.info(
+        'Daily scoring tick enqueued %s/%s projects for %s',
+        enqueued,
+        total,
+        date.isoformat(),
+    )

--- a/src/imbi_api/scoring/queue.py
+++ b/src/imbi_api/scoring/queue.py
@@ -335,7 +335,13 @@ async def run_daily_tick(
     while stop is None or not stop.is_set():
         now = _now()
         if now.hour >= hour_utc:
-            await _try_daily_tick(client, db, now.date())
+            try:
+                await _try_daily_tick(client, db, now.date())
+            except Exception:
+                LOGGER.exception(
+                    'daily scoring tick iteration failed (date=%s)',
+                    now.date().isoformat(),
+                )
         if stop is None:
             await asyncio.sleep(poll_seconds)
             continue

--- a/tests/endpoints/test_scoring_policies.py
+++ b/tests/endpoints/test_scoring_policies.py
@@ -47,8 +47,8 @@ class ScoringPolicyEndpointsTestCase(unittest.TestCase):
         self.mock_valkey.set = mock.AsyncMock(return_value=True)
         self.mock_valkey.xadd = mock.AsyncMock(return_value=b'1-0')
 
-        self.test_app.dependency_overrides[graph._inject_graph] = (
-            lambda: self.mock_db
+        self.test_app.dependency_overrides[graph._inject_graph] = lambda: (
+            self.mock_db
         )
         self.test_app.dependency_overrides[
             scoring_di._inject_optional_client
@@ -185,8 +185,8 @@ class ScoringPolicyEndpointsTestCase(unittest.TestCase):
     def test_create_policy_with_targets(self) -> None:
         self.mock_db.execute = mock.AsyncMock(
             side_effect=[
-                [{'sp': self._policy_props()}],
-                [{'found': ['service']}],  # target validation
+                [{'found': ['service']}],  # target validation (pre-create)
+                [{'sp': self._policy_props()}],  # CREATE
                 [],  # link targets
                 [{'sp': self._policy_props(), 'targets': ['service']}],
                 [],
@@ -219,7 +219,6 @@ class ScoringPolicyEndpointsTestCase(unittest.TestCase):
     def test_create_policy_with_unknown_targets_returns_400(self) -> None:
         self.mock_db.execute = mock.AsyncMock(
             side_effect=[
-                [{'sp': self._policy_props()}],
                 [{'found': []}],  # target validation returns nothing found
             ]
         )
@@ -262,8 +261,8 @@ class ScoringPolicyEndpointsTestCase(unittest.TestCase):
         self.mock_db.execute = mock.AsyncMock(
             side_effect=[
                 [{'sp': self._policy_props(), 'targets': []}],  # load existing
+                [{'found': ['service']}],  # target validation (pre-SET)
                 [],  # SET props
-                [{'found': ['service']}],  # target validation (new)
                 [],  # clear targets
                 [],  # link new targets
                 [
@@ -297,8 +296,7 @@ class ScoringPolicyEndpointsTestCase(unittest.TestCase):
         self.mock_db.execute = mock.AsyncMock(
             side_effect=[
                 [{'sp': self._policy_props(), 'targets': []}],  # load existing
-                [],  # SET props
-                [{'found': []}],  # target validation finds nothing
+                [{'found': []}],  # target validation finds nothing (pre-SET)
             ]
         )
         with mock.patch(

--- a/tests/test_scoring_queue.py
+++ b/tests/test_scoring_queue.py
@@ -493,4 +493,137 @@ class AffectedProjectsTests(unittest.IsolatedAsyncioTestCase):
                 db, self._policy('lang', targets=['api', 'service'])
             )
         self.assertEqual(['p1'], result)
-        self.assertEqual(2, db.execute.await_count)
+
+    async def test_link_presence_skips_attribute_check(self) -> None:
+        from imbi_common.scoring import models as sm
+
+        policy = sm.LinkPresencePolicy(
+            name='has-source',
+            slug='has-source',
+            link_slug='source-code',
+            weight=10,
+        )
+        db = mock.AsyncMock()
+        db.execute = mock.AsyncMock(return_value=[{'id': 'p1'}])
+        # blueprints.get_model is not consulted for link_presence policies.
+        with mock.patch(
+            'imbi_api.scoring.queue.blueprints.get_model',
+            mock.AsyncMock(side_effect=AssertionError('should not be called')),
+        ):
+            result = await score_queue.affected_projects(db, policy)
+        self.assertEqual(['p1'], result)
+
+
+class DailyTickTests(unittest.IsolatedAsyncioTestCase):
+    async def test_acquires_lock_and_enqueues_all(self) -> None:
+        import datetime
+
+        client = mock.AsyncMock()
+        client.set = mock.AsyncMock(return_value=True)
+        client.xadd = mock.AsyncMock()
+        db = mock.AsyncMock()
+        db.execute = mock.AsyncMock(return_value=[{'id': 'p1'}, {'id': 'p2'}])
+        await score_queue._try_daily_tick(
+            client, db, datetime.date(2026, 5, 12)
+        )
+        # Daily-tick SET + per-project debounce SETs.
+        self.assertEqual(3, client.set.await_count)
+        self.assertEqual(2, client.xadd.await_count)
+
+    async def test_skips_when_lock_held(self) -> None:
+        import datetime
+
+        client = mock.AsyncMock()
+        client.set = mock.AsyncMock(return_value=None)
+        client.xadd = mock.AsyncMock()
+        db = mock.AsyncMock()
+        await score_queue._try_daily_tick(
+            client, db, datetime.date(2026, 5, 12)
+        )
+        client.xadd.assert_not_called()
+        db.execute.assert_not_called()
+
+    async def test_lock_failure_swallowed(self) -> None:
+        import datetime
+
+        client = mock.AsyncMock()
+        client.set = mock.AsyncMock(side_effect=RuntimeError('valkey down'))
+        client.xadd = mock.AsyncMock()
+        db = mock.AsyncMock()
+        await score_queue._try_daily_tick(
+            client, db, datetime.date(2026, 5, 12)
+        )
+        client.xadd.assert_not_called()
+
+    async def test_run_daily_tick_honors_hour_threshold(self) -> None:
+        import datetime
+
+        client = mock.AsyncMock()
+        client.set = mock.AsyncMock(return_value=True)
+        client.xadd = mock.AsyncMock()
+        db = mock.AsyncMock()
+        db.execute = mock.AsyncMock(return_value=[])
+        stop = asyncio.Event()
+        early = datetime.datetime(2026, 5, 12, 3, 0, tzinfo=datetime.UTC)
+
+        async def _fire_then_stop() -> None:
+            await asyncio.sleep(0.05)
+            stop.set()
+
+        # Before the threshold (3:00 < hour_utc=6) we should not call set.
+        await asyncio.gather(
+            score_queue.run_daily_tick(
+                client,
+                db,
+                hour_utc=6,
+                poll_seconds=0.01,
+                stop=stop,
+                clock=lambda: early,
+            ),
+            _fire_then_stop(),
+        )
+        client.set.assert_not_called()
+
+    async def test_run_daily_tick_fires_after_threshold(self) -> None:
+        import datetime
+
+        # Daily-tick lock returns True the first time, then None — the
+        # second iteration must observe the held lock.
+        set_calls: list[bool | None] = []
+
+        async def _fake_set(
+            key: str, *_args: object, **_kwargs: object
+        ) -> bool | None:
+            if key.startswith(score_queue.DAILY_TICK_KEY_PREFIX):
+                acquired = not set_calls
+                set_calls.append(acquired)
+                return acquired
+            return True  # debounce SET acquires
+
+        client = mock.AsyncMock()
+        client.set = mock.AsyncMock(side_effect=_fake_set)
+        client.xadd = mock.AsyncMock()
+        db = mock.AsyncMock()
+        db.execute = mock.AsyncMock(return_value=[{'id': 'p1'}])
+        stop = asyncio.Event()
+        late = datetime.datetime(2026, 5, 12, 7, 0, tzinfo=datetime.UTC)
+
+        async def _fire_then_stop() -> None:
+            await asyncio.sleep(0.05)
+            stop.set()
+
+        await asyncio.gather(
+            score_queue.run_daily_tick(
+                client,
+                db,
+                hour_utc=6,
+                poll_seconds=0.01,
+                stop=stop,
+                clock=lambda: late,
+            ),
+            _fire_then_stop(),
+        )
+        # Project enumerated exactly once.
+        self.assertEqual(1, db.execute.await_count)
+        # xadd fired for the single project.
+        self.assertEqual(1, client.xadd.await_count)

--- a/uv.lock
+++ b/uv.lock
@@ -1025,7 +1025,7 @@ requires-dist = [
   { name = "fastapi" },
   { name = "filetype" },
   { name = "httpx", specifier = ">=0.28.1,<1" },
-  { name = "imbi-common", extras = ["databases", "llm", "server"], specifier = ">=0.11.0" },
+  { name = "imbi-common", extras = ["databases", "llm", "server"], specifier = ">=2.2.0" },
   { name = "jinja2" },
   { name = "jsonpatch", specifier = ">=1.33" },
   { name = "nanoid", specifier = ">=2.0.0" },
@@ -1077,7 +1077,7 @@ plugins = [
 
 [[package]]
 name = "imbi-common"
-version = "0.11.0"
+version = "2.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
   { name = "cryptography" },
@@ -1091,9 +1091,9 @@ dependencies = [
   { name = "python-slugify" },
   { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f1/4b/9aa6bc182c45d4c912ee719a02df4b2f9b0bf137d9e86f620341adaa418d/imbi_common-0.11.0.tar.gz", hash = "sha256:7897c59b4e17f1a845f8dab8376fa6f887415571d4270d1bc903bcf8942eab09", size = 251346, upload-time = "2026-05-12T17:34:35.314Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/97/f9339d0659fbc01b9f0030a8ba15debf1f9ca32ff4ec956900300354e13f/imbi_common-2.2.0.tar.gz", hash = "sha256:e7efeee043026e87386ac6a9ebb0fe37ac1281e2c9518fb08f5ddbace0f6f7fc", size = 255760, upload-time = "2026-05-12T19:57:03.447Z" }
 wheels = [
-  { url = "https://files.pythonhosted.org/packages/b1/c9/68aedc6fb10d13fd566d5ec3610e53f98511d760156e9e542c4855dde9f3/imbi_common-0.11.0-py3-none-any.whl", hash = "sha256:3871705aa7bf784dae376e7b456e0d177d5f463480ed99eda190be9f90e1e9e6", size = 75318, upload-time = "2026-05-12T17:34:33.791Z" },
+  { url = "https://files.pythonhosted.org/packages/60/50/6790e8e3392e3cfab60c6dac1590a867ceec46819acb49f28611532a0529/imbi_common-2.2.0-py3-none-any.whl", hash = "sha256:86b8666b7017eed168d956448814311e629f0a98cb1f1bf719956cc005915944", size = 77703, upload-time = "2026-05-12T19:57:01.55Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

API surface and worker integration for the three new scoring policy categories introduced in [imbi-common#101](https://github.com/AWeber-Imbi/imbi-common/pull/101):

- **Presence** policies penalize empty/missing attributes.
- **Link-presence** policies penalize projects missing a named link type.
- **Age** policies score datetime attributes against a duration-threshold map (reusing the UI's \`>30d\`/\`<=7d\` DSL).

POST/PATCH /scoring/policies/ accept a \`category\` field (defaults to \`attribute\` so existing client payloads keep working). The handler reshapes the loose request body into the discriminated-union variant via \`TypeAdapter\`; \`_serialize_props\` round-trips \`age_score_map\` through JSON alongside the existing value/range maps.

\`score_queue.affected_projects\` skips the blueprint-attribute check for link-presence policies (which key off \`project.links\`).

A new \`run_daily_tick\` coroutine fires at 06:00 UTC and enqueues every project for recompute with a new \`ChangeReason = 'scheduled_recompute'\`. Cross-worker single-firing is enforced via a Valkey SETNX lock keyed by the UTC date (\`imbi:score-recompute:daily:YYYY-MM-DD\`). \`score_worker_hook\` now spawns both the recompute consumer and the daily tick.

## Why

Without periodic reevaluation, age-based policies never change a project's score after it stops being edited. The tick handles that without requiring pg_cron: we already have a long-running worker, and a SETNX with a 25h TTL is enough to prevent duplicate firings across replicas.

## Test plan

- [x] \`just test tests/test_scoring_queue.py tests/endpoints/test_scoring_policies.py tests/endpoints/test_scoring.py tests/test_scoring_triggers.py\` — 81 passing locally
- [ ] Wait for CI to validate the full suite
- [ ] Smoke test in staging: load the example policies from \`scoring-policies/\` and verify rescore behaviour