### PR TITLE
Fix env patch for nodes missing release-train flags

### DIFF
--- a/src/imbi_api/endpoints/environments.py
+++ b/src/imbi_api/endpoints/environments.py
@@ -405,6 +405,8 @@ async def patch_environment(
     current.pop('updated_at', None)
     current.pop('organization', None)
     current.setdefault('sort_order', 0)
+    current.setdefault('can_deploy', False)
+    current.setdefault('can_promote', False)
 
     patched = json_patch.apply_patch(current, operations)
     patched.pop('organization_slug', None)

--- a/tests/endpoints/test_environments.py
+++ b/tests/endpoints/test_environments.py
@@ -365,6 +365,57 @@ class EnvironmentEndpointsTestCase(unittest.TestCase):
 
         self.assertEqual(response.status_code, 404)
 
+    def test_patch_can_promote_on_pre_migration_env(self) -> None:
+        """Replace can_promote when node lacks the field (pre-migration)."""
+        from imbi_common import models as common_models
+
+        existing_env = {
+            'name': 'Production',
+            'slug': 'production',
+            'description': None,
+            'sort_order': 0,
+        }
+        self.mock_db.execute.side_effect = [
+            [
+                {
+                    'e': existing_env,
+                    'o': {'name': 'Engineering', 'slug': 'engineering'},
+                }
+            ],
+            [
+                {
+                    'e': {
+                        'name': 'Production',
+                        'slug': 'production',
+                        'sort_order': 0,
+                        'can_deploy': True,
+                        'can_promote': True,
+                    },
+                    'o': {'name': 'Engineering', 'slug': 'engineering'},
+                    'project_count': 0,
+                }
+            ],
+        ]
+
+        with (
+            mock.patch(
+                'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+            ),
+            mock.patch(
+                'imbi_common.blueprints.get_model',
+                return_value=common_models.Environment,
+            ),
+        ):
+            response = self.client.patch(
+                '/organizations/engineering/environments/production',
+                json=[
+                    {'op': 'replace', 'path': '/can_promote', 'value': True}
+                ],
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.json()['can_promote'])
+
     def test_patch_environment_slug_conflict(self) -> None:
         """Patch that renames slug to an existing one returns 409."""
         from imbi_common import models as common_models


### PR DESCRIPTION
## Summary
Patching `can_promote` (or `can_deploy`) on a pre-migration Environment node failed with:

> Invalid patch: can't replace a non-existent object 'can_promote'

…because `patch_environment` builds the JSON Patch base from the live graph node, and bare nodes created before the release-train flags landed don't carry those properties yet. The list/get endpoints already defended against this with `setdefault`; the patch endpoint didn't.

This change adds `setdefault('can_deploy', False)` and `setdefault('can_promote', False)` on the snapshot before applying the patch, so a `replace` op succeeds on the first toggle regardless of when the env was created.

## Test plan
- [ ] On a pre-migration env, toggle "Allow promote" in the admin form and save — succeeds (no "Invalid patch" toast).
- [ ] Same for "Allow deploy".
- [ ] New regression test `test_patch_can_promote_on_pre_migration_env` covers the bare-node toggle path.