### PR TITLE
Expose plugin ops-log templates to the UI

### DIFF
--- a/src/imbi_api/endpoints/admin_plugins.py
+++ b/src/imbi_api/endpoints/admin_plugins.py
@@ -173,6 +173,10 @@ def _serialize(
         'widget_text': _resolve_widget_text(widget_default, widget_override),
         'widget_text_default': widget_default,
         'widget_text_override': widget_override,
+        'ops_log_templates': {
+            action: tpl.model_dump()
+            for action, tpl in entry.manifest.ops_log_templates.items()
+        },
     }
 
 
@@ -201,6 +205,7 @@ def _placeholder(package_name: str) -> dict[str, typing.Any]:
         'widget_text': None,
         'widget_text_default': None,
         'widget_text_override': None,
+        'ops_log_templates': {},
     }
 
 

--- a/src/imbi_api/endpoints/operations_log.py
+++ b/src/imbi_api/endpoints/operations_log.py
@@ -24,6 +24,8 @@ import fastapi.responses
 import nanoid
 import pydantic
 from imbi_common import clickhouse, models
+from imbi_common.plugins import OpsLogTemplate
+from imbi_common.plugins.registry import list_plugins
 
 from imbi_api import patch as json_patch
 from imbi_api.auth import permissions
@@ -117,7 +119,7 @@ def _decode_cursor(
     padding = '=' * (-len(cursor) % 4)
     try:
         raw = base64.urlsafe_b64decode(cursor + padding).decode('utf-8')
-    except (ValueError, UnicodeDecodeError):
+    except ValueError, UnicodeDecodeError:
         return None
     if '|' not in raw:
         return None
@@ -457,6 +459,51 @@ async def _list_impl(
     )
     response.headers['Link'] = _build_link_header(request, next_cursor)
     return response
+
+
+class PluginOpsLogTemplate(pydantic.BaseModel):
+    """One plugin's set of ops-log templates as exposed to the UI."""
+
+    slug: str
+    name: str
+    templates: dict[str, OpsLogTemplate] = {}
+
+
+class PluginOpsLogTemplatesResponse(pydantic.BaseModel):
+    plugins: list[PluginOpsLogTemplate]
+
+
+@operations_log_router.get(
+    '/plugin-templates',
+    response_model=PluginOpsLogTemplatesResponse,
+)
+async def list_plugin_ops_log_templates(
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('operations_log:read'),
+        ),
+    ],
+) -> PluginOpsLogTemplatesResponse:
+    """Return every registered plugin's ops-log render templates.
+
+    The UI fetches this once per session and applies templates by
+    ``(plugin_slug, action)`` to format rows in the operations log
+    and recent-activity views.  Plugins without ``ops_log_templates``
+    declared simply emit an empty ``templates`` dict.
+    """
+    _ = auth
+    return PluginOpsLogTemplatesResponse(
+        plugins=[
+            PluginOpsLogTemplate(
+                slug=entry.manifest.slug,
+                name=entry.manifest.name,
+                templates=dict(entry.manifest.ops_log_templates),
+            )
+            for entry in list_plugins()
+            if entry.manifest.ops_log_templates
+        ]
+    )
 
 
 @operations_log_router.get(

--- a/src/imbi_api/endpoints/operations_log.py
+++ b/src/imbi_api/endpoints/operations_log.py
@@ -498,10 +498,9 @@ async def list_plugin_ops_log_templates(
             PluginOpsLogTemplate(
                 slug=entry.manifest.slug,
                 name=entry.manifest.name,
-                templates=dict(entry.manifest.ops_log_templates),
+                templates=dict(entry.manifest.ops_log_templates or {}),
             )
             for entry in list_plugins()
-            if entry.manifest.ops_log_templates
         ]
     )
 

--- a/src/imbi_api/endpoints/project_deployments.py
+++ b/src/imbi_api/endpoints/project_deployments.py
@@ -594,11 +594,17 @@ async def resync_for_project(
                 project_id,
                 observed.environment,
             )
+            # Keep the full traceback in logs (above) but only return
+            # the exception class to clients so plugin internals and
+            # database error text aren't leaked through the API.
             summary.errors.append(
                 ResyncProjectError(
                     project_id=project_id,
                     environment=observed.environment,
-                    detail=f'{type(exc).__name__}: {exc}',
+                    detail=(
+                        f'Resync apply failed ({type(exc).__name__}); '
+                        'see server logs.'
+                    ),
                 )
             )
     return summary

