### PR TITLE
Pull requests, release identity, and project list enrichment

### DIFF
--- a/src/imbi_api/auth/permissions.py
+++ b/src/imbi_api/auth/permissions.py
@@ -153,27 +153,41 @@ async def _load_user_identities(
     db: graph.Graph,
     user_id: str,
 ) -> list[IdentityInfo]:
-    """Return active third-party identity connections for the user."""
+    """Return active third-party identity connections for the user.
+
+    Identity enrichment is auxiliary — authentication has already
+    succeeded by the time this runs.  A failure here (DB hiccup,
+    AGType parse error) must not turn a valid token into a 5xx, so
+    all exceptions are caught, logged, and treated as "no identities".
+    """
     query: typing.LiteralString = """
     MATCH (u:User {{id: {user_id}}})-[:HAS_IDENTITY]->(c:IdentityConnection)
     WHERE c.status = 'active'
     OPTIONAL MATCH (c)-[:USES_PLUGIN]->(p:Plugin)
     RETURN p.plugin_slug AS plugin_slug, c.subject AS subject
     """
-    records = await db.execute(
-        query,
-        {'user_id': user_id},
-        ['plugin_slug', 'subject'],
-    )
-    result: list[IdentityInfo] = []
-    for row in records:
-        plugin_slug = graph.parse_agtype(row['plugin_slug'])
-        subject = graph.parse_agtype(row['subject'])
-        if plugin_slug and subject:
-            result.append(
-                IdentityInfo(plugin_slug=plugin_slug, subject=subject)
-            )
-    return result
+    try:
+        records = await db.execute(
+            query,
+            {'user_id': user_id},
+            ['plugin_slug', 'subject'],
+        )
+        result: list[IdentityInfo] = []
+        for row in records:
+            plugin_slug = graph.parse_agtype(row['plugin_slug'])
+            subject = graph.parse_agtype(row['subject'])
+            if plugin_slug and subject:
+                result.append(
+                    IdentityInfo(plugin_slug=plugin_slug, subject=subject)
+                )
+        return result
+    except Exception:  # noqa: BLE001
+        LOGGER.warning(
+            'Failed to load identity connections for user_id=%s',
+            user_id,
+            exc_info=True,
+        )
+        return []
 
 
 async def authenticate_jwt(

--- a/src/imbi_api/auth/permissions.py
+++ b/src/imbi_api/auth/permissions.py
@@ -21,6 +21,13 @@ LOGGER = logging.getLogger(__name__)
 oauth2_scheme = security.HTTPBearer(auto_error=False)
 
 
+class IdentityInfo(pydantic.BaseModel):
+    """A single third-party identity connection for an authenticated user."""
+
+    plugin_slug: str
+    subject: str
+
+
 class AuthContext(pydantic.BaseModel):
     """Authentication context for the current request."""
 
@@ -29,6 +36,14 @@ class AuthContext(pydantic.BaseModel):
     session_id: str | None = None
     auth_method: typing.Literal['jwt', 'api_key', 'client_credentials']
     permissions: set[str] = pydantic.Field(default_factory=set)
+    identities: list[IdentityInfo] = pydantic.Field(default_factory=list)
+
+    def identity_for(self, plugin_slug: str) -> str | None:
+        """Return the subject for the given plugin_slug, or None."""
+        for i in self.identities:
+            if i.plugin_slug == plugin_slug:
+                return i.subject
+        return None
 
     @property
     def principal_name(self) -> str:
@@ -134,6 +149,33 @@ async def load_principal_permissions(
     return set()
 
 
+async def _load_user_identities(
+    db: graph.Graph,
+    user_id: str,
+) -> list[IdentityInfo]:
+    """Return active third-party identity connections for the user."""
+    query: typing.LiteralString = """
+    MATCH (u:User {{id: {user_id}}})-[:HAS_IDENTITY]->(c:IdentityConnection)
+    WHERE c.status = 'active'
+    OPTIONAL MATCH (c)-[:USES_PLUGIN]->(p:Plugin)
+    RETURN p.plugin_slug AS plugin_slug, c.subject AS subject
+    """
+    records = await db.execute(
+        query,
+        {'user_id': user_id},
+        ['plugin_slug', 'subject'],
+    )
+    result = []
+    for row in records:
+        plugin_slug = graph.parse_agtype(row['plugin_slug'])
+        subject = graph.parse_agtype(row['subject'])
+        if plugin_slug and subject:
+            result.append(
+                IdentityInfo(plugin_slug=plugin_slug, subject=subject)
+            )
+    return result
+
+
 async def authenticate_jwt(
     db: graph.Graph,
     token: str,
@@ -237,12 +279,14 @@ async def authenticate_jwt(
 
     # Load permissions
     perms = await load_principal_permissions(db, 'User', 'email', subject)
+    identities = await _load_user_identities(db, user.id)
 
     return AuthContext(
         user=user,
         session_id=jti,
         auth_method='jwt',
         permissions=perms,
+        identities=identities,
     )
 
 
@@ -372,6 +416,7 @@ async def authenticate_api_key(
         db, 'User', 'email', user.email
     )
     filtered = all_perms.intersection(set(scopes)) if scopes else all_perms
+    identities = await _load_user_identities(db, user.id)
 
     # Update last_used only after all validation passes
     now = datetime.datetime.now(datetime.UTC).isoformat()
@@ -385,6 +430,7 @@ async def authenticate_api_key(
         session_id=key_id,
         auth_method='api_key',
         permissions=filtered,
+        identities=identities,
     )
 
 

--- a/src/imbi_api/auth/permissions.py
+++ b/src/imbi_api/auth/permissions.py
@@ -165,7 +165,7 @@ async def _load_user_identities(
         {'user_id': user_id},
         ['plugin_slug', 'subject'],
     )
-    result = []
+    result: list[IdentityInfo] = []
     for row in records:
         plugin_slug = graph.parse_agtype(row['plugin_slug'])
         subject = graph.parse_agtype(row['subject'])

--- a/src/imbi_api/endpoints/organizations.py
+++ b/src/imbi_api/endpoints/organizations.py
@@ -27,6 +27,7 @@ from .project_plugins import project_plugins_router
 from .project_type_plugins import project_type_plugins_router
 from .project_types import project_types_router
 from .projects import projects_router
+from .pull_requests import pull_requests_project_router, pull_requests_router
 from .releases import releases_router
 from .search import search_router
 from .service_plugins import service_plugins_router
@@ -128,6 +129,14 @@ organizations_router.include_router(
 organizations_router.include_router(
     project_deployments_router,
     prefix='/{org_slug}/projects/{project_id}/deployments',
+)
+organizations_router.include_router(
+    pull_requests_project_router,
+    prefix='/{org_slug}/projects/{project_id}/pull-requests',
+)
+organizations_router.include_router(
+    pull_requests_router,
+    prefix='/{org_slug}/pull-requests',
 )
 organizations_router.include_router(
     search_router,

--- a/src/imbi_api/endpoints/project_deployments.py
+++ b/src/imbi_api/endpoints/project_deployments.py
@@ -1383,12 +1383,17 @@ async def _upsert_release_node(
         else json.dumps([])
     )
     new_id: str = nanoid.generate()
+    # Match the exact identity (committish, tag) before deciding to
+    # create.  Filtering inside ``OPTIONAL MATCH`` keeps a sibling
+    # release with the same committish but a different tag from
+    # spawning a duplicate ``(committish, tag)`` row.
     create_query: typing.LiteralString = """
     MATCH (p:Project {{id: {project_id}}})
     OPTIONAL MATCH (p)-[:HAS_RELEASE]
         ->(existing:Release {{committish: {committish}}})
+    WHERE COALESCE(existing.tag, '') = COALESCE({tag}, '')
     WITH p, existing
-    WHERE existing IS NULL OR COALESCE(existing.tag, '') <> COALESCE({tag}, '')
+    WHERE existing IS NULL
     CREATE (p)-[:HAS_RELEASE]->(:Release {{
         id: {id},
         tag: {tag},

--- a/src/imbi_api/endpoints/project_deployments.py
+++ b/src/imbi_api/endpoints/project_deployments.py
@@ -380,7 +380,8 @@ async def _record_deployment_audit(
     environment_slug: str,
     recorded_by: str,
     action: str,
-    version: str,
+    tag: str | None,
+    committish: str,
     plugin_slug: str,
     run_url: str | None,
     release_url: str | None = None,
@@ -393,6 +394,10 @@ async def _record_deployment_audit(
     project's history pane surfaces deploys/promotes the same way
     it surfaces config changes.  Audit failures intentionally
     propagate so a bad write never silently desyncs the log.
+
+    ``OperationLog.version`` is populated with ``tag if tag else
+    committish`` — a single human-friendly display string that the
+    operations-log UI can render directly.
     """
     description = json.dumps(
         {
@@ -415,7 +420,7 @@ async def _record_deployment_audit(
         entry_type='Deployed',
         description=description,
         link=run_url,
-        version=version,
+        version=tag or committish,
         plugin_slug=plugin_slug,
     )
     row = entry.model_dump(by_alias=True, mode='python')
@@ -435,19 +440,23 @@ async def _record_deployment_audit(
 _SEMVER_REF_RE = re.compile(r'^v?\d+\.\d+\.\d+(?:[-+].*)?$')
 
 
-def _resync_version(observed: RemoteDeployment) -> str:
-    """Pick the ``Release.version`` to record for an observed deployment.
+def _resync_release_identity(
+    observed: RemoteDeployment,
+) -> tuple[str | None, str]:
+    """Pick ``(tag, committish)`` to record for an observed deployment.
 
     Mirrors the CEL expression the gateway uses on
-    ``imbi_gateway.actions.create_release``:
-    semver-shaped ``ref`` wins, otherwise the first 7 chars of the
-    commit SHA.  Keeping the rules aligned means a project whose
-    webhooks recover later sees the same ``version`` strings the
-    gateway would have created, so the badge does not flip.
+    ``imbi_gateway.actions.create_release``: semver-shaped ``ref``
+    becomes the tag; the committish is always the first 7 chars of
+    the commit SHA. Keeping the rules aligned means a project whose
+    webhooks recover later produces the same ``(tag, committish)``
+    pair the gateway would have created, so deduplication stays
+    consistent.
     """
+    tag: str | None = None
     if observed.ref and _SEMVER_REF_RE.match(observed.ref):
-        return observed.ref
-    return observed.sha[:7]
+        tag = observed.ref
+    return tag, observed.sha[:7].lower()
 
 
 async def _load_resync_environments(
@@ -487,25 +496,40 @@ async def _load_resync_environments(
     ]
 
 
-async def _release_exists(
+async def _release_id_for(
     db: graph.Graph,
     *,
     project_id: str,
-    version: str,
-) -> bool:
-    """Cheap existence probe for ``project -[:HAS_RELEASE]-> Release``."""
+    committish: str,
+    tag: str | None,
+) -> str | None:
+    """Return the ``Release.id`` matching ``(project, committish, tag)``.
+
+    Acts as both an existence probe and a lookup for the release-id
+    the caller needs to pass to ``append_deployment_event`` and the
+    deployment-audit writer. AGE doesn't expose NULL equality, so
+    tag-matching is COALESCEd through a sentinel.
+    """
     query: typing.LiteralString = """
     MATCH (:Project {{id: {project_id}}})
-        -[:HAS_RELEASE]->(r:Release {{version: {version}}})
+        -[:HAS_RELEASE]->(r:Release {{committish: {committish}}})
+    WHERE COALESCE(r.tag, '') = COALESCE({tag}, '')
     RETURN r.id AS rid
     LIMIT 1
     """
     rows = await db.execute(
         query,
-        {'project_id': project_id, 'version': version},
+        {
+            'project_id': project_id,
+            'committish': committish,
+            'tag': tag,
+        },
         ['rid'],
     )
-    return bool(rows)
+    if not rows:
+        return None
+    rid = graph.parse_agtype(rows[0].get('rid'))
+    return str(rid) if rid else None
 
 
 async def resync_for_project(
@@ -570,11 +594,11 @@ async def resync_for_project(
             ),
         ) from exc
     summary.observed = len(observations)
-    # Track versions we've already touched so ``releases_created`` /
-    # ``releases_updated`` are counted once per distinct ``version`` --
-    # the same tag promoted across multiple environments is one
-    # Release node, not N.
-    seen_versions: set[str] = set()
+    # Track identities we've already touched so ``releases_created`` /
+    # ``releases_updated`` are counted once per distinct
+    # ``(committish, tag)`` pair -- the same tag promoted across
+    # multiple environments is one Release node, not N.
+    seen_identities: set[tuple[str, str | None]] = set()
     for observed in observations:
         try:
             await _apply_remote_deployment(
@@ -586,7 +610,7 @@ async def resync_for_project(
                 recorded_by=auth.principal_name,
                 observed=observed,
                 summary=summary,
-                seen_versions=seen_versions,
+                seen_identities=seen_identities,
             )
         except Exception as exc:
             LOGGER.exception(
@@ -620,30 +644,41 @@ async def _apply_remote_deployment(
     recorded_by: str,
     observed: RemoteDeployment,
     summary: ResyncSummary,
-    seen_versions: set[str],
+    seen_identities: set[tuple[str, str | None]],
 ) -> None:
     """Persist one observed remote deployment + audit row.
 
-    ``seen_versions`` is mutated to track which ``version`` strings
-    have already been counted against ``releases_created`` /
-    ``releases_updated`` during this resync, so a tag promoted across
-    multiple environments is counted as one Release node, not N.
+    ``seen_identities`` is mutated to track which
+    ``(committish, tag)`` pairs have already been counted against
+    ``releases_created`` / ``releases_updated`` during this resync,
+    so a tag promoted across multiple environments is counted as one
+    Release node, not N.
     """
-    version = _resync_version(observed)
-    title = observed.description or observed.ref or version
-    first_time_this_resync = version not in seen_versions
-    existed = await _release_exists(db, project_id=project_id, version=version)
-    await _upsert_release_node(
+    tag, committish = _resync_release_identity(observed)
+    title = observed.description or observed.ref or tag or committish
+    identity = (committish, tag)
+    first_time_this_resync = identity not in seen_identities
+    existed = (
+        await _release_id_for(
+            db,
+            project_id=project_id,
+            committish=committish,
+            tag=tag,
+        )
+        is not None
+    )
+    release_id = await _upsert_release_node(
         db,
         project_id=project_id,
-        version=version,
+        tag=tag,
+        committish=committish,
         title=title,
         notes_markdown=observed.description or '',
         release_url=observed.deployment_url,
         created_by=recorded_by,
     )
     if first_time_this_resync:
-        seen_versions.add(version)
+        seen_identities.add(identity)
         if existed:
             summary.releases_updated += 1
         else:
@@ -652,7 +687,7 @@ async def _apply_remote_deployment(
         db,
         org_slug=org_slug,
         project_id=project_id,
-        version=version,
+        release_id=release_id,
         env_slug=observed.environment,
         status=observed.status,
         note=f'resync via {plugin_slug}',
@@ -669,8 +704,10 @@ async def _apply_remote_deployment(
                 project_id=project_id,
                 environment=observed.environment,
                 detail=(
-                    f'Could not attach DeploymentEvent for version '
-                    f'{version!r} -- release or environment not found.'
+                    f'Could not attach DeploymentEvent for release '
+                    f'{release_id!r} (committish={committish!r} '
+                    f'tag={tag!r}) -- release or environment not '
+                    f'found.'
                 ),
             )
         )
@@ -691,7 +728,8 @@ async def _apply_remote_deployment(
         environment_slug=observed.environment,
         recorded_by=recorded_by,
         action='resync',
-        version=version,
+        tag=tag,
+        committish=committish,
         plugin_slug=plugin_slug,
         run_url=observed.run_url,
         release_url=observed.deployment_url,
@@ -993,14 +1031,32 @@ async def _handle_deploy(
         run.run_id,
     )
     note = f'via {resolved.plugin_slug}'
-    recorded_version: str | None = None
+    committish_short = body.committish[:7].lower()
+    candidate_tag = (
+        body.ref_label
+        if body.ref_label and _SEMVER_REF_RE.match(body.ref_label)
+        else None
+    )
+    # Look up the release that was deployed. Try (committish, tag) first
+    # so a SHA that ships under a tag matches the tagged Release node;
+    # fall back to (committish, None) so a raw-SHA deploy still finds
+    # an untagged Release if one exists.
     result: tuple[ReleaseEnvironmentEdgeResponse, AppendOutcome] | None = None
-    for candidate in filter(None, (body.ref_label, body.committish)):
+    matched_tag: str | None = None
+    for try_tag in [candidate_tag, None] if candidate_tag else [None]:
+        release_id = await _release_id_for(
+            db,
+            project_id=project_id,
+            committish=committish_short,
+            tag=try_tag,
+        )
+        if release_id is None:
+            continue
         result = await append_deployment_event(
             db,
             org_slug=org_slug,
             project_id=project_id,
-            version=candidate,
+            release_id=release_id,
             env_slug=body.environment,
             status='in_progress',
             note=note,
@@ -1008,7 +1064,7 @@ async def _handle_deploy(
             external_run_url=run.run_url,
         )
         if result is not None:
-            recorded_version = candidate
+            matched_tag = try_tag
             break
     await _record_deployment_audit(
         project_id=project_id,
@@ -1016,7 +1072,8 @@ async def _handle_deploy(
         environment_slug=body.environment,
         recorded_by=auth.principal_name,
         action=body.action,
-        version=recorded_version or body.ref_label or body.committish,
+        tag=matched_tag if result is not None else candidate_tag,
+        committish=committish_short,
         plugin_slug=resolved.plugin_slug,
         run_url=run.run_url,
     )
@@ -1240,10 +1297,12 @@ async def _handle_promote(
 
     # 4. Upsert the Release node so future deploys of the same tag
     #    can attach a DeploymentEvent.
-    await _upsert_release_node(
+    promoted_committish = body.from_committish[:7].lower()
+    release_id = await _upsert_release_node(
         db,
         project_id=project_id,
-        version=body.tag,
+        tag=body.tag,
+        committish=promoted_committish,
         title=body.release_name or body.tag,
         notes_markdown=body.release_notes_markdown,
         release_url=release_url,
@@ -1256,7 +1315,7 @@ async def _handle_promote(
         db,
         org_slug=org_slug,
         project_id=project_id,
-        version=body.tag,
+        release_id=release_id,
         env_slug=body.to_environment,
         status='in_progress',
         note=note,
@@ -1281,7 +1340,8 @@ async def _handle_promote(
         environment_slug=body.to_environment,
         recorded_by=auth.principal_name,
         action='promote',
-        version=body.tag,
+        tag=body.tag,
+        committish=promoted_committish,
         plugin_slug=resolved.plugin_slug,
         run_url=run.run_url,
         release_url=release_url,
@@ -1302,17 +1362,19 @@ async def _upsert_release_node(
     db: graph.Graph,
     *,
     project_id: str,
-    version: str,
+    tag: str | None,
+    committish: str,
     title: str,
     notes_markdown: str,
     release_url: str | None,
     created_by: str,
-) -> None:
+) -> str:
     """Create the ``Release`` node if missing, otherwise update notes.
 
-    Uses MATCH-then-CREATE-or-SET so the second-promote-of-same-tag
-    case (rare; tag re-creation will already have failed at the
-    plugin) is benign rather than blowing up on a duplicate node.
+    Identity is ``(project, committish, tag)``: re-promoting the same
+    tag from the same SHA is benign and refreshes notes / links;
+    re-tagging the same SHA produces a new ``Release`` node.
+    Returns the resulting ``Release.id``.
     """
     now = datetime.datetime.now(datetime.UTC).isoformat()
     links_json = (
@@ -1320,15 +1382,17 @@ async def _upsert_release_node(
         if release_url
         else json.dumps([])
     )
-    query: typing.LiteralString = """
+    new_id: str = nanoid.generate()
+    create_query: typing.LiteralString = """
     MATCH (p:Project {{id: {project_id}}})
     OPTIONAL MATCH (p)-[:HAS_RELEASE]
-        ->(existing:Release {{version: {version}}})
+        ->(existing:Release {{committish: {committish}}})
     WITH p, existing
-    WHERE existing IS NULL
+    WHERE existing IS NULL OR COALESCE(existing.tag, '') <> COALESCE({tag}, '')
     CREATE (p)-[:HAS_RELEASE]->(:Release {{
         id: {id},
-        version: {version},
+        tag: {tag},
+        committish: {committish},
         title: {title},
         description: {description},
         links: {links},
@@ -1338,11 +1402,12 @@ async def _upsert_release_node(
     }})
     """
     await db.execute(
-        query,
+        create_query,
         {
             'project_id': project_id,
-            'version': version,
-            'id': nanoid.generate(),
+            'committish': committish,
+            'tag': tag,
+            'id': new_id,
             'title': title,
             'description': notes_markdown,
             'links': links_json,
@@ -1352,24 +1417,34 @@ async def _upsert_release_node(
         [],
     )
     # Update notes / links on a pre-existing release (idempotent re-run).
+    # Match on (committish, tag) — tag matching uses COALESCE so a NULL
+    # tag compares equal to a NULL tag (AGE has no NULL equality).
     update_query: typing.LiteralString = """
     MATCH (p:Project {{id: {project_id}}})
-          -[:HAS_RELEASE]->(r:Release {{version: {version}}})
+          -[:HAS_RELEASE]->(r:Release {{committish: {committish}}})
+    WHERE COALESCE(r.tag, '') = COALESCE({tag}, '')
     SET r.description = {description},
         r.links = {links},
         r.updated_at = {now}
+    RETURN r.id AS rid
     """
-    await db.execute(
+    rows = await db.execute(
         update_query,
         {
             'project_id': project_id,
-            'version': version,
+            'committish': committish,
+            'tag': tag,
             'description': notes_markdown,
             'links': links_json,
             'now': now,
         },
-        [],
+        ['rid'],
     )
+    if rows:
+        rid = graph.parse_agtype(rows[0].get('rid'))
+        if rid:
+            return str(rid)
+    return new_id
 
 
 # ---------------------------------------------------------------------------
@@ -1650,32 +1725,46 @@ async def list_promotion_options(
         to_release = to_item['release']
         if not from_release:
             continue
-        from_version = str(from_release.get('version') or '')
-        to_version = (
-            str(to_release.get('version') or '') if to_release else None
-        )
+        from_committish = str(from_release.get('committish') or '')
+        from_tag = from_release.get('tag')
+        from_display = str(from_tag) if from_tag else (from_committish or None)
+        if to_release:
+            to_committish = str(to_release.get('committish') or '')
+            to_tag = to_release.get('tag')
+            to_display = str(to_tag) if to_tag else (to_committish or None)
+        else:
+            to_committish = ''
+            to_display = None
         commits_pending: int | None = None
-        if to_version and to_version != from_version:
+        if (
+            to_committish
+            and from_committish
+            and to_committish != from_committish
+        ):
             try:
                 cmp_result = await call_with_timeout(
                     handler.compare(
                         ctx,
                         credentials,
-                        base=to_version,
-                        head=from_version,
+                        base=to_committish,
+                        head=from_committish,
                     )
                 )
                 commits_pending = cmp_result.ahead
             except Exception:  # noqa: BLE001
                 LOGGER.debug(
-                    'compare failed for %s..%s', to_version, from_version
+                    'compare failed for %s..%s',
+                    to_committish,
+                    from_committish,
                 )
         options.append(
             PromotionOption(
                 from_environment=from_item['env']['slug'],
                 to_environment=to_item['env']['slug'],
-                from_version=from_version or None,
-                to_version=to_version or None,
+                from_version=from_display,
+                to_version=to_display,
+                from_sha=from_committish or None,
+                to_sha=to_committish or None,
                 commits_pending=commits_pending,
             )
         )

--- a/src/imbi_api/endpoints/projects.py
+++ b/src/imbi_api/endpoints/projects.py
@@ -865,10 +865,15 @@ async def list_projects(
     display_names = await _resolve_display_names(db, emails)
     for env_map in releases.values():
         for slug, info in env_map.items():
-            if info.performed_by and info.performed_by in display_names:
-                env_map[slug] = info.model_copy(
-                    update={'performed_by': display_names[info.performed_by]}
-                )
+            if not info.performed_by:
+                continue
+            if info.performed_by in display_names:
+                name: str = display_names[info.performed_by]
+            elif '@' in info.performed_by:
+                name = info.performed_by.split('@')[0]
+            else:
+                continue
+            env_map[slug] = info.model_copy(update={'performed_by': name})
 
     for project_data in project_data_list:
         pid = str(project_data.get('id', ''))

--- a/src/imbi_api/endpoints/projects.py
+++ b/src/imbi_api/endpoints/projects.py
@@ -149,6 +149,8 @@ class ProjectResponse(pydantic.BaseModel):
     score: float | None = None
     breakdown: scoring_models.ScoreBreakdown | None = None
     relationships: ProjectRelationships | None = None
+    open_pr_count: int = 0
+    closed_pr_count: int = 0
 
     @pydantic.field_validator(
         'links',
@@ -252,6 +254,37 @@ async def _validate_env_slugs(
             status_code=422,
             detail=(f'Environment slug(s) not found: {sorted(missing)!r}'),
         )
+
+
+async def _fetch_pr_counts(
+    project_ids: list[str],
+) -> dict[str, tuple[int, int]]:
+    """Return {project_id: (open_count, closed_count)} for the given IDs.
+
+    Errors are swallowed — PR counts are best-effort and should not
+    fail the project list endpoint.
+    """
+    if not project_ids:
+        return {}
+    sql = (
+        'SELECT project_id,'
+        " countIf(state = 'open') AS open_count,"
+        " countIf(state = 'closed') AS closed_count"
+        ' FROM pull_requests FINAL'
+        ' WHERE project_id IN {project_ids:Array(String)}'
+        ' GROUP BY project_id'
+    )
+    try:
+        rows = await ch_client.Clickhouse.get_instance().query(
+            sql, {'project_ids': project_ids}
+        )
+    except Exception:  # noqa: BLE001
+        LOGGER.warning('Failed to fetch PR counts for projects', exc_info=True)
+        return {}
+    return {
+        str(r['project_id']): (int(r['open_count']), int(r['closed_count']))
+        for r in rows
+    }
 
 
 _EVENT_SKIP_FIELDS: frozenset[str] = frozenset(
@@ -700,6 +733,7 @@ async def list_projects(
         },
         ['project', 'outbound_count', 'inbound_count'],
     )
+    project_data_list: list[dict[str, typing.Any]] = []
     for record in records:
         project_data = graph.parse_agtype(record['project'])
         _flatten_edge_props(project_data)
@@ -710,9 +744,19 @@ async def list_projects(
             graph.parse_agtype(record['outbound_count']),
             graph.parse_agtype(record['inbound_count']),
         )
-        results.append(
-            ProjectResponse.model_validate(project_data),
-        )
+        project_data_list.append(project_data)
+
+    project_ids = [
+        str(p.get('id', '')) for p in project_data_list if p.get('id')
+    ]
+    pr_counts = await _fetch_pr_counts(project_ids)
+
+    for project_data in project_data_list:
+        pid = str(project_data.get('id', ''))
+        open_count, closed_count = pr_counts.get(pid, (0, 0))
+        project_data['open_pr_count'] = open_count
+        project_data['closed_pr_count'] = closed_count
+        results.append(ProjectResponse.model_validate(project_data))
     return results
 
 

--- a/src/imbi_api/endpoints/projects.py
+++ b/src/imbi_api/endpoints/projects.py
@@ -129,11 +129,18 @@ class ProjectRelationships(pydantic.BaseModel):
 
 
 class ReleaseInfo(pydantic.BaseModel):
-    """Current release for a project in an environment."""
+    """Current release for a project in an environment.
+
+    ``tag`` is the optional human-readable label (e.g. ``1.0.0``);
+    ``committish`` is the 7-char short SHA. The UI displays
+    ``tag ?? committish`` and uses ``committish`` equality to group
+    environments showing the same release.
+    """
 
     deployed_at: datetime.datetime
     performed_by: str | None = None
-    version: str
+    tag: str | None = None
+    committish: str | None = None
 
 
 class ProjectResponse(pydantic.BaseModel):
@@ -347,9 +354,21 @@ async def _resolve_display_names(
 
 
 async def _fetch_current_releases(
+    db: graph.Graph,
     project_ids: list[str],
 ) -> dict[str, dict[str, ReleaseInfo]]:
     """Return {project_id: {env_slug: ReleaseInfo}} for current releases.
+
+    ClickHouse tells us which release ``version`` string is currently
+    deployed per (project, environment). The Release node itself
+    carries the structured ``tag`` + ``committish`` fields, so we
+    join back to AGE with a single bulk query keyed on
+    ``(project_id, version)`` — matching ``r.tag = version`` for
+    tagged releases and ``r.committish = version`` for raw-SHA
+    deploys. The ops_log writer (see
+    ``project_deployments._record_deployment_audit``) stores
+    ``tag if tag else committish`` in ``version``, so the ``OR``
+    branch is exhaustive in normal data.
 
     Errors are swallowed — release data is best-effort.
     """
@@ -374,14 +393,93 @@ async def _fetch_current_releases(
             'Failed to fetch current releases for projects', exc_info=True
         )
         return {}
+    # First pass: collect rows and the (project_id, version) pairs we
+    # need to translate to (tag, committish).
+    rows_list = list(rows)
+    pairs = sorted(
+        {
+            (str(r['project_id']), str(r['version']))
+            for r in rows_list
+            if r.get('version')
+        }
+    )
+    identity_by_pair = await _resolve_release_identities(db, pairs)
     result: dict[str, dict[str, ReleaseInfo]] = {}
-    for r in rows:
+    for r in rows_list:
         pid = str(r['project_id'])
         env_slug = str(r['environment_slug'])
+        version_value = str(r['version']) if r.get('version') else ''
+        tag, committish = identity_by_pair.get(
+            (pid, version_value), (None, None)
+        )
         result.setdefault(pid, {})[env_slug] = ReleaseInfo(
-            version=str(r['version']),
+            tag=tag,
+            committish=committish,
             performed_by=r.get('performed_by') or None,
             deployed_at=r['deployed_at'],
+        )
+    return result
+
+
+async def _resolve_release_identities(
+    db: graph.Graph,
+    pairs: list[tuple[str, str]],
+) -> dict[tuple[str, str], tuple[str | None, str | None]]:
+    """Look up ``(tag, committish)`` for each ``(project_id, version)`` pair.
+
+    Issues a single Cypher query that UNWINDs the pair list and
+    matches Release nodes where ``r.tag = version`` or
+    ``r.committish = version``. When both branches match (rare —
+    would require a tag string equal to another release's
+    committish), the tag-branch row wins because it appears first in
+    the result set ordering. Pairs with no match map to
+    ``(None, None)`` so the caller can render an empty ReleaseInfo
+    rather than crash.
+    """
+    if not pairs:
+        return {}
+    project_ids = [pid for pid, _ in pairs]
+    versions = [v for _, v in pairs]
+    query: typing.LiteralString = """
+    UNWIND range(0, size({project_ids}) - 1) AS i
+    WITH {project_ids}[i] AS project_id, {versions}[i] AS version
+    MATCH (p:Project {{id: project_id}})
+          -[:HAS_RELEASE]->(r:Release)
+    WHERE r.tag = version OR r.committish = version
+    RETURN project_id  AS project_id,
+           version     AS version,
+           r.tag       AS tag,
+           r.committish AS committish,
+           CASE WHEN r.tag = version THEN 0 ELSE 1 END AS rank
+    ORDER BY project_id, version, rank
+    """
+    try:
+        rows = await db.execute(
+            query,
+            {'project_ids': project_ids, 'versions': versions},
+            ['project_id', 'version', 'tag', 'committish', 'rank'],
+        )
+    except Exception:  # noqa: BLE001
+        LOGGER.warning(
+            'Failed to resolve release identities from the graph',
+            exc_info=True,
+        )
+        return {}
+    result: dict[tuple[str, str], tuple[str | None, str | None]] = {}
+    for row in rows:
+        pid = graph.parse_agtype(row.get('project_id'))
+        version = graph.parse_agtype(row.get('version'))
+        tag = graph.parse_agtype(row.get('tag'))
+        committish = graph.parse_agtype(row.get('committish'))
+        if not isinstance(pid, str) or not isinstance(version, str):
+            continue
+        key = (pid, version)
+        if key in result:
+            # Prefer the first row (tag match wins over committish).
+            continue
+        result[key] = (
+            str(tag) if tag else None,
+            str(committish) if committish else None,
         )
     return result
 
@@ -851,7 +949,7 @@ async def list_projects(
     viewer = auth.identity_for('github-enterprise-cloud')
     pr_counts, releases = await asyncio.gather(
         _fetch_pr_counts(project_ids, viewer=viewer),
-        _fetch_current_releases(project_ids),
+        _fetch_current_releases(db, project_ids),
     )
 
     emails = list(

--- a/src/imbi_api/endpoints/projects.py
+++ b/src/imbi_api/endpoints/projects.py
@@ -4,6 +4,7 @@ Projects are identified by a Nano-ID (``id`` field) and may
 belong to multiple project types.  See ADR-0006 for rationale.
 """
 
+import asyncio
 import datetime
 import json
 import logging
@@ -127,6 +128,13 @@ class ProjectRelationships(pydantic.BaseModel):
     inbound_count: int = 0
 
 
+class ReleaseInfo(pydantic.BaseModel):
+    """Current release for a project in an environment."""
+
+    deployed_at: datetime.datetime
+    version: str
+
+
 class ProjectResponse(pydantic.BaseModel):
     """Response body for a project."""
 
@@ -151,6 +159,11 @@ class ProjectResponse(pydantic.BaseModel):
     relationships: ProjectRelationships | None = None
     open_pr_count: int = 0
     closed_pr_count: int = 0
+    viewer_open_pr_count: int = 0
+    viewer_closed_pr_count: int = 0
+    current_releases: dict[str, ReleaseInfo] = pydantic.Field(
+        default_factory=dict
+    )
 
     @pydantic.field_validator(
         'links',
@@ -258,33 +271,93 @@ async def _validate_env_slugs(
 
 async def _fetch_pr_counts(
     project_ids: list[str],
-) -> dict[str, tuple[int, int]]:
-    """Return {project_id: (open_count, closed_count)} for the given IDs.
+    viewer: str | None = None,
+) -> dict[str, tuple[int, int, int, int]]:
+    """Return {project_id: (open, closed, viewer_open, viewer_closed)}.
 
     Errors are swallowed — PR counts are best-effort and should not
     fail the project list endpoint.
     """
     if not project_ids:
         return {}
+    params: dict[str, typing.Any] = {'project_ids': project_ids}
+    if viewer:
+        sql = (
+            'SELECT project_id,'
+            " countIf(state = 'open') AS open_count,"
+            " countIf(state = 'closed') AS closed_count,"
+            " countIf(state = 'open' AND author = {viewer:String})"
+            ' AS viewer_open_count,'
+            " countIf(state = 'closed' AND author = {viewer:String})"
+            ' AS viewer_closed_count'
+            ' FROM pull_requests FINAL'
+            ' WHERE project_id IN {project_ids:Array(String)}'
+            ' GROUP BY project_id'
+        )
+        params['viewer'] = viewer
+    else:
+        sql = (
+            'SELECT project_id,'
+            " countIf(state = 'open') AS open_count,"
+            " countIf(state = 'closed') AS closed_count,"
+            ' 0 AS viewer_open_count,'
+            ' 0 AS viewer_closed_count'
+            ' FROM pull_requests FINAL'
+            ' WHERE project_id IN {project_ids:Array(String)}'
+            ' GROUP BY project_id'
+        )
+    try:
+        rows = await ch_client.Clickhouse.get_instance().query(sql, params)
+    except Exception:  # noqa: BLE001
+        LOGGER.warning('Failed to fetch PR counts for projects', exc_info=True)
+        return {}
+    return {
+        str(r['project_id']): (
+            int(r['open_count']),
+            int(r['closed_count']),
+            int(r['viewer_open_count']),
+            int(r['viewer_closed_count']),
+        )
+        for r in rows
+    }
+
+
+async def _fetch_current_releases(
+    project_ids: list[str],
+) -> dict[str, dict[str, ReleaseInfo]]:
+    """Return {project_id: {env_slug: ReleaseInfo}} for current releases.
+
+    Errors are swallowed — release data is best-effort.
+    """
+    if not project_ids:
+        return {}
     sql = (
-        'SELECT project_id,'
-        " countIf(state = 'open') AS open_count,"
-        " countIf(state = 'closed') AS closed_count"
-        ' FROM pull_requests FINAL'
-        ' WHERE project_id IN {project_ids:Array(String)}'
-        ' GROUP BY project_id'
+        'SELECT project_id, environment_slug,'
+        ' argMax(version, occurred_at) AS version,'
+        ' max(occurred_at) AS deployed_at'
+        ' FROM operations_log FINAL'
+        " WHERE entry_type = 'Deployed'"
+        ' AND project_id IN {project_ids:Array(String)}'
+        ' GROUP BY project_id, environment_slug'
     )
     try:
         rows = await ch_client.Clickhouse.get_instance().query(
             sql, {'project_ids': project_ids}
         )
     except Exception:  # noqa: BLE001
-        LOGGER.warning('Failed to fetch PR counts for projects', exc_info=True)
+        LOGGER.warning(
+            'Failed to fetch current releases for projects', exc_info=True
+        )
         return {}
-    return {
-        str(r['project_id']): (int(r['open_count']), int(r['closed_count']))
-        for r in rows
-    }
+    result: dict[str, dict[str, ReleaseInfo]] = {}
+    for r in rows:
+        pid = str(r['project_id'])
+        env_slug = str(r['environment_slug'])
+        result.setdefault(pid, {})[env_slug] = ReleaseInfo(
+            version=str(r['version']),
+            deployed_at=r['deployed_at'],
+        )
+    return result
 
 
 _EVENT_SKIP_FIELDS: frozenset[str] = frozenset(
@@ -749,13 +822,22 @@ async def list_projects(
     project_ids = [
         str(p.get('id', '')) for p in project_data_list if p.get('id')
     ]
-    pr_counts = await _fetch_pr_counts(project_ids)
+    viewer = auth.identity_for('github-enterprise-cloud')
+    pr_counts, releases = await asyncio.gather(
+        _fetch_pr_counts(project_ids, viewer=viewer),
+        _fetch_current_releases(project_ids),
+    )
 
     for project_data in project_data_list:
         pid = str(project_data.get('id', ''))
-        open_count, closed_count = pr_counts.get(pid, (0, 0))
+        open_count, closed_count, viewer_open, viewer_closed = pr_counts.get(
+            pid, (0, 0, 0, 0)
+        )
         project_data['open_pr_count'] = open_count
         project_data['closed_pr_count'] = closed_count
+        project_data['viewer_open_pr_count'] = viewer_open
+        project_data['viewer_closed_pr_count'] = viewer_closed
+        project_data['current_releases'] = releases.get(pid, {})
         results.append(ProjectResponse.model_validate(project_data))
     return results
 

--- a/src/imbi_api/endpoints/projects.py
+++ b/src/imbi_api/endpoints/projects.py
@@ -323,6 +323,29 @@ async def _fetch_pr_counts(
     }
 
 
+async def _resolve_display_names(
+    db: graph.Graph,
+    emails: list[str],
+) -> dict[str, str]:
+    """Return {email: display_name} for known User nodes."""
+    if not emails:
+        return {}
+    query: typing.LiteralString = (
+        'MATCH (u:User) WHERE u.email IN {emails}'
+        ' RETURN u.email AS email, u.display_name AS display_name'
+    )
+    records = await db.execute(
+        query, {'emails': emails}, ['email', 'display_name']
+    )
+    return {
+        str(graph.parse_agtype(r['email'])): str(
+            graph.parse_agtype(r['display_name'])
+        )
+        for r in records
+        if r.get('email') and r.get('display_name')
+    }
+
+
 async def _fetch_current_releases(
     project_ids: list[str],
 ) -> dict[str, dict[str, ReleaseInfo]]:
@@ -830,6 +853,22 @@ async def list_projects(
         _fetch_pr_counts(project_ids, viewer=viewer),
         _fetch_current_releases(project_ids),
     )
+
+    emails = list(
+        {
+            info.performed_by
+            for env_map in releases.values()
+            for info in env_map.values()
+            if info.performed_by
+        }
+    )
+    display_names = await _resolve_display_names(db, emails)
+    for env_map in releases.values():
+        for slug, info in env_map.items():
+            if info.performed_by and info.performed_by in display_names:
+                env_map[slug] = info.model_copy(
+                    update={'performed_by': display_names[info.performed_by]}
+                )
 
     for project_data in project_data_list:
         pid = str(project_data.get('id', ''))

--- a/src/imbi_api/endpoints/projects.py
+++ b/src/imbi_api/endpoints/projects.py
@@ -334,16 +334,27 @@ async def _resolve_display_names(
     db: graph.Graph,
     emails: list[str],
 ) -> dict[str, str]:
-    """Return {email: display_name} for known User nodes."""
+    """Return {email: display_name} for known User nodes.
+
+    Best-effort enrichment: callers fall back to the local-part of
+    the email when a name is not returned, so DB errors should never
+    surface as a 500.
+    """
     if not emails:
         return {}
     query: typing.LiteralString = (
         'MATCH (u:User) WHERE u.email IN {emails}'
         ' RETURN u.email AS email, u.display_name AS display_name'
     )
-    records = await db.execute(
-        query, {'emails': emails}, ['email', 'display_name']
-    )
+    try:
+        records = await db.execute(
+            query, {'emails': emails}, ['email', 'display_name']
+        )
+    except Exception:  # noqa: BLE001
+        LOGGER.warning(
+            'Failed to resolve performer display names', exc_info=True
+        )
+        return {}
     return {
         str(graph.parse_agtype(r['email'])): str(
             graph.parse_agtype(r['display_name'])

--- a/src/imbi_api/endpoints/projects.py
+++ b/src/imbi_api/endpoints/projects.py
@@ -427,37 +427,29 @@ async def _resolve_release_identities(
 ) -> dict[tuple[str, str], tuple[str | None, str | None]]:
     """Look up ``(tag, committish)`` for each ``(project_id, version)`` pair.
 
-    Issues a single Cypher query that UNWINDs the pair list and
-    matches Release nodes where ``r.tag = version`` or
-    ``r.committish = version``. When both branches match (rare —
-    would require a tag string equal to another release's
-    committish), the tag-branch row wins because it appears first in
-    the result set ordering. Pairs with no match map to
-    ``(None, None)`` so the caller can render an empty ReleaseInfo
-    rather than crash.
+    Fetches every release for the projects involved in one bulk
+    Cypher query, then joins against ``pairs`` in Python. Avoids
+    the cross-product scan that an inline UNWIND + ``OR`` filter
+    would force per pair (no tag/committish indexes exist, so each
+    pair would otherwise walk every Release for its project).
+
+    When a ``(project_id, version)`` matches both a release's
+    ``tag`` and another release's ``committish``, the tag match
+    wins so the human-readable label stays canonical.
     """
     if not pairs:
         return {}
-    project_ids = [pid for pid, _ in pairs]
-    versions = [v for _, v in pairs]
+    project_ids = sorted({pid for pid, _ in pairs})
     query: typing.LiteralString = """
-    UNWIND range(0, size({project_ids}) - 1) AS i
-    WITH {project_ids}[i] AS project_id, {versions}[i] AS version
-    MATCH (p:Project {{id: project_id}})
-          -[:HAS_RELEASE]->(r:Release)
-    WHERE r.tag = version OR r.committish = version
-    RETURN project_id  AS project_id,
-           version     AS version,
-           r.tag       AS tag,
-           r.committish AS committish,
-           CASE WHEN r.tag = version THEN 0 ELSE 1 END AS rank
-    ORDER BY project_id, version, rank
+    MATCH (p:Project)-[:HAS_RELEASE]->(r:Release)
+    WHERE p.id IN {project_ids}
+    RETURN p.id AS project_id, r.tag AS tag, r.committish AS committish
     """
     try:
         rows = await db.execute(
             query,
-            {'project_ids': project_ids, 'versions': versions},
-            ['project_id', 'version', 'tag', 'committish', 'rank'],
+            {'project_ids': project_ids},
+            ['project_id', 'tag', 'committish'],
         )
     except Exception:  # noqa: BLE001
         LOGGER.warning(
@@ -465,22 +457,34 @@ async def _resolve_release_identities(
             exc_info=True,
         )
         return {}
-    result: dict[tuple[str, str], tuple[str | None, str | None]] = {}
+
+    # Build two indexes per project: tag → (tag, committish) and
+    # committish → (tag, committish). The tag index wins for lookup
+    # so a ``version`` that happens to match both indexes resolves
+    # to the tagged release.
+    by_tag: dict[tuple[str, str], tuple[str | None, str | None]] = {}
+    by_committish: dict[tuple[str, str], tuple[str | None, str | None]] = {}
     for row in rows:
         pid = graph.parse_agtype(row.get('project_id'))
-        version = graph.parse_agtype(row.get('version'))
-        tag = graph.parse_agtype(row.get('tag'))
-        committish = graph.parse_agtype(row.get('committish'))
-        if not isinstance(pid, str) or not isinstance(version, str):
+        tag_val = graph.parse_agtype(row.get('tag'))
+        committish_val = graph.parse_agtype(row.get('committish'))
+        if not isinstance(pid, str):
             continue
+        tag = str(tag_val) if tag_val else None
+        committish = str(committish_val) if committish_val else None
+        identity = (tag, committish)
+        if tag:
+            by_tag.setdefault((pid, tag), identity)
+        if committish:
+            by_committish.setdefault((pid, committish), identity)
+
+    result: dict[tuple[str, str], tuple[str | None, str | None]] = {}
+    for pid, version in pairs:
         key = (pid, version)
-        if key in result:
-            # Prefer the first row (tag match wins over committish).
-            continue
-        result[key] = (
-            str(tag) if tag else None,
-            str(committish) if committish else None,
-        )
+        if key in by_tag:
+            result[key] = by_tag[key]
+        elif key in by_committish:
+            result[key] = by_committish[key]
     return result
 
 

--- a/src/imbi_api/endpoints/projects.py
+++ b/src/imbi_api/endpoints/projects.py
@@ -132,6 +132,7 @@ class ReleaseInfo(pydantic.BaseModel):
     """Current release for a project in an environment."""
 
     deployed_at: datetime.datetime
+    performed_by: str | None = None
     version: str
 
 
@@ -334,6 +335,7 @@ async def _fetch_current_releases(
     sql = (
         'SELECT project_id, environment_slug,'
         ' argMax(version, occurred_at) AS version,'
+        ' argMax(performed_by, occurred_at) AS performed_by,'
         ' max(occurred_at) AS deployed_at'
         ' FROM operations_log FINAL'
         " WHERE entry_type = 'Deployed'"
@@ -355,6 +357,7 @@ async def _fetch_current_releases(
         env_slug = str(r['environment_slug'])
         result.setdefault(pid, {})[env_slug] = ReleaseInfo(
             version=str(r['version']),
+            performed_by=r.get('performed_by') or None,
             deployed_at=r['deployed_at'],
         )
     return result

--- a/src/imbi_api/endpoints/pull_requests.py
+++ b/src/imbi_api/endpoints/pull_requests.py
@@ -98,6 +98,7 @@ async def _list_prs(
     *,
     project_ids: list[str],
     state: str | None = None,
+    author: str | None = None,
     limit: int = DEFAULT_LIMIT,
     offset: int = 0,
 ) -> PullRequestListResponse:
@@ -116,6 +117,10 @@ async def _list_prs(
     if state is not None:
         clauses.append('state = {state:String}')
         params['state'] = state
+
+    if author is not None:
+        clauses.append('author = {author:String}')
+        params['author'] = author
 
     where = ' AND '.join(clauses)
     count_sql = (
@@ -158,18 +163,21 @@ async def list_project_pull_requests(
         ),
     ],
     state: str | None = None,
+    author: str | None = None,
     limit: int = DEFAULT_LIMIT,
     offset: int = 0,
 ) -> PullRequestListResponse:
     """List pull requests for a single project.
 
     Optional ``state`` filter accepts ``open`` or ``closed``.
+    Optional ``author`` filter accepts a GitHub login.
     Results are ordered newest first.
     """
     del org_slug
     return await _list_prs(
         project_ids=[project_id],
         state=state,
+        author=author,
         limit=limit,
         offset=offset,
     )
@@ -189,6 +197,7 @@ async def list_org_pull_requests(
         ),
     ],
     state: str | None = None,
+    author: str | None = None,
     limit: int = DEFAULT_LIMIT,
     offset: int = 0,
 ) -> PullRequestListResponse:
@@ -196,12 +205,14 @@ async def list_org_pull_requests(
 
     The set of projects is resolved from the graph so results are
     scoped to the calling user's org.  Optional ``state`` filter
-    accepts ``open`` or ``closed``.  Results are ordered newest first.
+    accepts ``open`` or ``closed``.  Optional ``author`` filter
+    accepts a GitHub login.  Results are ordered newest first.
     """
     project_ids = await _fetch_org_project_ids(db, org_slug)
     return await _list_prs(
         project_ids=project_ids,
         state=state,
+        author=author,
         limit=limit,
         offset=offset,
     )

--- a/src/imbi_api/endpoints/pull_requests.py
+++ b/src/imbi_api/endpoints/pull_requests.py
@@ -1,0 +1,207 @@
+"""Pull request read endpoints (ClickHouse-backed, read-only).
+
+Two routers are provided:
+
+- ``pull_requests_project_router`` — mounted under
+  ``/organizations/{org_slug}/projects/{project_id}/pull-requests``
+  returns PRs for a single project.
+
+- ``pull_requests_router`` — mounted under
+  ``/organizations/{org_slug}/pull-requests``
+  returns PRs across all projects in the org.  The org's project IDs
+  are resolved from the graph first so the response is scoped correctly.
+"""
+
+from __future__ import annotations
+
+import datetime
+import logging
+import typing
+
+import fastapi
+import pydantic
+from imbi_common import clickhouse, graph
+
+from imbi_api.auth import permissions
+
+LOGGER = logging.getLogger(__name__)
+
+pull_requests_router = fastapi.APIRouter(tags=['Pull Requests'])
+pull_requests_project_router = fastapi.APIRouter(tags=['Pull Requests'])
+
+DEFAULT_LIMIT: int = 50
+MAX_LIMIT: int = 500
+
+_TIMESTAMP_FIELDS: frozenset[str] = frozenset(
+    {'created_at', 'updated_at', 'merged_at'}
+)
+
+
+class PullRequestResponse(pydantic.BaseModel):
+    """A single pull request record from ClickHouse."""
+
+    project_id: str
+    pr_id: str
+    pr_number: int
+    title: str
+    url: str
+    state: str
+    author: str
+    draft: bool
+    merged: bool
+    created_at: datetime.datetime
+    updated_at: datetime.datetime
+    merged_at: datetime.datetime | None = None
+    additions: int
+    deletions: int
+    changed_files: int
+
+
+class PullRequestListResponse(pydantic.BaseModel):
+    data: list[PullRequestResponse]
+    total: int
+
+
+def _row_to_response(row: dict[str, typing.Any]) -> dict[str, typing.Any]:
+    """Attach UTC tzinfo to naive datetime columns from ClickHouse."""
+    out: dict[str, typing.Any] = {}
+    for k, v in row.items():
+        if (
+            k in _TIMESTAMP_FIELDS
+            and isinstance(v, datetime.datetime)
+            and v.tzinfo is None
+        ):
+            v = v.replace(tzinfo=datetime.UTC)
+        out[k] = v
+    return out
+
+
+async def _fetch_org_project_ids(
+    db: graph.Pool,
+    org_slug: str,
+) -> list[str]:
+    """Return all project IDs belonging to the org."""
+    query: typing.LiteralString = """
+    MATCH (p:Project)-[:OWNED_BY]->(:Team)
+          -[:BELONGS_TO]->(o:Organization {{slug: {org_slug}}})
+    RETURN p.id AS id
+    """
+    records = await db.execute(query, {'org_slug': org_slug}, ['id'])
+    return [
+        graph.parse_agtype(r['id'])
+        for r in records
+        if graph.parse_agtype(r['id'])
+    ]
+
+
+async def _list_prs(
+    *,
+    project_ids: list[str],
+    state: str | None = None,
+    limit: int = DEFAULT_LIMIT,
+    offset: int = 0,
+) -> PullRequestListResponse:
+    """Run the ClickHouse query and return a paginated response."""
+    if limit < 1 or limit > MAX_LIMIT:
+        raise fastapi.HTTPException(
+            status_code=400,
+            detail=f'limit must be 1..{MAX_LIMIT}',
+        )
+    if not project_ids:
+        return PullRequestListResponse(data=[], total=0)
+
+    clauses: list[str] = ['project_id IN {project_ids:Array(String)}']
+    params: dict[str, typing.Any] = {'project_ids': project_ids}
+
+    if state is not None:
+        clauses.append('state = {state:String}')
+        params['state'] = state
+
+    where = ' AND '.join(clauses)
+    count_sql = (
+        'SELECT count() AS total FROM pull_requests FINAL WHERE '  # noqa: S608
+        + where
+    )
+    params['limit'] = limit
+    params['offset'] = offset
+    data_sql = (
+        'SELECT * FROM pull_requests FINAL WHERE '  # noqa: S608
+        + where
+        + ' ORDER BY created_at DESC, pr_id DESC'
+        + ' LIMIT {limit:UInt32} OFFSET {offset:UInt32}'
+    )
+
+    count_rows = await clickhouse.query(count_sql, params)
+    total = int(count_rows[0]['total']) if count_rows else 0
+
+    data_rows = await clickhouse.query(data_sql, params)
+    return PullRequestListResponse(
+        data=[
+            PullRequestResponse.model_validate(_row_to_response(r))
+            for r in data_rows
+        ],
+        total=total,
+    )
+
+
+@pull_requests_project_router.get(
+    '/',
+    response_model=PullRequestListResponse,
+)
+async def list_project_pull_requests(
+    org_slug: str,
+    project_id: str,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('project:read'),
+        ),
+    ],
+    state: str | None = None,
+    limit: int = DEFAULT_LIMIT,
+    offset: int = 0,
+) -> PullRequestListResponse:
+    """List pull requests for a single project.
+
+    Optional ``state`` filter accepts ``open`` or ``closed``.
+    Results are ordered newest first.
+    """
+    del org_slug
+    return await _list_prs(
+        project_ids=[project_id],
+        state=state,
+        limit=limit,
+        offset=offset,
+    )
+
+
+@pull_requests_router.get(
+    '/',
+    response_model=PullRequestListResponse,
+)
+async def list_org_pull_requests(
+    org_slug: str,
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('project:read'),
+        ),
+    ],
+    state: str | None = None,
+    limit: int = DEFAULT_LIMIT,
+    offset: int = 0,
+) -> PullRequestListResponse:
+    """List pull requests across all projects in the organization.
+
+    The set of projects is resolved from the graph so results are
+    scoped to the calling user's org.  Optional ``state`` filter
+    accepts ``open`` or ``closed``.  Results are ordered newest first.
+    """
+    project_ids = await _fetch_org_project_ids(db, org_slug)
+    return await _list_prs(
+        project_ids=project_ids,
+        state=state,
+        limit=limit,
+        offset=offset,
+    )

--- a/src/imbi_api/endpoints/pull_requests.py
+++ b/src/imbi_api/endpoints/pull_requests.py
@@ -109,6 +109,11 @@ async def _list_prs(
             status_code=400,
             detail=f'limit must be 1..{MAX_LIMIT}',
         )
+    if offset < 0:
+        raise fastapi.HTTPException(
+            status_code=400,
+            detail='offset must be >= 0',
+        )
     if not project_ids:
         return PullRequestListResponse(data=[], project_count=0, total=0)
 
@@ -160,6 +165,7 @@ async def _list_prs(
 async def list_project_pull_requests(
     org_slug: str,
     project_id: str,
+    db: graph.Pool,
     auth: typing.Annotated[
         permissions.AuthContext,
         fastapi.Depends(
@@ -177,7 +183,15 @@ async def list_project_pull_requests(
     Optional ``author`` filter accepts a GitHub login.
     Results are ordered newest first.
     """
-    del org_slug
+    org_project_ids = await _fetch_org_project_ids(db, org_slug)
+    if project_id not in org_project_ids:
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail=(
+                f'Project {project_id!r} not found in organization'
+                f' {org_slug!r}'
+            ),
+        )
     return await _list_prs(
         project_ids=[project_id],
         state=state,

--- a/src/imbi_api/endpoints/pull_requests.py
+++ b/src/imbi_api/endpoints/pull_requests.py
@@ -59,6 +59,7 @@ class PullRequestResponse(pydantic.BaseModel):
 
 class PullRequestListResponse(pydantic.BaseModel):
     data: list[PullRequestResponse]
+    project_count: int
     total: int
 
 
@@ -109,7 +110,7 @@ async def _list_prs(
             detail=f'limit must be 1..{MAX_LIMIT}',
         )
     if not project_ids:
-        return PullRequestListResponse(data=[], total=0)
+        return PullRequestListResponse(data=[], project_count=0, total=0)
 
     clauses: list[str] = ['project_id IN {project_ids:Array(String)}']
     params: dict[str, typing.Any] = {'project_ids': project_ids}
@@ -124,8 +125,9 @@ async def _list_prs(
 
     where = ' AND '.join(clauses)
     count_sql = (
-        'SELECT count() AS total FROM pull_requests FINAL WHERE '  # noqa: S608
-        + where
+        'SELECT count() AS total,'  # noqa: S608
+        ' count(DISTINCT project_id) AS project_count'
+        ' FROM pull_requests FINAL WHERE ' + where
     )
     params['limit'] = limit
     params['offset'] = offset
@@ -138,6 +140,7 @@ async def _list_prs(
 
     count_rows = await clickhouse.query(count_sql, params)
     total = int(count_rows[0]['total']) if count_rows else 0
+    project_count = int(count_rows[0]['project_count']) if count_rows else 0
 
     data_rows = await clickhouse.query(data_sql, params)
     return PullRequestListResponse(
@@ -145,6 +148,7 @@ async def _list_prs(
             PullRequestResponse.model_validate(_row_to_response(r))
             for r in data_rows
         ],
+        project_count=project_count,
         total=total,
     )
 

--- a/src/imbi_api/endpoints/releases.py
+++ b/src/imbi_api/endpoints/releases.py
@@ -744,6 +744,37 @@ async def patch_release(
     serialized_links = _serialize_links(merged_links_raw)
     del update
 
+    # Identity is ``(committish, tag)`` — reject a patch that would
+    # collide with another release on this project's same SHA.  AGE
+    # has no NULL equality, so compare via ``COALESCE`` to a sentinel.
+    conflict_query: typing.LiteralString = """
+    MATCH (:Project {{id: {project_id}}})
+          -[:HAS_RELEASE]->(other:Release {{committish: {committish}}})
+    WHERE other.id <> {release_id}
+      AND COALESCE(other.tag, '') = COALESCE({tag}, '')
+    RETURN other.id AS id
+    LIMIT 1
+    """
+    conflict = await db.execute(
+        conflict_query,
+        {
+            'project_id': project_id,
+            'release_id': release_id,
+            'committish': data['committish'],
+            'tag': merged_tag,
+        },
+        ['id'],
+    )
+    if conflict:
+        raise fastapi.HTTPException(
+            status_code=409,
+            detail=(
+                f'Release committish={data["committish"]!r}'
+                f' tag={merged_tag!r} already exists for project'
+                f' {project_id!r}'
+            ),
+        )
+
     update_query: typing.LiteralString = """
     MATCH (p:Project {{id: {project_id}}})
           -[:HAS_RELEASE]->(r:Release {{id: {release_id}}})

--- a/src/imbi_api/endpoints/releases.py
+++ b/src/imbi_api/endpoints/releases.py
@@ -1,10 +1,12 @@
 """Release CRUD and deployment-edge endpoints.
 
-Releases are identified by a per-project ``version`` string. The
-``Release`` node is connected to its ``Project`` via an incoming
-``HAS_RELEASE`` edge and to every ``Environment`` it has been
-deployed to via a ``DEPLOYED_TO`` edge carrying an append-only
-``deployments`` history.
+Releases are identified by their stable nano-id (``Release.id``).
+A ``Release`` node carries an optional ``tag`` (human-readable
+business identity such as ``1.0.0``) and a required 7-char
+``committish`` (lowercase short SHA).  It is connected to its
+``Project`` via an incoming ``HAS_RELEASE`` edge and to every
+``Environment`` it has been deployed to via a ``DEPLOYED_TO`` edge
+carrying an append-only ``deployments`` history.
 
 """
 
@@ -46,7 +48,17 @@ class ReleaseCreate(pydantic.BaseModel):
 
     model_config = pydantic.ConfigDict(extra='forbid')
 
-    version: str
+    tag: str | None = None
+    committish: typing.Annotated[
+        str,
+        pydantic.Field(
+            pattern=r'^[0-9a-f]{7}$',
+            description=(
+                'Short commit SHA (7 lowercase hexadecimal chars) '
+                'identifying the source revision for this release.'
+            ),
+        ),
+    ]
     title: str
     description: str | None = None
     links: list[models.ReleaseLink] = []
@@ -56,12 +68,13 @@ class ReleaseCreate(pydantic.BaseModel):
 class ReleaseUpdate(pydantic.BaseModel):
     """JSON Patch-compatible release shape.
 
-    Only ``title``, ``description``, and ``links`` may be patched;
-    ``version`` / ``id`` / timestamps / project are read-only.
+    ``title``, ``description``, ``links``, and ``tag`` may be patched;
+    ``id`` / ``committish`` / timestamps / project are read-only.
     """
 
     model_config = pydantic.ConfigDict(extra='forbid')
 
+    tag: str | None = None
     title: str | None = None
     description: str | None = None
     links: list[models.ReleaseLink] | None = None
@@ -72,7 +85,8 @@ class ReleaseResponse(pydantic.BaseModel):
 
     id: str
     project_id: str
-    version: str
+    tag: str | None = None
+    committish: str
     title: str
     description: str | None = None
     links: list[models.ReleaseLink] = []
@@ -140,7 +154,7 @@ class CurrentReleaseEnvironment(pydantic.BaseModel):
 _RELEASE_READONLY_PATHS: frozenset[str] = frozenset(
     [
         '/id',
-        '/version',
+        '/committish',
         '/project_id',
         '/created_at',
         '/updated_at',
@@ -187,7 +201,8 @@ def _release_to_response(
         {
             'id': data['id'],
             'project_id': project_id,
-            'version': data['version'],
+            'tag': data.get('tag'),
+            'committish': data['committish'],
             'title': data['title'],
             'description': data.get('description'),
             'links': raw_links,
@@ -222,14 +237,14 @@ async def _fetch_release(
     db: graph.Graph,
     org_slug: str,
     project_id: str,
-    version: str,
+    release_id: str,
 ) -> dict[str, typing.Any] | None:
-    """Fetch a release node by project and version."""
+    """Fetch a release node by project and release id."""
     query: typing.LiteralString = """
     MATCH (p:Project {{id: {project_id}}})
           -[:OWNED_BY]->(:Team)
           -[:BELONGS_TO]->(:Organization {{slug: {org_slug}}})
-    MATCH (p)-[:HAS_RELEASE]->(r:Release {{version: {version}}})
+    MATCH (p)-[:HAS_RELEASE]->(r:Release {{id: {release_id}}})
     RETURN r{{.*}} AS release
     """
     rows = await db.execute(
@@ -237,7 +252,7 @@ async def _fetch_release(
         {
             'project_id': project_id,
             'org_slug': org_slug,
-            'version': version,
+            'release_id': release_id,
         },
         ['release'],
     )
@@ -285,21 +300,22 @@ async def _hydrate_release_train(
     Failures are tolerated silently — the release train must keep
     rendering even if the plugin can't be resolved or its calls hiccup.
     """
-    in_flight: list[tuple[str, str, models.DeploymentEvent]] = []
+    in_flight: list[tuple[str, str, str, models.DeploymentEvent]] = []
     deployed: list[tuple[str, str]] = []
     for slug, (_env, release_raw, event) in by_env.items():
         if release_raw is None:
             continue
-        version = str(release_raw.get('version') or '')
-        if not version:
+        release_id = str(release_raw.get('id') or '')
+        committish = str(release_raw.get('committish') or '')
+        if not release_id or not committish:
             continue
-        deployed.append((slug, version))
+        deployed.append((slug, committish))
         if (
             event is not None
             and event.status == 'in_progress'
             and event.external_run_id
         ):
-            in_flight.append((slug, version, event))
+            in_flight.append((slug, release_id, committish, event))
 
     if not in_flight and not deployed:
         return {}
@@ -332,21 +348,23 @@ async def _hydrate_release_train(
                     ctx, credentials, run_id=str(event.external_run_id)
                 )
             )
-            for _, _, event in in_flight
+            for _, _, _, event in in_flight
         ),
         return_exceptions=True,
     )
     ci_results = await asyncio.gather(
         *(
             call_with_timeout(
-                handler.get_check_status(ctx, credentials, committish=version)
+                handler.get_check_status(
+                    ctx, credentials, committish=committish
+                )
             )
-            for _, version in deployed
+            for _, committish in deployed
         ),
         return_exceptions=True,
     )
 
-    for (slug, version, event), result in zip(
+    for (slug, release_id, _committish, event), result in zip(
         in_flight, run_results, strict=True
     ):
         if isinstance(result, BaseException):
@@ -368,7 +386,7 @@ async def _hydrate_release_train(
                     db,
                     org_slug=org_slug,
                     project_id=project_id,
-                    version=version,
+                    release_id=release_id,
                     env_slug=slug,
                     status=new_status,
                     note='via release-train hydration',
@@ -384,7 +402,9 @@ async def _hydrate_release_train(
                 )
 
     ci_status_by_slug: dict[str, CheckStatus | None] = {}
-    for (slug, _version), ci_result in zip(deployed, ci_results, strict=True):
+    for (slug, _committish), ci_result in zip(
+        deployed, ci_results, strict=True
+    ):
         if isinstance(ci_result, BaseException) or ci_result == 'unknown':
             ci_status_by_slug[slug] = None
         else:
@@ -409,31 +429,37 @@ async def create_release(
     ],
 ) -> ReleaseResponse:
     """Create a new release for a project."""
-    version = data.version
-
     if not await _project_exists(db, org_slug, project_id):
         raise fastapi.HTTPException(
             status_code=404,
             detail=f'Project {project_id!r} not found',
         )
 
-    # Per-project version uniqueness pre-check.
+    # Per-project (committish, tag) uniqueness pre-check. A SHA can
+    # ship under multiple tags and a tag is optional, so the natural
+    # key combines both fields. AGE has no NULL equality, so the tag
+    # comparison is split via COALESCE to a sentinel.
     existing_query: typing.LiteralString = """
     MATCH (p:Project {{id: {project_id}}})
-          -[:HAS_RELEASE]->(r:Release {{version: {version}}})
+          -[:HAS_RELEASE]->(r:Release {{committish: {committish}}})
+    WHERE COALESCE(r.tag, '') = COALESCE({tag}, '')
     RETURN r.id AS id
     """
     existing = await db.execute(
         existing_query,
-        {'project_id': project_id, 'version': version},
+        {
+            'project_id': project_id,
+            'committish': data.committish,
+            'tag': data.tag,
+        },
         ['id'],
     )
     if existing:
         raise fastapi.HTTPException(
             status_code=409,
             detail=(
-                f'Release {version!r} already exists'
-                f' for project {project_id!r}'
+                f'Release committish={data.committish!r} tag={data.tag!r}'
+                f' already exists for project {project_id!r}'
             ),
         )
 
@@ -445,7 +471,8 @@ async def create_release(
     now = datetime.datetime.now(datetime.UTC)
     props: dict[str, typing.Any] = {
         'id': nanoid.generate(),
-        'version': version,
+        'tag': data.tag,
+        'committish': data.committish,
         'title': data.title,
         'description': data.description,
         'links': _serialize_links(data.links),
@@ -458,7 +485,8 @@ async def create_release(
     MATCH (p:Project {{id: {project_id}}})
     CREATE (r:Release {{
         id: {id},
-        version: {version},
+        tag: {tag},
+        committish: {committish},
         title: {title},
         description: {description},
         links: {links},
@@ -628,11 +656,11 @@ async def list_current_releases(
     return [item for _, _, item in sortable]
 
 
-@releases_router.get('/{version}', response_model=ReleaseResponse)
+@releases_router.get('/{release_id}', response_model=ReleaseResponse)
 async def get_release(
     org_slug: str,
     project_id: str,
-    version: str,
+    release_id: str,
     db: graph.Pool,
     auth: typing.Annotated[
         permissions.AuthContext,
@@ -641,24 +669,24 @@ async def get_release(
         ),
     ],
 ) -> ReleaseResponse:
-    """Get a single release by version."""
+    """Get a single release by id."""
     del auth
-    data = await _fetch_release(db, org_slug, project_id, version)
+    data = await _fetch_release(db, org_slug, project_id, release_id)
     if data is None:
         raise fastapi.HTTPException(
             status_code=404,
             detail=(
-                f'Release {version!r} for project {project_id!r} not found'
+                f'Release {release_id!r} for project {project_id!r} not found'
             ),
         )
     return _release_to_response(data, project_id)
 
 
-@releases_router.patch('/{version}', response_model=ReleaseResponse)
+@releases_router.patch('/{release_id}', response_model=ReleaseResponse)
 async def patch_release(
     org_slug: str,
     project_id: str,
-    version: str,
+    release_id: str,
     operations: list[json_patch.PatchOperation],
     db: graph.Pool,
     auth: typing.Annotated[
@@ -670,12 +698,12 @@ async def patch_release(
 ) -> ReleaseResponse:
     """Apply a JSON Patch (RFC 6902) to a release."""
     del auth
-    data = await _fetch_release(db, org_slug, project_id, version)
+    data = await _fetch_release(db, org_slug, project_id, release_id)
     if data is None:
         raise fastapi.HTTPException(
             status_code=404,
             detail=(
-                f'Release {version!r} for project {project_id!r} not found'
+                f'Release {release_id!r} for project {project_id!r} not found'
             ),
         )
 
@@ -683,6 +711,7 @@ async def patch_release(
     if isinstance(raw_links, str):
         raw_links = json.loads(raw_links)
     patchable: dict[str, typing.Any] = {
+        'tag': data.get('tag'),
         'title': data['title'],
         'description': data.get('description'),
         'links': raw_links,
@@ -708,6 +737,7 @@ async def patch_release(
     # Use key presence, not truthiness, so explicit empty strings
     # (``replace /title ""``) are persisted rather than silently
     # reverted to the old value.
+    merged_tag = patched['tag'] if 'tag' in patched else data.get('tag')
     merged_title = patched['title'] if 'title' in patched else data['title']
     merged_description = patched.get('description')
     merged_links_raw = patched.get('links', raw_links)
@@ -716,8 +746,9 @@ async def patch_release(
 
     update_query: typing.LiteralString = """
     MATCH (p:Project {{id: {project_id}}})
-          -[:HAS_RELEASE]->(r:Release {{version: {version}}})
-    SET r.title = {title},
+          -[:HAS_RELEASE]->(r:Release {{id: {release_id}}})
+    SET r.tag = {tag},
+        r.title = {title},
         r.description = {description},
         r.links = {links},
         r.updated_at = {updated_at}
@@ -727,7 +758,8 @@ async def patch_release(
         update_query,
         {
             'project_id': project_id,
-            'version': version,
+            'release_id': release_id,
+            'tag': merged_tag,
             'title': merged_title,
             'description': merged_description,
             'links': serialized_links,
@@ -739,7 +771,7 @@ async def patch_release(
         raise fastapi.HTTPException(
             status_code=404,
             detail=(
-                f'Release {version!r} for project {project_id!r} not found'
+                f'Release {release_id!r} for project {project_id!r} not found'
             ),
         )
     release_data = graph.parse_agtype(rows[0]['release'])
@@ -753,13 +785,13 @@ async def _fetch_deployment_edge(
     db: graph.Graph,
     org_slug: str,
     project_id: str,
-    version: str,
+    release_id: str,
     env_slug: str,
 ) -> tuple[dict[str, typing.Any] | None, list[models.DeploymentEvent]]:
     """Fetch environment and any existing DEPLOYED_TO edge."""
     query: typing.LiteralString = """
     MATCH (p:Project {{id: {project_id}}})
-          -[:HAS_RELEASE]->(r:Release {{version: {version}}})
+          -[:HAS_RELEASE]->(r:Release {{id: {release_id}}})
     MATCH (e:Environment {{slug: {env_slug}}})
           -[:BELONGS_TO]->(:Organization {{slug: {org_slug}}})
     OPTIONAL MATCH (r)-[d:DEPLOYED_TO]->(e)
@@ -771,7 +803,7 @@ async def _fetch_deployment_edge(
         query,
         {
             'project_id': project_id,
-            'version': version,
+            'release_id': release_id,
             'env_slug': env_slug,
             'org_slug': org_slug,
         },
@@ -811,7 +843,7 @@ async def append_deployment_event(
     *,
     org_slug: str,
     project_id: str,
-    version: str,
+    release_id: str,
     env_slug: str,
     status: typing.Literal[
         'pending', 'in_progress', 'success', 'failed', 'rolled_back'
@@ -845,11 +877,11 @@ async def append_deployment_event(
     ``timestamp`` lets the resync flow record the remote's deployment
     creation time rather than ``now()``; defaults to now when omitted.
     """
-    release = await _fetch_release(db, org_slug, project_id, version)
+    release = await _fetch_release(db, org_slug, project_id, release_id)
     if release is None:
         return None
     env, existing = await _fetch_deployment_edge(
-        db, org_slug, project_id, version, env_slug
+        db, org_slug, project_id, release_id, env_slug
     )
     if env is None:
         return None
@@ -885,7 +917,7 @@ async def append_deployment_event(
                 updated_edge = await _set_deployments(
                     db,
                     project_id=project_id,
-                    version=version,
+                    release_id=release_id,
                     env_slug=env_slug,
                     deployments=updated_list,
                     env=env,
@@ -903,7 +935,7 @@ async def append_deployment_event(
         appended_edge = await _set_deployments(
             db,
             project_id=project_id,
-            version=version,
+            release_id=release_id,
             env_slug=env_slug,
             deployments=deployments,
             env=env,
@@ -912,7 +944,7 @@ async def append_deployment_event(
     created_edge = await _create_deployments_edge(
         db,
         project_id=project_id,
-        version=version,
+        release_id=release_id,
         env_slug=env_slug,
         org_slug=org_slug,
         deployments=deployments,
@@ -925,7 +957,7 @@ async def _set_deployments(
     db: graph.Graph,
     *,
     project_id: str,
-    version: str,
+    release_id: str,
     env_slug: str,
     deployments: list[models.DeploymentEvent],
     env: dict[str, typing.Any],
@@ -934,7 +966,7 @@ async def _set_deployments(
     serialized = json.dumps([e.model_dump(mode='json') for e in deployments])
     set_query: typing.LiteralString = """
     MATCH (:Project {{id: {project_id}}})
-          -[:HAS_RELEASE]->(r:Release {{version: {version}}})
+          -[:HAS_RELEASE]->(r:Release {{id: {release_id}}})
     MATCH (r)-[d:DEPLOYED_TO]->(:Environment {{slug: {env_slug}}})
     SET d.deployments = {deployments}
     RETURN d.deployments AS deployments
@@ -943,7 +975,7 @@ async def _set_deployments(
         set_query,
         {
             'project_id': project_id,
-            'version': version,
+            'release_id': release_id,
             'env_slug': env_slug,
             'deployments': serialized,
         },
@@ -956,7 +988,7 @@ async def _set_deployments(
         raise fastapi.HTTPException(
             status_code=409,
             detail=(
-                f'Release {version!r} or its deployment to '
+                f'Release {release_id!r} or its deployment to '
                 f'environment {env_slug!r} no longer exists'
             ),
         )
@@ -967,7 +999,7 @@ async def _create_deployments_edge(
     db: graph.Graph,
     *,
     project_id: str,
-    version: str,
+    release_id: str,
     env_slug: str,
     org_slug: str,
     deployments: list[models.DeploymentEvent],
@@ -977,7 +1009,7 @@ async def _create_deployments_edge(
     serialized = json.dumps([e.model_dump(mode='json') for e in deployments])
     create_query: typing.LiteralString = """
     MATCH (:Project {{id: {project_id}}})
-          -[:HAS_RELEASE]->(r:Release {{version: {version}}})
+          -[:HAS_RELEASE]->(r:Release {{id: {release_id}}})
     MATCH (e:Environment {{slug: {env_slug}}})
           -[:BELONGS_TO]->(:Organization {{slug: {org_slug}}})
     CREATE (r)-[d:DEPLOYED_TO {{deployments: {deployments}}}]->(e)
@@ -987,7 +1019,7 @@ async def _create_deployments_edge(
         create_query,
         {
             'project_id': project_id,
-            'version': version,
+            'release_id': release_id,
             'env_slug': env_slug,
             'org_slug': org_slug,
             'deployments': serialized,
@@ -1001,7 +1033,7 @@ async def _create_deployments_edge(
         raise fastapi.HTTPException(
             status_code=409,
             detail=(
-                f'Release {version!r} or environment {env_slug!r} in '
+                f'Release {release_id!r} or environment {env_slug!r} in '
                 f'organization {org_slug!r} no longer exists'
             ),
         )
@@ -1009,13 +1041,13 @@ async def _create_deployments_edge(
 
 
 @releases_router.post(
-    '/{version}/environments/{env_slug}',
+    '/{release_id}/environments/{env_slug}',
     response_model=ReleaseEnvironmentEdgeResponse,
 )
 async def record_deployment(
     org_slug: str,
     project_id: str,
-    version: str,
+    release_id: str,
     env_slug: str,
     data: DeploymentEventInput,
     db: graph.Pool,
@@ -1028,17 +1060,17 @@ async def record_deployment(
 ) -> ReleaseEnvironmentEdgeResponse:
     """Record a deployment event for a release in an environment."""
     del auth
-    release = await _fetch_release(db, org_slug, project_id, version)
+    release = await _fetch_release(db, org_slug, project_id, release_id)
     if release is None:
         raise fastapi.HTTPException(
             status_code=404,
             detail=(
-                f'Release {version!r} for project {project_id!r} not found'
+                f'Release {release_id!r} for project {project_id!r} not found'
             ),
         )
 
     env, existing = await _fetch_deployment_edge(
-        db, org_slug, project_id, version, env_slug
+        db, org_slug, project_id, release_id, env_slug
     )
     if env is None:
         raise fastapi.HTTPException(
@@ -1062,7 +1094,7 @@ async def record_deployment(
     if existing:
         set_query: typing.LiteralString = """
         MATCH (:Project {{id: {project_id}}})
-              -[:HAS_RELEASE]->(r:Release {{version: {version}}})
+              -[:HAS_RELEASE]->(r:Release {{id: {release_id}}})
         MATCH (r)-[d:DEPLOYED_TO]->(:Environment {{slug: {env_slug}}})
         SET d.deployments = {deployments}
         RETURN d.deployments AS deployments
@@ -1071,7 +1103,7 @@ async def record_deployment(
             set_query,
             {
                 'project_id': project_id,
-                'version': version,
+                'release_id': release_id,
                 'env_slug': env_slug,
                 'deployments': serialized,
             },
@@ -1080,7 +1112,7 @@ async def record_deployment(
     else:
         create_query: typing.LiteralString = """
         MATCH (:Project {{id: {project_id}}})
-              -[:HAS_RELEASE]->(r:Release {{version: {version}}})
+              -[:HAS_RELEASE]->(r:Release {{id: {release_id}}})
         MATCH (e:Environment {{slug: {env_slug}}})
               -[:BELONGS_TO]->(:Organization {{slug: {org_slug}}})
         CREATE (r)-[d:DEPLOYED_TO {{deployments: {deployments}}}]->(e)
@@ -1090,7 +1122,7 @@ async def record_deployment(
             create_query,
             {
                 'project_id': project_id,
-                'version': version,
+                'release_id': release_id,
                 'env_slug': env_slug,
                 'org_slug': org_slug,
                 'deployments': serialized,
@@ -1102,13 +1134,13 @@ async def record_deployment(
 
 
 @releases_router.get(
-    '/{version}/environments',
+    '/{release_id}/environments',
     response_model=list[ReleaseEnvironmentEdgeResponse],
 )
 async def list_deployment_edges(
     org_slug: str,
     project_id: str,
-    version: str,
+    release_id: str,
     db: graph.Pool,
     auth: typing.Annotated[
         permissions.AuthContext,
@@ -1119,12 +1151,12 @@ async def list_deployment_edges(
 ) -> list[ReleaseEnvironmentEdgeResponse]:
     """List every environment edge for a release."""
     del auth
-    release = await _fetch_release(db, org_slug, project_id, version)
+    release = await _fetch_release(db, org_slug, project_id, release_id)
     if release is None:
         raise fastapi.HTTPException(
             status_code=404,
             detail=(
-                f'Release {version!r} for project {project_id!r} not found'
+                f'Release {release_id!r} for project {project_id!r} not found'
             ),
         )
 
@@ -1132,7 +1164,7 @@ async def list_deployment_edges(
     MATCH (p:Project {{id: {project_id}}})
           -[:OWNED_BY]->(:Team)
           -[:BELONGS_TO]->(:Organization {{slug: {org_slug}}})
-    MATCH (p)-[:HAS_RELEASE]->(r:Release {{version: {version}}})
+    MATCH (p)-[:HAS_RELEASE]->(r:Release {{id: {release_id}}})
     MATCH (r)-[d:DEPLOYED_TO]->(e:Environment)
     RETURN e{{.slug, .name}} AS env, d.deployments AS deployments
     ORDER BY e.slug
@@ -1142,7 +1174,7 @@ async def list_deployment_edges(
         {
             'project_id': project_id,
             'org_slug': org_slug,
-            'version': version,
+            'release_id': release_id,
         },
         ['env', 'deployments'],
     )
@@ -1159,13 +1191,13 @@ async def list_deployment_edges(
 
 
 @releases_router.get(
-    '/{version}/environments/{env_slug}',
+    '/{release_id}/environments/{env_slug}',
     response_model=ReleaseEnvironmentEdgeResponse,
 )
 async def get_deployment_edge(
     org_slug: str,
     project_id: str,
-    version: str,
+    release_id: str,
     env_slug: str,
     db: graph.Pool,
     auth: typing.Annotated[
@@ -1177,22 +1209,22 @@ async def get_deployment_edge(
 ) -> ReleaseEnvironmentEdgeResponse:
     """Get a single deployment edge by environment slug."""
     del auth
-    release = await _fetch_release(db, org_slug, project_id, version)
+    release = await _fetch_release(db, org_slug, project_id, release_id)
     if release is None:
         raise fastapi.HTTPException(
             status_code=404,
             detail=(
-                f'Release {version!r} for project {project_id!r} not found'
+                f'Release {release_id!r} for project {project_id!r} not found'
             ),
         )
     env, deployments = await _fetch_deployment_edge(
-        db, org_slug, project_id, version, env_slug
+        db, org_slug, project_id, release_id, env_slug
     )
     if env is None or not deployments:
         raise fastapi.HTTPException(
             status_code=404,
             detail=(
-                f'Deployment edge for release {version!r} in'
+                f'Deployment edge for release {release_id!r} in'
                 f' environment {env_slug!r} not found'
             ),
         )

--- a/src/imbi_api/endpoints/user_activity.py
+++ b/src/imbi_api/endpoints/user_activity.py
@@ -930,7 +930,8 @@ _GRAPH_ACTIVITY_COLUMNS: dict[str, list[str]] = {
     'release': [
         'id',
         'ts',
-        'version',
+        'tag',
+        'committish',
         'title',
         'project_id',
         'project_slug',

--- a/src/imbi_api/endpoints/user_activity.py
+++ b/src/imbi_api/endpoints/user_activity.py
@@ -839,7 +839,8 @@ _GRAPH_ACTIVITY_QUERIES: dict[str, str] = {
           AND r.created_at <= {before}
         RETURN r.id AS id,
                r.created_at AS ts,
-               r.version AS version,
+               r.tag AS tag,
+               r.committish AS committish,
                r.title AS title,
                p.id AS project_id,
                p.slug AS project_slug,
@@ -878,13 +879,15 @@ def _graph_summary(label: str, row: dict[str, typing.Any]) -> str:
         )
         return f'Wrote document "{title}" on {proj}'
     if label == 'release':
-        version = graph.parse_agtype(row.get('version')) or ''
+        tag = graph.parse_agtype(row.get('tag'))
+        committish = graph.parse_agtype(row.get('committish'))
+        display = str(tag) if tag else (str(committish) if committish else '')
         proj = (
             graph.parse_agtype(row.get('project_name'))
             or graph.parse_agtype(row.get('project_slug'))
             or 'a project'
         )
-        return f'Released {version} of {proj}'.strip()
+        return f'Released {display} of {proj}'.strip()
     if label == 'upload':
         filename = graph.parse_agtype(row.get('filename')) or '(unknown)'
         return f'Uploaded {filename}'

--- a/tests/endpoints/test_project_deployments.py
+++ b/tests/endpoints/test_project_deployments.py
@@ -834,19 +834,19 @@ class ProjectDeploymentsTestCase(unittest.TestCase):
                 {
                     'env': '{"slug": "testing", "name": "Testing", '
                     '"sort_order": 1}',
-                    'release': '{"version": "v6.4.0"}',
+                    'release': '{"tag": "v6.4.0", "committish": "aaa6400"}',
                     'deployments': None,
                 },
                 {
                     'env': '{"slug": "staging", "name": "Staging", '
                     '"sort_order": 2}',
-                    'release': '{"version": "v6.3.0"}',
+                    'release': '{"tag": "v6.3.0", "committish": "bbb6300"}',
                     'deployments': None,
                 },
                 {
                     'env': '{"slug": "production", "name": "Production", '
                     '"sort_order": 3}',
-                    'release': '{"version": "v6.2.0"}',
+                    'release': '{"tag": "v6.2.0", "committish": "ccc6200"}',
                     'deployments': None,
                 },
             ]
@@ -881,7 +881,7 @@ class ProjectDeploymentsTestCase(unittest.TestCase):
                 {
                     'env': '{"slug": "testing", "name": "Testing", '
                     '"sort_order": 1}',
-                    'release': '{"version": "v6.3.0"}',
+                    'release': '{"tag": "v6.3.0", "committish": "bbb6300"}',
                     'deployments': (
                         '[{"timestamp": "2024-01-01T00:00:00+00:00", '
                         '"status": "success"}]'
@@ -890,7 +890,7 @@ class ProjectDeploymentsTestCase(unittest.TestCase):
                 {
                     'env': '{"slug": "testing", "name": "Testing", '
                     '"sort_order": 1}',
-                    'release': '{"version": "v6.4.0"}',
+                    'release': '{"tag": "v6.4.0", "committish": "aaa6400"}',
                     'deployments': (
                         '[{"timestamp": "2024-06-01T00:00:00+00:00", '
                         '"status": "success"}]'
@@ -899,7 +899,7 @@ class ProjectDeploymentsTestCase(unittest.TestCase):
                 {
                     'env': '{"slug": "staging", "name": "Staging", '
                     '"sort_order": 2}',
-                    'release': '{"version": "v6.2.0"}',
+                    'release': '{"tag": "v6.2.0", "committish": "ccc6200"}',
                     'deployments': None,
                 },
             ]
@@ -933,13 +933,13 @@ class ProjectDeploymentsTestCase(unittest.TestCase):
                 {
                     'env': '{"slug": "testing", "name": "Testing", '
                     '"sort_order": 1}',
-                    'release': '{"version": "v1.0.0"}',
+                    'release': '{"tag": "v1.0.0", "committish": "abc1000"}',
                     'deployments': None,
                 },
                 {
                     'env': '{"slug": "staging", "name": "Staging", '
                     '"sort_order": 2}',
-                    'release': '{"version": "v0.9.0"}',
+                    'release': '{"tag": "v0.9.0", "committish": "def0900"}',
                     'deployments': None,
                 },
             ]

--- a/tests/endpoints/test_project_deployments.py
+++ b/tests/endpoints/test_project_deployments.py
@@ -317,20 +317,29 @@ class ProjectDeploymentsTestCase(unittest.TestCase):
 
     def test_trigger_deploy_records_event_when_release_matches(self) -> None:
         self.mocks['append_deployment_event'].return_value = mock.Mock()
+        # Mock _release_id_for so the deploy flow finds a Release node
+        # to attach the in-progress DeploymentEvent to.
+        self._start(
+            mock.patch(
+                f'{_MODULE}._release_id_for',
+                return_value='matched-release-id',
+            )
+        )
         with testclient.TestClient(self.test_app) as client:
             response = client.post(
                 '/organizations/myorg/projects/proj1/deployments',
                 json={
                     'action': 'deploy',
                     'environment': 'staging',
-                    'committish': 'v6.4.0',
+                    'committish': 'abc1234',
+                    'ref_label': 'v6.4.0',
                 },
             )
         self.assertEqual(response.status_code, 202)
         self.assertTrue(response.json()['recorded'])
         self.mocks['append_deployment_event'].assert_called_once()
         call = self.mocks['append_deployment_event'].call_args
-        self.assertEqual(call.kwargs['version'], 'v6.4.0')
+        self.assertEqual(call.kwargs['release_id'], 'matched-release-id')
         self.assertEqual(call.kwargs['env_slug'], 'staging')
         self.assertEqual(call.kwargs['status'], 'in_progress')
         self.assertEqual(call.kwargs['external_run_id'], '42')
@@ -990,7 +999,7 @@ class ProjectDeploymentsTestCase(unittest.TestCase):
                 json={
                     'action': 'deploy',
                     'environment': 'testing',
-                    'committish': 'main',
+                    'committish': 'abc1234',
                     'ref_label': 'main',
                 },
             )
@@ -1006,7 +1015,10 @@ class ProjectDeploymentsTestCase(unittest.TestCase):
         self.assertEqual(row['entry_type'], 'Deployed')
         self.assertEqual(row['environment_slug'], 'testing')
         self.assertEqual(row['link'], 'https://gh/runs/42')
-        self.assertEqual(row['version'], 'main')
+        # ``ref_label='main'`` is not semver-shaped, so it's treated as
+        # a non-tag and the audit row's ``version`` falls back to the
+        # committish short SHA.
+        self.assertEqual(row['version'], 'abc1234')
         self.assertEqual(row['plugin_slug'], 'github-deployment')
 
     def test_promote_writes_operations_log_audit(self) -> None:
@@ -1067,14 +1079,15 @@ class ResyncProjectDeploymentsTestCase(ProjectDeploymentsTestCase):
         )
         self.mocks['release_exists'] = self._start(
             mock.patch(
-                f'{_MODULE}._release_exists',
-                return_value=release_exists,
+                f'{_MODULE}._release_id_for',
+                # Existing returns a release_id; missing returns None
+                return_value='existing-release-id' if release_exists else None,
             )
         )
         self.mocks['upsert_release_node'] = self._start(
             mock.patch(
                 f'{_MODULE}._upsert_release_node',
-                return_value=None,
+                return_value='upserted-release-id',
             )
         )
         if edge_status == 'missing':
@@ -1132,19 +1145,21 @@ class ResyncProjectDeploymentsTestCase(ProjectDeploymentsTestCase):
         self.assertEqual(data['releases_updated'], 0)
         self.assertEqual(data['events_recorded'], 1)
         self.assertEqual(data['errors'], [])
-        # Sha-style ref derives version from sha prefix (matches the
-        # gateway's create_release CEL expression).
+        # Sha-style ref produces (tag=None, committish=sha[:7]).
         upsert_call = self.mocks['upsert_release_node'].call_args
-        self.assertEqual(upsert_call.kwargs['version'], '2668cd0')
+        self.assertIsNone(upsert_call.kwargs['tag'])
+        self.assertEqual(upsert_call.kwargs['committish'], '2668cd0')
         append_call = self.mocks['append_deployment_event'].call_args
-        self.assertEqual(append_call.kwargs['version'], '2668cd0')
+        self.assertEqual(
+            append_call.kwargs['release_id'], 'upserted-release-id'
+        )
         self.assertEqual(
             append_call.kwargs['env_slug'], 'infrastructure-testing'
         )
         self.assertEqual(append_call.kwargs['external_run_id'], '12345')
         self.assertEqual(append_call.kwargs['timestamp'], observed.created_at)
 
-    def test_resync_uses_semver_ref_as_version(self) -> None:
+    def test_resync_uses_semver_ref_as_tag(self) -> None:
         self._arm(
             [self._observed(ref='v1.2.3', sha='deadbeefcafebabe')],
             release_exists=True,
@@ -1158,7 +1173,8 @@ class ResyncProjectDeploymentsTestCase(ProjectDeploymentsTestCase):
         self.assertEqual(data['releases_created'], 0)
         self.assertEqual(data['releases_updated'], 1)
         upsert_call = self.mocks['upsert_release_node'].call_args
-        self.assertEqual(upsert_call.kwargs['version'], 'v1.2.3')
+        self.assertEqual(upsert_call.kwargs['tag'], 'v1.2.3')
+        self.assertEqual(upsert_call.kwargs['committish'], 'deadbee')
 
     def test_resync_400_when_plugin_opts_out(self) -> None:
         # Override the resolved plugin to advertise the no-sync flavor.

--- a/tests/endpoints/test_projects_helpers.py
+++ b/tests/endpoints/test_projects_helpers.py
@@ -1,0 +1,305 @@
+"""Tests for project endpoint helper functions.
+
+Covers the private helpers added in the release-committish work:
+``_fetch_pr_counts``, ``_resolve_display_names``,
+``_fetch_current_releases`` and ``_resolve_release_identities``.
+"""
+
+import datetime
+import unittest
+from unittest import mock
+
+from imbi_api.endpoints import projects
+
+
+class FetchPrCountsTestCase(unittest.IsolatedAsyncioTestCase):
+    """Coverage for ``_fetch_pr_counts``."""
+
+    async def test_empty_project_ids_short_circuits(self) -> None:
+        self.assertEqual(await projects._fetch_pr_counts([]), {})
+
+    async def test_returns_counts_without_viewer(self) -> None:
+        rows = [
+            {
+                'project_id': 'p1',
+                'open_count': 3,
+                'closed_count': 1,
+                'viewer_open_count': 0,
+                'viewer_closed_count': 0,
+            }
+        ]
+        ch = mock.MagicMock()
+        ch.query = mock.AsyncMock(return_value=rows)
+        with mock.patch(
+            'imbi_api.endpoints.projects.ch_client.Clickhouse.get_instance',
+            return_value=ch,
+        ):
+            result = await projects._fetch_pr_counts(['p1'])
+        self.assertEqual(result, {'p1': (3, 1, 0, 0)})
+        # No viewer param when viewer is None
+        called_sql, called_params = ch.query.call_args.args
+        self.assertNotIn('viewer', called_params)
+        self.assertIn('0 AS viewer_open_count', called_sql)
+
+    async def test_returns_counts_with_viewer(self) -> None:
+        rows = [
+            {
+                'project_id': 'p1',
+                'open_count': 5,
+                'closed_count': 4,
+                'viewer_open_count': 2,
+                'viewer_closed_count': 1,
+            }
+        ]
+        ch = mock.MagicMock()
+        ch.query = mock.AsyncMock(return_value=rows)
+        with mock.patch(
+            'imbi_api.endpoints.projects.ch_client.Clickhouse.get_instance',
+            return_value=ch,
+        ):
+            result = await projects._fetch_pr_counts(
+                ['p1'], viewer='alice@example.com'
+            )
+        self.assertEqual(result, {'p1': (5, 4, 2, 1)})
+        called_sql, called_params = ch.query.call_args.args
+        self.assertEqual(called_params['viewer'], 'alice@example.com')
+        self.assertIn('viewer_open_count', called_sql)
+
+    async def test_swallows_clickhouse_errors(self) -> None:
+        ch = mock.MagicMock()
+        ch.query = mock.AsyncMock(side_effect=RuntimeError('boom'))
+        with mock.patch(
+            'imbi_api.endpoints.projects.ch_client.Clickhouse.get_instance',
+            return_value=ch,
+        ):
+            result = await projects._fetch_pr_counts(['p1'])
+        self.assertEqual(result, {})
+
+
+class ResolveDisplayNamesTestCase(unittest.IsolatedAsyncioTestCase):
+    """Coverage for ``_resolve_display_names``."""
+
+    async def test_empty_emails_short_circuits(self) -> None:
+        db = mock.AsyncMock()
+        self.assertEqual(await projects._resolve_display_names(db, []), {})
+        db.execute.assert_not_called()
+
+    async def test_returns_mapping(self) -> None:
+        db = mock.AsyncMock()
+        db.execute.return_value = [
+            {'email': 'a@example.com', 'display_name': 'Alice'},
+            {'email': 'b@example.com', 'display_name': 'Bob'},
+        ]
+        with mock.patch(
+            'imbi_api.endpoints.projects.graph.parse_agtype',
+            side_effect=lambda v: v,
+        ):
+            result = await projects._resolve_display_names(
+                db, ['a@example.com', 'b@example.com']
+            )
+        self.assertEqual(
+            result,
+            {'a@example.com': 'Alice', 'b@example.com': 'Bob'},
+        )
+
+    async def test_skips_rows_missing_fields(self) -> None:
+        db = mock.AsyncMock()
+        db.execute.return_value = [
+            {'email': 'a@example.com', 'display_name': None},
+            {'email': None, 'display_name': 'NoEmail'},
+            {'email': 'c@example.com', 'display_name': 'Carol'},
+        ]
+        with mock.patch(
+            'imbi_api.endpoints.projects.graph.parse_agtype',
+            side_effect=lambda v: v,
+        ):
+            result = await projects._resolve_display_names(
+                db, ['a@example.com', 'c@example.com']
+            )
+        self.assertEqual(result, {'c@example.com': 'Carol'})
+
+    async def test_swallows_db_errors(self) -> None:
+        db = mock.AsyncMock()
+        db.execute.side_effect = RuntimeError('graph down')
+        result = await projects._resolve_display_names(db, ['a@example.com'])
+        self.assertEqual(result, {})
+
+
+class ResolveReleaseIdentitiesTestCase(unittest.IsolatedAsyncioTestCase):
+    """Coverage for ``_resolve_release_identities``."""
+
+    async def test_empty_pairs_short_circuits(self) -> None:
+        db = mock.AsyncMock()
+        result = await projects._resolve_release_identities(db, [])
+        self.assertEqual(result, {})
+        db.execute.assert_not_called()
+
+    async def test_resolves_tag_and_committish(self) -> None:
+        db = mock.AsyncMock()
+        db.execute.return_value = [
+            {'project_id': 'p1', 'tag': '1.0.0', 'committish': 'abcdef0'},
+            {'project_id': 'p1', 'tag': None, 'committish': '1234567'},
+            {'project_id': 'p2', 'tag': '2.0.0', 'committish': 'fedcba9'},
+        ]
+        with mock.patch(
+            'imbi_api.endpoints.projects.graph.parse_agtype',
+            side_effect=lambda v: v,
+        ):
+            result = await projects._resolve_release_identities(
+                db,
+                [
+                    ('p1', '1.0.0'),  # matches by tag
+                    ('p1', '1234567'),  # matches by committish only
+                    ('p2', 'fedcba9'),  # matches by committish (has tag too)
+                    ('p2', 'not-there'),  # no match — omitted
+                ],
+            )
+        self.assertEqual(result[('p1', '1.0.0')], ('1.0.0', 'abcdef0'))
+        self.assertEqual(result[('p1', '1234567')], (None, '1234567'))
+        self.assertEqual(result[('p2', 'fedcba9')], ('2.0.0', 'fedcba9'))
+        self.assertNotIn(('p2', 'not-there'), result)
+
+    async def test_tag_wins_when_version_matches_both(self) -> None:
+        # A version equal to one release's tag AND another release's
+        # committish must resolve to the tagged release.
+        db = mock.AsyncMock()
+        db.execute.return_value = [
+            # Release A: has tag 'shared'
+            {'project_id': 'p1', 'tag': 'shared', 'committish': 'aaaaaaa'},
+            # Release B: has committish 'shared'
+            {'project_id': 'p1', 'tag': '1.2.3', 'committish': 'shared'},
+        ]
+        with mock.patch(
+            'imbi_api.endpoints.projects.graph.parse_agtype',
+            side_effect=lambda v: v,
+        ):
+            result = await projects._resolve_release_identities(
+                db, [('p1', 'shared')]
+            )
+        self.assertEqual(result[('p1', 'shared')], ('shared', 'aaaaaaa'))
+
+    async def test_skips_rows_with_non_string_project_id(self) -> None:
+        db = mock.AsyncMock()
+        db.execute.return_value = [
+            {'project_id': 12345, 'tag': '1.0.0', 'committish': 'abc'},
+        ]
+        with mock.patch(
+            'imbi_api.endpoints.projects.graph.parse_agtype',
+            side_effect=lambda v: v,
+        ):
+            result = await projects._resolve_release_identities(
+                db, [('12345', '1.0.0')]
+            )
+        self.assertEqual(result, {})
+
+    async def test_swallows_db_errors(self) -> None:
+        db = mock.AsyncMock()
+        db.execute.side_effect = RuntimeError('graph down')
+        result = await projects._resolve_release_identities(
+            db, [('p1', '1.0.0')]
+        )
+        self.assertEqual(result, {})
+
+
+class FetchCurrentReleasesTestCase(unittest.IsolatedAsyncioTestCase):
+    """Coverage for ``_fetch_current_releases``."""
+
+    async def test_empty_project_ids_short_circuits(self) -> None:
+        db = mock.AsyncMock()
+        result = await projects._fetch_current_releases(db, [])
+        self.assertEqual(result, {})
+
+    async def test_returns_release_info_per_env(self) -> None:
+        deployed = datetime.datetime(2026, 4, 1, 12, 0, 0, tzinfo=datetime.UTC)
+        ch_rows = [
+            {
+                'project_id': 'p1',
+                'environment_slug': 'prod',
+                'version': '1.0.0',
+                'performed_by': 'alice@example.com',
+                'deployed_at': deployed,
+            },
+            {
+                'project_id': 'p1',
+                'environment_slug': 'stage',
+                'version': '7654321',
+                'performed_by': None,
+                'deployed_at': deployed,
+            },
+        ]
+        ch = mock.MagicMock()
+        ch.query = mock.AsyncMock(return_value=ch_rows)
+
+        db = mock.AsyncMock()
+        db.execute.return_value = [
+            {'project_id': 'p1', 'tag': '1.0.0', 'committish': 'abcdef0'},
+            {'project_id': 'p1', 'tag': None, 'committish': '7654321'},
+        ]
+
+        with (
+            mock.patch(
+                'imbi_api.endpoints.projects.ch_client.Clickhouse.'
+                'get_instance',
+                return_value=ch,
+            ),
+            mock.patch(
+                'imbi_api.endpoints.projects.graph.parse_agtype',
+                side_effect=lambda v: v,
+            ),
+        ):
+            result = await projects._fetch_current_releases(db, ['p1'])
+
+        prod = result['p1']['prod']
+        stage = result['p1']['stage']
+        self.assertEqual(prod.tag, '1.0.0')
+        self.assertEqual(prod.committish, 'abcdef0')
+        self.assertEqual(prod.performed_by, 'alice@example.com')
+        self.assertEqual(prod.deployed_at, deployed)
+        self.assertIsNone(stage.tag)
+        self.assertEqual(stage.committish, '7654321')
+        self.assertIsNone(stage.performed_by)
+
+    async def test_missing_version_omits_release_identity(self) -> None:
+        deployed = datetime.datetime(2026, 4, 1, 12, 0, 0, tzinfo=datetime.UTC)
+        ch_rows = [
+            {
+                'project_id': 'p1',
+                'environment_slug': 'prod',
+                'version': '',
+                'performed_by': 'bob@example.com',
+                'deployed_at': deployed,
+            },
+        ]
+        ch = mock.MagicMock()
+        ch.query = mock.AsyncMock(return_value=ch_rows)
+
+        db = mock.AsyncMock()
+        db.execute.return_value = []
+
+        with (
+            mock.patch(
+                'imbi_api.endpoints.projects.ch_client.Clickhouse.'
+                'get_instance',
+                return_value=ch,
+            ),
+            mock.patch(
+                'imbi_api.endpoints.projects.graph.parse_agtype',
+                side_effect=lambda v: v,
+            ),
+        ):
+            result = await projects._fetch_current_releases(db, ['p1'])
+        info = result['p1']['prod']
+        self.assertIsNone(info.tag)
+        self.assertIsNone(info.committish)
+        self.assertEqual(info.performed_by, 'bob@example.com')
+
+    async def test_swallows_clickhouse_errors(self) -> None:
+        ch = mock.MagicMock()
+        ch.query = mock.AsyncMock(side_effect=RuntimeError('boom'))
+        db = mock.AsyncMock()
+        with mock.patch(
+            'imbi_api.endpoints.projects.ch_client.Clickhouse.get_instance',
+            return_value=ch,
+        ):
+            result = await projects._fetch_current_releases(db, ['p1'])
+        self.assertEqual(result, {})

--- a/tests/endpoints/test_pull_requests.py
+++ b/tests/endpoints/test_pull_requests.py
@@ -1,0 +1,181 @@
+"""Tests for the pull request read endpoints."""
+
+import datetime
+import typing
+import unittest
+from unittest import mock
+
+import fastapi.testclient
+from imbi_common import graph
+
+from imbi_api import app, models
+
+ORG = 'engineering'
+PROJECT_ID = 'proj123nanoid'
+
+
+def _pr_row(**overrides: typing.Any) -> dict[str, typing.Any]:
+    """Build a ClickHouse-shaped pull_requests row."""
+    data: dict[str, typing.Any] = {
+        'project_id': PROJECT_ID,
+        'pr_id': 'pr-1',
+        'pr_number': 42,
+        'title': 'Fix bug',
+        'url': 'https://github.com/example/repo/pull/42',
+        'state': 'open',
+        'author': 'alice',
+        'draft': False,
+        'merged': False,
+        # ClickHouse returns naive datetimes; the endpoint attaches
+        # UTC via ``_row_to_response``.
+        'created_at': datetime.datetime(2026, 4, 1, 12, 0, 0),  # noqa: DTZ001
+        'updated_at': datetime.datetime(2026, 4, 2, 12, 0, 0),  # noqa: DTZ001
+        'merged_at': None,
+        'additions': 5,
+        'deletions': 2,
+        'changed_files': 1,
+    }
+    data.update(overrides)
+    return data
+
+
+class _PullRequestsTestBase(unittest.TestCase):
+    """Shared setup mounting pull request endpoints with admin auth."""
+
+    permissions_granted: typing.ClassVar[set[str]] = {'project:read'}
+
+    def setUp(self) -> None:
+        from imbi_api.auth import permissions
+
+        self.test_app = app.create_app()
+
+        self.admin_user = models.User(
+            email='alice@example.com',
+            display_name='Alice',
+            password_hash='$argon2id$hashed',
+            is_active=True,
+            is_admin=True,
+            is_service_account=False,
+            created_at=datetime.datetime.now(datetime.UTC),
+        )
+        self.auth_context = permissions.AuthContext(
+            user=self.admin_user,
+            session_id='test-session',
+            auth_method='jwt',
+            permissions=self.permissions_granted,
+        )
+
+        async def _current_user() -> permissions.AuthContext:
+            return self.auth_context
+
+        self.test_app.dependency_overrides[permissions.get_current_user] = (
+            _current_user
+        )
+
+        self.mock_db = mock.AsyncMock(spec=graph.Graph)
+        self.test_app.dependency_overrides[graph._inject_graph] = lambda: (
+            self.mock_db
+        )
+        self.client = fastapi.testclient.TestClient(self.test_app)
+        self.addCleanup(self.client.close)
+
+
+class ListProjectPullRequestsTestCase(_PullRequestsTestBase):
+    """GET /organizations/{org}/projects/{pid}/pull-requests/"""
+
+    def _url(self, query: str = '') -> str:
+        base = f'/organizations/{ORG}/projects/{PROJECT_ID}/pull-requests/'
+        return f'{base}{query}'
+
+    def test_list_returns_prs_after_org_scope_check(self) -> None:
+        # First db.execute is the org->project_ids check; subsequent
+        # calls are ClickHouse, mocked separately.
+        self.mock_db.execute.return_value = [{'id': PROJECT_ID}]
+        with (
+            mock.patch(
+                'imbi_common.graph.parse_agtype',
+                side_effect=lambda x: x,
+            ),
+            mock.patch(
+                'imbi_api.endpoints.pull_requests.clickhouse.query',
+                new=mock.AsyncMock(
+                    side_effect=[
+                        [{'total': 1, 'project_count': 1}],
+                        [_pr_row()],
+                    ]
+                ),
+            ),
+        ):
+            response = self.client.get(self._url())
+        self.assertEqual(response.status_code, 200)
+        body = response.json()
+        self.assertEqual(body['total'], 1)
+        self.assertEqual(body['project_count'], 1)
+        self.assertEqual(len(body['data']), 1)
+        self.assertEqual(body['data'][0]['pr_number'], 42)
+
+    def test_list_404_when_project_not_in_org(self) -> None:
+        # Org scope check returns no rows → project_id not in org.
+        self.mock_db.execute.return_value = []
+        response = self.client.get(self._url())
+        self.assertEqual(response.status_code, 404)
+        self.assertIn('not found in organization', response.json()['detail'])
+
+    def test_list_400_on_invalid_limit(self) -> None:
+        self.mock_db.execute.return_value = [{'id': PROJECT_ID}]
+        response = self.client.get(self._url('?limit=0'))
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('limit must be', response.json()['detail'])
+
+    def test_list_400_on_negative_offset(self) -> None:
+        self.mock_db.execute.return_value = [{'id': PROJECT_ID}]
+        response = self.client.get(self._url('?offset=-1'))
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('offset must be >= 0', response.json()['detail'])
+
+
+class ListOrgPullRequestsTestCase(_PullRequestsTestBase):
+    """GET /organizations/{org}/pull-requests/"""
+
+    def _url(self, query: str = '') -> str:
+        return f'/organizations/{ORG}/pull-requests/{query}'
+
+    def test_list_empty_when_no_projects(self) -> None:
+        self.mock_db.execute.return_value = []
+        response = self.client.get(self._url())
+        self.assertEqual(response.status_code, 200)
+        body = response.json()
+        self.assertEqual(body['total'], 0)
+        self.assertEqual(body['project_count'], 0)
+        self.assertEqual(body['data'], [])
+
+    def test_list_returns_prs_across_org_projects(self) -> None:
+        self.mock_db.execute.return_value = [
+            {'id': PROJECT_ID},
+            {'id': 'proj-2'},
+        ]
+        with (
+            mock.patch(
+                'imbi_common.graph.parse_agtype',
+                side_effect=lambda x: x,
+            ),
+            mock.patch(
+                'imbi_api.endpoints.pull_requests.clickhouse.query',
+                new=mock.AsyncMock(
+                    side_effect=[
+                        [{'total': 2, 'project_count': 2}],
+                        [
+                            _pr_row(pr_id='pr-a', pr_number=1),
+                            _pr_row(pr_id='pr-b', pr_number=2),
+                        ],
+                    ]
+                ),
+            ),
+        ):
+            response = self.client.get(
+                self._url('?state=open&author=alice&limit=10&offset=0')
+            )
+        self.assertEqual(response.status_code, 200)
+        body = response.json()
+        self.assertEqual(body['total'], 2)
+        self.assertEqual(len(body['data']), 2)

--- a/tests/endpoints/test_releases.py
+++ b/tests/endpoints/test_releases.py
@@ -324,6 +324,7 @@ class PatchReleaseTestCase(_ReleasesTestBase):
     def test_patch_title(self) -> None:
         self.mock_db.execute.side_effect = [
             [{'release': _release_row()}],
+            [],  # _conflict_query — no collision
             [{'release': _release_row(title='Updated')}],
         ]
         with mock.patch(
@@ -342,6 +343,7 @@ class PatchReleaseTestCase(_ReleasesTestBase):
     def test_patch_description_and_links(self) -> None:
         self.mock_db.execute.side_effect = [
             [{'release': _release_row()}],
+            [],  # _conflict_query — no collision
             [
                 {
                     'release': _release_row(
@@ -392,6 +394,7 @@ class PatchReleaseTestCase(_ReleasesTestBase):
         """Explicit empty-string patches of ``title`` must persist."""
         self.mock_db.execute.side_effect = [
             [{'release': _release_row()}],
+            [],  # _conflict_query — no collision
             [{'release': _release_row(title='')}],
         ]
         with mock.patch(
@@ -408,7 +411,8 @@ class PatchReleaseTestCase(_ReleasesTestBase):
         self.assertEqual(response.json()['title'], '')
         # Confirm the SET clause received the empty string, not the old
         # title — i.e. the fix for truthiness-vs-presence is effective.
-        update_call = self.mock_db.execute.await_args_list[1]
+        # Index 2 = [fetch_release, conflict_query, update_query].
+        update_call = self.mock_db.execute.await_args_list[2]
         self.assertEqual(update_call.args[1]['title'], '')
 
     def test_patch_readonly_committish(self) -> None:
@@ -457,6 +461,28 @@ class PatchReleaseTestCase(_ReleasesTestBase):
                 ],
             )
         self.assertEqual(response.status_code, 404)
+
+    def test_patch_tag_collision_returns_409(self) -> None:
+        """Tagging a release with another release's ``(committish, tag)``
+        pair must 409 rather than silently creating an ambiguous pair."""
+        self.mock_db.execute.side_effect = [
+            [{'release': _release_row(tag=None)}],
+            # _conflict_query: another release on this SHA already has
+            # the target tag.
+            [{'id': 'other-release-id'}],
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            response = self.client.patch(
+                self._url(f'/{RELEASE_ID}'),
+                json=[
+                    {'op': 'replace', 'path': '/tag', 'value': 'v1.2.3'},
+                ],
+            )
+        self.assertEqual(response.status_code, 409)
+        self.assertIn('already exists', response.json()['detail'])
 
 
 class DeploymentEdgeTestCase(_ReleasesTestBase):

--- a/tests/endpoints/test_releases.py
+++ b/tests/endpoints/test_releases.py
@@ -16,10 +16,14 @@ RELEASE_ID = 'rel456nanoid'
 ORG = 'engineering'
 
 
+DEFAULT_COMMITTISH = 'abc1234'
+
+
 def _release_row(**overrides: typing.Any) -> dict[str, typing.Any]:
     data: dict[str, typing.Any] = {
         'id': RELEASE_ID,
-        'version': '1.2.3',
+        'tag': '1.2.3',
+        'committish': DEFAULT_COMMITTISH,
         'title': 'Initial release',
         'description': None,
         'links': json.dumps([]),
@@ -102,7 +106,8 @@ class CreateReleaseTestCase(_ReleasesTestBase):
             response = self.client.post(
                 self._url('/'),
                 json={
-                    'version': '1.2.3',
+                    'tag': '1.2.3',
+                    'committish': DEFAULT_COMMITTISH,
                     'title': 'Initial release',
                     'description': 'First cut',
                     'links': [
@@ -116,7 +121,8 @@ class CreateReleaseTestCase(_ReleasesTestBase):
 
         self.assertEqual(response.status_code, 201)
         body = response.json()
-        self.assertEqual(body['version'], '1.2.3')
+        self.assertEqual(body['tag'], '1.2.3')
+        self.assertEqual(body['committish'], DEFAULT_COMMITTISH)
         self.assertEqual(body['project_id'], PROJECT_ID)
         self.assertEqual(body['id'], RELEASE_ID)
         self.assertEqual(body['created_by'], 'alice@example.com')
@@ -140,7 +146,8 @@ class CreateReleaseTestCase(_ReleasesTestBase):
             response = self.client.post(
                 self._url('/'),
                 json={
-                    'version': '1.2.3',
+                    'tag': '1.2.3',
+                    'committish': DEFAULT_COMMITTISH,
                     'title': 'Initial release',
                     'created_by': 'deploy-bot',
                 },
@@ -156,7 +163,11 @@ class CreateReleaseTestCase(_ReleasesTestBase):
         ):
             response = self.client.post(
                 self._url('/'),
-                json={'version': '1.0.0', 'title': 'x'},
+                json={
+                    'tag': '1.0.0',
+                    'committish': DEFAULT_COMMITTISH,
+                    'title': 'x',
+                },
             )
         self.assertEqual(response.status_code, 404)
 
@@ -171,7 +182,11 @@ class CreateReleaseTestCase(_ReleasesTestBase):
         ):
             response = self.client.post(
                 self._url('/'),
-                json={'version': '1.2.3', 'title': 'x'},
+                json={
+                    'tag': '1.2.3',
+                    'committish': DEFAULT_COMMITTISH,
+                    'title': 'x',
+                },
             )
         self.assertEqual(response.status_code, 409)
 
@@ -194,25 +209,41 @@ class CreateReleaseTestCase(_ReleasesTestBase):
         ):
             response = self.client.post(
                 self._url('/'),
-                json={'version': '1.2.3', 'title': 'x'},
+                json={
+                    'tag': '1.2.3',
+                    'committish': DEFAULT_COMMITTISH,
+                    'title': 'x',
+                },
             )
         self.assertEqual(response.status_code, 201)
 
     def test_create_two_releases_commitish_then_semver(self) -> None:
-        """Create both a commitish and a semver release for one project.
-
-        ``version_format`` is fixed at process start, so this test does
-        not flip it mid-run.
-        """
+        """Create commitish-only + tagged releases for one project."""
         self.mock_db.execute.side_effect = [
-            # First create: 214e932
+            # First create: commitish-only
             [{'id': PROJECT_ID}],
             [],
-            [{'release': _release_row(version='214e932', id='rel-commitish')}],
-            # Second create: 2.2.0
+            [
+                {
+                    'release': _release_row(
+                        tag=None,
+                        committish='214e932',
+                        id='rel-commitish',
+                    )
+                }
+            ],
+            # Second create: tagged
             [{'id': PROJECT_ID}],
             [],
-            [{'release': _release_row(version='2.2.0', id='rel-semver')}],
+            [
+                {
+                    'release': _release_row(
+                        tag='2.2.0',
+                        committish=DEFAULT_COMMITTISH,
+                        id='rel-semver',
+                    )
+                }
+            ],
         ]
         with (
             mock.patch(
@@ -226,19 +257,25 @@ class CreateReleaseTestCase(_ReleasesTestBase):
         ):
             first = self.client.post(
                 self._url('/'),
-                json={'version': '214e932', 'title': 'commitish build'},
+                json={'committish': '214e932', 'title': 'commitish build'},
             )
             second = self.client.post(
                 self._url('/'),
-                json={'version': '2.2.0', 'title': 'semver release'},
+                json={
+                    'tag': '2.2.0',
+                    'committish': DEFAULT_COMMITTISH,
+                    'title': 'semver release',
+                },
             )
 
         self.assertEqual(first.status_code, 201)
-        self.assertEqual(first.json()['version'], '214e932')
+        self.assertEqual(first.json()['tag'], None)
+        self.assertEqual(first.json()['committish'], '214e932')
         self.assertEqual(first.json()['id'], 'rel-commitish')
 
         self.assertEqual(second.status_code, 201)
-        self.assertEqual(second.json()['version'], '2.2.0')
+        self.assertEqual(second.json()['tag'], '2.2.0')
+        self.assertEqual(second.json()['committish'], DEFAULT_COMMITTISH)
         self.assertEqual(second.json()['id'], 'rel-semver')
 
 
@@ -247,8 +284,8 @@ class ListGetReleaseTestCase(_ReleasesTestBase):
 
     def test_list_releases(self) -> None:
         self.mock_db.execute.return_value = [
-            {'release': _release_row(version='1.0.0', id='a')},
-            {'release': _release_row(version='1.1.0', id='b')},
+            {'release': _release_row(tag='1.0.0', id='a')},
+            {'release': _release_row(tag='1.1.0', id='b')},
         ]
         with mock.patch(
             'imbi_common.graph.parse_agtype',
@@ -258,7 +295,7 @@ class ListGetReleaseTestCase(_ReleasesTestBase):
         self.assertEqual(response.status_code, 200)
         data = response.json()
         self.assertEqual(len(data), 2)
-        self.assertEqual(data[0]['version'], '1.0.0')
+        self.assertEqual(data[0]['tag'], '1.0.0')
         self.assertEqual(data[0]['project_id'], PROJECT_ID)
 
     def test_get_release_success(self) -> None:
@@ -267,9 +304,9 @@ class ListGetReleaseTestCase(_ReleasesTestBase):
             'imbi_common.graph.parse_agtype',
             side_effect=lambda x: x,
         ):
-            response = self.client.get(self._url('/1.2.3'))
+            response = self.client.get(self._url(f'/{RELEASE_ID}'))
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json()['version'], '1.2.3')
+        self.assertEqual(response.json()['tag'], '1.2.3')
 
     def test_get_release_not_found(self) -> None:
         self.mock_db.execute.return_value = []
@@ -277,12 +314,12 @@ class ListGetReleaseTestCase(_ReleasesTestBase):
             'imbi_common.graph.parse_agtype',
             side_effect=lambda x: x,
         ):
-            response = self.client.get(self._url('/9.9.9'))
+            response = self.client.get(self._url('/missing-id'))
         self.assertEqual(response.status_code, 404)
 
 
 class PatchReleaseTestCase(_ReleasesTestBase):
-    """PATCH /releases/{version}"""
+    """PATCH /releases/{release_id}"""
 
     def test_patch_title(self) -> None:
         self.mock_db.execute.side_effect = [
@@ -294,7 +331,7 @@ class PatchReleaseTestCase(_ReleasesTestBase):
             side_effect=lambda x: x,
         ):
             response = self.client.patch(
-                self._url('/1.2.3'),
+                self._url(f'/{RELEASE_ID}'),
                 json=[
                     {'op': 'replace', 'path': '/title', 'value': 'Updated'},
                 ],
@@ -327,7 +364,7 @@ class PatchReleaseTestCase(_ReleasesTestBase):
             side_effect=lambda x: x,
         ):
             response = self.client.patch(
-                self._url('/1.2.3'),
+                self._url(f'/{RELEASE_ID}'),
                 json=[
                     {
                         'op': 'replace',
@@ -362,7 +399,7 @@ class PatchReleaseTestCase(_ReleasesTestBase):
             side_effect=lambda x: x,
         ):
             response = self.client.patch(
-                self._url('/1.2.3'),
+                self._url(f'/{RELEASE_ID}'),
                 json=[
                     {'op': 'replace', 'path': '/title', 'value': ''},
                 ],
@@ -374,16 +411,20 @@ class PatchReleaseTestCase(_ReleasesTestBase):
         update_call = self.mock_db.execute.await_args_list[1]
         self.assertEqual(update_call.args[1]['title'], '')
 
-    def test_patch_readonly_version(self) -> None:
+    def test_patch_readonly_committish(self) -> None:
         self.mock_db.execute.side_effect = [[{'release': _release_row()}]]
         with mock.patch(
             'imbi_common.graph.parse_agtype',
             side_effect=lambda x: x,
         ):
             response = self.client.patch(
-                self._url('/1.2.3'),
+                self._url(f'/{RELEASE_ID}'),
                 json=[
-                    {'op': 'replace', 'path': '/version', 'value': '2.0.0'},
+                    {
+                        'op': 'replace',
+                        'path': '/committish',
+                        'value': 'deadbee',
+                    },
                 ],
             )
         self.assertEqual(response.status_code, 400)
@@ -396,7 +437,7 @@ class PatchReleaseTestCase(_ReleasesTestBase):
             side_effect=lambda x: x,
         ):
             response = self.client.patch(
-                self._url('/1.2.3'),
+                self._url(f'/{RELEASE_ID}'),
                 json=[
                     {'op': 'replace', 'path': '/bogus', 'value': 'x'},
                 ],
@@ -410,7 +451,7 @@ class PatchReleaseTestCase(_ReleasesTestBase):
             side_effect=lambda x: x,
         ):
             response = self.client.patch(
-                self._url('/1.2.3'),
+                self._url(f'/{RELEASE_ID}'),
                 json=[
                     {'op': 'replace', 'path': '/title', 'value': 'x'},
                 ],
@@ -436,7 +477,7 @@ class DeploymentEdgeTestCase(_ReleasesTestBase):
             side_effect=lambda x: x,
         ):
             response = self.client.post(
-                self._url('/1.2.3/environments/production'),
+                self._url(f'/{RELEASE_ID}/environments/production'),
                 json={'status': 'pending'},
             )
         self.assertEqual(response.status_code, 200)
@@ -469,7 +510,7 @@ class DeploymentEdgeTestCase(_ReleasesTestBase):
             side_effect=lambda x: x,
         ):
             response = self.client.post(
-                self._url('/1.2.3/environments/production'),
+                self._url(f'/{RELEASE_ID}/environments/production'),
                 json={'status': 'success', 'note': 'rolled out'},
             )
         self.assertEqual(response.status_code, 200)
@@ -487,7 +528,7 @@ class DeploymentEdgeTestCase(_ReleasesTestBase):
             side_effect=lambda x: x,
         ):
             response = self.client.post(
-                self._url('/1.2.3/environments/ghost'),
+                self._url(f'/{RELEASE_ID}/environments/ghost'),
                 json={'status': 'pending'},
             )
         self.assertEqual(response.status_code, 422)
@@ -499,7 +540,7 @@ class DeploymentEdgeTestCase(_ReleasesTestBase):
             side_effect=lambda x: x,
         ):
             response = self.client.post(
-                self._url('/9.9.9/environments/production'),
+                self._url('/missing-id/environments/production'),
                 json={'status': 'pending'},
             )
         self.assertEqual(response.status_code, 404)
@@ -532,7 +573,7 @@ class DeploymentEdgeTestCase(_ReleasesTestBase):
             side_effect=lambda x: x,
         ):
             response = self.client.get(
-                self._url('/1.2.3/environments'),
+                self._url(f'/{RELEASE_ID}/environments'),
             )
         self.assertEqual(response.status_code, 200)
         data = response.json()
@@ -550,7 +591,7 @@ class DeploymentEdgeTestCase(_ReleasesTestBase):
             side_effect=lambda x: x,
         ):
             response = self.client.get(
-                self._url('/1.2.3/environments/production'),
+                self._url(f'/{RELEASE_ID}/environments/production'),
             )
         self.assertEqual(response.status_code, 404)
 
@@ -573,7 +614,7 @@ class DeploymentEdgeTestCase(_ReleasesTestBase):
             side_effect=lambda x: x,
         ):
             response = self.client.get(
-                self._url('/1.2.3/environments/production'),
+                self._url(f'/{RELEASE_ID}/environments/production'),
             )
         self.assertEqual(response.status_code, 200)
         body = response.json()
@@ -614,7 +655,7 @@ class AppendDeploymentEventDedupeTestCase(_ReleasesTestBase):
                     self.mock_db,
                     org_slug=ORG,
                     project_id=PROJECT_ID,
-                    version='1.2.3',
+                    release_id=RELEASE_ID,
                     env_slug='production',
                     status=typing.cast(typing.Any, status),
                     note=note,
@@ -755,14 +796,14 @@ class CurrentReleasesTestCase(_ReleasesTestBase):
             [
                 {
                     'env': self._env('production', sort_order=30),
-                    'release': _release_row(version='1.0.0', id='r1'),
+                    'release': _release_row(tag='1.0.0', id='r1'),
                     'deployments': self._events(
                         ('2026-04-20T10:00:00+00:00', 'success'),
                     ),
                 },
                 {
                     'env': self._env('production', sort_order=30),
-                    'release': _release_row(version='1.1.0', id='r2'),
+                    'release': _release_row(tag='1.1.0', id='r2'),
                     'deployments': self._events(
                         ('2026-04-22T10:00:00+00:00', 'success'),
                     ),
@@ -777,7 +818,7 @@ class CurrentReleasesTestCase(_ReleasesTestBase):
         self.assertEqual(response.status_code, 200)
         data = response.json()
         self.assertEqual(len(data), 1)
-        self.assertEqual(data[0]['release']['version'], '1.1.0')
+        self.assertEqual(data[0]['release']['tag'], '1.1.0')
         self.assertEqual(data[0]['current_status'], 'success')
         self.assertEqual(data[0]['last_event_at'], '2026-04-22T10:00:00Z')
 
@@ -789,7 +830,7 @@ class CurrentReleasesTestCase(_ReleasesTestBase):
             [
                 {
                     'env': self._env('production'),
-                    'release': _release_row(version='1.0.0', id='r1'),
+                    'release': _release_row(tag='1.0.0', id='r1'),
                     'deployments': self._events(
                         ('2026-04-20T10:00:00+00:00', 'success'),
                         ('2026-04-23T10:00:00+00:00', 'success'),
@@ -797,7 +838,7 @@ class CurrentReleasesTestCase(_ReleasesTestBase):
                 },
                 {
                     'env': self._env('production'),
-                    'release': _release_row(version='1.1.0', id='r2'),
+                    'release': _release_row(tag='1.1.0', id='r2'),
                     'deployments': self._events(
                         ('2026-04-22T10:00:00+00:00', 'success'),
                         (
@@ -815,7 +856,7 @@ class CurrentReleasesTestCase(_ReleasesTestBase):
             response = self.client.get(self._url('/current'))
         self.assertEqual(response.status_code, 200)
         data = response.json()
-        self.assertEqual(data[0]['release']['version'], '1.0.0')
+        self.assertEqual(data[0]['release']['tag'], '1.0.0')
         self.assertEqual(data[0]['current_status'], 'success')
 
     def test_sorts_by_environment_sort_order(self) -> None:
@@ -825,17 +866,17 @@ class CurrentReleasesTestCase(_ReleasesTestBase):
             [
                 {
                     'env': self._env('production', sort_order=30),
-                    'release': _release_row(version='1.0.0', id='r1'),
+                    'release': _release_row(tag='1.0.0', id='r1'),
                     'deployments': events,
                 },
                 {
                     'env': self._env('testing', sort_order=10),
-                    'release': _release_row(version='1.0.0', id='r1'),
+                    'release': _release_row(tag='1.0.0', id='r1'),
                     'deployments': events,
                 },
                 {
                     'env': self._env('staging', sort_order=20),
-                    'release': _release_row(version='1.0.0', id='r1'),
+                    'release': _release_row(tag='1.0.0', id='r1'),
                     'deployments': events,
                 },
             ],
@@ -855,7 +896,7 @@ class CurrentReleasesTestCase(_ReleasesTestBase):
             [
                 {
                     'env': self._env('production', sort_order=30),
-                    'release': _release_row(version='1.0.0', id='r1'),
+                    'release': _release_row(tag='1.0.0', id='r1'),
                     'deployments': self._events(
                         ('2026-04-20T10:00:00+00:00', 'success'),
                     ),
@@ -877,7 +918,7 @@ class CurrentReleasesTestCase(_ReleasesTestBase):
         self.assertEqual(len(data), 2)
         by_slug = {row['environment']['slug']: row for row in data}
         self.assertIsNone(by_slug['testing']['release'])
-        self.assertEqual(by_slug['production']['release']['version'], '1.0.0')
+        self.assertEqual(by_slug['production']['release']['tag'], '1.0.0')
 
 
 class CurrentReleasesHydrationTestCase(_ReleasesTestBase):
@@ -962,7 +1003,7 @@ class CurrentReleasesHydrationTestCase(_ReleasesTestBase):
             [
                 {
                     'env': self._env('production', sort_order=30),
-                    'release': _release_row(version='1.0.0', id='r1'),
+                    'release': _release_row(tag='1.0.0', id='r1'),
                     'deployments': self._events_with_run(
                         '2026-04-20T10:00:00+00:00', 'success'
                     ),
@@ -998,7 +1039,7 @@ class CurrentReleasesHydrationTestCase(_ReleasesTestBase):
             [
                 {
                     'env': self._env('production', sort_order=30),
-                    'release': _release_row(version='1.0.0', id='r1'),
+                    'release': _release_row(tag='1.0.0', id='r1'),
                     'deployments': self._events_with_run(
                         '2026-04-20T10:00:00+00:00',
                         'in_progress',
@@ -1010,7 +1051,7 @@ class CurrentReleasesHydrationTestCase(_ReleasesTestBase):
             # The persistence path does additional db.execute calls
             # (re-fetch release, edge MATCH, SET).  Provide enough
             # truthy results so append_deployment_event can land.
-            [{'release': _release_row(version='1.0.0', id='r1')}],
+            [{'release': _release_row(tag='1.0.0', id='r1')}],
             [{'env': self._env('production'), 'deployments': None}],
             [{'deployments': '[]'}],
         ]
@@ -1036,7 +1077,7 @@ class CurrentReleasesHydrationTestCase(_ReleasesTestBase):
             [
                 {
                     'env': self._env('production', sort_order=30),
-                    'release': _release_row(version='1.0.0', id='r1'),
+                    'release': _release_row(tag='1.0.0', id='r1'),
                     'deployments': self._events_with_run(
                         '2026-04-20T10:00:00+00:00', 'success'
                     ),
@@ -1066,7 +1107,7 @@ class CurrentReleasesHydrationTestCase(_ReleasesTestBase):
             [
                 {
                     'env': self._env('production', sort_order=30),
-                    'release': _release_row(version='1.0.0', id='r1'),
+                    'release': _release_row(tag='1.0.0', id='r1'),
                     'deployments': self._events_with_run(
                         '2026-04-20T10:00:00+00:00',
                         'in_progress',


### PR DESCRIPTION
## Summary
- Add read-only pull request endpoints and surface PR counts on the project list
- Migrate release endpoints and underlying queries to the new tag/committish identity model
- Enrich the project list with current releases and `performed_by` (display name with email fallback)
- Extend AuthContext with user identity connections so PR ownership can be attributed to the viewer
- Speed up `_resolve_release_identities` by joining in Python

## Test plan
- [ ] Verify pull request endpoints return data and respect the new author filter
- [ ] Confirm `/projects` returns `open_pr_count`, `viewer_open_pr_count`, `current_releases`, and `performed_by`
- [ ] Confirm releases identified by tag/committish round-trip via the API
- [ ] Confirm display name falls back to the local-part of the email when no name is set
- [ ] Run the unit tests for releases, deployment, and activity endpoints