### PR TITLE
Add deployment resync endpoints + external_run_id dedupe

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -222,6 +222,13 @@ plugins = [
   "imbi-plugin-oidc>=1.0.0",
 ]
 
+# Track the unmerged imbi-common feature branch that adds
+# ``DeploymentPlugin.list_recent_deployments`` + ``RemoteDeployment`` +
+# ``supports_deployment_sync``.  Drop this block once imbi-common's PR
+# merges and a new release is cut.
+[tool.uv.sources]
+imbi-common = { git = "https://github.com/AWeber-Imbi/imbi-common.git", branch = "feature/deployment-resync-plugin-contract" }
+
 [[tool.uv.index]]
 url = "https://pypi.org/simple"
 default = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -222,12 +222,12 @@ plugins = [
   "imbi-plugin-oidc>=1.0.0",
 ]
 
-# Track the unmerged imbi-common feature branch that adds
+# Track imbi-common's ``main`` directly until a release with
 # ``DeploymentPlugin.list_recent_deployments`` + ``RemoteDeployment`` +
-# ``supports_deployment_sync``.  Drop this block once imbi-common's PR
-# merges and a new release is cut.
+# ``supports_deployment_sync`` is cut.  Drop this block (and bump the
+# ``imbi-common`` floor on the dep above) once that release ships.
 [tool.uv.sources]
-imbi-common = { git = "https://github.com/AWeber-Imbi/imbi-common.git", branch = "feature/deployment-resync-plugin-contract" }
+imbi-common = { git = "https://github.com/AWeber-Imbi/imbi-common.git", branch = "main" }
 
 [[tool.uv.index]]
 url = "https://pypi.org/simple"

--- a/src/imbi_api/domain/models.py
+++ b/src/imbi_api/domain/models.py
@@ -881,6 +881,11 @@ class PluginAssignmentResponse(pydantic.BaseModel):
     # (e.g. the histogram strip on the Logs tab) for plugins whose
     # underlying API does not support them.
     supports_histogram: bool = False
+    # Set on deployment plugins that implement
+    # ``list_recent_deployments`` -- gates the "Resync deployments"
+    # card on the project settings page (and the admin TPS page) so
+    # the UI doesn't surface a button that the API will 400 on.
+    supports_deployment_sync: bool = False
 
 
 # -- Configuration / Logs response models ---------------------------------

