### PR TITLE
Add vector similarity search endpoint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,3 @@
-[build-system]
-requires = ["build", "hatchling", "wheel"]
-build-backend = "hatchling.build"
-
 [project]
 name = "imbi-api"
 version = "2.3.1"
@@ -47,6 +43,9 @@ dependencies = [
 ]
 license-file = "LICENSE"
 
+[project.scripts]
+imbi-api = "imbi_api.entrypoint:main"
+
 [project.optional-dependencies]
 otel = [
   "opentelemetry-distro",
@@ -57,8 +56,36 @@ otel = [
 ]
 sentry = ["sentry-sdk"]
 
-[project.scripts]
-imbi-api = "imbi_api.entrypoint:main"
+[dependency-groups]
+dev = [
+  "basedpyright",
+  "build",
+  "coverage[toml]",
+  "httpx",
+  "mypy",
+  "pre-commit",
+  "pytest",
+  "pytest-cov",
+  "ruff",
+  "watchfiles"
+]
+docs = [
+  "griffe-pydantic",
+  "mkdocs>=1.5,<2",
+  "mkdocs-material>9.5,<10",
+  "mkdocstrings-python-xref>=1.6,<2",
+  "mkdocstrings[python]"
+]
+plugins = [
+  "imbi-plugin-aws>=1.0.0",
+  "imbi-plugin-github>=1.0.0",
+  "imbi-plugin-logzio>=1.0.0",
+  "imbi-plugin-oidc>=1.0.0",
+]
+
+[build-system]
+requires = ["build", "hatchling", "wheel"]
+build-backend = "hatchling.build"
 
 [tool.coverage.html]
 directory = "build/coverage"
@@ -142,12 +169,12 @@ reportUnusedFunction = "none"
 extraPaths = ["src", "."]
 
 [tool.pytest.ini_options]
-testpaths = ["tests"]
 addopts = [
   "--cov=src/imbi_api",
   "--cov-report=xml:build/coverage.xml",
   "--cov-report=term",
 ]
+testpaths = ["tests"]
 
 [tool.ruff]
 line-length = 79
@@ -194,33 +221,6 @@ max-complexity = 15
 
 [tool.ruff.lint.per-file-ignores]
 "tests/**/*.py" = ["S"]
-
-[dependency-groups]
-dev = [
-  "basedpyright",
-  "build",
-  "coverage[toml]",
-  "httpx",
-  "mypy",
-  "pre-commit",
-  "pytest",
-  "pytest-cov",
-  "ruff",
-  "watchfiles"
-]
-docs = [
-  "griffe-pydantic",
-  "mkdocs>=1.5,<2",
-  "mkdocs-material>9.5,<10",
-  "mkdocstrings-python-xref>=1.6,<2",
-  "mkdocstrings[python]"
-]
-plugins = [
-  "imbi-plugin-aws>=1.0.0",
-  "imbi-plugin-github>=1.0.0",
-  "imbi-plugin-logzio>=1.0.0",
-  "imbi-plugin-oidc>=1.0.0",
-]
 
 [[tool.uv.index]]
 url = "https://pypi.org/simple"

--- a/src/imbi_api/auth/seed.py
+++ b/src/imbi_api/auth/seed.py
@@ -365,6 +365,13 @@ STANDARD_PERMISSIONS: list[tuple[str, str, str, str]] = [
         'deployment:write',
         'Trigger deployments and promotions via plugins',
     ),
+    # Vector search
+    (
+        'search:read',
+        'search',
+        'read',
+        'Search nodes by semantic similarity',
+    ),
     # Identity plugin connections
     (
         'me:identities:manage',
@@ -436,6 +443,7 @@ DEFAULT_ROLES: list[tuple[str, str, str, int, list[str], bool]] = [
             'document:delete',
             'document_template:read',
             'me:identities:manage',
+            'search:read',
         ],
         False,
     ),
@@ -456,6 +464,7 @@ DEFAULT_ROLES: list[tuple[str, str, str, int, list[str], bool]] = [
             'project:read',
             'project_type:read',
             'role:read',
+            'search:read',
             'tag:read',
             'team:read',
             'third_party_service:read',
@@ -478,6 +487,7 @@ DEFAULT_ROLES: list[tuple[str, str, str, int, list[str], bool]] = [
             'project:read',
             'project_type:read',
             'organization:read',
+            'search:read',
             'team:read',
             'third_party_service:read',
             'user:read',

--- a/src/imbi_api/backfill_embeddings.py
+++ b/src/imbi_api/backfill_embeddings.py
@@ -1,0 +1,79 @@
+"""One-shot backfill: generate embeddings for all existing nodes.
+
+Run with:
+    uv run python -m imbi_api.backfill_embeddings
+
+Iterates every embeddable node type and calls _auto_embed for each
+instance that doesn't already have embeddings (or re-embeds if the
+stored vectors are stale).
+"""
+
+import asyncio
+import logging
+
+from imbi_common import graph, models
+from imbi_common.graph.client import (
+    _embeddable_fields,  # type: ignore[attr-defined]
+)
+
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s %(levelname)-8s %(name)s: %(message)s',
+)
+LOGGER = logging.getLogger('backfill_embeddings')
+
+# Node subclasses — _auto_embed is called normally.
+_NODE_TYPES: list[type[models.Node]] = [
+    models.Organization,
+    models.Blueprint,
+    models.Team,
+    models.Environment,
+    models.ProjectType,
+    models.ThirdPartyService,
+    models.Tag,
+    models.LinkDefinition,
+    models.DocumentTemplate,
+    models.Project,
+]
+
+# GraphModel types that have Embeddable fields but are not Node subclasses.
+# match() still works via model_construct fallback; _auto_embed accepts any
+# GraphModel even though its type annotation says Node.
+_GRAPH_MODEL_TYPES: list[type[models.GraphModel]] = [
+    models.Document,
+    models.Release,
+]
+
+
+async def _embed_type(
+    db: graph.Graph,
+    node_type: type[models.GraphModel],
+) -> int:
+    nodes = await db.match(node_type)  # type: ignore[arg-type]
+    count = 0
+    for node in nodes:
+        if not _embeddable_fields(node):  # type: ignore[arg-type]
+            continue
+        await db._auto_embed(node)  # type: ignore[arg-type]
+        count += 1
+    return count
+
+
+async def run() -> None:
+    db = graph.Graph()
+    await db.open()
+    try:
+        total = 0
+        for node_type in [*_NODE_TYPES, *_GRAPH_MODEL_TYPES]:
+            label = node_type.__name__
+            LOGGER.info('Embedding %s nodes...', label)
+            n = await _embed_type(db, node_type)
+            LOGGER.info('  %s: %d nodes embedded', label, n)
+            total += n
+        LOGGER.info('Done. Total nodes embedded: %d', total)
+    finally:
+        await db.close()
+
+
+if __name__ == '__main__':
+    asyncio.run(run())

--- a/src/imbi_api/backfill_embeddings.py
+++ b/src/imbi_api/backfill_embeddings.py
@@ -41,7 +41,6 @@ _NODE_TYPES: list[type[models.Node]] = [
 # GraphModel even though its type annotation says Node.
 _GRAPH_MODEL_TYPES: list[type[models.GraphModel]] = [
     models.Document,
-    models.Release,
 ]
 
 

--- a/src/imbi_api/endpoints/__init__.py
+++ b/src/imbi_api/endpoints/__init__.py
@@ -22,7 +22,6 @@ from .roles import roles_router
 from .sa_api_keys import sa_api_keys_router
 from .scoring import scoring_router
 from .scoring_policies import scoring_policies_router
-from .search import search_router
 from .service_accounts import service_accounts_router
 from .status import status_router
 from .uploads import uploads_router
@@ -47,7 +46,6 @@ prefixed_routers: list[fastapi.APIRouter] = [
     sa_api_keys_router,
     scoring_policies_router,
     scoring_router,
-    search_router,
     service_accounts_router,
     status_router,
     uploads_router,

--- a/src/imbi_api/endpoints/__init__.py
+++ b/src/imbi_api/endpoints/__init__.py
@@ -22,6 +22,7 @@ from .roles import roles_router
 from .sa_api_keys import sa_api_keys_router
 from .scoring import scoring_router
 from .scoring_policies import scoring_policies_router
+from .search import search_router
 from .service_accounts import service_accounts_router
 from .status import status_router
 from .uploads import uploads_router
@@ -46,6 +47,7 @@ prefixed_routers: list[fastapi.APIRouter] = [
     sa_api_keys_router,
     scoring_policies_router,
     scoring_router,
+    search_router,
     service_accounts_router,
     status_router,
     uploads_router,

--- a/src/imbi_api/endpoints/organizations.py
+++ b/src/imbi_api/endpoints/organizations.py
@@ -28,6 +28,7 @@ from .project_type_plugins import project_type_plugins_router
 from .project_types import project_types_router
 from .projects import projects_router
 from .releases import releases_router
+from .search import search_router
 from .service_plugins import service_plugins_router
 from .tags import tags_router
 from .teams import teams_router
@@ -127,6 +128,10 @@ organizations_router.include_router(
 organizations_router.include_router(
     project_deployments_router,
     prefix='/{org_slug}/projects/{project_id}/deployments',
+)
+organizations_router.include_router(
+    search_router,
+    prefix='/{org_slug}',
 )
 
 

--- a/src/imbi_api/endpoints/search.py
+++ b/src/imbi_api/endpoints/search.py
@@ -10,7 +10,8 @@ from imbi_api.auth import permissions
 
 search_router = fastapi.APIRouter(tags=['Search'])
 
-_OVER_FETCH = 5
+_INITIAL_BATCH = 50
+_BATCH_GROWTH = 2
 
 
 class SearchResult(pydantic.BaseModel):
@@ -124,30 +125,44 @@ async def search(
             detail=f'Organization with slug {org_slug!r} not found',
         )
 
-    raw = await db.search(
-        q,
-        model_name=model,
-        node_label=node_label,
-        limit=limit * _OVER_FETCH,
-        distance_threshold=threshold,
-    )
-
     out: list[SearchResult] = []
-    for r in raw:
-        if r.node_id not in org_node_ids:
-            continue
-        if attribute is not None and r.attribute != attribute:
-            continue
-        out.append(
-            SearchResult(
-                node_label=r.node_label,
-                node_id=r.node_id,
-                attribute=r.attribute,
-                chunk_text=r.chunk_text,
-                distance=r.distance,
-            )
+    batch_size = max(_INITIAL_BATCH, limit)
+    seen: set[str] = set()
+
+    while len(out) < limit:
+        raw = await db.search(
+            q,
+            model_name=model,
+            node_label=node_label,
+            limit=batch_size,
+            distance_threshold=threshold,
         )
-        if len(out) == limit:
+
+        for r in raw:
+            if r.node_id in seen:
+                continue
+            seen.add(r.node_id)
+            if r.node_id not in org_node_ids:
+                continue
+            if attribute is not None and r.attribute != attribute:
+                continue
+            out.append(
+                SearchResult(
+                    node_label=r.node_label,
+                    node_id=r.node_id,
+                    attribute=r.attribute,
+                    chunk_text=r.chunk_text,
+                    distance=r.distance,
+                )
+            )
+            if len(out) == limit:
+                break
+
+        # Stop only when the backend returned fewer rows than requested,
+        # which means the result set is exhausted.
+        if len(raw) < batch_size:
             break
+
+        batch_size *= _BATCH_GROWTH
 
     return out

--- a/src/imbi_api/endpoints/search.py
+++ b/src/imbi_api/endpoints/search.py
@@ -35,7 +35,10 @@ async def search(
     attribute: str | None = None,
     model: str = 'text',
     limit: typing.Annotated[int, fastapi.Query(ge=1, le=100)] = 10,
-    threshold: float | None = None,
+    threshold: typing.Annotated[
+        float | None,
+        fastapi.Query(ge=0.0, le=2.0),
+    ] = None,
 ) -> list[SearchResult]:
     """Search nodes by semantic similarity.
 
@@ -47,10 +50,11 @@ async def search(
         q,
         model_name=model,
         node_label=node_label,
-        attribute=attribute,
         limit=limit,
         distance_threshold=threshold,
     )
+    if attribute is not None:
+        results = [r for r in results if r.attribute == attribute]
     return [
         SearchResult(
             node_label=r.node_label,

--- a/src/imbi_api/endpoints/search.py
+++ b/src/imbi_api/endpoints/search.py
@@ -1,5 +1,6 @@
 """Vector similarity search endpoint."""
 
+import logging
 import typing
 
 import fastapi
@@ -7,6 +8,8 @@ import pydantic
 from imbi_common import graph
 
 from imbi_api.auth import permissions
+
+LOGGER = logging.getLogger(__name__)
 
 search_router = fastapi.APIRouter(tags=['Search'])
 

--- a/src/imbi_api/endpoints/search.py
+++ b/src/imbi_api/endpoints/search.py
@@ -10,6 +10,8 @@ from imbi_api.auth import permissions
 
 search_router = fastapi.APIRouter(tags=['Search'])
 
+_OVER_FETCH = 5
+
 
 class SearchResult(pydantic.BaseModel):
     """A single vector search result."""
@@ -21,8 +23,77 @@ class SearchResult(pydantic.BaseModel):
     distance: float
 
 
+async def _get_org_node_ids(
+    db: graph.Graph,
+    org_slug: str,
+) -> set[str] | None:
+    """Return node IDs for all nodes in the org, or None if org not found.
+
+    Covers: the org itself, direct BELONGS_TO children (Team, Environment,
+    ProjectType, ThirdPartyService, Tag, DocumentTemplate, LinkDefinition),
+    Projects, Documents, and Releases.
+    """
+    org_rows = await db.execute(
+        'MATCH (o:Organization {{slug: {org_slug}}}) RETURN o.id AS org_id',
+        {'org_slug': org_slug},
+        columns=['org_id'],
+    )
+    if not org_rows:
+        return None
+
+    node_ids: set[str] = set()
+    org_id = graph.parse_agtype(org_rows[0]['org_id'])
+    if org_id:
+        node_ids.add(org_id)
+
+    for row in await db.execute(
+        'MATCH (n)-[:BELONGS_TO]->(:Organization {{slug: {org_slug}}})'
+        ' RETURN n.id AS nid',
+        {'org_slug': org_slug},
+        columns=['nid'],
+    ):
+        nid = graph.parse_agtype(row['nid'])
+        if nid:
+            node_ids.add(nid)
+
+    for row in await db.execute(
+        'MATCH (p:Project)-[:OWNED_BY]->(:Team)-[:BELONGS_TO]->'
+        '(:Organization {{slug: {org_slug}}}) RETURN p.id AS nid',
+        {'org_slug': org_slug},
+        columns=['nid'],
+    ):
+        nid = graph.parse_agtype(row['nid'])
+        if nid:
+            node_ids.add(nid)
+
+    for row in await db.execute(
+        'MATCH (d:Document)-[:ATTACHED_TO]->(:Project)-[:OWNED_BY]->'
+        '(:Team)-[:BELONGS_TO]->(:Organization {{slug: {org_slug}}})'
+        ' RETURN d.id AS nid',
+        {'org_slug': org_slug},
+        columns=['nid'],
+    ):
+        nid = graph.parse_agtype(row['nid'])
+        if nid:
+            node_ids.add(nid)
+
+    for row in await db.execute(
+        'MATCH (:Organization {{slug: {org_slug}}})<-[:BELONGS_TO]-'
+        '(:Team)<-[:OWNED_BY]-(:Project)-[:HAS_RELEASE]->(r:Release)'
+        ' RETURN r.id AS nid',
+        {'org_slug': org_slug},
+        columns=['nid'],
+    ):
+        nid = graph.parse_agtype(row['nid'])
+        if nid:
+            node_ids.add(nid)
+
+    return node_ids
+
+
 @search_router.get('/search')
 async def search(
+    org_slug: str,
     db: graph.Pool,
     auth: typing.Annotated[
         permissions.AuthContext,
@@ -40,28 +111,43 @@ async def search(
         fastapi.Query(ge=0.0, le=2.0),
     ] = None,
 ) -> list[SearchResult]:
-    """Search nodes by semantic similarity.
+    """Search nodes by semantic similarity within an organization.
 
     Results are ordered by cosine distance ascending (most similar
     first). ``threshold`` is a distance ceiling: 0.0 = identical,
     2.0 = maximally dissimilar.
     """
-    results = await db.search(
+    org_node_ids = await _get_org_node_ids(db, org_slug)
+    if org_node_ids is None:
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail=f'Organization with slug {org_slug!r} not found',
+        )
+
+    raw = await db.search(
         q,
         model_name=model,
         node_label=node_label,
-        limit=limit,
+        limit=limit * _OVER_FETCH,
         distance_threshold=threshold,
     )
-    if attribute is not None:
-        results = [r for r in results if r.attribute == attribute]
-    return [
-        SearchResult(
-            node_label=r.node_label,
-            node_id=r.node_id,
-            attribute=r.attribute,
-            chunk_text=r.chunk_text,
-            distance=r.distance,
+
+    out: list[SearchResult] = []
+    for r in raw:
+        if r.node_id not in org_node_ids:
+            continue
+        if attribute is not None and r.attribute != attribute:
+            continue
+        out.append(
+            SearchResult(
+                node_label=r.node_label,
+                node_id=r.node_id,
+                attribute=r.attribute,
+                chunk_text=r.chunk_text,
+                distance=r.distance,
+            )
         )
-        for r in results
-    ]
+        if len(out) == limit:
+            break
+
+    return out

--- a/src/imbi_api/endpoints/search.py
+++ b/src/imbi_api/endpoints/search.py
@@ -1,0 +1,63 @@
+"""Vector similarity search endpoint."""
+
+import typing
+
+import fastapi
+import pydantic
+from imbi_common import graph
+
+from imbi_api.auth import permissions
+
+search_router = fastapi.APIRouter(tags=['Search'])
+
+
+class SearchResult(pydantic.BaseModel):
+    """A single vector search result."""
+
+    node_label: str
+    node_id: str
+    attribute: str
+    chunk_text: str
+    distance: float
+
+
+@search_router.get('/search')
+async def search(
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('search:read'),
+        ),
+    ],
+    q: typing.Annotated[str, fastapi.Query(min_length=1)],
+    node_label: str | None = None,
+    attribute: str | None = None,
+    model: str = 'text',
+    limit: typing.Annotated[int, fastapi.Query(ge=1, le=100)] = 10,
+    threshold: float | None = None,
+) -> list[SearchResult]:
+    """Search nodes by semantic similarity.
+
+    Results are ordered by cosine distance ascending (most similar
+    first). ``threshold`` is a distance ceiling: 0.0 = identical,
+    2.0 = maximally dissimilar.
+    """
+    results = await db.search(
+        q,
+        model_name=model,
+        node_label=node_label,
+        attribute=attribute,
+        limit=limit,
+        distance_threshold=threshold,
+    )
+    return [
+        SearchResult(
+            node_label=r.node_label,
+            node_id=r.node_id,
+            attribute=r.attribute,
+            chunk_text=r.chunk_text,
+            distance=r.distance,
+        )
+        for r in results
+    ]

--- a/tests/endpoints/test_search.py
+++ b/tests/endpoints/test_search.py
@@ -269,6 +269,142 @@ class SearchEndpointTestCase(unittest.TestCase):
         response = self.client.get(f'{_BASE_URL}?q=foo&threshold=2.0')
         self.assertEqual(response.status_code, 200)
 
+    def test_falsy_org_id_and_nids_skipped(self) -> None:
+        """parse_agtype returning falsy for org_id or any nid skips it."""
+        # org_id is falsy ('') so org node is not added to the set,
+        # but the org IS found (non-empty list returned).
+        # BELONGS_TO and Document/Release return falsy nids; Projects is valid.
+        self.mock_db.execute.side_effect = [
+            [{'org_id': '""'}],  # org found but parse_agtype -> ''
+            [{'nid': '""'}],  # BELONGS_TO: falsy nid skipped
+            [{'nid': '"proj-1"'}],  # Project: valid nid included
+            [{'nid': '""'}],  # Document: falsy nid skipped
+            [{'nid': '""'}],  # Release: falsy nid skipped
+        ]
+        self.mock_db.search.return_value = [
+            self._make_result(node_id='proj-1'),
+        ]
+        response = self.client.get(f'{_BASE_URL}?q=test')
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]['node_id'], 'proj-1')
+
+    def test_belongs_to_node_ids_included(self) -> None:
+        """Nodes returned by the BELONGS_TO query are included in org scope."""
+        self.mock_db.execute.side_effect = [
+            [{'org_id': '"org-abc"'}],
+            [{'nid': '"team-1"'}],  # BELONGS_TO child (e.g. Team)
+            [],  # Projects
+            [],  # Documents
+            [],  # Releases
+        ]
+        self.mock_db.search.return_value = [
+            self._make_result(node_id='team-1', node_label='Team'),
+        ]
+        response = self.client.get(f'{_BASE_URL}?q=test')
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]['node_id'], 'team-1')
+
+    def test_document_node_ids_included(self) -> None:
+        """Document ATTACHED_TO query nodes are included in org scope."""
+        self.mock_db.execute.side_effect = [
+            [{'org_id': '"org-abc"'}],
+            [],  # BELONGS_TO
+            [],  # Projects
+            [{'nid': '"doc-1"'}],  # Documents
+            [],  # Releases
+        ]
+        self.mock_db.search.return_value = [
+            self._make_result(node_id='doc-1', node_label='Document'),
+        ]
+        response = self.client.get(f'{_BASE_URL}?q=test')
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]['node_id'], 'doc-1')
+
+    def test_release_node_ids_included(self) -> None:
+        """Nodes returned by the Release HAS_RELEASE query are in org scope."""
+        self.mock_db.execute.side_effect = [
+            [{'org_id': '"org-abc"'}],
+            [],  # BELONGS_TO
+            [],  # Projects
+            [],  # Documents
+            [{'nid': '"rel-1"'}],  # Releases
+        ]
+        self.mock_db.search.return_value = [
+            self._make_result(node_id='rel-1', node_label='Release'),
+        ]
+        response = self.client.get(f'{_BASE_URL}?q=test')
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]['node_id'], 'rel-1')
+
+    def test_limit_reached_mid_batch_stops_inner_loop(self) -> None:
+        """Inner loop breaks early when limit is reached mid-batch."""
+        self._setup_org(node_ids=['a', 'b', 'c'])
+        # Three in-org results in one batch; limit=2 should stop after 'b'.
+        self.mock_db.search.return_value = [
+            self._make_result(node_id='a', distance=0.1),
+            self._make_result(node_id='b', distance=0.2),
+            self._make_result(node_id='c', distance=0.3),
+        ]
+        response = self.client.get(f'{_BASE_URL}?q=test&limit=2')
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(len(data), 2)
+        self.assertEqual(data[0]['node_id'], 'a')
+        self.assertEqual(data[1]['node_id'], 'b')
+        # Only one search call needed because the limit was met in the batch.
+        self.assertEqual(self.mock_db.search.await_count, 1)
+
+    def test_project_falsy_nid_skipped(self) -> None:
+        """A falsy nid from the Project query is skipped."""
+        self.mock_db.execute.side_effect = [
+            [{'org_id': '"org-abc"'}],
+            [],  # BELONGS_TO
+            [{'nid': '""'}],  # Project: falsy nid skipped
+            [],  # Documents
+            [],  # Releases
+        ]
+        self.mock_db.search.return_value = []
+        response = self.client.get(f'{_BASE_URL}?q=test')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), [])
+
+    def test_while_exits_at_condition_after_full_batch(self) -> None:
+        """While loop exits at condition when limit is met and batch was full.
+
+        When limit results are found mid-batch (inner break fires) but the
+        batch was not exhausted (len(raw) >= batch_size), the code re-enters
+        the while condition check, which is now false, and exits cleanly.
+        """
+        self._setup_org(node_ids=['target'])
+        # Return exactly _INITIAL_BATCH (50) items; first is in-org.
+        # That means len(raw)=50 == batch_size=50, so the exhaustion check
+        # does NOT break — we fall through to batch_size *= 2 and re-check
+        # the while condition, which is now false (limit already met).
+        from imbi_api.endpoints.search import _INITIAL_BATCH
+
+        batch = [
+            self._make_result(node_id='target', distance=0.01),
+        ] + [
+            self._make_result(node_id=f'out-{i}', distance=float(i + 1) / 10)
+            for i in range(_INITIAL_BATCH - 1)
+        ]
+        self.mock_db.search.return_value = batch
+        response = self.client.get(f'{_BASE_URL}?q=test&limit=1')
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]['node_id'], 'target')
+        # Only one db.search call (limit met mid-batch, no second call needed).
+        self.assertEqual(self.mock_db.search.await_count, 1)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/endpoints/test_search.py
+++ b/tests/endpoints/test_search.py
@@ -133,6 +133,7 @@ class SearchEndpointTestCase(unittest.TestCase):
         self.assertEqual(call_kwargs['node_label'], 'Team')
 
     def test_attribute_filter(self) -> None:
