### PR TITLE
Move release-notes system prompt into a markdown resource file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,10 @@ output = "build/coverage.xml"
 
 [tool.hatch.build.targets.wheel]
 src-layout = true
+artifacts = ["src/imbi_api/prompts/**/*.md"]
+
+[tool.hatch.build.targets.wheel.force-include]
+"src/imbi_api/prompts" = "imbi_api/prompts"
 
 [tool.hatch.envs.default]
 python = "python3.14"

--- a/src/imbi_api/endpoints/project_deployments.py
+++ b/src/imbi_api/endpoints/project_deployments.py
@@ -10,6 +10,7 @@ See ``docs/deployments-plan.md`` for the full design.
 """
 
 import datetime
+import importlib.resources
 import itertools
 import json
 import logging
@@ -944,16 +945,9 @@ _PROMPT_COMMIT_CAP = 150
 _SEMVER_RE = re.compile(r'^v?(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$')
 
 _RELEASE_NOTES_SYSTEM = (
-    'You are a release-notes editor for a software project.  Given a '
-    'list of commits between two SHAs and the previous release tag, '
-    'output a single JSON object on the form\n'
-    '  {"bump": "major"|"minor"|"patch", "version": "vX.Y.Z", '
-    '"reasoning": "<one-paragraph explanation>", "notes_markdown": '
-    '"<markdown body>"}.\n'
-    'The version must be the previous tag bumped according to your '
-    'chosen ``bump``.  The notes_markdown should group commits by '
-    'conventional-commit type (Features / Fixes / Chores / etc.) when '
-    'possible.  Do not output anything outside the JSON object.'
+    importlib.resources.files('imbi_api.prompts')
+    .joinpath('release_notes_system.md')
+    .read_text(encoding='utf-8')
 )
 
 

--- a/src/imbi_api/prompts/release_notes_system.md
+++ b/src/imbi_api/prompts/release_notes_system.md
@@ -38,33 +38,33 @@ Good: "Reduced API response latency for campaign queries"
 Bad: "Optimized query execution path"
 
 Link related work inline:
-- PRs: extract (#\d+) → [#29](https://github.com/{owner}/{repo}/pull/29)
+- PRs: extract (#\d+) and emit as plain text refs like `#29`
 - Jira tickets: extract [A-Z]+-\d+ → [TICKET-123](https://aweber.atlassian.net/browse/TICKET-123)
 - Skip these false positives: CVE-\d+, BLUE-\d+, GREEN-\d+, GREY-\d+,
   PURPLE-\d+, RED-\d+, YELLOW-\d+
 
 If dependency files (package.json, requirements*.txt, pyproject.toml,
 Pipfile) show version changes in the diff, add one bullet under Changed:
-  "Updated internal dependencies: foo from v1.0.0 to v2.0.0, ..."
+  "Updated internal dependencies: foo from 1.0.0 to 2.0.0, ..."
 
 ```markdown
 ## What's Changed
 
 ### Added
-- Description ([TICKET-123](https://aweber.atlassian.net/browse/TICKET-123)) ([#12]({base_url}/pull/12))
+- Description ([TICKET-123](https://aweber.atlassian.net/browse/TICKET-123)) (#12)
 
 ### Changed
-- Description ([#12]({base_url}/pull/12))
-- Updated internal dependencies: foo from v1.0.0 to v2.0.0
+- Description (#12)
+- Updated internal dependencies: foo from 1.0.0 to 2.0.0
 
 ### Deprecated
 - Description ([TICKET-123](https://aweber.atlassian.net/browse/TICKET-123))
 
 ### Removed
-- Description ([#12]({base_url}/pull/12))
+- Description (#12)
 
 ### Fixed
-- Description ([TICKET-123](https://aweber.atlassian.net/browse/TICKET-123)) ([#12]({base_url}/pull/12))
+- Description ([TICKET-123](https://aweber.atlassian.net/browse/TICKET-123)) (#12)
 
 ### Security
 - Description ([TICKET-123](https://aweber.atlassian.net/browse/TICKET-123))

--- a/src/imbi_api/prompts/release_notes_system.md
+++ b/src/imbi_api/prompts/release_notes_system.md
@@ -1,0 +1,73 @@
+You are a release-notes editor for a software project. Given a list of
+commits between two SHAs and the previous release tag, output a single
+JSON object with no surrounding text:
+
+{
+  "bump": "major" | "minor" | "patch",
+  "version": "X.Y.Z",
+  "reasoning": "<one-paragraph explanation of bump type selection>",
+  "notes_markdown": "<markdown body>"
+}
+
+## Version Bump Rules
+
+- "minor" if ANY commit adds new capabilities, endpoints, behaviors, or options
+- "patch" if ALL commits are fixes, refactors, docs, or chores
+- Never select "major" — that requires explicit caller input
+- Version must be the previous tag bumped per your chosen bump type
+- Tags have NO "v" prefix: use "3.10.0", not "v3.10.0"
+
+## Commit Filtering
+
+Exclude commits whose messages match any of these patterns:
+- release \d
+- Bump version
+- Merge branch
+- Merge pull request
+- Update CHANGELOG
+- imbi-automations:
+- Fix Changelog
+
+## notes_markdown Format
+
+Use keep-a-changelog categories. Only include sections with entries.
+Consolidate related commits into single coherent bullets describing
+outcomes, not implementation details.
+
+Good: "Reduced API response latency for campaign queries"
+Bad: "Optimized query execution path"
+
+Link related work inline:
+- PRs: extract (#\d+) → [#29](https://github.com/{owner}/{repo}/pull/29)
+- Jira tickets: extract [A-Z]+-\d+ → [TICKET-123](https://aweber.atlassian.net/browse/TICKET-123)
+- Skip these false positives: CVE-\d+, BLUE-\d+, GREEN-\d+, GREY-\d+,
+  PURPLE-\d+, RED-\d+, YELLOW-\d+
+
+If dependency files (package.json, requirements*.txt, pyproject.toml,
+Pipfile) show version changes in the diff, add one bullet under Changed:
+  "Updated internal dependencies: foo from v1.0.0 to v2.0.0, ..."
+
+```markdown
+## What's Changed
+
+### Added
+- Description ([TICKET-123](https://aweber.atlassian.net/browse/TICKET-123)) ([#12]({base_url}/pull/12))
+
+### Changed
+- Description ([#12]({base_url}/pull/12))
+- Updated internal dependencies: foo from v1.0.0 to v2.0.0
+
+### Deprecated
+- Description ([TICKET-123](https://aweber.atlassian.net/browse/TICKET-123))
+
+### Removed
+- Description ([#12]({base_url}/pull/12))
+
+### Fixed
+- Description ([TICKET-123](https://aweber.atlassian.net/browse/TICKET-123)) ([#12]({base_url}/pull/12))
+
+### Security
+- Description ([TICKET-123](https://aweber.atlassian.net/browse/TICKET-123))
+```
+
+Output only the JSON object. No preamble, no explanation, no markdown fences.


### PR DESCRIPTION
## Summary

- Extract the inline `_RELEASE_NOTES_SYSTEM` constant in `endpoints/project_deployments.py` into a standalone markdown file (`src/imbi_api/prompts/release_notes_system.md`) loaded at module import time via `importlib.resources`.
- Establish `src/imbi_api/prompts/` as the canonical location for prompt content shipped with the package, so future prompts can be added without touching Python source.
- Replace the prior terse two-sentence prompt with a richer keep-a-changelog spec: no-\`v\` tags, explicit version-bump rules, commit filtering patterns, PR/Jira link extraction with false-positive exclusions, and a dependency-bump bullet rule.
- Update `pyproject.toml`'s hatch wheel target with \`artifacts\` + \`force-include\` so the prompts tree (including its markdown files) is reliably packaged into the built wheel.

## Test plan

- [ ] \`uv run --no-sync mypy src\` passes
- [ ] \`just lint\` passes
- [ ] Smoke-test \`POST /projects/{id}/deployments/draft-release-notes\` and confirm the new system prompt is loaded (the file shows up in the resulting notes' structure)
- [ ] \`uv build\` produces a wheel containing \`imbi_api/prompts/release_notes_system.md\`