### PR TITLE
Add sentry-sdk dependency for error reporting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
   "fastapi",
   "filetype",
   "httpx>=0.28.1,<1",
-  "imbi-common[databases,llm,server]>=2.4.0",
+  "imbi-common[databases,llm,sentry,server]>=2.4.0",
   "jinja2",
   "jsonpatch>=1.33",
   "nanoid>=2.0.0",
@@ -36,6 +36,7 @@ dependencies = [
   "pyotp>=2.9.0",
   "python-multipart>=0.0.26",
   "qrcode>=8.0",
+  "sentry-sdk>=2.48.0",
   "slowapi==0.1.9",  # Pin: alpha quality, API may change
   "typer",
   "uvicorn",

--- a/uv.lock
+++ b/uv.lock
@@ -6,9 +6,6 @@ resolution-markers = [
   "python_full_version < '3.15'",
 ]
 
-[options]
-prerelease-mode = "allow"
-
 [[package]]
 name = "aioboto3"
 version = "15.5.0"
@@ -954,7 +951,7 @@ wheels = [
 
 [[package]]
 name = "imbi-api"
-version = "2.3.1"
+version = "2.4.0"
 source = { editable = "." }
 dependencies = [
   { name = "aioboto3" },
@@ -974,6 +971,7 @@ dependencies = [
   { name = "pyotp" },
   { name = "python-multipart" },
   { name = "qrcode" },
+  { name = "sentry-sdk" },
   { name = "slowapi" },
   { name = "typer" },
   { name = "uvicorn" },
@@ -1028,7 +1026,7 @@ requires-dist = [
   { name = "fastapi" },
   { name = "filetype" },
   { name = "httpx", specifier = ">=0.28.1,<1" },
-  { name = "imbi-common", extras = ["databases", "llm", "server"], specifier = ">=2.3.0" },
+  { name = "imbi-common", extras = ["databases", "llm", "sentry", "server"], specifier = ">=2.4.0" },
   { name = "jinja2" },
   { name = "jsonpatch", specifier = ">=1.33" },
   { name = "nanoid", specifier = ">=2.0.0" },
@@ -1043,6 +1041,7 @@ requires-dist = [
   { name = "pyotp", specifier = ">=2.9.0" },
   { name = "python-multipart", specifier = ">=0.0.26" },
   { name = "qrcode", specifier = ">=8.0" },
+  { name = "sentry-sdk", specifier = ">=2.48.0" },
   { name = "sentry-sdk", marker = "extra == 'sentry'" },
   { name = "slowapi", specifier = "==0.1.9" },
   { name = "typer" },
@@ -1080,10 +1079,11 @@ plugins = [
 
 [[package]]
 name = "imbi-common"
-version = "2.3.0"
+version = "2.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
   { name = "cryptography" },
+  { name = "httpx" },
   { name = "jsonschema-models" },
   { name = "markdown-it-py" },
   { name = "nanoid" },
@@ -1094,9 +1094,9 @@ dependencies = [
   { name = "python-slugify" },
   { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/82/ae/cbd0fcb9849d223c1a7ff99b04c3cb250770000206f38a77bbe1a6078fa0/imbi_common-2.3.0.tar.gz", hash = "sha256:db992d57b2cdf06c2024fbf9ec6c0fc231fd3796a7f1fe209d10771d3e1e1050", size = 266530, upload-time = "2026-05-13T22:42:15.429Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/90/0e613931f0309a08ba07ace0d567d3fcf69c60bc0bc908d216e58c2f2c85/imbi_common-2.4.0.tar.gz", hash = "sha256:eefb7c53256cfbad45881d00dc60479d05488f2e94aa63a17625f693edae6992", size = 269729, upload-time = "2026-05-14T21:33:28.946Z" }
 wheels = [
-  { url = "https://files.pythonhosted.org/packages/81/5a/3150e7fd54cbe2acff01dee1ebd1a1d494523d94619ed9989b04bef47885/imbi_common-2.3.0-py3-none-any.whl", hash = "sha256:eca5c4c219bd1405adbd1dca9d0f18e3a70f42c4982a4843a907723da2945216", size = 82885, upload-time = "2026-05-13T22:42:14.089Z" },
+  { url = "https://files.pythonhosted.org/packages/27/94/c56575ae624db3cef3e0d5b65dc33dfea3d29d12514c68ebe2f8c3bf2f2f/imbi_common-2.4.0-py3-none-any.whl", hash = "sha256:f43c927f677e565c0c8cbe04f4d06cf6c1b57eb5bd36b6428d9a96917b1c4f20", size = 86575, upload-time = "2026-05-14T21:33:27.334Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

- Add `sentry-sdk>=2.48.0` to runtime dependencies
- Initialization is handled by `imbi_common.server.serve()` via the `sentry` module added in the corresponding imbi-common PR

## Problem

Sentry was not initialized for imbi-api.

## Solution

Adding `sentry-sdk` as a dependency ensures the package is available at runtime. `imbi_common.server.serve()` calls `sentry.init()` automatically before uvicorn starts. Sentry is a no-op if `SENTRY_DSN` is not set.

## Test plan

- [ ] Confirm service starts without `SENTRY_DSN` set (no-op)
- [ ] Confirm errors are captured when `SENTRY_DSN` is configured