+        """attribute is post-filtered after org-scoping."""
         self._setup_org(node_ids=['a', 'b'])
         self.mock_db.search.return_value = [
             self._make_result(node_id='a', attribute='name'),
@@ -144,12 +145,44 @@ class SearchEndpointTestCase(unittest.TestCase):
         self.assertEqual(len(data), 1)
         self.assertEqual(data[0]['node_id'], 'a')
 
-    def test_limit_passed_with_over_fetch(self) -> None:
+    def test_initial_batch_at_least_limit(self) -> None:
+        """First db.search call uses at least limit rows."""
         self._setup_org()
         self.mock_db.search.return_value = []
         self.client.get(f'{_BASE_URL}?q=foo&limit=10')
         call_kwargs = self.mock_db.search.call_args.kwargs
-        self.assertEqual(call_kwargs['limit'], 50)
+        self.assertGreaterEqual(call_kwargs['limit'], 10)
+
+    def test_paged_loop_fetches_more_when_needed(self) -> None:
+        """When first batch has no in-org results a second batch is fetched."""
+        self._setup_org(node_ids=['proj-in-org'])
+        out_of_org = [
+            self._make_result(node_id=f'out-{i}', distance=float(i) / 100)
+            for i in range(50)
+        ]
+        in_org = [self._make_result(node_id='proj-in-org', distance=0.99)]
+        self.mock_db.search.side_effect = [out_of_org, in_org]
+        response = self.client.get(f'{_BASE_URL}?q=test&limit=1')
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]['node_id'], 'proj-in-org')
+        self.assertEqual(self.mock_db.search.await_count, 2)
+
+    def test_stops_when_result_set_exhausted(self) -> None:
+        """Loop stops when db.search returns fewer rows than requested."""
+        self._setup_org(node_ids=['proj-1'])
+        # Return only 3 rows (less than the batch size), all out-of-org except
+        # the last; ensures we don't loop forever.
+        self.mock_db.search.return_value = [
+            self._make_result(node_id='out-1', distance=0.1),
+            self._make_result(node_id='proj-1', distance=0.2),
+        ]
+        response = self.client.get(f'{_BASE_URL}?q=test&limit=5')
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(len(data), 1)
+        self.assertEqual(self.mock_db.search.await_count, 1)
 
     def test_threshold_param(self) -> None:
         self._setup_org()

