### PR TITLE
Fix deploy triggering with SHA instead of tag ref when ref_label is set

### DIFF
--- a/src/imbi_api/endpoints/project_deployments.py
+++ b/src/imbi_api/endpoints/project_deployments.py
@@ -966,12 +966,14 @@ async def _handle_deploy(
     else:
         merged_inputs = None
 
+    ref = body.ref_label or body.committish
+
     async def _trigger(c: PluginContext) -> DeploymentRun:
         return await call_with_timeout(
             handler.trigger_deployment(
                 c,
                 _resolve_credentials(c, credentials),
-                ref_or_sha=body.committish,
+                ref_or_sha=ref,
                 inputs=merged_inputs,
             )
         )
@@ -984,7 +986,7 @@ async def _handle_deploy(
         'action=%s actor=%s run_id=%s',
         project_id,
         body.environment,
-        body.committish,
+        ref,
         resolved.plugin_slug,
         body.action,
         ctx.actor_user_id,

--- a/tests/endpoints/test_project_deployments.py
+++ b/tests/endpoints/test_project_deployments.py
@@ -339,6 +339,85 @@ class ProjectDeploymentsTestCase(unittest.TestCase):
         # external_run_url field now.
         self.assertNotIn('https://gh/runs/42', call.kwargs['note'] or '')
 
+    def test_trigger_deploy_uses_ref_label_as_ref_when_set(self) -> None:
+        # When the user selects a tag, the frontend sends committish=SHA
+        # and ref_label=tag_name.  trigger_deployment must receive the tag
+        # name as ref_or_sha so GitHub Actions dispatches against the tag,
+        # not an anonymous SHA.
+        captured: dict[str, typing.Any] = {}
+
+        class _Capturing(_FakeDeploymentPlugin):
+            async def trigger_deployment(  # type: ignore[override]
+                self, ctx, credentials, ref_or_sha, inputs=None
+            ):
+                captured['ref_or_sha'] = ref_or_sha
+                return await super().trigger_deployment(
+                    ctx, credentials, ref_or_sha, inputs
+                )
+
+        self.mocks['resolve_plugin'].return_value = ResolvedPlugin(
+            plugin_id='p-1',
+            plugin_slug='github-deployment',
+            entry=RegistryEntry(
+                handler_cls=_Capturing,
+                manifest=_Capturing.manifest,
+                package_name='x',
+                package_version='1',
+            ),
+            options={'owner': 'octo', 'repo': 'demo'},
+            env_payloads={},
+        )
+        with testclient.TestClient(self.test_app) as client:
+            response = client.post(
+                '/organizations/myorg/projects/proj1/deployments',
+                json={
+                    'action': 'deploy',
+                    'environment': 'staging',
+                    'committish': 'abc1234def5678',
+                    'ref_label': 'v2.3.1',
+                },
+            )
+        self.assertEqual(response.status_code, 202)
+        self.assertEqual(captured['ref_or_sha'], 'v2.3.1')
+
+    def test_trigger_deploy_uses_committish_when_ref_label_absent(
+        self,
+    ) -> None:
+        captured: dict[str, typing.Any] = {}
+
+        class _Capturing(_FakeDeploymentPlugin):
+            async def trigger_deployment(  # type: ignore[override]
+                self, ctx, credentials, ref_or_sha, inputs=None
+            ):
+                captured['ref_or_sha'] = ref_or_sha
+                return await super().trigger_deployment(
+                    ctx, credentials, ref_or_sha, inputs
+                )
+
+        self.mocks['resolve_plugin'].return_value = ResolvedPlugin(
+            plugin_id='p-1',
+            plugin_slug='github-deployment',
+            entry=RegistryEntry(
+                handler_cls=_Capturing,
+                manifest=_Capturing.manifest,
+                package_name='x',
+                package_version='1',
+            ),
+            options={'owner': 'octo', 'repo': 'demo'},
+            env_payloads={},
+        )
+        with testclient.TestClient(self.test_app) as client:
+            response = client.post(
+                '/organizations/myorg/projects/proj1/deployments',
+                json={
+                    'action': 'deploy',
+                    'environment': 'staging',
+                    'committish': 'abc1234def5678',
+                },
+            )
+        self.assertEqual(response.status_code, 202)
+        self.assertEqual(captured['ref_or_sha'], 'abc1234def5678')
+
     def test_trigger_redeploy(self) -> None:
         with testclient.TestClient(self.test_app) as client:
             response = client.post(


### PR DESCRIPTION
## Summary
When a user selects a tag to deploy, the `trigger_deployment` plugin call now receives the tag name as `ref_or_sha` rather than the underlying SHA.

## Problem
The frontend sends `committish=<SHA>` and `ref_label=<tag_name>` when a user deploys a tag. `_handle_deploy` was unconditionally passing `ref_or_sha=body.committish` (the SHA) to the plugin. For GitHub Actions `workflow_dispatch`, this dispatches against a raw SHA rather than the tag ref, so the run is not properly associated with the tag.

## Solution
Compute `ref = body.ref_label or body.committish` before calling `trigger_deployment`, preferring the human-readable ref (branch name or tag name) when provided. The log line was updated to record the same value. Two tests cover the new behaviour: one asserting the tag name is forwarded when `ref_label` is set, and one asserting the SHA fallback when it is absent.

## Impact
Deploy and redeploy actions for tag-based environments will now trigger GitHub Actions workflows with the tag ref instead of a SHA. No schema or API changes.