### PR TITLE
Accept tab='lifecycle' on plugin assignment endpoints

### DIFF
--- a/src/imbi_api/domain/models.py
+++ b/src/imbi_api/domain/models.py
@@ -858,7 +858,7 @@ class PluginAssignmentCreate(pydantic.BaseModel):
     """Request model for assigning a plugin to a project-type or project."""
 
     plugin_id: str
-    tab: typing.Literal['configuration', 'logs', 'deployment']
+    tab: typing.Literal['configuration', 'logs', 'deployment', 'lifecycle']
     default: bool = False
     options: dict[str, typing.Any] = pydantic.Field(default_factory=dict)
     identity_plugin_id: str | None = None
@@ -870,7 +870,7 @@ class PluginAssignmentResponse(pydantic.BaseModel):
     plugin_id: str
     plugin_slug: str
     label: str
-    tab: typing.Literal['configuration', 'logs', 'deployment']
+    tab: typing.Literal['configuration', 'logs', 'deployment', 'lifecycle']
     default: bool
     options: dict[str, typing.Any] = {}
     source: typing.Literal['project', 'project_type', 'merged'] = (

--- a/src/imbi_api/endpoints/service_plugins.py
+++ b/src/imbi_api/endpoints/service_plugins.py
@@ -654,7 +654,7 @@ async def patch_service_plugin_configuration(
 
 class _AssignmentInput(pydantic.BaseModel):
     project_type_slug: str
-    tab: typing.Literal['configuration', 'logs', 'deployment']
+    tab: typing.Literal['configuration', 'logs', 'deployment', 'lifecycle']
     default: bool = False
     options: dict[str, typing.Any] = {}
     identity_plugin_id: str | None = None
@@ -663,7 +663,7 @@ class _AssignmentInput(pydantic.BaseModel):
 class _AssignmentRow(pydantic.BaseModel):
     project_type_slug: str
     project_type_name: str
-    tab: typing.Literal['configuration', 'logs', 'deployment']
+    tab: typing.Literal['configuration', 'logs', 'deployment', 'lifecycle']
     default: bool
     options: dict[str, typing.Any]
     identity_plugin_id: str | None = None

--- a/src/imbi_api/plugins/assignments.py
+++ b/src/imbi_api/plugins/assignments.py
@@ -13,7 +13,7 @@ from imbi_api.plugins import parse_options
 
 class PluginAssignmentRow(typing.TypedDict):
     plugin_id: str
-    tab: typing.Literal['configuration', 'logs', 'deployment']
+    tab: typing.Literal['configuration', 'logs', 'deployment', 'lifecycle']
     default: bool
     options: dict[str, typing.Any]
     identity_plugin_id: typing.NotRequired[str | None]


### PR DESCRIPTION
## Summary

- Adds `'lifecycle'` to the five Pydantic `Literal` definitions that validate the `tab` field on plugin assignment write / response models, so assigning a lifecycle plugin to a project type (or project) no longer 422s before reaching the graph.

## Problem

[#299](https://github.com/AWeber-Imbi/imbi-api/pull/299) wired the lifecycle plugin type through `resolve_all_plugins` and `lifecycle_dispatch.dispatch_lifecycle` (which resolves on `tab='lifecycle'`), and `imbi-common`'s `PluginManifest.plugin_type` Literal already accepts `'lifecycle'`. But the request/response models that gate assignment writes were never updated, so any PUT carrying `tab: 'lifecycle'` fails with:

```
[{"type":"literal_error","loc":["body",0,"tab"],"msg":"Input should be 'configuration', 'logs' or 'deployment'","input":"lifecycle"}]
```

The imbi-ui admin third-party-services flow takes its `tab` value from `manifest.supported_tabs[0]`, so the moment the GitHub lifecycle plugin (or any future lifecycle plugin) ships, the editor submits `'lifecycle'` and the API rejects it.

## Solution

Widen the five `tab` Literals to include `'lifecycle'`:

- `PluginAssignmentRow` — `src/imbi_api/plugins/assignments.py`
- `PluginAssignmentCreate` / `PluginAssignmentResponse` — `src/imbi_api/domain/models.py`
- `_AssignmentInput` / `_AssignmentRow` — `src/imbi_api/endpoints/service_plugins.py`

No changes to `validate_one_default_per_tab`: it already iterates only over tabs that have assignments, so it doesn't demand a lifecycle default unless lifecycle plugins are actually assigned. The "exactly one default per tab" rule is unchanged across all tabs.

## Test plan

- [x] `ruff check` / `ruff format --check` / `mypy` (via pre-commit) clean
- [x] Existing plugin/service-plugin/project-type-plugin tests pass (73 cases)
- [ ] Manual: assign the GitHub lifecycle plugin to a project type and confirm the PUT now succeeds (depends on imbi-plugin-github lifecycle plugin)