--- a/tests/endpoints/test_search.py
+++ b/tests/endpoints/test_search.py
@@ -1,4 +1,4 @@
-"""Tests for the vector similarity search endpoint."""
+"""Tests for the org-scoped vector similarity search endpoint."""
 
 import datetime
 import unittest
@@ -10,6 +10,9 @@ from imbi_common.graph.client import SearchResult
 
 from imbi_api import app, models
 from imbi_api.auth import permissions
+
+_ORG_SLUG = 'test-org'
+_BASE_URL = f'/organizations/{_ORG_SLUG}/search'
 
 
 class SearchEndpointTestCase(unittest.TestCase):
@@ -62,11 +65,33 @@ class SearchEndpointTestCase(unittest.TestCase):
             distance=distance,
         )
 
-    def test_basic_search(self) -> None:
-        self.mock_db.search.return_value = [
-            self._make_result(),
+    def _setup_org(self, node_ids: list[str] | None = None) -> None:
+        """Configure mock_db.execute for the five org-membership queries.
+
+        The search handler calls db.execute in this order:
+          1. org lookup -> [{org_id: ...}] or []
+          2. direct BELONGS_TO children -> [{nid: ...}, ...]
+          3. Project nodes -> [{nid: ...}, ...]
+          4. Document nodes -> []
+          5. Release nodes -> []
+        """
+        if node_ids is None:
+            node_ids = ['proj-1']
+        self.mock_db.execute.side_effect = [
+            [{'org_id': '"org-abc"'}],
+            [],
+            [{'nid': f'"{nid}"'} for nid in node_ids],
+            [],
+            [],
         ]
-        response = self.client.get('/search?q=api+gateway')
+
+    def _setup_org_not_found(self) -> None:
+        self.mock_db.execute.side_effect = [[]]
+
+    def test_basic_search(self) -> None:
+        self._setup_org()
+        self.mock_db.search.return_value = [self._make_result()]
+        response = self.client.get(f'{_BASE_URL}?q=api+gateway')
         self.assertEqual(response.status_code, 200)
         data = response.json()
         self.assertEqual(len(data), 1)
@@ -75,77 +100,95 @@ class SearchEndpointTestCase(unittest.TestCase):
         self.assertEqual(data[0]['attribute'], 'description')
         self.assertAlmostEqual(data[0]['distance'], 0.12)
 
+    def test_org_not_found_returns_404(self) -> None:
+        self._setup_org_not_found()
+        response = self.client.get(f'{_BASE_URL}?q=foo')
+        self.assertEqual(response.status_code, 404)
+
+    def test_filters_results_to_org(self) -> None:
+        self._setup_org(node_ids=['proj-1'])
+        self.mock_db.search.return_value = [
+            self._make_result(node_id='proj-1', distance=0.10),
+            self._make_result(node_id='proj-2', distance=0.20),
+        ]
+        response = self.client.get(f'{_BASE_URL}?q=test')
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]['node_id'], 'proj-1')
+
     def test_passes_query_to_db_search(self) -> None:
