### PR TITLE
Release-train env flags + ref-shape promote inference

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -222,13 +222,6 @@ plugins = [
   "imbi-plugin-oidc>=1.0.0",
 ]
 
-# Track imbi-common's ``main`` directly until a release with
-# ``DeploymentPlugin.list_recent_deployments`` + ``RemoteDeployment`` +
-# ``supports_deployment_sync`` is cut.  Drop this block (and bump the
-# ``imbi-common`` floor on the dep above) once that release ships.
-[tool.uv.sources]
-imbi-common = { git = "https://github.com/AWeber-Imbi/imbi-common.git", branch = "main" }
-
 [[tool.uv.index]]
 url = "https://pypi.org/simple"
 default = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
   "fastapi",
   "filetype",
   "httpx>=0.28.1,<1",
-  "imbi-common[databases,llm,server]>=2.2.0",
+  "imbi-common[databases,llm,server]>=2.3.0",
   "jinja2",
   "jsonpatch>=1.33",
   "nanoid>=2.0.0",

--- a/src/imbi_api/domain/models.py
+++ b/src/imbi_api/domain/models.py
@@ -862,6 +862,13 @@ class PluginAssignmentCreate(pydantic.BaseModel):
     default: bool = False
     options: dict[str, typing.Any] = pydantic.Field(default_factory=dict)
     identity_plugin_id: str | None = None
+    # Per-env workflow-input overrides keyed by env slug.  Merged into
+    # the deploy / promote dispatch payload at trigger time.  Sibling
+    # to ``options`` (which is plugin-level) because the axis is the
+    # *environment* being deployed into, not the plugin's own config.
+    env_payloads: dict[str, dict[str, typing.Any]] = pydantic.Field(
+        default_factory=dict,
+    )
 
 
 class PluginAssignmentResponse(pydantic.BaseModel):
@@ -877,6 +884,9 @@ class PluginAssignmentResponse(pydantic.BaseModel):
         'project_type'
     )
     identity_plugin_id: str | None = None
+    env_payloads: dict[str, dict[str, typing.Any]] = pydantic.Field(
+        default_factory=dict,
+    )
     # Pulled from the plugin manifest so the UI can hide affordances
     # (e.g. the histogram strip on the Logs tab) for plugins whose
     # underlying API does not support them.