--- a/src/imbi_api/endpoints/admin_plugins.py
+++ b/src/imbi_api/endpoints/admin_plugins.py
@@ -160,6 +160,9 @@ def _serialize(
         'requires_identity': entry.manifest.requires_identity,
         'docs_url': getattr(entry.manifest, 'docs_url', None),
         'supported_tabs': [entry.manifest.plugin_type],
+        'supports_deployment_sync': bool(
+            getattr(entry.manifest, 'supports_deployment_sync', False)
+        ),
         'options': [o.model_dump() for o in entry.manifest.options],
         'credentials': [c.model_dump() for c in entry.manifest.credentials],
         'vertex_labels': [
@@ -190,6 +193,7 @@ def _placeholder(package_name: str) -> dict[str, typing.Any]:
         'requires_identity': False,
         'docs_url': None,
         'supported_tabs': [],
+        'supports_deployment_sync': False,
         'options': [],
         'credentials': [],
         'vertex_labels': [],

--- a/src/imbi_api/endpoints/project_deployments.py
+++ b/src/imbi_api/endpoints/project_deployments.py
@@ -29,6 +29,7 @@ from imbi_common.plugins.base import (
     DeploymentRun,
     PluginContext,
     Ref,
+    RemoteDeployment,
 )
 from imbi_common.plugins.errors import PluginCredentialsMissing
 
@@ -138,6 +139,34 @@ class DraftReleaseNotesResponse(pydantic.BaseModel):
     notes_markdown: str
     degraded: bool = False
     commits_considered: int = 0
+
+
+class ResyncProjectError(pydantic.BaseModel):
+    """One non-fatal failure encountered during a resync."""
+
+    project_id: str | None = None
+    environment: str | None = None
+    detail: str
+
+
+class ResyncSummary(pydantic.BaseModel):
+    """Aggregate counts returned by a resync run.
+
+    ``observed`` is the number of remote deployments the plugin returned;
+    ``releases_created`` / ``releases_updated`` count distinct
+    ``Release`` nodes affected; ``events_recorded`` counts the
+    ``DeploymentEvent`` rows actually appended (dedupe-suppressed rows
+    do not count); ``events_skipped`` counts rows the dedupe path
+    short-circuited.
+    """
+
+    projects: int = 0
+    observed: int = 0
+    releases_created: int = 0
+    releases_updated: int = 0
+    events_recorded: int = 0
+    events_skipped: int = 0
+    errors: list[ResyncProjectError] = []
 
 
 class PromotionOption(pydantic.BaseModel):
@@ -395,6 +424,262 @@ async def _record_deployment_audit(
 
 
 # ---------------------------------------------------------------------------
+# Resync helpers
+# ---------------------------------------------------------------------------
+
+
+_SEMVER_REF_RE = re.compile(r'^v?\d+\.\d+\.\d+(?:[-+].*)?$')
+
+
+def _resync_version(observed: RemoteDeployment) -> str:
+    """Pick the ``Release.version`` to record for an observed deployment.
+
+    Mirrors the CEL expression the gateway uses on
+    ``imbi_gateway.actions.create_release``:
+    semver-shaped ``ref`` wins, otherwise the first 7 chars of the
+    commit SHA.  Keeping the rules aligned means a project whose
+    webhooks recover later sees the same ``version`` strings the
+    gateway would have created, so the badge does not flip.
+    """
+    if observed.ref and _SEMVER_REF_RE.match(observed.ref):
+        return observed.ref
+    return observed.sha[:7]
+
+
+async def _load_resync_environments(
+    db: graph.Graph,
+    *,
+    project_id: str,
+) -> list[str]:
+    """Return the environment slugs the project is wired up to deploy to.
+
+    Source of truth is the project's ``DEPLOYED_IN`` edges (the same
+    ones the promotion-options endpoint walks).  Order by ``sort_order``
+    so the plugin sees the project's preferred order when it fans out.
+    """
+    query: typing.LiteralString = """
+    MATCH (p:Project {{id: {project_id}}})-[:DEPLOYED_IN]->(e:Environment)
+    RETURN e.slug AS slug, e.sort_order AS sort_order
+    """
+    rows = await db.execute(
+        query,
+        {'project_id': project_id},
+        ['slug', 'sort_order'],
+    )
+
+    def _order(row: dict[str, typing.Any]) -> tuple[int, str]:
+        order = graph.parse_agtype(row.get('sort_order'))
+        slug = str(graph.parse_agtype(row.get('slug')) or '')
+        # ``sort_order`` is nullable on Environment; rows missing it
+        # sort after the ones that do, then break ties on slug so the
+        # ordering is deterministic even with NULLs.
+        order_int = int(order) if isinstance(order, int | float) else 1_000_000
+        return order_int, slug
+
+    return [
+        str(graph.parse_agtype(row.get('slug')))
+        for row in sorted(rows, key=_order)
+        if graph.parse_agtype(row.get('slug'))
+    ]
+
+
+async def _release_exists(
+    db: graph.Graph,
+    *,
+    project_id: str,
+    version: str,
+) -> bool:
+    """Cheap existence probe for ``project -[:HAS_RELEASE]-> Release``."""
+    query: typing.LiteralString = """
+    MATCH (:Project {{id: {project_id}}})
+        -[:HAS_RELEASE]->(r:Release {{version: {version}}})
+    RETURN r.id AS rid
+    LIMIT 1
+    """
+    rows = await db.execute(
+        query,
+        {'project_id': project_id, 'version': version},
+        ['rid'],
+    )
+    return bool(rows)
+
+
+async def _resync_for_project(
+    db: graph.Graph,
+    *,
+    org_slug: str,
+    project_id: str,
+    auth: permissions.AuthContext,
+    source: str | None = None,
+) -> ResyncSummary:
+    """Resync remote deployments for a single project.
+
+    Resolves the project's deployment plugin, asks it for the most
+    recent deployment per environment, upserts ``Release`` nodes for
+    any observed versions that are missing, appends ``DeploymentEvent``
+    rows on the ``DEPLOYED_TO`` edge (dedup'd by ``external_run_id``),
+    and writes a single audit row per environment.  Returns counts +
+    a per-environment error list so the host can surface partial
+    results rather than failing the whole call on one bad env.
+    """
+    summary = ResyncSummary(projects=1)
+    resolved, ctx, credentials = await _resolve_and_context(
+        db, org_slug, project_id, auth, source=source
+    )
+    if not getattr(resolved.entry.manifest, 'supports_deployment_sync', False):
+        raise fastapi.HTTPException(
+            status_code=400,
+            detail=(
+                f'Plugin {resolved.plugin_slug!r} does not support '
+                'deployment resync.'
+            ),
+        )
+    environments = await _load_resync_environments(db, project_id=project_id)
+    if not environments:
+        return summary
+    handler = _handler(resolved)
+
+    async def _fetch(c: PluginContext) -> list[RemoteDeployment]:
+        return await call_with_timeout(
+            handler.list_recent_deployments(
+                c,
+                _resolve_credentials(c, credentials),
+                environments=environments,
+                limit=1,
+            )
+        )
+
+    try:
+        observations = await call_with_identity_retry(
+            db, ctx, resolved, auth, fn=_fetch, attached=True
+        )
+    except NotImplementedError as exc:
+        # Manifest advertised sync but the implementation didn't.
+        # Surface as a 400 so the operator notices rather than logging
+        # silently and reporting an empty resync.
+        raise fastapi.HTTPException(
+            status_code=400,
+            detail=(
+                f'Plugin {resolved.plugin_slug!r} advertises '
+                'supports_deployment_sync but did not implement '
+                'list_recent_deployments.'
+            ),
+        ) from exc
+    summary.observed = len(observations)
+    for observed in observations:
+        try:
+            await _apply_remote_deployment(
+                db,
+                org_slug=org_slug,
+                project_id=project_id,
+                project_slug=ctx.project_slug,
+                plugin_slug=resolved.plugin_slug,
+                recorded_by=auth.principal_name,
+                observed=observed,
+                summary=summary,
+            )
+        except Exception as exc:
+            LOGGER.exception(
+                'Resync apply failed for project=%s env=%s',
+                project_id,
+                observed.environment,
+            )
+            summary.errors.append(
+                ResyncProjectError(
+                    project_id=project_id,
+                    environment=observed.environment,
+                    detail=f'{type(exc).__name__}: {exc}',
+                )
+            )
+    return summary
+
+
+async def _apply_remote_deployment(
+    db: graph.Graph,
+    *,
+    org_slug: str,
+    project_id: str,
+    project_slug: str,
+    plugin_slug: str,
+    recorded_by: str,
+    observed: RemoteDeployment,
+    summary: ResyncSummary,
+) -> None:
+    """Persist one observed remote deployment + audit row."""
+    version = _resync_version(observed)
+    title = observed.description or observed.ref or version
+    existed = await _release_exists(db, project_id=project_id, version=version)
+    await _upsert_release_node(
+        db,
+        project_id=project_id,
+        version=version,
+        title=title,
+        notes_markdown=observed.description or '',
+        release_url=observed.deployment_url,
+        created_by=recorded_by,
+    )
+    if existed:
+        summary.releases_updated += 1
+    else:
+        summary.releases_created += 1
+    edge = await append_deployment_event(
+        db,
+        org_slug=org_slug,
+        project_id=project_id,
+        version=version,
+        env_slug=observed.environment,
+        status=observed.status,
+        note=f'resync via {plugin_slug}',
+        external_run_id=observed.external_run_id,
+        external_run_url=observed.run_url,
+        timestamp=observed.created_at,
+    )
+    if edge is None:
+        # Either the Release upsert didn't take or the env slug isn't
+        # wired up in this org -- record as an error so the operator
+        # has a thread to pull rather than a silently swallowed row.
+        summary.errors.append(
+            ResyncProjectError(
+                project_id=project_id,
+                environment=observed.environment,
+                detail=(
+                    f'Could not attach DeploymentEvent for version '
+                    f'{version!r} -- release or environment not found.'
+                ),
+            )
+        )
+        return
+    # Count records by comparing the latest event timestamp against
+    # the observed creation time: dedupe path returns the existing
+    # edge unchanged, so the latest event's external_run_id matches
+    # but its timestamp may differ from ``observed.created_at`` only
+    # if we actually persisted a row this call.  Simpler heuristic:
+    # only the dedupe-no-op path leaves the deployment list unchanged
+    # in length, so compare counts via the edge response.
+    latest = edge.deployments[-1] if edge.deployments else None
+    if latest and latest.external_run_id == observed.external_run_id:
+        # Heuristic: same id + same status as the observed remote ->
+        # treat as recorded (covers both first-time append and
+        # dedupe-update paths); a true no-op leaves the timestamp
+        # unchanged from a prior run.  In practice we report at the
+        # event level: a row exists for this run on this edge.
+        summary.events_recorded += 1
+    else:
+        summary.events_skipped += 1
+    await _record_deployment_audit(
+        project_id=project_id,
+        project_slug=project_slug,
+        environment_slug=observed.environment,
+        recorded_by=recorded_by,
+        action='resync',
+        version=version,
+        plugin_slug=plugin_slug,
+        run_url=observed.run_url,
+        release_url=observed.deployment_url,
+    )
+
+
+# ---------------------------------------------------------------------------
 # Endpoints
 # ---------------------------------------------------------------------------
 
@@ -530,6 +815,40 @@ async def trigger_deployment(
         )
     return await _handle_deploy(
         db, org_slug, project_id, auth, body, source=source
+    )
+
+
+@project_deployments_router.post('/resync')
+async def resync_project_deployments(
+    org_slug: str,
+    project_id: str,
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('project:deployment:write'),
+        ),
+    ],
+    source: str | None = None,
+) -> ResyncSummary:
+    """Backfill Release nodes + DEPLOYED_TO edges from the remote.
+
+    Asks the project's deployment plugin for the most recent
+    deployment per environment, upserts any missing ``Release`` nodes,
+    and dedup-appends ``DeploymentEvent`` rows so the badges advance
+    even when the gateway webhook flow has lapsed.  Records one
+    audit row per environment with ``action='resync'``.
+
+    Surfaces 400 when the project's deployment plugin does not
+    advertise ``supports_deployment_sync`` -- callers should hide the
+    button using the plugin manifest flag.
+    """
+    return await _resync_for_project(
+        db,
+        org_slug=org_slug,
+        project_id=project_id,
+        auth=auth,
+        source=source,
     )
 
 

--- a/src/imbi_api/endpoints/project_deployments.py
+++ b/src/imbi_api/endpoints/project_deployments.py
@@ -39,7 +39,11 @@ from imbi_api.endpoints._helpers import (
     lookup_project_slugs,
     lookup_project_type_slugs,
 )
-from imbi_api.endpoints.releases import append_deployment_event
+from imbi_api.endpoints.releases import (
+    AppendOutcome,
+    ReleaseEnvironmentEdgeResponse,
+    append_deployment_event,
+)
 from imbi_api.identity.host_integration import (
     attach_identity,
     call_with_identity_retry,
@@ -504,7 +508,7 @@ async def _release_exists(
     return bool(rows)
 
 
-async def _resync_for_project(
+async def resync_for_project(
     db: graph.Graph,
     *,
     org_slug: str,
@@ -566,6 +570,11 @@ async def _resync_for_project(
             ),
         ) from exc
     summary.observed = len(observations)
+    # Track versions we've already touched so ``releases_created`` /
+    # ``releases_updated`` are counted once per distinct ``version`` --
+    # the same tag promoted across multiple environments is one
+    # Release node, not N.
+    seen_versions: set[str] = set()
     for observed in observations:
         try:
             await _apply_remote_deployment(
@@ -577,6 +586,7 @@ async def _resync_for_project(
                 recorded_by=auth.principal_name,
                 observed=observed,
                 summary=summary,
+                seen_versions=seen_versions,
             )
         except Exception as exc:
             LOGGER.exception(
@@ -604,10 +614,18 @@ async def _apply_remote_deployment(
     recorded_by: str,
     observed: RemoteDeployment,
     summary: ResyncSummary,
+    seen_versions: set[str],
 ) -> None:
-    """Persist one observed remote deployment + audit row."""
+    """Persist one observed remote deployment + audit row.
+
+    ``seen_versions`` is mutated to track which ``version`` strings
+    have already been counted against ``releases_created`` /
+    ``releases_updated`` during this resync, so a tag promoted across
+    multiple environments is counted as one Release node, not N.
+    """
     version = _resync_version(observed)
     title = observed.description or observed.ref or version
+    first_time_this_resync = version not in seen_versions
     existed = await _release_exists(db, project_id=project_id, version=version)
     await _upsert_release_node(
         db,
@@ -618,11 +636,13 @@ async def _apply_remote_deployment(
         release_url=observed.deployment_url,
         created_by=recorded_by,
     )
-    if existed:
-        summary.releases_updated += 1
-    else:
-        summary.releases_created += 1
-    edge = await append_deployment_event(
+    if first_time_this_resync:
+        seen_versions.add(version)
+        if existed:
+            summary.releases_updated += 1
+        else:
+            summary.releases_created += 1
+    result = await append_deployment_event(
         db,
         org_slug=org_slug,
         project_id=project_id,
@@ -634,7 +654,7 @@ async def _apply_remote_deployment(
         external_run_url=observed.run_url,
         timestamp=observed.created_at,
     )
-    if edge is None:
+    if result is None:
         # Either the Release upsert didn't take or the env slug isn't
         # wired up in this org -- record as an error so the operator
         # has a thread to pull rather than a silently swallowed row.
@@ -649,23 +669,16 @@ async def _apply_remote_deployment(
             )
         )
         return
-    # Count records by comparing the latest event timestamp against
-    # the observed creation time: dedupe path returns the existing
-    # edge unchanged, so the latest event's external_run_id matches
-    # but its timestamp may differ from ``observed.created_at`` only
-    # if we actually persisted a row this call.  Simpler heuristic:
-    # only the dedupe-no-op path leaves the deployment list unchanged
-    # in length, so compare counts via the edge response.
-    latest = edge.deployments[-1] if edge.deployments else None
-    if latest and latest.external_run_id == observed.external_run_id:
-        # Heuristic: same id + same status as the observed remote ->
-        # treat as recorded (covers both first-time append and
-        # dedupe-update paths); a true no-op leaves the timestamp
-        # unchanged from a prior run.  In practice we report at the
-        # event level: a row exists for this run on this edge.
-        summary.events_recorded += 1
-    else:
+    _edge, outcome = result
+    # Outcome comes straight from ``append_deployment_event``: a real
+    # write (``appended`` / ``updated``) bumps ``events_recorded``; a
+    # ``noop`` (dedupe matched an identical row) bumps
+    # ``events_skipped`` so a replay against an idle remote doesn't
+    # masquerade as fresh activity.
+    if outcome == 'noop':
         summary.events_skipped += 1
+    else:
+        summary.events_recorded += 1
     await _record_deployment_audit(
         project_id=project_id,
         project_slug=project_slug,
@@ -843,7 +856,7 @@ async def resync_project_deployments(
     advertise ``supports_deployment_sync`` -- callers should hide the
     button using the plugin manifest flag.
     """
-    return await _resync_for_project(
+    return await resync_for_project(
         db,
         org_slug=org_slug,
         project_id=project_id,
@@ -935,9 +948,9 @@ async def _handle_deploy(
     )
     note = f'via {resolved.plugin_slug}'
     recorded_version: str | None = None
-    edge = None
+    result: tuple[ReleaseEnvironmentEdgeResponse, AppendOutcome] | None = None
     for candidate in filter(None, (body.ref_label, body.committish)):
-        edge = await append_deployment_event(
+        result = await append_deployment_event(
             db,
             org_slug=org_slug,
             project_id=project_id,
@@ -948,7 +961,7 @@ async def _handle_deploy(
             external_run_id=str(run.run_id) if run.run_id else None,
             external_run_url=run.run_url,
         )
-        if edge is not None:
+        if result is not None:
             recorded_version = candidate
             break
     await _record_deployment_audit(
@@ -965,7 +978,7 @@ async def _handle_deploy(
         run=run,
         plugin_id=resolved.plugin_id,
         plugin_slug=resolved.plugin_slug,
-        recorded=edge is not None,
+        recorded=result is not None,
     )
 
 
@@ -1136,7 +1149,7 @@ async def _handle_promote(
 
     # 5. Record the deployment event.
     note = f'via {resolved.plugin_slug}'
-    edge = await append_deployment_event(
+    promote_result = await append_deployment_event(
         db,
         org_slug=org_slug,
         project_id=project_id,
@@ -1175,7 +1188,7 @@ async def _handle_promote(
         run=run,
         plugin_id=resolved.plugin_id,
         plugin_slug=resolved.plugin_slug,
-        recorded=edge is not None,
+        recorded=promote_result is not None,
         release_url=release_url,
         tag=body.tag,
         warning='; '.join(warnings) if warnings else None,

--- a/src/imbi_api/endpoints/releases.py
+++ b/src/imbi_api/endpoints/releases.py
@@ -798,6 +798,14 @@ def _edge_to_response(
     )
 
 
+#: Outcome reported by :func:`append_deployment_event`.  Lets callers
+#: distinguish a brand-new row (``appended``) from a dedupe path that
+#: refreshed an existing row in place (``updated``) versus a no-op
+#: replay (``noop``).  The resync flow uses this to keep its summary
+#: counters honest; the deploy/promote flows ignore it.
+AppendOutcome = typing.Literal['appended', 'updated', 'noop']
+
+
 async def append_deployment_event(
     db: graph.Graph,
     *,
@@ -812,13 +820,17 @@ async def append_deployment_event(
     external_run_id: str | None = None,
     external_run_url: str | None = None,
     timestamp: datetime.datetime | None = None,
-) -> ReleaseEnvironmentEdgeResponse | None:
+) -> tuple[ReleaseEnvironmentEdgeResponse, AppendOutcome] | None:
     """Append a ``DeploymentEvent`` to ``Release -[:DEPLOYED_TO]-> Env``.
 
-    Returns the resulting edge, or ``None`` when the named ``Release``
-    or ``Environment`` cannot be found — callers that auto-record from
-    a deploy of a SHA (which has no ``Release`` node) treat ``None`` as
-    "skip persistence, deploy still succeeded".
+    Returns a ``(edge, outcome)`` tuple, or ``None`` when the named
+    ``Release`` or ``Environment`` cannot be found — callers that
+    auto-record from a deploy of a SHA (which has no ``Release`` node)
+    treat ``None`` as "skip persistence, deploy still succeeded".
+
+    ``outcome`` is one of ``'appended'`` (new row), ``'updated'``
+    (dedupe path refreshed an existing row in place), or ``'noop'``
+    (dedupe path matched an identical existing row and made no write).
 
     Deduplicates on ``external_run_id``: when the caller supplies one
     and the most recent existing event already carries the same id,
@@ -855,7 +867,7 @@ async def append_deployment_event(
                     and candidate.note == note
                     and candidate.external_run_url == external_run_url
                 ):
-                    return _edge_to_response(env, existing)
+                    return _edge_to_response(env, existing), 'noop'
                 refreshed = candidate.model_copy(
                     update={
                         'status': status,
@@ -870,7 +882,7 @@ async def append_deployment_event(
                     refreshed,
                     *existing[idx + 1 :],
                 ]
-                return await _set_deployments(
+                updated_edge = await _set_deployments(
                     db,
                     project_id=project_id,
                     version=version,
@@ -878,6 +890,7 @@ async def append_deployment_event(
                     deployments=updated_list,
                     env=env,
                 )
+                return updated_edge, 'updated'
     event = models.DeploymentEvent(
         timestamp=timestamp or datetime.datetime.now(datetime.UTC),
         status=status,
@@ -887,7 +900,7 @@ async def append_deployment_event(
     )
     deployments = [*existing, event]
     if existing:
-        return await _set_deployments(
+        appended_edge = await _set_deployments(
             db,
             project_id=project_id,
             version=version,
@@ -895,7 +908,8 @@ async def append_deployment_event(
             deployments=deployments,
             env=env,
         )
-    return await _create_deployments_edge(
+        return appended_edge, 'appended'
+    created_edge = await _create_deployments_edge(
         db,
         project_id=project_id,
         version=version,
@@ -904,6 +918,7 @@ async def append_deployment_event(
         deployments=deployments,
         env=env,
     )
+    return created_edge, 'appended'
 
 
 async def _set_deployments(

--- a/src/imbi_api/endpoints/releases.py
+++ b/src/imbi_api/endpoints/releases.py
@@ -811,6 +811,7 @@ async def append_deployment_event(
     note: str | None = None,
     external_run_id: str | None = None,
     external_run_url: str | None = None,
+    timestamp: datetime.datetime | None = None,
 ) -> ReleaseEnvironmentEdgeResponse | None:
     """Append a ``DeploymentEvent`` to ``Release -[:DEPLOYED_TO]-> Env``.
 
@@ -818,6 +819,19 @@ async def append_deployment_event(
     or ``Environment`` cannot be found — callers that auto-record from
     a deploy of a SHA (which has no ``Release`` node) treat ``None`` as
     "skip persistence, deploy still succeeded".
+
+    Deduplicates on ``external_run_id``: when the caller supplies one
+    and the most recent existing event already carries the same id,
+    the row is treated as a status update -- if ``status`` changed
+    the existing event is updated in-place, otherwise the call is a
+    no-op.  This lets resync re-replay the remote's recent history
+    without doubling up rows on the edge, while still letting an
+    in-flight workflow advance from ``in_progress`` -> ``success``.
+    Callers that omit ``external_run_id`` keep the previous append-
+    only semantics so the deploy / promote flows are unchanged.
+
+    ``timestamp`` lets the resync flow record the remote's deployment
+    creation time rather than ``now()``; defaults to now when omitted.
     """
     release = await _fetch_release(db, org_slug, project_id, version)
     if release is None:
@@ -827,55 +841,133 @@ async def append_deployment_event(
     )
     if env is None:
         return None
+    if external_run_id and existing:
+        # Walk newest-first so the "most recent event for this run"
+        # wins when older entries with the same id exist (rare; only
+        # possible if a caller appended duplicates before the dedupe
+        # landed).  Comparing by status keeps the no-op fast path
+        # cheap when resync re-runs against an idle remote.
+        for idx in range(len(existing) - 1, -1, -1):
+            candidate = existing[idx]
+            if candidate.external_run_id == external_run_id:
+                if (
+                    candidate.status == status
+                    and candidate.note == note
+                    and candidate.external_run_url == external_run_url
+                ):
+                    return _edge_to_response(env, existing)
+                refreshed = candidate.model_copy(
+                    update={
+                        'status': status,
+                        'note': note,
+                        'external_run_url': external_run_url,
+                        'timestamp': timestamp
+                        or datetime.datetime.now(datetime.UTC),
+                    }
+                )
+                updated_list = [
+                    *existing[:idx],
+                    refreshed,
+                    *existing[idx + 1 :],
+                ]
+                return await _set_deployments(
+                    db,
+                    project_id=project_id,
+                    version=version,
+                    env_slug=env_slug,
+                    deployments=updated_list,
+                    env=env,
+                )
     event = models.DeploymentEvent(
-        timestamp=datetime.datetime.now(datetime.UTC),
+        timestamp=timestamp or datetime.datetime.now(datetime.UTC),
         status=status,
         note=note,
         external_run_id=external_run_id,
         external_run_url=external_run_url,
     )
     deployments = [*existing, event]
-    serialized = json.dumps(
-        [e.model_dump(mode='json') for e in deployments],
-    )
     if existing:
-        set_query: typing.LiteralString = """
-        MATCH (:Project {{id: {project_id}}})
-              -[:HAS_RELEASE]->(r:Release {{version: {version}}})
-        MATCH (r)-[d:DEPLOYED_TO]->(:Environment {{slug: {env_slug}}})
-        SET d.deployments = {deployments}
-        RETURN d.deployments AS deployments
-        """
-        await db.execute(
-            set_query,
-            {
-                'project_id': project_id,
-                'version': version,
-                'env_slug': env_slug,
-                'deployments': serialized,
-            },
-            ['deployments'],
+        return await _set_deployments(
+            db,
+            project_id=project_id,
+            version=version,
+            env_slug=env_slug,
+            deployments=deployments,
+            env=env,
         )
-    else:
-        create_query: typing.LiteralString = """
-        MATCH (:Project {{id: {project_id}}})
-              -[:HAS_RELEASE]->(r:Release {{version: {version}}})
-        MATCH (e:Environment {{slug: {env_slug}}})
-              -[:BELONGS_TO]->(:Organization {{slug: {org_slug}}})
-        CREATE (r)-[d:DEPLOYED_TO {{deployments: {deployments}}}]->(e)
-        RETURN d.deployments AS deployments
-        """
-        await db.execute(
-            create_query,
-            {
-                'project_id': project_id,
-                'version': version,
-                'env_slug': env_slug,
-                'org_slug': org_slug,
-                'deployments': serialized,
-            },
-            ['deployments'],
-        )
+    return await _create_deployments_edge(
+        db,
+        project_id=project_id,
+        version=version,
+        env_slug=env_slug,
+        org_slug=org_slug,
+        deployments=deployments,
+        env=env,
+    )
+
+
+async def _set_deployments(
+    db: graph.Graph,
+    *,
+    project_id: str,
+    version: str,
+    env_slug: str,
+    deployments: list[models.DeploymentEvent],
+    env: dict[str, typing.Any],
+) -> ReleaseEnvironmentEdgeResponse:
+    """Overwrite ``deployments`` on an existing ``DEPLOYED_TO`` edge."""
+    serialized = json.dumps([e.model_dump(mode='json') for e in deployments])
+    set_query: typing.LiteralString = """
+    MATCH (:Project {{id: {project_id}}})
+          -[:HAS_RELEASE]->(r:Release {{version: {version}}})
+    MATCH (r)-[d:DEPLOYED_TO]->(:Environment {{slug: {env_slug}}})
+    SET d.deployments = {deployments}
+    RETURN d.deployments AS deployments
+    """
+    await db.execute(
+        set_query,
+        {
+            'project_id': project_id,
+            'version': version,
+            'env_slug': env_slug,
+            'deployments': serialized,
+        },
+        ['deployments'],
+    )
+    return _edge_to_response(env, deployments)
+
+
+async def _create_deployments_edge(
+    db: graph.Graph,
+    *,
+    project_id: str,
+    version: str,
+    env_slug: str,
+    org_slug: str,
+    deployments: list[models.DeploymentEvent],
+    env: dict[str, typing.Any],
+) -> ReleaseEnvironmentEdgeResponse:
+    """Create the first ``DEPLOYED_TO`` edge for ``(release, env)``."""
+    serialized = json.dumps([e.model_dump(mode='json') for e in deployments])
+    create_query: typing.LiteralString = """
+    MATCH (:Project {{id: {project_id}}})
+          -[:HAS_RELEASE]->(r:Release {{version: {version}}})
+    MATCH (e:Environment {{slug: {env_slug}}})
+          -[:BELONGS_TO]->(:Organization {{slug: {org_slug}}})
+    CREATE (r)-[d:DEPLOYED_TO {{deployments: {deployments}}}]->(e)
+    RETURN d.deployments AS deployments
+    """
+    await db.execute(
+        create_query,
+        {
+            'project_id': project_id,
+            'version': version,
+            'env_slug': env_slug,
+            'org_slug': org_slug,
+            'deployments': serialized,
+        },
+        ['deployments'],
+    )
     return _edge_to_response(env, deployments)
 
 

--- a/src/imbi_api/endpoints/third_party_services.py
+++ b/src/imbi_api/endpoints/third_party_services.py
@@ -1,5 +1,6 @@
 """Third-party service management endpoints."""
 
+import asyncio
 import collections.abc
 import json
 import logging
@@ -15,9 +16,21 @@ from imbi_common.auth import encryption
 from imbi_api import patch as json_patch
 from imbi_api.auth import permissions
 from imbi_api.domain import models
+from imbi_api.endpoints.project_deployments import (
+    ResyncProjectError,
+    ResyncSummary,
+    _resync_for_project,
+)
 from imbi_api.graph_sql import props_template, set_clause
 
 LOGGER = logging.getLogger(__name__)
+
+#: Cap on concurrent per-project resync calls when fanning out from a
+#: TPS-wide trigger.  Keeps a single admin click from saturating the
+#: remote (GitHub's per-org secondary rate limit is the binding
+#: constraint) while still finishing in reasonable wall-clock for an
+#: org with O(100) projects.
+_TPS_RESYNC_CONCURRENCY = 5
 
 
 _SERVICE_JSON_FIELDS: dict[str, list[str] | dict[str, typing.Any]] = {
@@ -440,6 +453,132 @@ async def delete_third_party_service(
             status_code=404,
             detail=(f'Third-party service with slug {slug!r} not found'),
         )
+
+
+# --- Deployment resync endpoints ---
+
+
+async def _projects_using_tps_for_deployment(
+    db: graph.Graph,
+    *,
+    org_slug: str,
+    slug: str,
+) -> list[str]:
+    """Return project ids whose deployment plugin is owned by this TPS.
+
+    Walks both project-level and project-type-level ``USES_PLUGIN``
+    edges with ``tab='deployment'`` whose target ``Plugin`` is owned
+    (via ``HAS_PLUGIN``) by the named ThirdPartyService.  Returns a
+    de-duplicated, deterministic list so the resync fan-out is stable
+    across calls.
+    """
+    query: typing.LiteralString = """
+    MATCH (tps:ThirdPartyService {{slug: {slug}}})
+          -[:BELONGS_TO]->(:Organization {{slug: {org_slug}}})
+    MATCH (tps)-[:HAS_PLUGIN]->(plugin:Plugin)
+    OPTIONAL MATCH (p:Project)-[upe:USES_PLUGIN]->(plugin)
+    WHERE upe.tab = 'deployment'
+    OPTIONAL MATCH (p2:Project)-[:TYPE]
+        ->(:ProjectType)-[upte:USES_PLUGIN]->(plugin)
+    WHERE upte.tab = 'deployment'
+    WITH collect(DISTINCT p.id) AS direct_ids,
+         collect(DISTINCT p2.id) AS typed_ids
+    RETURN direct_ids + typed_ids AS project_ids
+    """
+    rows = await db.execute(
+        query,
+        {'slug': slug, 'org_slug': org_slug},
+        ['project_ids'],
+    )
+    if not rows:
+        return []
+    parsed = graph.parse_agtype(rows[0].get('project_ids')) or []
+    return sorted({str(pid) for pid in parsed if pid})
+
+
+def _accumulate(into: ResyncSummary, summary: ResyncSummary) -> None:
+    """Sum counts from a per-project run into the aggregate response."""
+    into.projects += summary.projects
+    into.observed += summary.observed
+    into.releases_created += summary.releases_created
+    into.releases_updated += summary.releases_updated
+    into.events_recorded += summary.events_recorded
+    into.events_skipped += summary.events_skipped
+    into.errors.extend(summary.errors)
+
+
+@third_party_services_router.post('/{slug}/deployments/resync')
+async def resync_service_deployments(
+    org_slug: str,
+    slug: str,
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('third_party_service:update'),
+        ),
+    ],
+) -> ResyncSummary:
+    """Resync deployments for every project using this TPS's plugin.
+
+    Iterates the projects that resolve to a deployment plugin owned by
+    the named ThirdPartyService and runs the per-project resync flow
+    on each with bounded concurrency.  Surfaces aggregate counts plus
+    a per-project error list rather than failing the call on the first
+    bad project -- the operator-facing UI renders the warnings inline
+    so partial recovery is visible.
+    """
+    project_ids = await _projects_using_tps_for_deployment(
+        db, org_slug=org_slug, slug=slug
+    )
+    aggregate = ResyncSummary()
+    if not project_ids:
+        return aggregate
+    semaphore = asyncio.Semaphore(_TPS_RESYNC_CONCURRENCY)
+
+    async def _run(project_id: str) -> ResyncSummary:
+        async with semaphore:
+            try:
+                return await _resync_for_project(
+                    db,
+                    org_slug=org_slug,
+                    project_id=project_id,
+                    auth=auth,
+                )
+            except fastapi.HTTPException as exc:
+                # A 400 from the project-level endpoint (e.g. plugin
+                # opts out of sync mid-flight) becomes a row in the
+                # aggregate errors list rather than failing the whole
+                # batch -- one project misconfiguration should not
+                # block recovery for the rest of the org.
+                LOGGER.warning(
+                    'Resync HTTPException for project=%s: %s',
+                    project_id,
+                    exc.detail,
+                )
+                summary = ResyncSummary()
+                summary.errors.append(
+                    ResyncProjectError(
+                        project_id=project_id,
+                        detail=f'HTTP {exc.status_code}: {exc.detail}',
+                    )
+                )
+                return summary
+            except Exception as exc:
+                LOGGER.exception('Resync failed for project=%s', project_id)
+                summary = ResyncSummary()
+                summary.errors.append(
+                    ResyncProjectError(
+                        project_id=project_id,
+                        detail=f'{type(exc).__name__}: {exc}',
+                    )
+                )
+                return summary
+
+    results = await asyncio.gather(*(_run(pid) for pid in project_ids))
+    for result in results:
+        _accumulate(aggregate, result)
+    return aggregate
 
 
 # --- Service Webhook endpoints ---
@@ -1134,7 +1273,7 @@ async def delete_service_application(
     if 'auth_providers:write' not in auth.permissions:
         try:
             existing = await _fetch_application(db, org_slug, slug, app_slug)
-        except (fastapi.HTTPException, KeyError):
+        except fastapi.HTTPException, KeyError:
             existing = None
         if existing and existing.get('usage') in ('login', 'both'):
             raise fastapi.HTTPException(

--- a/src/imbi_api/endpoints/third_party_services.py
+++ b/src/imbi_api/endpoints/third_party_services.py
@@ -19,7 +19,7 @@ from imbi_api.domain import models
 from imbi_api.endpoints.project_deployments import (
     ResyncProjectError,
     ResyncSummary,
-    _resync_for_project,
+    resync_for_project,
 )
 from imbi_api.graph_sql import props_template, set_clause
 
@@ -472,14 +472,20 @@ async def _projects_using_tps_for_deployment(
     de-duplicated, deterministic list so the resync fan-out is stable
     across calls.
     """
+    # Scope both Project branches to the requested organization via the
+    # OWNED_BY -> BELONGS_TO path so a TPS-wide resync triggered against
+    # one org can't sweep in projects in another org that happen to use
+    # the same plugin node.
     query: typing.LiteralString = """
     MATCH (tps:ThirdPartyService {{slug: {slug}}})
-          -[:BELONGS_TO]->(:Organization {{slug: {org_slug}}})
+          -[:BELONGS_TO]->(o:Organization {{slug: {org_slug}}})
     MATCH (tps)-[:HAS_PLUGIN]->(plugin:Plugin)
-    OPTIONAL MATCH (p:Project)-[upe:USES_PLUGIN]->(plugin)
+    OPTIONAL MATCH (p:Project)-[upe:USES_PLUGIN]->(plugin),
+                   (p)-[:OWNED_BY]->(:Team)-[:BELONGS_TO]->(o)
     WHERE upe.tab = 'deployment'
     OPTIONAL MATCH (p2:Project)-[:TYPE]
-        ->(:ProjectType)-[upte:USES_PLUGIN]->(plugin)
+        ->(:ProjectType)-[upte:USES_PLUGIN]->(plugin),
+                   (p2)-[:OWNED_BY]->(:Team)-[:BELONGS_TO]->(o)
     WHERE upte.tab = 'deployment'
     WITH collect(DISTINCT p.id) AS direct_ids,
          collect(DISTINCT p2.id) AS typed_ids
@@ -492,7 +498,12 @@ async def _projects_using_tps_for_deployment(
     )
     if not rows:
         return []
-    parsed = graph.parse_agtype(rows[0].get('project_ids')) or []
+    raw: typing.Any = graph.parse_agtype(rows[0].get('project_ids'))
+    parsed: list[typing.Any] = (
+        list(typing.cast(collections.abc.Iterable[typing.Any], raw))
+        if isinstance(raw, list)
+        else []
+    )
     return sorted({str(pid) for pid in parsed if pid})
 
 
@@ -539,7 +550,7 @@ async def resync_service_deployments(
     async def _run(project_id: str) -> ResyncSummary:
         async with semaphore:
             try:
-                return await _resync_for_project(
+                return await resync_for_project(
                     db,
                     org_slug=org_slug,
                     project_id=project_id,

--- a/src/imbi_api/plugins/assignments.py
+++ b/src/imbi_api/plugins/assignments.py
@@ -107,9 +107,12 @@ def build_assignment_response(
 ) -> models.PluginAssignmentResponse:
     """Build a PluginAssignmentResponse from parsed plugin/edge dicts."""
     supports_histogram = False
+    supports_deployment_sync = False
     try:
-        supports_histogram = bool(
-            get_plugin(plugin['plugin_slug']).manifest.supports_histogram
+        manifest = get_plugin(plugin['plugin_slug']).manifest
+        supports_histogram = bool(manifest.supports_histogram)
+        supports_deployment_sync = bool(
+            getattr(manifest, 'supports_deployment_sync', False)
         )
     except PluginNotFoundError:
         pass
@@ -125,4 +128,5 @@ def build_assignment_response(
             edge.get('identity_plugin_id')
         ),
         supports_histogram=supports_histogram,
+        supports_deployment_sync=supports_deployment_sync,
     )

--- a/tests/endpoints/test_project_deployments.py
+++ b/tests/endpoints/test_project_deployments.py
@@ -910,11 +910,16 @@ class ResyncProjectDeploymentsTestCase(ProjectDeploymentsTestCase):
         if edge_status == 'missing':
             self.mocks['append_deployment_event'].return_value = None
         else:
-            self.mocks['append_deployment_event'].return_value = mock.Mock(
+            outcome = 'noop' if edge_status == 'dedupe' else 'appended'
+            edge = mock.Mock(
                 deployments=[
                     mock.Mock(external_run_id=o.external_run_id)
                     for o in recent
                 ]
+            )
+            self.mocks['append_deployment_event'].return_value = (
+                edge,
+                outcome,
             )
 
     def _observed(

--- a/tests/endpoints/test_project_deployments.py
+++ b/tests/endpoints/test_project_deployments.py
@@ -17,6 +17,7 @@ from imbi_common.plugins.base import (
     Ref,
     RefInfo,
     ReleaseInfo,
+    RemoteDeployment,
 )
 from imbi_common.plugins.registry import RegistryEntry
 
@@ -32,6 +33,7 @@ class _FakeDeploymentPlugin(DeploymentPlugin):
         slug='github-deployment',
         name='GitHub Deployment',
         plugin_type='deployment',
+        supports_deployment_sync=True,
     )
 
     async def list_refs(  # type: ignore[override]
@@ -95,6 +97,23 @@ class _FakeDeploymentPlugin(DeploymentPlugin):
             url=f'https://api.gh/releases/{tag}',
             prerelease=prerelease,
         )
+
+    async def list_recent_deployments(  # type: ignore[override]
+        self, ctx, credentials, environments, limit=1
+    ):
+        # Override per-test by setting ``_recent`` on the instance.
+        return getattr(self, '_recent', [])
+
+
+class _FakeNoSyncDeploymentPlugin(_FakeDeploymentPlugin):
+    """Deployment plugin that opts *out* of resync."""
+
+    manifest = PluginManifest(
+        slug='no-sync-deployment',
+        name='No-Sync Deployment',
+        plugin_type='deployment',
+        supports_deployment_sync=False,
+    )
 
 
 def _entry() -> RegistryEntry:
@@ -844,6 +863,219 @@ class ProjectDeploymentsTestCase(unittest.TestCase):
         self.assertEqual(row['environment_slug'], 'staging')
         self.assertEqual(row['version'], 'v6.4.0')
         self.assertEqual(row['plugin_slug'], 'github-deployment')
+
+
+class ResyncProjectDeploymentsTestCase(ProjectDeploymentsTestCase):
+    """End-to-end coverage for the per-project resync endpoint."""
+
+    def _arm(
+        self,
+        recent: list[RemoteDeployment],
+        *,
+        environments: list[str] | None = None,
+        release_exists: bool = False,
+        edge_status: typing.Literal['append', 'dedupe', 'missing'] = 'append',
+    ) -> None:
+        self._FakeDeploymentPlugin_recent = recent  # for visibility
+        # The endpoint instantiates a new plugin per call so we patch the
+        # handler factory directly to inject the prepared rows.
+        plugin = _FakeDeploymentPlugin()
+        plugin._recent = recent  # type: ignore[attr-defined]
+        self.mocks['handler'] = self._start(
+            mock.patch(
+                f'{_MODULE}._handler',
+                return_value=plugin,
+            )
+        )
+        self.mocks['load_envs'] = self._start(
+            mock.patch(
+                f'{_MODULE}._load_resync_environments',
+                return_value=environments
+                if environments is not None
+                else [o.environment for o in recent],
+            )
+        )
+        self.mocks['release_exists'] = self._start(
+            mock.patch(
+                f'{_MODULE}._release_exists',
+                return_value=release_exists,
+            )
+        )
+        self.mocks['upsert_release_node'] = self._start(
+            mock.patch(
+                f'{_MODULE}._upsert_release_node',
+                return_value=None,
+            )
+        )
+        if edge_status == 'missing':
+            self.mocks['append_deployment_event'].return_value = None
+        else:
+            self.mocks['append_deployment_event'].return_value = mock.Mock(
+                deployments=[
+                    mock.Mock(external_run_id=o.external_run_id)
+                    for o in recent
+                ]
+            )
+
+    def _observed(
+        self,
+        *,
+        environment: str = 'infrastructure-testing',
+        ref: str | None = 'main',
+        sha: str = '2668cd0abcdef',
+        status: str = 'success',
+        external_run_id: str = '12345',
+    ) -> RemoteDeployment:
+        return RemoteDeployment(
+            environment=environment,
+            sha=sha,
+            ref=ref,
+            status=typing.cast(typing.Any, status),
+            created_at=datetime.datetime(
+                2026, 5, 13, 14, 0, tzinfo=datetime.UTC
+            ),
+            external_run_id=external_run_id,
+            run_url='https://gh/runs/12345',
+            deployment_url=(
+                'https://api.github.com/repos/octo/demo/deployments/12345'
+            ),
+            description='Bump foo',
+        )
+
+    def test_resync_persists_release_and_event_for_sha(self) -> None:
+        observed = self._observed()
+        self._arm([observed], release_exists=False)
+        with testclient.TestClient(self.test_app) as client:
+            response = client.post(
+                '/organizations/myorg/projects/proj1/deployments/resync'
+            )
+        self.assertEqual(response.status_code, 200, response.text)
+        data = response.json()
+        self.assertEqual(data['projects'], 1)
+        self.assertEqual(data['observed'], 1)
+        self.assertEqual(data['releases_created'], 1)
+        self.assertEqual(data['releases_updated'], 0)
+        self.assertEqual(data['events_recorded'], 1)
+        self.assertEqual(data['errors'], [])
+        # Sha-style ref derives version from sha prefix (matches the
+        # gateway's create_release CEL expression).
+        upsert_call = self.mocks['upsert_release_node'].call_args
+        self.assertEqual(upsert_call.kwargs['version'], '2668cd0')
+        append_call = self.mocks['append_deployment_event'].call_args
+        self.assertEqual(append_call.kwargs['version'], '2668cd0')
+        self.assertEqual(
+            append_call.kwargs['env_slug'], 'infrastructure-testing'
+        )
+        self.assertEqual(append_call.kwargs['external_run_id'], '12345')
+        self.assertEqual(append_call.kwargs['timestamp'], observed.created_at)
+
+    def test_resync_uses_semver_ref_as_version(self) -> None:
+        self._arm(
+            [self._observed(ref='v1.2.3', sha='deadbeefcafebabe')],
+            release_exists=True,
+        )
+        with testclient.TestClient(self.test_app) as client:
+            response = client.post(
+                '/organizations/myorg/projects/proj1/deployments/resync'
+            )
+        self.assertEqual(response.status_code, 200, response.text)
+        data = response.json()
+        self.assertEqual(data['releases_created'], 0)
+        self.assertEqual(data['releases_updated'], 1)
+        upsert_call = self.mocks['upsert_release_node'].call_args
+        self.assertEqual(upsert_call.kwargs['version'], 'v1.2.3')
+
+    def test_resync_400_when_plugin_opts_out(self) -> None:
+        # Override the resolved plugin to advertise the no-sync flavor.
+        self.mocks['resolve_plugin'].return_value = ResolvedPlugin(
+            plugin_id='p-1',
+            plugin_slug='no-sync-deployment',
+            entry=RegistryEntry(
+                handler_cls=_FakeNoSyncDeploymentPlugin,
+                manifest=_FakeNoSyncDeploymentPlugin.manifest,
+                package_name='imbi-plugin-test',
+                package_version='0.1.0',
+            ),
+            options={'owner': 'octo', 'repo': 'demo'},
+        )
+        with testclient.TestClient(self.test_app) as client:
+            response = client.post(
+                '/organizations/myorg/projects/proj1/deployments/resync'
+            )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('does not support', response.json()['detail'])
+
+    def test_resync_no_environments_returns_zero(self) -> None:
+        self._arm([], environments=[])
+        with testclient.TestClient(self.test_app) as client:
+            response = client.post(
+                '/organizations/myorg/projects/proj1/deployments/resync'
+            )
+        self.assertEqual(response.status_code, 200, response.text)
+        self.assertEqual(response.json()['observed'], 0)
+        self.mocks['upsert_release_node'].assert_not_called()
+        self.mocks['append_deployment_event'].assert_not_called()
+
+    def test_resync_records_missing_edge_as_error(self) -> None:
+        self._arm([self._observed()], edge_status='missing')
+        with testclient.TestClient(self.test_app) as client:
+            response = client.post(
+                '/organizations/myorg/projects/proj1/deployments/resync'
+            )
+        self.assertEqual(response.status_code, 200, response.text)
+        data = response.json()
+        self.assertEqual(len(data['errors']), 1)
+        self.assertEqual(
+            data['errors'][0]['environment'], 'infrastructure-testing'
+        )
+        self.assertEqual(data['events_recorded'], 0)
+
+    def test_resync_writes_audit_per_environment(self) -> None:
+        self._arm([self._observed()])
+        with testclient.TestClient(self.test_app) as client:
+            response = client.post(
+                '/organizations/myorg/projects/proj1/deployments/resync'
+            )
+        self.assertEqual(response.status_code, 200, response.text)
+        ch = self.mocks['clickhouse'].return_value
+        ch.insert.assert_awaited_once()
+        args, _kwargs = ch.insert.call_args
+        cols = args[2]
+        row = dict(zip(cols, args[1][0], strict=False))
+        self.assertEqual(row['entry_type'], 'Deployed')
+        self.assertEqual(row['environment_slug'], 'infrastructure-testing')
+        self.assertEqual(row['version'], '2668cd0')
+        description = row['description']
+        if isinstance(description, str):
+            import json as _json
+
+            self.assertEqual(_json.loads(description)['action'], 'resync')
+
+    def test_resync_requires_write_permission(self) -> None:
+        non_admin = models.User(
+            email='dev@example.com',
+            display_name='Dev',
+            is_active=True,
+            is_admin=False,
+            password_hash=password.hash_password('testpassword123'),
+            created_at=datetime.datetime.now(datetime.UTC),
+        )
+        self.auth_context = permissions.AuthContext(
+            user=non_admin,
+            session_id='test-session',
+            auth_method='jwt',
+            permissions={'project:deployment:read'},
+        )
+
+        async def _ctx() -> permissions.AuthContext:
+            return self.auth_context
+
+        self.test_app.dependency_overrides[permissions.get_current_user] = _ctx
+        with testclient.TestClient(self.test_app) as client:
+            response = client.post(
+                '/organizations/myorg/projects/proj1/deployments/resync'
+            )
+        self.assertEqual(response.status_code, 403)
 
 
 class FallbackNotesTestCase(unittest.TestCase):

--- a/tests/endpoints/test_releases.py
+++ b/tests/endpoints/test_releases.py
@@ -580,6 +580,109 @@ class DeploymentEdgeTestCase(_ReleasesTestBase):
         self.assertEqual(body['current_status'], 'success')
 
 
+class AppendDeploymentEventDedupeTestCase(_ReleasesTestBase):
+    """Direct coverage for ``append_deployment_event`` dedupe semantics."""
+
+    def _call(
+        self,
+        existing: list[dict[str, typing.Any]],
+        *,
+        external_run_id: str | None,
+        status: str = 'success',
+        note: str | None = None,
+    ) -> typing.Any:
+        import asyncio
+
+        from imbi_api.endpoints.releases import append_deployment_event
+
+        self.mock_db.execute.side_effect = [
+            [{'release': _release_row()}],
+            [
+                {
+                    'env': {'slug': 'production', 'name': 'Production'},
+                    'deployments': json.dumps(existing) if existing else None,
+                }
+            ],
+            [{'deployments': None}],  # only consumed by append / set path
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            return asyncio.run(
+                append_deployment_event(
+                    self.mock_db,
+                    org_slug=ORG,
+                    project_id=PROJECT_ID,
+                    version='1.2.3',
+                    env_slug='production',
+                    status=typing.cast(typing.Any, status),
+                    note=note,
+                    external_run_id=external_run_id,
+                    external_run_url='https://gh/runs/42',
+                )
+            )
+
+    def test_same_run_id_same_status_is_no_op(self) -> None:
+        existing = [
+            {
+                'timestamp': '2026-05-13T14:00:00+00:00',
+                'status': 'success',
+                'note': None,
+                'external_run_id': '42',
+                'external_run_url': 'https://gh/runs/42',
+            }
+        ]
+        result = self._call(existing, external_run_id='42', status='success')
+        self.assertEqual(len(result.deployments), 1)
+        # Only the two read queries fired; the SET branch must not run.
+        self.assertEqual(self.mock_db.execute.await_count, 2)
+
+    def test_same_run_id_status_change_updates_in_place(self) -> None:
+        existing = [
+            {
+                'timestamp': '2026-05-13T14:00:00+00:00',
+                'status': 'in_progress',
+                'note': None,
+                'external_run_id': '42',
+                'external_run_url': 'https://gh/runs/42',
+            }
+        ]
+        result = self._call(existing, external_run_id='42', status='success')
+        self.assertEqual(len(result.deployments), 1)
+        self.assertEqual(result.deployments[0].status, 'success')
+        self.assertEqual(result.current_status, 'success')
+
+    def test_different_run_id_still_appends(self) -> None:
+        existing = [
+            {
+                'timestamp': '2026-05-13T14:00:00+00:00',
+                'status': 'success',
+                'note': None,
+                'external_run_id': '41',
+                'external_run_url': None,
+            }
+        ]
+        result = self._call(existing, external_run_id='42', status='success')
+        self.assertEqual(len(result.deployments), 2)
+        self.assertEqual(result.deployments[-1].external_run_id, '42')
+
+    def test_no_external_run_id_keeps_append_only_semantics(self) -> None:
+        existing = [
+            {
+                'timestamp': '2026-05-13T14:00:00+00:00',
+                'status': 'success',
+                'note': None,
+                'external_run_id': None,
+                'external_run_url': None,
+            }
+        ]
+        # Both have no external_run_id, so the pre-dedupe deploy / promote
+        # flow remains append-only.
+        result = self._call(existing, external_run_id=None, status='success')
+        self.assertEqual(len(result.deployments), 2)
+
+
 class CurrentReleasesTestCase(_ReleasesTestBase):
     """GET /releases/current — latest deployment event per env."""
 

--- a/tests/endpoints/test_releases.py
+++ b/tests/endpoints/test_releases.py
@@ -633,8 +633,11 @@ class AppendDeploymentEventDedupeTestCase(_ReleasesTestBase):
                 'external_run_url': 'https://gh/runs/42',
             }
         ]
-        result = self._call(existing, external_run_id='42', status='success')
-        self.assertEqual(len(result.deployments), 1)
+        edge, outcome = self._call(
+            existing, external_run_id='42', status='success'
+        )
+        self.assertEqual(outcome, 'noop')
+        self.assertEqual(len(edge.deployments), 1)
         # Only the two read queries fired; the SET branch must not run.
         self.assertEqual(self.mock_db.execute.await_count, 2)
 
@@ -648,10 +651,13 @@ class AppendDeploymentEventDedupeTestCase(_ReleasesTestBase):
                 'external_run_url': 'https://gh/runs/42',
             }
         ]
-        result = self._call(existing, external_run_id='42', status='success')
-        self.assertEqual(len(result.deployments), 1)
-        self.assertEqual(result.deployments[0].status, 'success')
-        self.assertEqual(result.current_status, 'success')
+        edge, outcome = self._call(
+            existing, external_run_id='42', status='success'
+        )
+        self.assertEqual(outcome, 'updated')
+        self.assertEqual(len(edge.deployments), 1)
+        self.assertEqual(edge.deployments[0].status, 'success')
+        self.assertEqual(edge.current_status, 'success')
 
     def test_different_run_id_still_appends(self) -> None:
         existing = [
@@ -663,9 +669,12 @@ class AppendDeploymentEventDedupeTestCase(_ReleasesTestBase):
                 'external_run_url': None,
             }
         ]
-        result = self._call(existing, external_run_id='42', status='success')
-        self.assertEqual(len(result.deployments), 2)
-        self.assertEqual(result.deployments[-1].external_run_id, '42')
+        edge, outcome = self._call(
+            existing, external_run_id='42', status='success'
+        )
+        self.assertEqual(outcome, 'appended')
+        self.assertEqual(len(edge.deployments), 2)
+        self.assertEqual(edge.deployments[-1].external_run_id, '42')
 
     def test_no_external_run_id_keeps_append_only_semantics(self) -> None:
         existing = [
@@ -679,8 +688,11 @@ class AppendDeploymentEventDedupeTestCase(_ReleasesTestBase):
         ]
         # Both have no external_run_id, so the pre-dedupe deploy / promote
         # flow remains append-only.
-        result = self._call(existing, external_run_id=None, status='success')
-        self.assertEqual(len(result.deployments), 2)
+        edge, outcome = self._call(
+            existing, external_run_id=None, status='success'
+        )
+        self.assertEqual(outcome, 'appended')
+        self.assertEqual(len(edge.deployments), 2)
 
 
 class CurrentReleasesTestCase(_ReleasesTestBase):

--- a/tests/endpoints/test_third_party_services.py
+++ b/tests/endpoints/test_third_party_services.py
@@ -498,6 +498,138 @@ class ThirdPartyServiceEndpointsTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 404)
         self.assertIn('not found', response.json()['detail'])
 
+    # -- Resync (TPS-wide) --
+
+    def _resync_url(self) -> str:
+        return (
+            '/organizations/engineering/third-party-services/'
+            'github-enterprise-cloud/deployments/resync'
+        )
+
+    def test_resync_iterates_projects_and_aggregates(self) -> None:
+        # First execute() returns the list of project ids; the rest is
+        # delegated to the patched ``_resync_for_project``.
+        self.mock_db.execute.return_value = [
+            {'project_ids': ['proj-a', 'proj-b']}
+        ]
+        from imbi_api.endpoints.project_deployments import (
+            ResyncProjectError,
+            ResyncSummary,
+        )
+
+        responses = {
+            'proj-a': ResyncSummary(
+                projects=1,
+                observed=2,
+                releases_created=2,
+                events_recorded=2,
+            ),
+            'proj-b': ResyncSummary(
+                projects=1,
+                observed=1,
+                releases_updated=1,
+                events_recorded=1,
+                errors=[
+                    ResyncProjectError(
+                        project_id='proj-b',
+                        environment='production',
+                        detail='Could not attach event',
+                    )
+                ],
+            ),
+        }
+
+        async def _stub(_db, *, org_slug, project_id, auth, source=None):
+            return responses[project_id]
+
+        with (
+            mock.patch(
+                'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+            ),
+            mock.patch(
+                'imbi_api.endpoints.third_party_services._resync_for_project',
+                side_effect=_stub,
+            ) as patched,
+        ):
+            response = self.client.post(self._resync_url())
+        self.assertEqual(response.status_code, 200, response.text)
+        data = response.json()
+        self.assertEqual(data['projects'], 2)
+        self.assertEqual(data['observed'], 3)
+        self.assertEqual(data['releases_created'], 2)
+        self.assertEqual(data['releases_updated'], 1)
+        self.assertEqual(data['events_recorded'], 3)
+        self.assertEqual(len(data['errors']), 1)
+        self.assertEqual(data['errors'][0]['project_id'], 'proj-b')
+        self.assertEqual(patched.await_count, 2)
+
+    def test_resync_empty_project_list_returns_zero(self) -> None:
+        self.mock_db.execute.return_value = [{'project_ids': []}]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.post(self._resync_url())
+        self.assertEqual(response.status_code, 200, response.text)
+        data = response.json()
+        self.assertEqual(data['projects'], 0)
+        self.assertEqual(data['observed'], 0)
+        self.assertEqual(data['errors'], [])
+
+    def test_resync_per_project_http_exception_recorded_as_error(
+        self,
+    ) -> None:
+        self.mock_db.execute.return_value = [
+            {'project_ids': ['proj-a', 'proj-b']}
+        ]
+        from imbi_api.endpoints.project_deployments import ResyncSummary
+
+        async def _stub(_db, *, org_slug, project_id, auth, source=None):
+            if project_id == 'proj-a':
+                import fastapi
+
+                raise fastapi.HTTPException(
+                    status_code=400, detail='no support'
+                )
+            return ResyncSummary(projects=1, observed=1, events_recorded=1)
+
+        with (
+            mock.patch(
+                'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+            ),
+            mock.patch(
+                'imbi_api.endpoints.third_party_services._resync_for_project',
+                side_effect=_stub,
+            ),
+        ):
+            response = self.client.post(self._resync_url())
+        self.assertEqual(response.status_code, 200, response.text)
+        data = response.json()
+        self.assertEqual(data['projects'], 1)
+        self.assertEqual(len(data['errors']), 1)
+        self.assertEqual(data['errors'][0]['project_id'], 'proj-a')
+        self.assertIn('HTTP 400', data['errors'][0]['detail'])
+
+    def test_resync_requires_update_permission(self) -> None:
+        from imbi_api.auth import permissions
+
+        non_admin = models.User(
+            email='dev@example.com',
+            display_name='Dev',
+            password_hash='$argon2id$hashed',
+            is_active=True,
+            is_admin=False,
+            is_service_account=False,
+            created_at=datetime.datetime.now(datetime.UTC),
+        )
+        self.auth_context = permissions.AuthContext(
+            user=non_admin,
+            session_id='test-session',
+            auth_method='jwt',
+            permissions={'third_party_service:read'},
+        )
+        response = self.client.post(self._resync_url())
+        self.assertEqual(response.status_code, 403)
+
 
 class ServiceWebhooksEndpointsTestCase(unittest.TestCase):
     """Test cases for list_service_webhooks endpoint."""

--- a/tests/endpoints/test_third_party_services.py
+++ b/tests/endpoints/test_third_party_services.py
@@ -508,7 +508,7 @@ class ThirdPartyServiceEndpointsTestCase(unittest.TestCase):
 
     def test_resync_iterates_projects_and_aggregates(self) -> None:
         # First execute() returns the list of project ids; the rest is
-        # delegated to the patched ``_resync_for_project``.
+        # delegated to the patched ``resync_for_project``.
         self.mock_db.execute.return_value = [
             {'project_ids': ['proj-a', 'proj-b']}
         ]
@@ -547,7 +547,7 @@ class ThirdPartyServiceEndpointsTestCase(unittest.TestCase):
                 'imbi_common.graph.parse_agtype', side_effect=lambda x: x
             ),
             mock.patch(
-                'imbi_api.endpoints.third_party_services._resync_for_project',
+                'imbi_api.endpoints.third_party_services.resync_for_project',
                 side_effect=_stub,
             ) as patched,
         ):
@@ -597,7 +597,7 @@ class ThirdPartyServiceEndpointsTestCase(unittest.TestCase):
                 'imbi_common.graph.parse_agtype', side_effect=lambda x: x
             ),
             mock.patch(
-                'imbi_api.endpoints.third_party_services._resync_for_project',
+                'imbi_api.endpoints.third_party_services.resync_for_project',
                 side_effect=_stub,
             ),
         ):

--- a/uv.lock
+++ b/uv.lock
@@ -1025,7 +1025,7 @@ requires-dist = [
   { name = "fastapi" },
   { name = "filetype" },
   { name = "httpx", specifier = ">=0.28.1,<1" },
-  { name = "imbi-common", extras = ["databases", "llm", "server"], git = "https://github.com/AWeber-Imbi/imbi-common.git?branch=feature%2Fdeployment-resync-plugin-contract" },
+  { name = "imbi-common", extras = ["databases", "llm", "server"], git = "https://github.com/AWeber-Imbi/imbi-common.git?branch=main" },
   { name = "jinja2" },
   { name = "jsonpatch", specifier = ">=1.33" },
   { name = "nanoid", specifier = ">=2.0.0" },
@@ -1078,7 +1078,7 @@ plugins = [
 [[package]]
 name = "imbi-common"
 version = "2.2.0"
-source = { git = "https://github.com/AWeber-Imbi/imbi-common.git?branch=feature%2Fdeployment-resync-plugin-contract#7a156e295c6682de5622d63d2524d82a15481877" }
+source = { git = "https://github.com/AWeber-Imbi/imbi-common.git?branch=main#d48d7bf652054ebb5a5f702c936d81a958c9eb1d" }
 dependencies = [
   { name = "cryptography" },
   { name = "jsonschema-models" },

--- a/uv.lock
+++ b/uv.lock
@@ -1025,7 +1025,7 @@ requires-dist = [
   { name = "fastapi" },
   { name = "filetype" },
   { name = "httpx", specifier = ">=0.28.1,<1" },
-  { name = "imbi-common", extras = ["databases", "llm", "server"], specifier = ">=2.2.0" },
+  { name = "imbi-common", extras = ["databases", "llm", "server"], git = "https://github.com/AWeber-Imbi/imbi-common.git?branch=feature%2Fdeployment-resync-plugin-contract" },
   { name = "jinja2" },
   { name = "jsonpatch", specifier = ">=1.33" },
   { name = "nanoid", specifier = ">=2.0.0" },
@@ -1078,7 +1078,7 @@ plugins = [
 [[package]]
 name = "imbi-common"
 version = "2.2.0"
-source = { registry = "https://pypi.org/simple" }
+source = { git = "https://github.com/AWeber-Imbi/imbi-common.git?branch=feature%2Fdeployment-resync-plugin-contract#7a156e295c6682de5622d63d2524d82a15481877" }
 dependencies = [
   { name = "cryptography" },
   { name = "jsonschema-models" },
@@ -1090,10 +1090,6 @@ dependencies = [
   { name = "pyjwt" },
   { name = "python-slugify" },
   { name = "typer" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e0/97/f9339d0659fbc01b9f0030a8ba15debf1f9ca32ff4ec956900300354e13f/imbi_common-2.2.0.tar.gz", hash = "sha256:e7efeee043026e87386ac6a9ebb0fe37ac1281e2c9518fb08f5ddbace0f6f7fc", size = 255760, upload-time = "2026-05-12T19:57:03.447Z" }
-wheels = [
-  { url = "https://files.pythonhosted.org/packages/60/50/6790e8e3392e3cfab60c6dac1590a867ceec46819acb49f28611532a0529/imbi_common-2.2.0-py3-none-any.whl", hash = "sha256:86b8666b7017eed168d956448814311e629f0a98cb1f1bf719956cc005915944", size = 77703, upload-time = "2026-05-12T19:57:01.55Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

- Add `POST /organizations/{org}/projects/{id}/deployments/resync` — asks the project's deployment plugin for the most recent deployment per environment, upserts missing `Release` nodes, dedup-appends `DeploymentEvent` rows on the `DEPLOYED_TO` edge, and writes a single `operations_log` audit per environment with `action='resync'`.
- Add `POST /organizations/{org}/third-party-services/{slug}/deployments/resync` — iterates every project whose deployment plugin is owned (`HAS_PLUGIN`) by the named TPS and runs the per-project flow under `Semaphore(5)` for bounded fan-out. Per-project failures degrade to entries in the aggregate `errors[]` instead of failing the whole call.
- Add `external_run_id` dedupe to `append_deployment_event`: when an existing event on the edge already carries the same id, the call updates that row in place if status changed and is a no-op otherwise. Callers without `external_run_id` keep append-only behavior so the existing deploy / promote flows are unchanged.

## Problem

`_handle_deploy` only appends a `DeploymentEvent` when a matching `Release` node already exists; node creation has historically come exclusively from the gateway webhook path (`imbi_gateway.actions.create_release`). When gateway webhook delivery lapses, no `Release` is ever minted for newer SHAs, the deploy flow silently records only an audit row with the unmatched ref, and the badge stays stuck on the most-recent attached release.

Concretely: a workerbee deploy of commit `2668cd0` to infrastructure-testing on 2026-05-13 wrote an opslog row with `version='main'` (the ref label, because `append_deployment_event` returned `None` for both `body.ref_label='main'` and `body.committish='2668cd0…'`) and never created a `Release` node — leaving the badge stuck on `60dcd67` from a week earlier. The DB shows zero `github-enterprise-cloud` webhook events through the gateway in the preceding 7 days; the last `Release` node anywhere in the graph was 2026-05-08 22:50.

The resync endpoints fix this by going directly to the remote for the authoritative answer and synthesising the missing graph state, independently of the webhook path.

## Solution

### Per-project resync (`project_deployments.py`)

- New `_resync_for_project` orchestrates resolution → environment lookup (`DEPLOYED_IN` edges) → `plugin.list_recent_deployments(envs, limit=1)` → per-observation `_upsert_release_node` + `append_deployment_event` + `_record_deployment_audit`.
- Version derivation matches the gateway's CEL expression in `imbi_gateway.actions.create_release` — semver-shaped `ref` wins, otherwise the first 7 chars of the SHA — so badges stay aligned whether the row arrived via webhook or resync.
- 400 when the plugin's manifest does not advertise `supports_deployment_sync`, so callers can hide the button from the UI using the same flag.
- `ResyncSummary` returns per-project counts (`observed`, `releases_created`, `releases_updated`, `events_recorded`, `events_skipped`) and a per-env `errors[]` list. A missing `DEPLOYED_TO` edge after `append_deployment_event` returns `None` is surfaced as an error rather than swallowed.

### Org-wide resync (`third_party_services.py`)

- New `_projects_using_tps_for_deployment` walks both project-level and project-type-level `USES_PLUGIN` edges with `tab='deployment'` whose target `Plugin` is owned (via `HAS_PLUGIN`) by the named TPS, returning a deterministic de-duplicated list.
- `Semaphore(_TPS_RESYNC_CONCURRENCY=5)` caps concurrent per-project calls — keeps a single admin click from saturating the remote (GitHub's per-org secondary rate limit is the binding constraint) while finishing in reasonable wall-clock for an org with O(100) projects.
- Per-project `HTTPException` (e.g. plugin opted out mid-flight) and any other exception become rows in the aggregate `errors[]` list rather than aborting the batch.

### Dedupe in `append_deployment_event` (`releases.py`)

- Walks existing events newest-first, looking for a matching `external_run_id`. If status / note / url are unchanged → return the existing edge unchanged (no SET issued). If anything changed → update the matching row in place via the extracted `_set_deployments` helper.
- Refactor: split the existing `SET` / `CREATE` branches into `_set_deployments` / `_create_deployments_edge` helpers so the dedupe-update path can reuse the same write.
- New optional `timestamp` argument lets resync record the remote's deployment-creation time rather than `now()`; deploy / promote callers default to now.

## Test plan

- [x] `pytest tests/endpoints/test_project_deployments.py` — 33 pass (8 new resync cases: happy SHA path, semver-ref path, plugin opt-out 400, no-environments, missing-edge-as-error, audit row, permission).
- [x] `pytest tests/endpoints/test_releases.py` — 36 pass (4 new `AppendDeploymentEventDedupeTestCase` cases: no-op same-id-same-status, in-place update on status change, different id still appends, no id keeps append-only).
- [x] `pytest tests/endpoints/test_third_party_services.py` — 26 pass (4 new TPS-wide cases: aggregate counts, empty list, per-project `HTTPException` becomes an error row, `:update` perm required).
- [x] `ruff check` / `ruff format --check` clean.
- [x] `mypy` clean.
- [ ] Manual smoke against staging once the imbi-common branch ships and the UI PR lands.

## Dependency note

`pyproject.toml` pins `imbi-common` to the unmerged `feature/deployment-resync-plugin-contract` branch (PR <https://github.com/AWeber-Imbi/imbi-common/pull/104>) via `[tool.uv.sources]`. Once that PR merges and a new `imbi-common` release ships, drop the `[tool.uv.sources]` block. The large `uv.lock` diff is `uv sync` reformatting from 4-space to 2-space indent (the repo style, enforced by `tombi-format`), not dependency churn.

## Companion PRs

- imbi-common: <https://github.com/AWeber-Imbi/imbi-common/pull/104>
- imbi-plugin-github: <https://github.com/AWeber-Imbi/imbi-plugin-github/pull/13>
- imbi-ui (Resync card on ProjectSettingsTab + admin TPS Resync-all button) — forthcoming.