+        self._setup_org()
         self.mock_db.search.return_value = []
-        self.client.get('/search?q=hello+world')
+        self.client.get(f'{_BASE_URL}?q=hello+world')
         self.mock_db.search.assert_awaited_once()
         call_args = self.mock_db.search.call_args
         self.assertEqual(call_args.args[0], 'hello world')
 
     def test_node_label_filter(self) -> None:
+        self._setup_org()
         self.mock_db.search.return_value = []
-        self.client.get('/search?q=foo&node_label=Team')
+        self.client.get(f'{_BASE_URL}?q=foo&node_label=Team')
         call_kwargs = self.mock_db.search.call_args.kwargs
         self.assertEqual(call_kwargs['node_label'], 'Team')
 
     def test_attribute_filter(self) -> None:
-        # attribute filtering is applied in Python after db.search
+        self._setup_org(node_ids=['a', 'b'])
         self.mock_db.search.return_value = [
             self._make_result(node_id='a', attribute='name'),
             self._make_result(node_id='b', attribute='description'),
         ]
-        response = self.client.get('/search?q=foo&attribute=name')
+        response = self.client.get(f'{_BASE_URL}?q=foo&attribute=name')
         self.assertEqual(response.status_code, 200)
         data = response.json()
         self.assertEqual(len(data), 1)
         self.assertEqual(data[0]['node_id'], 'a')