--- a/src/imbi_api/endpoints/environments.py
+++ b/src/imbi_api/endpoints/environments.py
@@ -174,6 +174,8 @@ async def list_environments(
         org = graph.parse_agtype(record['o'])
         env['organization'] = org
         env.setdefault('sort_order', 0)
+        env.setdefault('can_deploy', True)
+        env.setdefault('can_promote', False)
         pc = graph.parse_agtype(record['project_count'])
         env['relationships'] = _environment_relationships(
             request, org_slug, env['slug'], pc or 0

--- a/src/imbi_api/endpoints/environments.py
+++ b/src/imbi_api/endpoints/environments.py
@@ -233,6 +233,8 @@ async def get_environment(
     org = graph.parse_agtype(records[0]['o'])
     env['organization'] = org
     env.setdefault('sort_order', 0)
+    env.setdefault('can_deploy', True)
+    env.setdefault('can_promote', False)
     pc = graph.parse_agtype(records[0]['project_count'])
     env['relationships'] = _environment_relationships(
         request, org_slug, env['slug'], pc or 0
@@ -335,6 +337,8 @@ async def _persist_environment(
     org = graph.parse_agtype(updated[0]['o'])
     env['organization'] = org
     env.setdefault('sort_order', 0)
+    env.setdefault('can_deploy', True)
+    env.setdefault('can_promote', False)
     pc = graph.parse_agtype(updated[0]['project_count'])
     env['relationships'] = _environment_relationships(
         request, org_slug, env['slug'], pc or 0

--- a/src/imbi_api/endpoints/project_deployments.py
+++ b/src/imbi_api/endpoints/project_deployments.py
@@ -307,9 +307,14 @@ class _EnvFlags(typing.NamedTuple):
 async def _load_env_flags(
     db: graph.Graph,
     *,
+    org_slug: str,
     env_slug: str,
 ) -> _EnvFlags:
     """Fetch ``can_deploy`` / ``can_promote`` for one env slug.
+
+    Scoped to the organization so multi-org data with overlapping
+    environment slugs (e.g. ``prod`` in two orgs) never reads flags
+    from the wrong org.
 
     Defaults conservative-but-permissive when the stored node predates
     the env-flag migration: ``can_deploy=True`` (no surprise lockouts)
@@ -317,11 +322,12 @@ async def _load_env_flags(
     """
     query: typing.LiteralString = """
     MATCH (e:Environment {{slug: {env_slug}}})
+          -[:BELONGS_TO]->(:Organization {{slug: {org_slug}}})
     RETURN e.can_deploy AS can_deploy, e.can_promote AS can_promote
     """
     rows = await db.execute(
         query,
-        {'env_slug': env_slug},
+        {'env_slug': env_slug, 'org_slug': org_slug},
         ['can_deploy', 'can_promote'],
     )
     if not rows:
@@ -912,7 +918,11 @@ async def _handle_deploy(
     *,
     source: str | None,
 ) -> DeploymentTriggerResponse:
-    env_flags = await _load_env_flags(db, env_slug=body.environment)
+    env_flags = await _load_env_flags(
+        db,
+        org_slug=org_slug,
+        env_slug=body.environment,
+    )
     if not env_flags.found:
         raise fastapi.HTTPException(
             status_code=404,
@@ -1113,7 +1123,11 @@ async def _handle_promote(
     *,
     source: str | None,
 ) -> DeploymentTriggerResponse:
-    env_flags = await _load_env_flags(db, env_slug=body.to_environment)
+    env_flags = await _load_env_flags(
+        db,
+        org_slug=org_slug,
+        env_slug=body.to_environment,
+    )
     if not env_flags.found:
         raise fastapi.HTTPException(
             status_code=404,

--- a/src/imbi_api/endpoints/project_deployments.py
+++ b/src/imbi_api/endpoints/project_deployments.py
@@ -20,7 +20,7 @@ import typing
 import fastapi
 import nanoid
 import pydantic
-from imbi_common import clickhouse, graph
+from imbi_common import clickhouse, graph, versioning
 from imbi_common import models as common_models
 from imbi_common.plugins.base import (
     Commit,
@@ -242,15 +242,15 @@ async def _resolve_and_context(
     project_slug, team_slug = await lookup_project_slugs(db, project_id)
     project_links = await lookup_project_links(db, project_id)
     project_type_slugs = await lookup_project_type_slugs(db, project_id)
-    # Per-env DEPLOYS_VIA edge properties — only meaningful when an
-    # environment is in scope.  Caller-side flows (status polls, ref
-    # listings) skip this and accept an empty dict, matching the
-    # plugin-side fallback in :class:`PluginContext`.
+    # Per-env payload pulled off the USES_PLUGIN edge (plan: release-train
+    # env flags).  The env_payloads dict is keyed by env slug and the
+    # value is shallow-merged into GitHub Deployment ``payload`` (workflow
+    # inputs) at trigger time.  Empty dict when there is no env in scope
+    # or no per-env payload is configured -- plugin authors should treat
+    # absent keys as "no extra inputs".
     environment_config: dict[str, typing.Any] = {}
-    if environment:
-        environment_config = await _resolve_deploys_via(
-            db, project_id=project_id, env_slug=environment
-        )
+    if environment and resolved.env_payloads:
+        environment_config = dict(resolved.env_payloads.get(environment, {}))
     ctx = PluginContext(
         project_id=project_id,
         project_slug=project_slug,
@@ -291,54 +291,48 @@ async def _resolve_and_context(
     return resolved, ctx, credentials
 
 
-async def _resolve_deploys_via(
+class _EnvFlags(typing.NamedTuple):
+    """Release-train flags resolved from an ``Environment`` node.
+
+    ``found`` is ``False`` when the environment slug doesn't match any
+    node in the graph; callers raise 404 in that case rather than
+    accidentally treating the env as deploy-and-promote-disabled.
+    """
+
+    found: bool
+    can_deploy: bool
+    can_promote: bool
+
+
+async def _load_env_flags(
     db: graph.Graph,
     *,
-    project_id: str,
     env_slug: str,
-) -> dict[str, typing.Any]:
-    """Return per-env deployment edge properties for ``(project, env)``.
+) -> _EnvFlags:
+    """Fetch ``can_deploy`` / ``can_promote`` for one env slug.
 
-    Resolves the ``DEPLOYS_VIA`` edge between the project (or its
-    project type, as a fallback) and the target ``Environment``,
-    returning the edge properties as a dict (``action``, ``payload``,
-    ``identity_plugin_id``, ...).  Project-level edge takes precedence
-    over project-type edge, matching the layering pattern used for
-    ``USES_PLUGIN`` options elsewhere.
-
-    Returns an empty dict when neither anchor has an edge; callers
-    treat that as "no remote action configured for this env" and skip
-    create_tag / create_release / trigger_deployment, recording only
-    the DeploymentEvent.
+    Defaults conservative-but-permissive when the stored node predates
+    the env-flag migration: ``can_deploy=True`` (no surprise lockouts)
+    and ``can_promote=False`` (opt-in, matching the model default).
     """
     query: typing.LiteralString = """
-    MATCH (env:Environment {{slug: {env_slug}}})
-    OPTIONAL MATCH (:Project {{id: {project_id}}})
-      -[pe:DEPLOYS_VIA]->(env)
-    OPTIONAL MATCH (:Project {{id: {project_id}}})
-      -[:TYPE]->(:ProjectType)-[pte:DEPLOYS_VIA]->(env)
-    RETURN
-      properties(pe) AS proj_props,
-      properties(pte) AS pt_props
+    MATCH (e:Environment {{slug: {env_slug}}})
+    RETURN e.can_deploy AS can_deploy, e.can_promote AS can_promote
     """
     rows = await db.execute(
         query,
-        {'project_id': project_id, 'env_slug': env_slug},
-        ['proj_props', 'pt_props'],
+        {'env_slug': env_slug},
+        ['can_deploy', 'can_promote'],
     )
     if not rows:
-        return {}
-
-    def _as_dict(raw: typing.Any) -> dict[str, typing.Any]:
-        return (
-            typing.cast(dict[str, typing.Any], raw)
-            if isinstance(raw, dict)
-            else {}
-        )
-
-    proj_props = _as_dict(graph.parse_agtype(rows[0].get('proj_props')))
-    pt_props = _as_dict(graph.parse_agtype(rows[0].get('pt_props')))
-    return {**pt_props, **proj_props}
+        return _EnvFlags(found=False, can_deploy=True, can_promote=False)
+    can_deploy = graph.parse_agtype(rows[0].get('can_deploy'))
+    can_promote = graph.parse_agtype(rows[0].get('can_promote'))
+    return _EnvFlags(
+        found=True,
+        can_deploy=True if can_deploy is None else bool(can_deploy),
+        can_promote=False if can_promote is None else bool(can_promote),
+    )
 
 
 def _promote_warning(step: str, exc: BaseException) -> str:
@@ -918,6 +912,21 @@ async def _handle_deploy(
     *,
     source: str | None,
 ) -> DeploymentTriggerResponse:
+    env_flags = await _load_env_flags(db, env_slug=body.environment)
+    if not env_flags.found:
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail=f'Environment {body.environment!r} not found',
+        )
+    if not env_flags.can_deploy:
+        raise fastapi.HTTPException(
+            status_code=400,
+            detail=(
+                f'Environment {body.environment!r} has can_deploy=false; '
+                'direct deploys are disabled.  Use promote, or enable '
+                "this env's can_deploy flag."
+            ),
+        )
     resolved, ctx, credentials = await _resolve_and_context(
         db,
         org_slug,
@@ -928,13 +937,32 @@ async def _handle_deploy(
     )
     handler = _handler(resolved)
 
+    # Merge env_payloads (from USES_PLUGIN edge) under the caller's
+    # explicit ``body.inputs`` so a manual input override always wins.
+    # Coerce to strings: the plugin interface (``trigger_deployment``)
+    # types ``inputs`` as ``dict[str, str]`` because GitHub's workflow
+    # ``inputs`` map only accepts strings.  env_payloads carry richer
+    # JSON-shaped values per the plan; we stringify scalars here and
+    # JSON-encode anything else so they still round-trip into the
+    # workflow.
+    merged_inputs: dict[str, str] | None
+    if ctx.environment_config or body.inputs:
+        merged_inputs = {
+            key: value if isinstance(value, str) else json.dumps(value)
+            for key, value in ctx.environment_config.items()
+        }
+        if body.inputs:
+            merged_inputs.update(body.inputs)
+    else:
+        merged_inputs = None
+
     async def _trigger(c: PluginContext) -> DeploymentRun:
         return await call_with_timeout(
             handler.trigger_deployment(
                 c,
                 _resolve_credentials(c, credentials),
                 ref_or_sha=body.committish,
-                inputs=body.inputs,
+                inputs=merged_inputs,
             )
         )
 
@@ -988,6 +1016,94 @@ async def _handle_deploy(
     )
 
 
+async def _promote_cut_release(
+    db: graph.Graph,
+    *,
+    ctx: PluginContext,
+    resolved: ResolvedPlugin,
+    handler: DeploymentPlugin,
+    credentials: dict[str, str],
+    auth: permissions.AuthContext,
+    body: PromoteActionRequest,
+    warnings: list[str],
+    project_id: str,
+) -> typing.Any:
+    """Cut a tag + create a release at ``body.from_committish``.
+
+    The repo's ``on: release: [published]`` workflow handles the
+    deploy, so we don't dispatch from here.  Failures degrade to a
+    warning appended to ``warnings`` rather than raising -- a flaky
+    GitHub API shouldn't bury the audit trail.  Returns the
+    plugin-returned ReleaseInfo on success (or ``None`` when the
+    plugin has no ``create_release``).
+    """
+    tag_message = body.release_name or body.tag
+
+    async def _create_tag(c: PluginContext) -> typing.Any:
+        return await call_with_timeout(
+            handler.create_tag(
+                c,
+                _resolve_credentials(c, credentials),
+                sha=body.from_committish,
+                tag=body.tag,
+                message=tag_message,
+            )
+        )
+
+    try:
+        await call_with_identity_retry(
+            db, ctx, resolved, auth, fn=_create_tag, attached=True
+        )
+    except NotImplementedError as exc:
+        raise fastapi.HTTPException(
+            status_code=400,
+            detail=(
+                f'Plugin {resolved.plugin_slug!r} does not support '
+                'creating tags; promote is not available.'
+            ),
+        ) from exc
+    except Exception as exc:
+        LOGGER.exception(
+            'create_tag failed for project=%s env=%s tag=%s',
+            project_id,
+            body.to_environment,
+            body.tag,
+        )
+        warnings.append(_promote_warning('create_tag', exc))
+
+    async def _create_release(c: PluginContext) -> typing.Any:
+        return await call_with_timeout(
+            handler.create_release(
+                c,
+                _resolve_credentials(c, credentials),
+                tag=body.tag,
+                name=body.release_name or body.tag,
+                body_markdown=body.release_notes_markdown,
+                prerelease=body.prerelease,
+            )
+        )
+
+    try:
+        return await call_with_identity_retry(
+            db, ctx, resolved, auth, fn=_create_release, attached=True
+        )
+    except NotImplementedError:
+        LOGGER.info(
+            'Plugin %r has no create_release; tag-only promote',
+            resolved.plugin_slug,
+        )
+        return None
+    except Exception as exc:
+        LOGGER.exception(
+            'create_release failed for project=%s env=%s tag=%s',
+            project_id,
+            body.to_environment,
+            body.tag,
+        )
+        warnings.append(_promote_warning('create_release', exc))
+        return None
+
+
 async def _handle_promote(
     db: graph.Graph,
     org_slug: str,
@@ -997,6 +1113,49 @@ async def _handle_promote(
     *,
     source: str | None,
 ) -> DeploymentTriggerResponse:
+    env_flags = await _load_env_flags(db, env_slug=body.to_environment)
+    if not env_flags.found:
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail=f'Environment {body.to_environment!r} not found',
+        )
+    if not env_flags.can_promote:
+        raise fastapi.HTTPException(
+            status_code=400,
+            detail=(
+                f'Environment {body.to_environment!r} has '
+                'can_promote=false; promotion into this env is disabled.  '
+                "Enable the env's can_promote flag to allow promotes."
+            ),
+        )
+
+    # Infer promote behaviour from the ref shape of ``body.tag``:
+    #
+    # * Semver-shaped (``1.2.3`` / ``v1.2.3``)  -> already a tag.  Skip
+    #   ``create_tag`` + ``create_release``; call ``trigger_deployment``
+    #   so the repo's ``on: deployment`` workflow fires.  This is the
+    #   "promote to prod from a stage release tag" path.
+    # * Git short/full SHA                       -> cut a tag at the SHA,
+    #   create a GitHub Release; the repo's ``on: release`` workflow
+    #   handles the deploy server-side.  This is the "first promote off
+    #   a build commit" path.
+    # * Anything else (e.g. ``main``)            -> 400.  We refuse to
+    #   silently cut a tag named after a branch; a typo at the API
+    #   boundary should fail loudly rather than mint ``refs/tags/main``.
+    if versioning.is_semver_tag(body.tag):
+        action: typing.Literal['release', 'deployment'] | None = 'deployment'
+    elif versioning.is_commitish(body.tag):
+        action = 'release'
+    else:
+        raise fastapi.HTTPException(
+            status_code=400,
+            detail=(
+                f'Promote target {body.tag!r} is neither a semver tag '
+                '(e.g. "v1.2.3") nor a git SHA (7-40 hex chars); refusing '
+                'to cut a tag at an ambiguous ref.'
+            ),
+        )
+
     resolved, ctx, credentials = await _resolve_and_context(
         db,
         org_slug,
@@ -1007,110 +1166,23 @@ async def _handle_promote(
     )
     handler = _handler(resolved)
 
-    # Which remote steps run depends on the per-env DEPLOYS_VIA edge:
-    #
-    # * ``action='release'``    -> create_tag + create_release; skip
-    #                              trigger_deployment (the repo's
-    #                              ``on: release: [published]`` workflow
-    #                              picks the release up server-side).
-    # * ``action='deployment'`` -> skip tag/release (the tag is expected
-    #                              to exist already from a prior promote
-    #                              into the lower environment); call
-    #                              trigger_deployment.
-    # * no edge configured      -> no remote action; record only the
-    #                              DeploymentEvent + surface a warning.
-    #
-    # Failures in any remote step degrade to a warning rather than a
-    # 500 -- a flaky GitHub API or a misconfigured workflow shouldn't
-    # bury the fact that the promote was attempted in the audit log.
-    action_raw = ctx.environment_config.get('action')
-    action = action_raw if isinstance(action_raw, str) else None
     warnings: list[str] = []
     run = DeploymentRun(run_id='', status='queued')
     release_info = None
     release_url: str | None = None
 
-    if action is None:
-        warnings.append(
-            f'No DEPLOYS_VIA edge configured for environment '
-            f'{body.to_environment!r}; promote recorded with no '
-            f'remote action.'
-        )
-    elif action not in {'release', 'deployment'}:
-        warnings.append(
-            f'Unknown DEPLOYS_VIA action {action!r} for environment '
-            f'{body.to_environment!r}; expected "release" or '
-            f'"deployment".  Promote recorded with no remote action.'
-        )
-        action = None
-
     if action == 'release':
-        # 1. Cut the annotated tag at the chosen build commit.
-        tag_message = body.release_name or body.tag
-
-        async def _create_tag(c: PluginContext) -> typing.Any:
-            return await call_with_timeout(
-                handler.create_tag(
-                    c,
-                    _resolve_credentials(c, credentials),
-                    sha=body.from_committish,
-                    tag=body.tag,
-                    message=tag_message,
-                )
-            )
-
-        try:
-            await call_with_identity_retry(
-                db, ctx, resolved, auth, fn=_create_tag, attached=True
-            )
-        except NotImplementedError as exc:
-            raise fastapi.HTTPException(
-                status_code=400,
-                detail=(
-                    f'Plugin {resolved.plugin_slug!r} does not support '
-                    'creating tags; promote is not available.'
-                ),
-            ) from exc
-        except Exception as exc:
-            LOGGER.exception(
-                'create_tag failed for project=%s env=%s tag=%s',
-                project_id,
-                body.to_environment,
-                body.tag,
-            )
-            warnings.append(_promote_warning('create_tag', exc))
-
-        # 2. Create the release on the remote.
-        async def _create_release(c: PluginContext) -> typing.Any:
-            return await call_with_timeout(
-                handler.create_release(
-                    c,
-                    _resolve_credentials(c, credentials),
-                    tag=body.tag,
-                    name=body.release_name or body.tag,
-                    body_markdown=body.release_notes_markdown,
-                    prerelease=body.prerelease,
-                )
-            )
-
-        try:
-            release_info = await call_with_identity_retry(
-                db, ctx, resolved, auth, fn=_create_release, attached=True
-            )
-        except NotImplementedError:
-            LOGGER.info(
-                'Plugin %r has no create_release; tag-only promote',
-                resolved.plugin_slug,
-            )
-        except Exception as exc:
-            LOGGER.exception(
-                'create_release failed for project=%s env=%s tag=%s',
-                project_id,
-                body.to_environment,
-                body.tag,
-            )
-            warnings.append(_promote_warning('create_release', exc))
-
+        release_info = await _promote_cut_release(
+            db,
+            ctx=ctx,
+            resolved=resolved,
+            handler=handler,
+            credentials=credentials,
+            auth=auth,
+            body=body,
+            warnings=warnings,
+            project_id=project_id,
+        )
         release_url = (release_info.html_url if release_info else None) or (
             release_info.url if release_info else None
         )
@@ -1118,13 +1190,22 @@ async def _handle_promote(
         # Dispatch against the existing tag.  We do this before upserting
         # the Release node so a trigger failure doesn't leave a Release
         # in the graph with no associated deployment run.
+        promote_inputs: dict[str, str] | None
+        if ctx.environment_config:
+            promote_inputs = {
+                key: value if isinstance(value, str) else json.dumps(value)
+                for key, value in ctx.environment_config.items()
+            }
+        else:
+            promote_inputs = None
+
         async def _trigger(c: PluginContext) -> DeploymentRun:
             return await call_with_timeout(
                 handler.trigger_deployment(
                     c,
                     _resolve_credentials(c, credentials),
                     ref_or_sha=body.tag,
-                    inputs=None,
+                    inputs=promote_inputs,
                 )
             )
 

--- a/src/imbi_api/endpoints/project_plugins.py
+++ b/src/imbi_api/endpoints/project_plugins.py
@@ -109,6 +109,7 @@ async def replace_project_plugins(
             default=a.default,
             options=a.options,
             identity_plugin_id=a.identity_plugin_id,
+            env_payloads=a.env_payloads,
         )
         for a in assignments
     ]
@@ -181,6 +182,9 @@ async def replace_project_plugins(
         identity_id = row.get('identity_plugin_id')
         if identity_id:
             edge_props['identity_plugin_id'] = identity_id
+        env_payloads = row.get('env_payloads')
+        if env_payloads:
+            edge_props['env_payloads'] = json.dumps(env_payloads)
         create_query: str = (
             'MATCH (proj:Project {{id: {project_id}}})'
             ' -[:OWNED_BY]->(:Team)-[:BELONGS_TO]->'

--- a/src/imbi_api/endpoints/project_type_plugins.py
+++ b/src/imbi_api/endpoints/project_type_plugins.py
@@ -79,6 +79,7 @@ async def replace_project_type_plugins(
             default=a.default,
             options=a.options,
             identity_plugin_id=a.identity_plugin_id,
+            env_payloads=a.env_payloads,
         )
         for a in assignments
     ]
@@ -148,6 +149,9 @@ async def replace_project_type_plugins(
         identity_id = row.get('identity_plugin_id')
         if identity_id:
             edge_props['identity_plugin_id'] = identity_id
+        env_payloads = row.get('env_payloads')
+        if env_payloads:
+            edge_props['env_payloads'] = json.dumps(env_payloads)
         merge_query: str = (
             'MATCH (pt:ProjectType {{slug: {pt_slug}}})'
             ' -[:BELONGS_TO]->(o:Organization {{slug: {org_slug}}})'

--- a/src/imbi_api/plugins/assignments.py
+++ b/src/imbi_api/plugins/assignments.py
@@ -17,6 +17,7 @@ class PluginAssignmentRow(typing.TypedDict):
     default: bool
     options: dict[str, typing.Any]
     identity_plugin_id: typing.NotRequired[str | None]
+    env_payloads: typing.NotRequired[dict[str, dict[str, typing.Any]]]
 
 
 def validate_one_default_per_tab(
@@ -127,6 +128,25 @@ def build_assignment_response(
         identity_plugin_id=coerce_identity_plugin_id(
             edge.get('identity_plugin_id')
         ),
+        env_payloads=_parse_env_payloads(edge.get('env_payloads')),
         supports_histogram=supports_histogram,
         supports_deployment_sync=supports_deployment_sync,
     )
+
+
+def _parse_env_payloads(
+    raw: typing.Any,
+) -> dict[str, dict[str, typing.Any]]:
+    """Parse a USES_PLUGIN edge ``env_payloads`` value to a dict.
+
+    Stored JSON-encoded on the AGE edge (the underlying property store
+    can't hold nested property maps).  Returns an empty dict when
+    missing, malformed, or shaped wrong -- malformed env_payloads
+    should not bring down deployment dispatch.
+    """
+    parsed = parse_options(raw)
+    return {
+        slug: payload
+        for slug, payload in parsed.items()
+        if isinstance(payload, dict)
+    }

--- a/src/imbi_api/plugins/resolution.py
+++ b/src/imbi_api/plugins/resolution.py
@@ -25,6 +25,40 @@ class ResolvedPlugin(typing.NamedTuple):
     entry: RegistryEntry
     options: dict[str, typing.Any]
     identity_plugin_id: str | None = None
+    # Per-env payload dict keyed by env slug; values are merged into
+    # GitHub Deployment ``payload`` (workflow inputs) at trigger time.
+    # Lives on the USES_PLUGIN edge so plugin-specific behaviour stays
+    # with the plugin assignment.  Two-tier merge (project edge wins per
+    # env slug over project-type edge).  ``None`` is treated as "no
+    # per-env payloads" by call sites; the default is None rather than
+    # {} so the NamedTuple does not carry a shared mutable default.
+    env_payloads: dict[str, dict[str, typing.Any]] | None = None
+
+
+def _merge_env_payloads(
+    pt_raw: typing.Any,
+    project_raw: typing.Any,
+) -> dict[str, dict[str, typing.Any]]:
+    """Two-tier merge of ``env_payloads`` from project-type + project edges.
+
+    Each tier is a ``{env_slug: {...payload}}`` dict (stored JSON-encoded
+    on the AGE edge).  For each env slug present in either tier we
+    shallow-merge the two payload dicts, with the project-edge value
+    winning per key, matching the precedence the rest of the resolver
+    uses for ``options``.
+    """
+    pt = parse_options(pt_raw)
+    project = parse_options(project_raw)
+    merged: dict[str, dict[str, typing.Any]] = {}
+    for slug, payload in pt.items():
+        if isinstance(payload, dict):
+            merged[slug] = dict(payload)  # pyright: ignore[reportUnknownArgumentType]
+    for slug, payload in project.items():
+        if not isinstance(payload, dict):
+            continue
+        existing = merged.get(slug, {})
+        merged[slug] = {**existing, **payload}  # pyright: ignore[reportUnknownArgumentType]
+    return merged
 
 
 async def resolve_plugin(
@@ -62,6 +96,7 @@ async def resolve_plugin(
     WITH
       collect(DISTINCT {{id: p.id, slug: p.plugin_slug,
                          edge_options: pe.options,
+                         edge_env_payloads: pe.env_payloads,
                          plugin_options: p.options,
                          identity_plugin_id: pe.identity_plugin_id,
                          plugin_identity_plugin_id: p.identity_plugin_id,
@@ -70,6 +105,7 @@ async def resolve_plugin(
        AS proj_plugins,
       collect(DISTINCT {{id: p2.id, slug: p2.plugin_slug,
                          edge_options: pte.options,
+                         edge_env_payloads: pte.env_payloads,
                          plugin_options: p2.options,
                          identity_plugin_id: pte.identity_plugin_id,
                          plugin_identity_plugin_id: p2.identity_plugin_id,
@@ -119,6 +155,7 @@ async def resolve_plugin(
             merged[pid] = {
                 **p,
                 'pt_edge_options': pt_by_id[pid].get('edge_options'),
+                'pt_edge_env_payloads': pt_by_id[pid].get('edge_env_payloads'),
                 'pt_identity_plugin_id': pt_by_id[pid].get(
                     'identity_plugin_id'
                 ),
@@ -194,6 +231,10 @@ async def resolve_plugin(
         raise PluginUnavailableError(plugin_slug) from exc
 
     identity_plugin_id = _select_identity_plugin_id(chosen)
+    env_payloads = _merge_env_payloads(
+        chosen.get('pt_edge_env_payloads'),
+        chosen.get('edge_env_payloads'),
+    )
 
     return ResolvedPlugin(
         plugin_id=plugin_id,
@@ -201,6 +242,7 @@ async def resolve_plugin(
         entry=entry,
         options=options,
         identity_plugin_id=identity_plugin_id,
+        env_payloads=env_payloads,
     )
 
 
@@ -235,6 +277,7 @@ async def resolve_all_plugins(
     WITH
       collect(DISTINCT {{id: p.id, slug: p.plugin_slug,
                          edge_options: pe.options,
+                         edge_env_payloads: pe.env_payloads,
                          plugin_options: p.options,
                          identity_plugin_id: pe.identity_plugin_id,
                          plugin_identity_plugin_id: p.identity_plugin_id,
@@ -243,6 +286,7 @@ async def resolve_all_plugins(
        AS proj_plugins,
       collect(DISTINCT {{id: p2.id, slug: p2.plugin_slug,
                          edge_options: pte.options,
+                         edge_env_payloads: pte.env_payloads,
                          plugin_options: p2.options,
                          identity_plugin_id: pte.identity_plugin_id,
                          plugin_identity_plugin_id: p2.identity_plugin_id,
@@ -281,6 +325,7 @@ async def resolve_all_plugins(
             merged[pid] = {
                 **p,
                 'pt_edge_options': pt_by_id[pid].get('edge_options'),
+                'pt_edge_env_payloads': pt_by_id[pid].get('edge_env_payloads'),
                 'pt_identity_plugin_id': pt_by_id[pid].get(
                     'identity_plugin_id'
                 ),
@@ -322,6 +367,10 @@ async def resolve_all_plugins(
                 entry=entry,
                 options=options,
                 identity_plugin_id=_select_identity_plugin_id(chosen),
+                env_payloads=_merge_env_payloads(
+                    chosen.get('pt_edge_env_payloads'),
+                    chosen.get('edge_env_payloads'),
+                ),
             )
         )
     return resolved

--- a/tests/endpoints/test_project_deployments.py
+++ b/tests/endpoints/test_project_deployments.py
@@ -23,7 +23,10 @@ from imbi_common.plugins.registry import RegistryEntry
 
 from imbi_api import app, models
 from imbi_api.auth import password, permissions
-from imbi_api.endpoints.project_deployments import DraftReleaseNotes
+from imbi_api.endpoints.project_deployments import (
+    DraftReleaseNotes,
+    _EnvFlags,
+)
 from imbi_api.llm.dependencies import _get_anthropic_client
 from imbi_api.plugins.resolution import ResolvedPlugin
 
@@ -206,14 +209,16 @@ class ProjectDeploymentsTestCase(unittest.TestCase):
                     return_value=None,
                 )
             ),
-            # Default the per-env edge to action='release' so the
-            # existing promote tests exercise the tag+release branch
-            # (matching how staging promotes work in practice).  Tests
-            # that need a different action override this on the mock.
-            '_resolve_deploys_via': self._start(
+            # Default env flags: deploy + promote both allowed.  Tests
+            # exercising the 400 guardrails override this on the mock.
+            '_load_env_flags': self._start(
                 mock.patch(
-                    f'{_MODULE}._resolve_deploys_via',
-                    return_value={'action': 'release'},
+                    f'{_MODULE}._load_env_flags',
+                    return_value=_EnvFlags(
+                        found=True,
+                        can_deploy=True,
+                        can_promote=True,
+                    ),
                 )
             ),
             'clickhouse': self._start(
@@ -477,9 +482,9 @@ class ProjectDeploymentsTestCase(unittest.TestCase):
         # last_tag bumped major: 6.3.0 → 7.0.0
         self.assertEqual(data['version'], 'v7.0.0')
 
-    def test_promote_release_action_cuts_tag_and_release(self) -> None:
-        # ``action='release'`` -- staging-style promote: cut a tag and
-        # create a release, but DO NOT dispatch.  The repo's
+    def test_promote_sha_ref_cuts_tag_and_release(self) -> None:
+        # Promote target is a git SHA -- the handler should cut a tag
+        # and create a release, but NOT dispatch.  The repo's
         # ``on: release: [published]`` workflow handles deployment.
         self.mocks['append_deployment_event'].return_value = mock.Mock()
         with testclient.TestClient(self.test_app) as client:
@@ -490,7 +495,7 @@ class ProjectDeploymentsTestCase(unittest.TestCase):
                     'from_environment': 'testing',
                     'to_environment': 'staging',
                     'from_committish': '1a9c610',
-                    'tag': 'v6.4.0',
+                    'tag': '1a9c610abcdef',
                     'release_name': 'v6.4.0',
                     'release_notes_markdown': '## Highlights\n- foo',
                     'prerelease': False,
@@ -498,24 +503,21 @@ class ProjectDeploymentsTestCase(unittest.TestCase):
             )
         self.assertEqual(response.status_code, 202)
         data = response.json()
-        self.assertEqual(data['tag'], 'v6.4.0')
-        self.assertEqual(data['release_url'], 'https://gh/releases/v6.4.0')
+        self.assertEqual(data['tag'], '1a9c610abcdef')
+        self.assertEqual(
+            data['release_url'], 'https://gh/releases/1a9c610abcdef'
+        )
         self.assertTrue(data['recorded'])
         self.assertIsNone(data['warning'])
-        self.assertGreaterEqual(self.mock_db.execute.call_count, 2)
         call = self.mocks['append_deployment_event'].call_args
-        self.assertEqual(call.kwargs['version'], 'v6.4.0')
         self.assertEqual(call.kwargs['env_slug'], 'staging')
         # No dispatch happened -> no external run id/url.
         self.assertIsNone(call.kwargs['external_run_id'])
         self.assertIsNone(call.kwargs['external_run_url'])
 
-    def test_promote_deployment_action_dispatches_only(self) -> None:
-        # ``action='deployment'`` -- production-style promote: dispatch
-        # against an existing tag with no new tag/release.
-        self.mocks['_resolve_deploys_via'].return_value = {
-            'action': 'deployment'
-        }
+    def test_promote_semver_tag_dispatches_only(self) -> None:
+        # Promote target is a semver tag -- the handler should dispatch
+        # against the existing tag with no new tag/release.
         self.mocks['append_deployment_event'].return_value = mock.Mock()
         with testclient.TestClient(self.test_app) as client:
             response = client.post(
@@ -539,11 +541,27 @@ class ProjectDeploymentsTestCase(unittest.TestCase):
         self.assertEqual(call.kwargs['external_run_id'], '42')
         self.assertEqual(call.kwargs['external_run_url'], 'https://gh/runs/42')
 
-    def test_promote_with_no_edge_records_event_with_warning(self) -> None:
-        # No DEPLOYS_VIA edge configured for the env -- promote records
-        # the event but takes no remote action and surfaces a warning.
-        self.mocks['_resolve_deploys_via'].return_value = {}
-        self.mocks['append_deployment_event'].return_value = mock.Mock()
+    def test_promote_400_on_non_semver_non_sha_ref(self) -> None:
+        # A branch-shaped ref like ``main`` is neither a tag nor a SHA;
+        # the handler must refuse rather than silently cut a tag.
+        with testclient.TestClient(self.test_app) as client:
+            response = client.post(
+                '/organizations/myorg/projects/proj1/deployments',
+                json={
+                    'action': 'promote',
+                    'from_environment': 'testing',
+                    'to_environment': 'staging',
+                    'from_committish': '1a9c610',
+                    'tag': 'main',
+                },
+            )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('neither a semver tag', response.json()['detail'])
+
+    def test_promote_400_when_can_promote_false(self) -> None:
+        self.mocks['_load_env_flags'].return_value = _EnvFlags(
+            found=True, can_deploy=True, can_promote=False
+        )
         with testclient.TestClient(self.test_app) as client:
             response = client.post(
                 '/organizations/myorg/projects/proj1/deployments',
@@ -555,19 +573,90 @@ class ProjectDeploymentsTestCase(unittest.TestCase):
                     'tag': 'v6.4.0',
                 },
             )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('can_promote=false', response.json()['detail'])
+
+    def test_deploy_400_when_can_deploy_false(self) -> None:
+        self.mocks['_load_env_flags'].return_value = _EnvFlags(
+            found=True, can_deploy=False, can_promote=True
+        )
+        with testclient.TestClient(self.test_app) as client:
+            response = client.post(
+                '/organizations/myorg/projects/proj1/deployments',
+                json={
+                    'action': 'deploy',
+                    'environment': 'production',
+                    'committish': 'v1.2.3',
+                },
+            )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('can_deploy=false', response.json()['detail'])
+
+    def test_promote_404_when_env_not_found(self) -> None:
+        self.mocks['_load_env_flags'].return_value = _EnvFlags(
+            found=False, can_deploy=True, can_promote=False
+        )
+        with testclient.TestClient(self.test_app) as client:
+            response = client.post(
+                '/organizations/myorg/projects/proj1/deployments',
+                json={
+                    'action': 'promote',
+                    'from_environment': 'testing',
+                    'to_environment': 'ghost',
+                    'from_committish': '1a9c610',
+                    'tag': 'v6.4.0',
+                },
+            )
+        self.assertEqual(response.status_code, 404)
+
+    def test_deploy_env_payloads_flow_into_trigger_inputs(self) -> None:
+        # ``env_payloads`` on the resolved plugin is merged into the
+        # ``inputs`` passed to ``trigger_deployment`` (caller-supplied
+        # ``body.inputs`` still wins on key collisions).
+        captured: dict[str, typing.Any] = {}
+
+        class _Capturing(_FakeDeploymentPlugin):
+            async def trigger_deployment(  # type: ignore[override]
+                self, ctx, credentials, ref_or_sha, inputs=None
+            ):
+                captured['inputs'] = inputs
+                return await super().trigger_deployment(
+                    ctx, credentials, ref_or_sha, inputs
+                )
+
+        self.mocks['resolve_plugin'].return_value = ResolvedPlugin(
+            plugin_id='p-1',
+            plugin_slug='github-deployment',
+            entry=RegistryEntry(
+                handler_cls=_Capturing,
+                manifest=_Capturing.manifest,
+                package_name='x',
+                package_version='1',
+            ),
+            options={'owner': 'octo', 'repo': 'demo'},
+            env_payloads={
+                'testing': {'environment': 'testing', 'tier': 'low'},
+            },
+        )
+        with testclient.TestClient(self.test_app) as client:
+            response = client.post(
+                '/organizations/myorg/projects/proj1/deployments',
+                json={
+                    'action': 'deploy',
+                    'environment': 'testing',
+                    'committish': 'main',
+                    'inputs': {'tier': 'override'},
+                },
+            )
         self.assertEqual(response.status_code, 202)
-        data = response.json()
-        self.assertIsNotNone(data['warning'])
-        self.assertIn('No DEPLOYS_VIA edge', data['warning'])
-        self.assertTrue(data['recorded'])
+        self.assertEqual(captured['inputs']['environment'], 'testing')
+        # Caller override beats env_payloads on shared keys.
+        self.assertEqual(captured['inputs']['tier'], 'override')
 
     def test_promote_deployment_failure_becomes_warning(self) -> None:
         # If trigger_deployment raises, the promote still records the
         # DeploymentEvent and surfaces the failure as a warning rather
         # than 500ing.
-        self.mocks['_resolve_deploys_via'].return_value = {
-            'action': 'deployment'
-        }
         self.mocks['append_deployment_event'].return_value = mock.Mock()
 
         class _Boom(_FakeDeploymentPlugin):
@@ -628,6 +717,8 @@ class ProjectDeploymentsTestCase(unittest.TestCase):
             ),
             options={},
         )
+        # Use a SHA tag so the ref-shape inference picks the
+        # ``create_tag`` branch (semver refs would skip create_tag).
         with testclient.TestClient(self.test_app) as client:
             response = client.post(
                 '/organizations/myorg/projects/proj1/deployments',
@@ -636,7 +727,7 @@ class ProjectDeploymentsTestCase(unittest.TestCase):
                     'from_environment': 'testing',
                     'to_environment': 'staging',
                     'from_committish': '1a9c610',
-                    'tag': 'v1.2.3',
+                    'tag': '1a9c610',
                 },
             )
         self.assertEqual(response.status_code, 400)

--- a/uv.lock
+++ b/uv.lock
@@ -1077,8 +1077,8 @@ plugins = [
 
 [[package]]
 name = "imbi-common"
-version = "2.2.0"
-source = { git = "https://github.com/AWeber-Imbi/imbi-common.git?branch=main#d882d975e4c13a34af2036c50e2bd2aa0a7800f3" }
+version = "2.3.0"
+source = { git = "https://github.com/AWeber-Imbi/imbi-common.git?branch=main#998243fdafcaf056d2e29458e87e22c634e4646e" }
 dependencies = [
   { name = "cryptography" },
   { name = "jsonschema-models" },

--- a/uv.lock
+++ b/uv.lock
@@ -1025,7 +1025,7 @@ requires-dist = [
   { name = "fastapi" },
   { name = "filetype" },
   { name = "httpx", specifier = ">=0.28.1,<1" },
-  { name = "imbi-common", extras = ["databases", "llm", "server"], git = "https://github.com/AWeber-Imbi/imbi-common.git?branch=main" },
+  { name = "imbi-common", extras = ["databases", "llm", "server"], specifier = ">=2.3.0" },
   { name = "jinja2" },
   { name = "jsonpatch", specifier = ">=1.33" },
   { name = "nanoid", specifier = ">=2.0.0" },
@@ -1078,7 +1078,7 @@ plugins = [
 [[package]]
 name = "imbi-common"
 version = "2.3.0"
-source = { git = "https://github.com/AWeber-Imbi/imbi-common.git?branch=main#998243fdafcaf056d2e29458e87e22c634e4646e" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
   { name = "cryptography" },
   { name = "jsonschema-models" },
@@ -1090,6 +1090,10 @@ dependencies = [
   { name = "pyjwt" },
   { name = "python-slugify" },
   { name = "typer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/82/ae/cbd0fcb9849d223c1a7ff99b04c3cb250770000206f38a77bbe1a6078fa0/imbi_common-2.3.0.tar.gz", hash = "sha256:db992d57b2cdf06c2024fbf9ec6c0fc231fd3796a7f1fe209d10771d3e1e1050", size = 266530, upload-time = "2026-05-13T22:42:15.429Z" }
+wheels = [
+  { url = "https://files.pythonhosted.org/packages/81/5a/3150e7fd54cbe2acff01dee1ebd1a1d494523d94619ed9989b04bef47885/imbi_common-2.3.0-py3-none-any.whl", hash = "sha256:eca5c4c219bd1405adbd1dca9d0f18e3a70f42c4982a4843a907723da2945216", size = 82885, upload-time = "2026-05-13T22:42:14.089Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary
- Replaces the per-`(project|project_type, env)` `DEPLOYS_VIA` edge with two booleans on `Environment` (added in imbi-common 2.3.0 via #107).  The `_handle_deploy` / `_handle_promote` endpoints now 400 when the target env disables that action.
- Infers promote behaviour from the ref shape of `body.tag`: semver-shaped (`v1.2.3`) → `trigger_deployment`; raw SHA → `create_tag` + `create_release`; anything else (e.g. `main`) → 400.  Drops the `_resolve_deploys_via` helper and the `action` switch entirely.
- Moves per-env workflow-input overrides off `DEPLOYS_VIA.payload` and onto a new `env_payloads` property on the `USES_PLUGIN` edge (JSON-encoded for AGE).  Surfaces it as `ResolvedPlugin.env_payloads` and `PluginAssignment(Create|Row|Response).env_payloads`, persisted by both `project_type_plugins` and `project_plugins` PUTs.
- Adds the `can_deploy` / `can_promote` flags to the environment endpoint responses (defaulted defensively for pre-migration envs).

## Problem
The original `DEPLOYS_VIA` edge made operators wire up promotion per project (or project-type) × env even though every project of a given type promotes the same way and the actual action ("cut a tag or trigger a deployment") is a property of the *target env*, not the project–env pair.  Four PRs were open along that line; this rewrite supersedes the action-switching half (the data-shape PRs in imbi-common #96 and imbi-plugin-github #11 still apply).

## Solution
Env-level flags drive UI affordances and API guardrails.  Promote behaviour falls out of "is this committish already a tag?" which is what the gateway's `version_expression` was checking via regex anyway — we just lifted the regex into `imbi-common` so both sides agree.

## Test plan
- [x] Unit tests for ref-shape inference (SHA → tag+release, semver → dispatch, branch name → 400)
- [x] Unit tests for `can_deploy=false` → 400 deploy, `can_promote=false` → 400 promote, missing env → 404
- [x] Unit tests for `env_payloads` flowing into `trigger_deployment` inputs (`body.inputs` wins on conflicts)
- [ ] After merge, run `imbi-env-flags --backfill` (migrator PR) against test to populate flags and sweep DEPLOYS_VIA edges
- [ ] Promote workerbee from `infrastructure-testing` to `infrastructure` (SHA build) — confirms tag + release cut
- [ ] Promote at-an-existing-tag — confirms Deployment trigger only

## Depends on
- imbi-common #107 (pinned via `imbi-common>=2.3.0`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)