--- a/src/imbi_api/endpoints/releases.py
+++ b/src/imbi_api/endpoints/releases.py
@@ -939,7 +939,7 @@ async def _set_deployments(
     SET d.deployments = {deployments}
     RETURN d.deployments AS deployments
     """
-    await db.execute(
+    rows = await db.execute(
         set_query,
         {
             'project_id': project_id,
@@ -949,6 +949,17 @@ async def _set_deployments(
         },
         ['deployments'],
     )
+    if not rows:
+        # The release or DEPLOYED_TO edge vanished between the read
+        # phase and this write -- raise rather than silently report
+        # success and skew resync counters.
+        raise fastapi.HTTPException(
+            status_code=409,
+            detail=(
+                f'Release {version!r} or its deployment to '
+                f'environment {env_slug!r} no longer exists'
+            ),
+        )
     return _edge_to_response(env, deployments)
 
 
@@ -972,7 +983,7 @@ async def _create_deployments_edge(
     CREATE (r)-[d:DEPLOYED_TO {{deployments: {deployments}}}]->(e)
     RETURN d.deployments AS deployments
     """
-    await db.execute(
+    rows = await db.execute(
         create_query,
         {
             'project_id': project_id,
@@ -983,6 +994,17 @@ async def _create_deployments_edge(
         },
         ['deployments'],
     )
+    if not rows:
+        # Either the release or the (env, org) pair disappeared
+        # between the read and this write; surface the failure rather
+        # than silently report 'appended' with no persisted edge.
+        raise fastapi.HTTPException(
+            status_code=409,
+            detail=(
+                f'Release {version!r} or environment {env_slug!r} in '
+                f'organization {org_slug!r} no longer exists'
+            ),
+        )
     return _edge_to_response(env, deployments)
 
 

--- a/src/imbi_api/endpoints/third_party_services.py
+++ b/src/imbi_api/endpoints/third_party_services.py
@@ -458,6 +458,24 @@ async def delete_third_party_service(
 # --- Deployment resync endpoints ---
 
 
+async def _tps_exists(
+    db: graph.Graph,
+    *,
+    org_slug: str,
+    slug: str,
+) -> bool:
+    """Return ``True`` if a TPS with ``slug`` exists in ``org_slug``."""
+    query: typing.LiteralString = """
+    MATCH (tps:ThirdPartyService {{slug: {slug}}})
+          -[:BELONGS_TO]->(:Organization {{slug: {org_slug}}})
+    RETURN 1 AS found LIMIT 1
+    """
+    rows = await db.execute(
+        query, {'slug': slug, 'org_slug': org_slug}, ['found']
+    )
+    return bool(rows)
+
+
 async def _projects_using_tps_for_deployment(
     db: graph.Graph,
     *,
@@ -471,7 +489,15 @@ async def _projects_using_tps_for_deployment(
     (via ``HAS_PLUGIN``) by the named ThirdPartyService.  Returns a
     de-duplicated, deterministic list so the resync fan-out is stable
     across calls.
+
+    Raises ``HTTPException(404)`` when the TPS does not exist so the
+    caller doesn't conflate "unknown service" with "no projects".
     """
+    if not await _tps_exists(db, org_slug=org_slug, slug=slug):
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail=f'Third-party service with slug {slug!r} not found',
+        )
     # Scope both Project branches to the requested organization via the
     # OWNED_BY -> BELONGS_TO path so a TPS-wide resync triggered against
     # one org can't sweep in projects in another org that happen to use

--- a/tests/endpoints/test_third_party_services.py
+++ b/tests/endpoints/test_third_party_services.py
@@ -575,6 +575,15 @@ class ThirdPartyServiceEndpointsTestCase(unittest.TestCase):
         self.assertEqual(data['observed'], 0)
         self.assertEqual(data['errors'], [])
 
+    def test_resync_unknown_tps_returns_404(self) -> None:
+        # First execute() is the existence check; an empty list means
+        # the TPS does not exist and the endpoint should 404 rather
+        # than return a misleading empty ResyncSummary.
+        self.mock_db.execute.return_value = []
+        response = self.client.post(self._resync_url())
+        self.assertEqual(response.status_code, 404, response.text)
+        self.assertIn('not found', response.json()['detail'])
+
     def test_resync_per_project_http_exception_recorded_as_error(
         self,
     ) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1078,7 +1078,7 @@ plugins = [
 [[package]]
 name = "imbi-common"
 version = "2.2.0"
-source = { git = "https://github.com/AWeber-Imbi/imbi-common.git?branch=main#d48d7bf652054ebb5a5f702c936d81a958c9eb1d" }
+source = { git = "https://github.com/AWeber-Imbi/imbi-common.git?branch=main#d882d975e4c13a34af2036c50e2bd2aa0a7800f3" }
 dependencies = [
   { name = "cryptography" },
   { name = "jsonschema-models" },


### PR DESCRIPTION
## Summary

- New endpoint `GET /operations-log/plugin-templates` returning every registered plugin's `ops_log_templates` map (gated on `operations_log:read`).
- `ops_log_templates` included in the existing `/admin/plugins` serializer (both list and detail) and in the placeholder response shape.

## Why

The UI today hardcodes ops-log entry formatting per `plugin_slug` / `change_type`. This endpoint lets the UI pull each plugin's mustache-style label templates and render rows generically, so adding a new plugin no longer requires a UI code drop.

## Response shape

```json
{
  "plugins": [
    {
      "slug": "github-deployment-ec",
      "name": "GitHub Enterprise Cloud Deployment",
      "templates": {
        "promote": {
          "label": "Promoted {{version}} to {{environment}} from {{from_environment}}",
          "summary": "promoted"
        }
      }
    }
  ]
}
```

## Coordination

Requires AWeber-Imbi/imbi-common feature/plugin-ops-log-templates (the new `OpsLogTemplate` model). The pyproject pin (`branch = "main"`) will resolve once imbi-common merges; CI will go green automatically.

Companion PRs:
- imbi-ui (consumer)
- imbi-plugin-github / imbi-plugin-aws (producers)

## Test plan

- [x] `pytest tests/endpoints/test_operations_log.py` (34 passed locally with editable imbi-common installed)
- [ ] Admin-plugins tests need a ClickHouse env to run; verified pre-existing infra-blocked tests remain blocked (no regression).
- [x] `ruff check` / `ruff format`