-        # attribute is NOT forwarded to the db layer
-        call_kwargs = self.mock_db.search.call_args.kwargs
-        self.assertNotIn('attribute', call_kwargs)
 
-    def test_limit_param(self) -> None:
+    def test_limit_passed_with_over_fetch(self) -> None:
+        self._setup_org()
         self.mock_db.search.return_value = []
-        self.client.get('/search?q=foo&limit=25')
+        self.client.get(f'{_BASE_URL}?q=foo&limit=10')
         call_kwargs = self.mock_db.search.call_args.kwargs
-        self.assertEqual(call_kwargs['limit'], 25)
+        self.assertEqual(call_kwargs['limit'], 50)
 
     def test_threshold_param(self) -> None:
+        self._setup_org()
         self.mock_db.search.return_value = []
-        self.client.get('/search?q=foo&threshold=0.5')
+        self.client.get(f'{_BASE_URL}?q=foo&threshold=0.5')
         call_kwargs = self.mock_db.search.call_args.kwargs
         self.assertAlmostEqual(call_kwargs['distance_threshold'], 0.5)
 
     def test_model_param(self) -> None:
+        self._setup_org()
         self.mock_db.search.return_value = []
-        self.client.get('/search?q=foo&model=code')
+        self.client.get(f'{_BASE_URL}?q=foo&model=code')
         call_kwargs = self.mock_db.search.call_args.kwargs
         self.assertEqual(call_kwargs['model_name'], 'code')
 
     def test_empty_query_rejected(self) -> None:
-        response = self.client.get('/search?q=')
+        response = self.client.get(f'{_BASE_URL}?q=')
         self.assertEqual(response.status_code, 422)
 
     def test_limit_too_large_rejected(self) -> None:
-        response = self.client.get('/search?q=foo&limit=101')
+        response = self.client.get(f'{_BASE_URL}?q=foo&limit=101')
         self.assertEqual(response.status_code, 422)
 
     def test_limit_zero_rejected(self) -> None:
-        response = self.client.get('/search?q=foo&limit=0')
+        response = self.client.get(f'{_BASE_URL}?q=foo&limit=0')
         self.assertEqual(response.status_code, 422)
 
     def test_missing_query_param_rejected(self) -> None:
-        response = self.client.get('/search')
+        response = self.client.get(_BASE_URL)
         self.assertEqual(response.status_code, 422)
 
-    def test_multiple_results_returned(self) -> None:
-        # Use out-of-order distances to verify the endpoint preserves
-        # the ordering returned by db.search (which the DB sorts).
+    def test_multiple_results_preserved_in_order(self) -> None:
+        self._setup_org(node_ids=['a', 'b', 'c'])
         self.mock_db.search.return_value = [
             self._make_result(node_id='b', distance=0.15),
             self._make_result(node_id='a', distance=0.05),
             self._make_result(node_id='c', distance=0.30),
         ]
-        response = self.client.get('/search?q=test')
+        response = self.client.get(f'{_BASE_URL}?q=test')
         self.assertEqual(response.status_code, 200)
         data = response.json()
         self.assertEqual(len(data), 3)
@@ -153,29 +196,44 @@ class SearchEndpointTestCase(unittest.TestCase):
         self.assertEqual(data[1]['node_id'], 'a')
         self.assertEqual(data[2]['node_id'], 'c')
 
+    def test_limit_truncates_after_org_filter(self) -> None:
+        self._setup_org(node_ids=['a', 'b', 'c'])
+        self.mock_db.search.return_value = [
+            self._make_result(node_id='a', distance=0.05),
+            self._make_result(node_id='b', distance=0.10),
+            self._make_result(node_id='c', distance=0.20),
+        ]
+        response = self.client.get(f'{_BASE_URL}?q=test&limit=2')
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(len(data), 2)
+        self.assertEqual(data[0]['node_id'], 'a')
+        self.assertEqual(data[1]['node_id'], 'b')
+
     def test_no_filter_defaults(self) -> None:
+        self._setup_org()
         self.mock_db.search.return_value = []
-        self.client.get('/search?q=test')
+        self.client.get(f'{_BASE_URL}?q=test')
         call_kwargs = self.mock_db.search.call_args.kwargs
         self.assertIsNone(call_kwargs['node_label'])
-        self.assertNotIn('attribute', call_kwargs)
         self.assertIsNone(call_kwargs['distance_threshold'])
-        self.assertEqual(call_kwargs['limit'], 10)
         self.assertEqual(call_kwargs['model_name'], 'text')
 
     def test_threshold_too_high_rejected(self) -> None:
-        response = self.client.get('/search?q=foo&threshold=2.1')
+        response = self.client.get(f'{_BASE_URL}?q=foo&threshold=2.1')
         self.assertEqual(response.status_code, 422)
 
     def test_threshold_negative_rejected(self) -> None:
-        response = self.client.get('/search?q=foo&threshold=-0.1')
+        response = self.client.get(f'{_BASE_URL}?q=foo&threshold=-0.1')
         self.assertEqual(response.status_code, 422)
 
     def test_threshold_boundary_values_accepted(self) -> None:
+        self._setup_org()
         self.mock_db.search.return_value = []
-        response = self.client.get('/search?q=foo&threshold=0.0')
+        response = self.client.get(f'{_BASE_URL}?q=foo&threshold=0.0')
         self.assertEqual(response.status_code, 200)
-        response = self.client.get('/search?q=foo&threshold=2.0')
+        self._setup_org()
+        response = self.client.get(f'{_BASE_URL}?q=foo&threshold=2.0')
         self.assertEqual(response.status_code, 200)
 
 

--- a/tests/endpoints/test_search.py
+++ b/tests/endpoints/test_search.py
@@ -138,16 +138,19 @@ class SearchEndpointTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 422)
 
     def test_multiple_results_returned(self) -> None:
+        # Use out-of-order distances to verify the endpoint preserves
+        # the ordering returned by db.search (which the DB sorts).
         self.mock_db.search.return_value = [
-            self._make_result(node_id='a', distance=0.05),
             self._make_result(node_id='b', distance=0.15),
+            self._make_result(node_id='a', distance=0.05),
             self._make_result(node_id='c', distance=0.30),
         ]
         response = self.client.get('/search?q=test')
         self.assertEqual(response.status_code, 200)
         data = response.json()
         self.assertEqual(len(data), 3)
-        self.assertEqual(data[0]['node_id'], 'a')
+        self.assertEqual(data[0]['node_id'], 'b')
+        self.assertEqual(data[1]['node_id'], 'a')
         self.assertEqual(data[2]['node_id'], 'c')
 
     def test_no_filter_defaults(self) -> None:

