### PR TITLE
Default can_deploy=True in env patch path

### DIFF
--- a/src/imbi_api/endpoints/environments.py
+++ b/src/imbi_api/endpoints/environments.py
@@ -405,7 +405,7 @@ async def patch_environment(
     current.pop('updated_at', None)
     current.pop('organization', None)
     current.setdefault('sort_order', 0)
-    current.setdefault('can_deploy', False)
+    current.setdefault('can_deploy', True)
     current.setdefault('can_promote', False)
 
     patched = json_patch.apply_patch(current, operations)

--- a/tests/endpoints/test_environments.py
+++ b/tests/endpoints/test_environments.py
@@ -50,8 +50,8 @@ class EnvironmentEndpointsTestCase(unittest.TestCase):
         )
 
         self.mock_db = mock.AsyncMock(spec=graph.Graph)
-        self.test_app.dependency_overrides[graph._inject_graph] = (
-            lambda: self.mock_db
+        self.test_app.dependency_overrides[graph._inject_graph] = lambda: (
+            self.mock_db
         )
 
         self.client = testclient.TestClient(self.test_app)
@@ -415,6 +415,63 @@ class EnvironmentEndpointsTestCase(unittest.TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertTrue(response.json()['can_promote'])
+        update_params = self.mock_db.execute.await_args_list[1].args[1]
+        self.assertTrue(update_params['can_promote'])
+        self.assertTrue(update_params['can_deploy'])
+
+    def test_patch_can_deploy_on_pre_migration_env(self) -> None:
+        """Replace can_deploy when node lacks the field (pre-migration)."""
+        from imbi_common import models as common_models
+
+        existing_env = {
+            'name': 'Production',
+            'slug': 'production',
+            'description': None,
+            'sort_order': 0,
+        }
+        self.mock_db.execute.side_effect = [
+            [
+                {
+                    'e': existing_env,
+                    'o': {'name': 'Engineering', 'slug': 'engineering'},
+                }
+            ],
+            [
+                {
+                    'e': {
+                        'name': 'Production',
+                        'slug': 'production',
+                        'sort_order': 0,
+                        'can_deploy': False,
+                        'can_promote': False,
+                    },
+                    'o': {'name': 'Engineering', 'slug': 'engineering'},
+                    'project_count': 0,
+                }
+            ],
+        ]
+
+        with (
+            mock.patch(
+                'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+            ),
+            mock.patch(
+                'imbi_common.blueprints.get_model',
+                return_value=common_models.Environment,
+            ),
+        ):
+            response = self.client.patch(
+                '/organizations/engineering/environments/production',
+                json=[
+                    {'op': 'replace', 'path': '/can_deploy', 'value': False}
+                ],
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.json()['can_deploy'])
+        update_params = self.mock_db.execute.await_args_list[1].args[1]
+        self.assertFalse(update_params['can_deploy'])
+        self.assertFalse(update_params['can_promote'])
 
     def test_patch_environment_slug_conflict(self) -> None:
         """Patch that renames slug to an existing one returns 409."""


### PR DESCRIPTION
## Summary

Follow-up to #307. CodeRabbit flagged that the `patch_environment` defaulting
for legacy/pre-migration nodes set `can_deploy` to `False`, which diverges
from the read-path fallback (which uses `True`). On a patch that only
touches `can_promote`, this silently disabled deploy on the node.

## Problem

`#307` added:

```python
current.setdefault('can_deploy', False)
current.setdefault('can_promote', False)
```

Read paths (lines 177, 236, 340 of `environments.py`) all use
`setdefault('can_deploy', True)`. The patch path was inconsistent and could
silently flip `can_deploy` from its legacy default of `True` to `False`
on the first patch of a pre-migration node.

## Solution

- Change `can_deploy` default in `patch_environment` to `True` to match
  read paths.
- Strengthen `test_patch_can_promote_on_pre_migration_env` to assert the
  persisted update params (second `db.execute` call) so the test cannot
  silently pass with a wrong `can_deploy` value.
- Add a sibling `test_patch_can_deploy_on_pre_migration_env` covering the
  symmetrical replace on `/can_deploy`.

## Test plan

- [x] `uv run pytest tests/endpoints/test_environments.py` (16 passed)
- [x] `ruff check` / `ruff format --check`