### PR TITLE
Add read-only pull request endpoints and PR counts on project list

### DIFF
--- a/src/imbi_api/endpoints/organizations.py
+++ b/src/imbi_api/endpoints/organizations.py
@@ -27,6 +27,7 @@ from .project_plugins import project_plugins_router
 from .project_type_plugins import project_type_plugins_router
 from .project_types import project_types_router
 from .projects import projects_router
+from .pull_requests import pull_requests_project_router, pull_requests_router
 from .releases import releases_router
 from .search import search_router
 from .service_plugins import service_plugins_router
@@ -128,6 +129,14 @@ organizations_router.include_router(
 organizations_router.include_router(
     project_deployments_router,
     prefix='/{org_slug}/projects/{project_id}/deployments',
+)
+organizations_router.include_router(
+    pull_requests_project_router,
+    prefix='/{org_slug}/projects/{project_id}/pull-requests',
+)
+organizations_router.include_router(
+    pull_requests_router,
+    prefix='/{org_slug}/pull-requests',
 )
 organizations_router.include_router(
     search_router,

--- a/src/imbi_api/endpoints/projects.py
+++ b/src/imbi_api/endpoints/projects.py
@@ -149,6 +149,8 @@ class ProjectResponse(pydantic.BaseModel):
     score: float | None = None
     breakdown: scoring_models.ScoreBreakdown | None = None
     relationships: ProjectRelationships | None = None
+    open_pr_count: int = 0
+    closed_pr_count: int = 0
 
     @pydantic.field_validator(
         'links',
@@ -252,6 +254,37 @@ async def _validate_env_slugs(
             status_code=422,
             detail=(f'Environment slug(s) not found: {sorted(missing)!r}'),
         )
+
+
+async def _fetch_pr_counts(
+    project_ids: list[str],
+) -> dict[str, tuple[int, int]]:
+    """Return {project_id: (open_count, closed_count)} for the given IDs.
+
+    Errors are swallowed — PR counts are best-effort and should not
+    fail the project list endpoint.
+    """
+    if not project_ids:
+        return {}
+    sql = (
+        'SELECT project_id,'
+        " countIf(state = 'open') AS open_count,"
+        " countIf(state = 'closed') AS closed_count"
+        ' FROM pull_requests FINAL'
+        ' WHERE project_id IN {project_ids:Array(String)}'
+        ' GROUP BY project_id'
+    )
+    try:
+        rows = await ch_client.Clickhouse.get_instance().query(
+            sql, {'project_ids': project_ids}
+        )
+    except Exception:  # noqa: BLE001
+        LOGGER.warning('Failed to fetch PR counts for projects', exc_info=True)
+        return {}
+    return {
+        str(r['project_id']): (int(r['open_count']), int(r['closed_count']))
+        for r in rows
+    }
 
 
 _EVENT_SKIP_FIELDS: frozenset[str] = frozenset(
@@ -700,6 +733,7 @@ async def list_projects(
         },
         ['project', 'outbound_count', 'inbound_count'],
     )
+    project_data_list: list[dict[str, typing.Any]] = []
     for record in records:
         project_data = graph.parse_agtype(record['project'])
         _flatten_edge_props(project_data)
@@ -710,9 +744,19 @@ async def list_projects(
             graph.parse_agtype(record['outbound_count']),
             graph.parse_agtype(record['inbound_count']),
         )
-        results.append(
-            ProjectResponse.model_validate(project_data),
-        )
+        project_data_list.append(project_data)
+
+    project_ids = [
+        str(p.get('id', '')) for p in project_data_list if p.get('id')
+    ]
+    pr_counts = await _fetch_pr_counts(project_ids)
+
+    for project_data in project_data_list:
+        pid = str(project_data.get('id', ''))
+        open_count, closed_count = pr_counts.get(pid, (0, 0))
+        project_data['open_pr_count'] = open_count
+        project_data['closed_pr_count'] = closed_count
+        results.append(ProjectResponse.model_validate(project_data))
     return results
 
 

--- a/src/imbi_api/endpoints/pull_requests.py
+++ b/src/imbi_api/endpoints/pull_requests.py
@@ -98,6 +98,7 @@ async def _list_prs(
     *,
     project_ids: list[str],
     state: str | None = None,
+    author: str | None = None,
     limit: int = DEFAULT_LIMIT,
     offset: int = 0,
 ) -> PullRequestListResponse:
@@ -116,6 +117,10 @@ async def _list_prs(
     if state is not None:
         clauses.append('state = {state:String}')
         params['state'] = state
+
+    if author is not None:
+        clauses.append('author = {author:String}')
+        params['author'] = author
 
     where = ' AND '.join(clauses)
     count_sql = (
@@ -158,18 +163,21 @@ async def list_project_pull_requests(
         ),
     ],
     state: str | None = None,
+    author: str | None = None,
     limit: int = DEFAULT_LIMIT,
     offset: int = 0,
 ) -> PullRequestListResponse:
     """List pull requests for a single project.
 
     Optional ``state`` filter accepts ``open`` or ``closed``.
+    Optional ``author`` filter accepts a GitHub login.
     Results are ordered newest first.
     """
     del org_slug
     return await _list_prs(
         project_ids=[project_id],
         state=state,
+        author=author,
         limit=limit,
         offset=offset,
     )
@@ -189,6 +197,7 @@ async def list_org_pull_requests(
         ),
     ],
     state: str | None = None,
+    author: str | None = None,
     limit: int = DEFAULT_LIMIT,
     offset: int = 0,
 ) -> PullRequestListResponse:
@@ -196,12 +205,14 @@ async def list_org_pull_requests(
 
     The set of projects is resolved from the graph so results are
     scoped to the calling user's org.  Optional ``state`` filter
-    accepts ``open`` or ``closed``.  Results are ordered newest first.
+    accepts ``open`` or ``closed``.  Optional ``author`` filter
+    accepts a GitHub login.  Results are ordered newest first.
     """
     project_ids = await _fetch_org_project_ids(db, org_slug)
     return await _list_prs(
         project_ids=project_ids,
         state=state,
+        author=author,
         limit=limit,
         offset=offset,
     )

--- a/src/imbi_api/endpoints/pull_requests.py
+++ b/src/imbi_api/endpoints/pull_requests.py
@@ -1,0 +1,207 @@
+"""Pull request read endpoints (ClickHouse-backed, read-only).
+
+Two routers are provided:
+
+- ``pull_requests_project_router`` — mounted under
+  ``/organizations/{org_slug}/projects/{project_id}/pull-requests``
+  returns PRs for a single project.
+
+- ``pull_requests_router`` — mounted under
+  ``/organizations/{org_slug}/pull-requests``
+  returns PRs across all projects in the org.  The org's project IDs
+  are resolved from the graph first so the response is scoped correctly.
+"""
+
+from __future__ import annotations
+
+import datetime
+import logging
+import typing
+
+import fastapi
+import pydantic
+from imbi_common import clickhouse, graph
+
+from imbi_api.auth import permissions
+
+LOGGER = logging.getLogger(__name__)
+
+pull_requests_router = fastapi.APIRouter(tags=['Pull Requests'])
+pull_requests_project_router = fastapi.APIRouter(tags=['Pull Requests'])
+
+DEFAULT_LIMIT: int = 50
+MAX_LIMIT: int = 500
+
+_TIMESTAMP_FIELDS: frozenset[str] = frozenset(
+    {'created_at', 'updated_at', 'merged_at'}
+)
+
+
+class PullRequestResponse(pydantic.BaseModel):
+    """A single pull request record from ClickHouse."""
+
+    project_id: str
+    pr_id: str
+    pr_number: int
+    title: str
+    url: str
+    state: str
+    author: str
+    draft: bool
+    merged: bool
+    created_at: datetime.datetime
+    updated_at: datetime.datetime
+    merged_at: datetime.datetime | None = None
+    additions: int
+    deletions: int
+    changed_files: int
+
+
+class PullRequestListResponse(pydantic.BaseModel):
+    data: list[PullRequestResponse]
+    total: int
+
+
+def _row_to_response(row: dict[str, typing.Any]) -> dict[str, typing.Any]:
+    """Attach UTC tzinfo to naive datetime columns from ClickHouse."""
+    out: dict[str, typing.Any] = {}
+    for k, v in row.items():
+        if (
+            k in _TIMESTAMP_FIELDS
+            and isinstance(v, datetime.datetime)
+            and v.tzinfo is None
+        ):
+            v = v.replace(tzinfo=datetime.UTC)
+        out[k] = v
+    return out
+
+
+async def _fetch_org_project_ids(
+    db: graph.Pool,
+    org_slug: str,
+) -> list[str]:
+    """Return all project IDs belonging to the org."""
+    query: typing.LiteralString = """
+    MATCH (p:Project)-[:OWNED_BY]->(:Team)
+          -[:BELONGS_TO]->(o:Organization {{slug: {org_slug}}})
+    RETURN p.id AS id
+    """
+    records = await db.execute(query, {'org_slug': org_slug}, ['id'])
+    return [
+        graph.parse_agtype(r['id'])
+        for r in records
+        if graph.parse_agtype(r['id'])
+    ]
+
+
+async def _list_prs(
+    *,
+    project_ids: list[str],
+    state: str | None = None,
+    limit: int = DEFAULT_LIMIT,
+    offset: int = 0,
+) -> PullRequestListResponse:
+    """Run the ClickHouse query and return a paginated response."""
+    if limit < 1 or limit > MAX_LIMIT:
+        raise fastapi.HTTPException(
+            status_code=400,
+            detail=f'limit must be 1..{MAX_LIMIT}',
+        )
+    if not project_ids:
+        return PullRequestListResponse(data=[], total=0)
+
+    clauses: list[str] = ['project_id IN {project_ids:Array(String)}']
+    params: dict[str, typing.Any] = {'project_ids': project_ids}
+
+    if state is not None:
+        clauses.append('state = {state:String}')
+        params['state'] = state
+
+    where = ' AND '.join(clauses)
+    count_sql = (
+        'SELECT count() AS total FROM pull_requests FINAL WHERE '  # noqa: S608
+        + where
+    )
+    params['limit'] = limit
+    params['offset'] = offset
+    data_sql = (
+        'SELECT * FROM pull_requests FINAL WHERE '  # noqa: S608
+        + where
+        + ' ORDER BY created_at DESC, pr_id DESC'
+        + ' LIMIT {limit:UInt32} OFFSET {offset:UInt32}'
+    )
+
+    count_rows = await clickhouse.query(count_sql, params)
+    total = int(count_rows[0]['total']) if count_rows else 0
+
+    data_rows = await clickhouse.query(data_sql, params)
+    return PullRequestListResponse(
+        data=[
+            PullRequestResponse.model_validate(_row_to_response(r))
+            for r in data_rows
+        ],
+        total=total,
+    )
+
+
+@pull_requests_project_router.get(
+    '/',
+    response_model=PullRequestListResponse,
+)
+async def list_project_pull_requests(
+    org_slug: str,
+    project_id: str,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('project:read'),
+        ),
+    ],
+    state: str | None = None,
+    limit: int = DEFAULT_LIMIT,
+    offset: int = 0,
+) -> PullRequestListResponse:
+    """List pull requests for a single project.
+
+    Optional ``state`` filter accepts ``open`` or ``closed``.
+    Results are ordered newest first.
+    """
+    del org_slug
+    return await _list_prs(
+        project_ids=[project_id],
+        state=state,
+        limit=limit,
+        offset=offset,
+    )
+
+
+@pull_requests_router.get(
+    '/',
+    response_model=PullRequestListResponse,
+)
+async def list_org_pull_requests(
+    org_slug: str,
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('project:read'),
+        ),
+    ],
+    state: str | None = None,
+    limit: int = DEFAULT_LIMIT,
+    offset: int = 0,
+) -> PullRequestListResponse:
+    """List pull requests across all projects in the organization.
+
+    The set of projects is resolved from the graph so results are
+    scoped to the calling user's org.  Optional ``state`` filter
+    accepts ``open`` or ``closed``.  Results are ordered newest first.
+    """
+    project_ids = await _fetch_org_project_ids(db, org_slug)
+    return await _list_prs(
+        project_ids=project_ids,
+        state=state,
+        limit=limit,
+        offset=offset,
+    )


### PR DESCRIPTION
## Summary

- Adds `GET /organizations/{org_slug}/projects/{project_id}/pull-requests` — project-scoped PR list
- Adds `GET /organizations/{org_slug}/pull-requests` — org-wide PR list (resolves all project IDs from the graph, then queries ClickHouse)
- Both endpoints accept `?state=open|closed`, `limit` (max 500), and `offset` filters; results ordered newest-first
- `ProjectResponse` gains `open_pr_count: int` and `closed_pr_count: int` (both default to 0)
- `list_projects` batch-fetches PR counts for all returned projects in a single ClickHouse `GROUP BY` query and merges them into each project; failures are logged and swallowed so a ClickHouse error never breaks the project index page

## Dependencies

Requires [imbi-common#115](https://github.com/AWeber-Imbi/imbi-common/pull/115) — the `pull_requests` table and materialized view must exist in ClickHouse before these endpoints return meaningful data.

## Test plan

- [ ] `GET /organizations/{org_slug}/pull-requests` returns all PRs with correct `project_id`
- [ ] `GET /organizations/{org_slug}/projects/{project_id}/pull-requests` returns only that project's PRs
- [ ] `?state=open` / `?state=closed` filters work correctly
- [ ] `list_projects` response includes `open_pr_count` and `closed_pr_count` per project
- [ ] If ClickHouse is unavailable, `list_projects` still returns projects (counts default to 0)
- [ ] Existing tests pass (`just test`)