--- a/tests/endpoints/test_search.py
+++ b/tests/endpoints/test_search.py
@@ -1,0 +1,156 @@
+"""Tests for the vector similarity search endpoint."""
+
+import datetime
+import unittest
+from unittest import mock
+
+from fastapi.testclient import TestClient
+from imbi_common import graph
+from imbi_common.graph.client import SearchResult
+
+from imbi_api import app, models
+from imbi_api.auth import permissions
+
+
+class SearchEndpointTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.test_app = app.create_app()
+
+        admin_user = models.User(
+            email='admin@example.com',
+            display_name='Admin User',
+            password_hash='$argon2id$hashed',
+            is_active=True,
+            is_admin=True,
+            is_service_account=False,
+            created_at=datetime.datetime.now(datetime.UTC),
+        )
+        auth_context = permissions.AuthContext(
+            user=admin_user,
+            session_id='test-session',
+            auth_method='jwt',
+            permissions={'search:read'},
+        )
+
+        async def mock_get_current_user():
+            return auth_context
+
+        self.test_app.dependency_overrides[permissions.get_current_user] = (
+            mock_get_current_user
+        )
+
+        self.mock_db = mock.AsyncMock(spec=graph.Graph)
+        self.test_app.dependency_overrides[graph._inject_graph] = lambda: (
+            self.mock_db
+        )
+
+        self.client = TestClient(self.test_app)
+
+    def _make_result(
+        self,
+        node_label: str = 'Project',
+        node_id: str = 'proj-1',
+        attribute: str = 'description',
+        chunk_text: str = 'a sample description',
+        distance: float = 0.12,
+    ) -> SearchResult:
+        return SearchResult(
+            node_label=node_label,
+            node_id=node_id,
+            attribute=attribute,
+            chunk_text=chunk_text,
+            distance=distance,
+        )
+
+    def test_basic_search(self) -> None:
+        self.mock_db.search.return_value = [
+            self._make_result(),
+        ]
+        response = self.client.get('/search?q=api+gateway')
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]['node_label'], 'Project')
+        self.assertEqual(data[0]['node_id'], 'proj-1')
+        self.assertEqual(data[0]['attribute'], 'description')
+        self.assertAlmostEqual(data[0]['distance'], 0.12)
+
+    def test_passes_query_to_db_search(self) -> None:
+        self.mock_db.search.return_value = []
+        self.client.get('/search?q=hello+world')
+        self.mock_db.search.assert_awaited_once()
+        call_args = self.mock_db.search.call_args
+        self.assertEqual(call_args.args[0], 'hello world')
+
+    def test_node_label_filter(self) -> None:
+        self.mock_db.search.return_value = []
+        self.client.get('/search?q=foo&node_label=Team')
+        call_kwargs = self.mock_db.search.call_args.kwargs
+        self.assertEqual(call_kwargs['node_label'], 'Team')
+
+    def test_attribute_filter(self) -> None:
+        self.mock_db.search.return_value = []
+        self.client.get('/search?q=foo&attribute=name')
+        call_kwargs = self.mock_db.search.call_args.kwargs
+        self.assertEqual(call_kwargs['attribute'], 'name')
+
+    def test_limit_param(self) -> None:
+        self.mock_db.search.return_value = []
+        self.client.get('/search?q=foo&limit=25')
+        call_kwargs = self.mock_db.search.call_args.kwargs
+        self.assertEqual(call_kwargs['limit'], 25)
+
+    def test_threshold_param(self) -> None:
+        self.mock_db.search.return_value = []
+        self.client.get('/search?q=foo&threshold=0.5')
+        call_kwargs = self.mock_db.search.call_args.kwargs
+        self.assertAlmostEqual(call_kwargs['distance_threshold'], 0.5)
+
+    def test_model_param(self) -> None:
+        self.mock_db.search.return_value = []
+        self.client.get('/search?q=foo&model=code')
+        call_kwargs = self.mock_db.search.call_args.kwargs
+        self.assertEqual(call_kwargs['model_name'], 'code')
+
+    def test_empty_query_rejected(self) -> None:
+        response = self.client.get('/search?q=')
+        self.assertEqual(response.status_code, 422)
+
+    def test_limit_too_large_rejected(self) -> None:
+        response = self.client.get('/search?q=foo&limit=101')
+        self.assertEqual(response.status_code, 422)
+
+    def test_limit_zero_rejected(self) -> None:
+        response = self.client.get('/search?q=foo&limit=0')
+        self.assertEqual(response.status_code, 422)
+
+    def test_missing_query_param_rejected(self) -> None:
+        response = self.client.get('/search')
+        self.assertEqual(response.status_code, 422)
+
+    def test_multiple_results_returned(self) -> None:
+        self.mock_db.search.return_value = [
+            self._make_result(node_id='a', distance=0.05),
+            self._make_result(node_id='b', distance=0.15),
+            self._make_result(node_id='c', distance=0.30),
+        ]
+        response = self.client.get('/search?q=test')
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(len(data), 3)
+        self.assertEqual(data[0]['node_id'], 'a')
+        self.assertEqual(data[2]['node_id'], 'c')
+
+    def test_no_filter_defaults(self) -> None:
+        self.mock_db.search.return_value = []
+        self.client.get('/search?q=test')
+        call_kwargs = self.mock_db.search.call_args.kwargs
+        self.assertIsNone(call_kwargs['node_label'])
+        self.assertIsNone(call_kwargs['attribute'])
+        self.assertIsNone(call_kwargs['distance_threshold'])
+        self.assertEqual(call_kwargs['limit'], 10)
+        self.assertEqual(call_kwargs['model_name'], 'text')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/endpoints/test_search.py
+++ b/tests/endpoints/test_search.py
@@ -89,10 +89,19 @@ class SearchEndpointTestCase(unittest.TestCase):
         self.assertEqual(call_kwargs['node_label'], 'Team')
 
     def test_attribute_filter(self) -> None:
-        self.mock_db.search.return_value = []
-        self.client.get('/search?q=foo&attribute=name')
+        # attribute filtering is applied in Python after db.search
+        self.mock_db.search.return_value = [
+            self._make_result(node_id='a', attribute='name'),
+            self._make_result(node_id='b', attribute='description'),
+        ]
+        response = self.client.get('/search?q=foo&attribute=name')
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]['node_id'], 'a')
+        # attribute is NOT forwarded to the db layer
         call_kwargs = self.mock_db.search.call_args.kwargs
-        self.assertEqual(call_kwargs['attribute'], 'name')
+        self.assertNotIn('attribute', call_kwargs)
 
     def test_limit_param(self) -> None:
         self.mock_db.search.return_value = []
@@ -146,10 +155,25 @@ class SearchEndpointTestCase(unittest.TestCase):
         self.client.get('/search?q=test')
         call_kwargs = self.mock_db.search.call_args.kwargs
         self.assertIsNone(call_kwargs['node_label'])
-        self.assertIsNone(call_kwargs['attribute'])
+        self.assertNotIn('attribute', call_kwargs)
         self.assertIsNone(call_kwargs['distance_threshold'])
         self.assertEqual(call_kwargs['limit'], 10)
         self.assertEqual(call_kwargs['model_name'], 'text')
+
+    def test_threshold_too_high_rejected(self) -> None:
+        response = self.client.get('/search?q=foo&threshold=2.1')
+        self.assertEqual(response.status_code, 422)
+
+    def test_threshold_negative_rejected(self) -> None:
+        response = self.client.get('/search?q=foo&threshold=-0.1')
+        self.assertEqual(response.status_code, 422)
+
+    def test_threshold_boundary_values_accepted(self) -> None:
+        self.mock_db.search.return_value = []
+        response = self.client.get('/search?q=foo&threshold=0.0')
+        self.assertEqual(response.status_code, 200)
+        response = self.client.get('/search?q=foo&threshold=2.0')
+        self.assertEqual(response.status_code, 200)
 
 
 if __name__ == '__main__':

--- a/tests/test_backfill_embeddings.py
+++ b/tests/test_backfill_embeddings.py
@@ -1,0 +1,81 @@
+"""Tests for the one-shot embedding backfill script."""
+
+import unittest
+from unittest import mock
+
+from imbi_api import backfill_embeddings
+
+
+class BackfillEmbeddingsTestCase(unittest.IsolatedAsyncioTestCase):
+    async def test_run_embeds_all_nodes(self) -> None:
+        mock_node = mock.MagicMock()
+        mock_db = mock.AsyncMock()
+        mock_db.match.return_value = [mock_node]
+
+        with mock.patch.object(
+            backfill_embeddings.graph, 'Graph', return_value=mock_db
+        ):
+            with mock.patch(
+                'imbi_api.backfill_embeddings._embeddable_fields',
+                return_value=['name'],
+            ):
+                await backfill_embeddings.run()
+
+        expected = len(backfill_embeddings._NODE_TYPES) + len(
+            backfill_embeddings._GRAPH_MODEL_TYPES
+        )
+        self.assertEqual(mock_db.match.await_count, expected)
+        self.assertEqual(mock_db._auto_embed.await_count, expected)
+        mock_db.open.assert_awaited_once()
+        mock_db.close.assert_awaited_once()
+
+    async def test_run_skips_non_embeddable_nodes(self) -> None:
+        mock_node = mock.MagicMock()
+        mock_db = mock.AsyncMock()
+        mock_db.match.return_value = [mock_node]
+
+        with mock.patch.object(
+            backfill_embeddings.graph, 'Graph', return_value=mock_db
+        ):
+            with mock.patch(
+                'imbi_api.backfill_embeddings._embeddable_fields',
+                return_value=[],
+            ):
+                await backfill_embeddings.run()
+
+        mock_db._auto_embed.assert_not_awaited()
+
+    async def test_run_closes_db_on_exception(self) -> None:
+        mock_db = mock.AsyncMock()
+        mock_db.match.side_effect = RuntimeError('simulated error')
+
+        with mock.patch.object(
+            backfill_embeddings.graph, 'Graph', return_value=mock_db
+        ):
+            with mock.patch(
+                'imbi_api.backfill_embeddings._embeddable_fields',
+                return_value=['name'],
+            ):
+                with self.assertRaises(RuntimeError):
+                    await backfill_embeddings.run()
+
+        mock_db.close.assert_awaited_once()
+
+    async def test_embed_type_empty_nodes(self) -> None:
+        mock_db = mock.AsyncMock()
+        mock_db.match.return_value = []
+
+        with mock.patch(
+            'imbi_api.backfill_embeddings._embeddable_fields',
+            return_value=['name'],
+        ):
+            count = await backfill_embeddings._embed_type(
+                mock_db, backfill_embeddings._NODE_TYPES[0]
+            )
+
+        self.assertEqual(count, 0)
+        mock_db._auto_embed.assert_not_awaited()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_graph_sql.py
+++ b/tests/test_graph_sql.py
@@ -1,0 +1,46 @@
+"""Tests for Cypher property-template helpers."""
+
+import unittest
+
+from imbi_api.graph_sql import escape_prop, props_template, set_clause
+
+
+class EscapePropTestCase(unittest.TestCase):
+    def test_plain_name(self) -> None:
+        self.assertEqual(escape_prop('name'), '`name`')
+
+    def test_backtick_in_name(self) -> None:
+        self.assertEqual(escape_prop('a`b'), '`a``b`')
+
+
+class PropsTemplateTestCase(unittest.TestCase):
+    def test_empty_dict_returns_empty_string(self) -> None:
+        self.assertEqual(props_template({}), '')
+
+    def test_single_prop(self) -> None:
+        result = props_template({'slug': 'x'})
+        self.assertEqual(result, '{{`slug`: {slug}}}')
+
+    def test_multiple_props(self) -> None:
+        result = props_template({'a': 1, 'b': 2})
+        self.assertIn('`a`: {a}', result)
+        self.assertIn('`b`: {b}', result)
+
+
+class SetClauseTestCase(unittest.TestCase):
+    def test_empty_dict_returns_empty_string(self) -> None:
+        self.assertEqual(set_clause('n', {}), '')
+
+    def test_single_prop(self) -> None:
+        result = set_clause('n', {'name': 'x'})
+        self.assertEqual(result, 'SET n.`name` = {name}')
+
+    def test_multiple_props(self) -> None:
+        result = set_clause('n', {'a': 1, 'b': 2})
+        self.assertTrue(result.startswith('SET '))
+        self.assertIn('n.`a` = {a}', result)
+        self.assertIn('n.`b` = {b}', result)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

- Adds `GET /search` endpoint for vector similarity search against the `public.embeddings` table
- Supports optional filters: `node_label` (node type), `attribute` (embedding attribute), `model`, `limit` (1–100), and `threshold` (max cosine distance)
- Adds `search:read` permission, granted to developer, default, and readonly roles
- Requires [imbi-common#109](https://github.com/AWeber-Imbi/imbi-common/pull/109) for the `attribute` filter parameter on `Graph.search()`

## Test plan

- [ ] `GET /search?q=api+gateway` returns results ordered by cosine distance ascending
- [ ] `node_label=Project` restricts results to Project embeddings
- [ ] `attribute=description` restricts results to description embeddings
- [ ] `threshold=0.5` excludes results with distance > 0.5
- [ ] `limit=0` and `limit=101` return 422
- [ ] Missing `q` returns 422
- [ ] Run `imbi-api setup` to seed the new `search:read` permission

🤖 Generated with [Claude Code](https://claude.com/claude-code)