### PR TITLE
Fix 500 on API key auth (missing RETURN in SET query)

### DIFF
--- a/src/imbi_api/auth/permissions.py
+++ b/src/imbi_api/auth/permissions.py
@@ -312,9 +312,12 @@ async def _stamp_api_key_last_used(db: graph.Graph, key_id: str) -> None:
     "Entity failed to be updated" error.
     """
     now = datetime.datetime.now(datetime.UTC).isoformat()
-    await db.execute(
+    query: typing.LiteralString = (
         'MATCH (k:APIKey {{key_id: {key_id}}})'
-        ' SET k.last_used = {now} RETURN k',
+        ' SET k.last_used = {now} RETURN k'
+    )
+    await db.execute(
+        query,
         {'key_id': key_id, 'now': now},
         columns=['k'],
     )

--- a/src/imbi_api/auth/permissions.py
+++ b/src/imbi_api/auth/permissions.py
@@ -304,6 +304,22 @@ async def authenticate_jwt(
     )
 
 
+async def _stamp_api_key_last_used(db: graph.Graph, key_id: str) -> None:
+    """Set last_used on the APIKey node identified by key_id.
+
+    AGE's cypher() wrapper requires a RETURN clause to properly
+    finalize a write operation — omitting it causes an internal
+    "Entity failed to be updated" error.
+    """
+    now = datetime.datetime.now(datetime.UTC).isoformat()
+    await db.execute(
+        'MATCH (k:APIKey {{key_id: {key_id}}})'
+        ' SET k.last_used = {now} RETURN k',
+        {'key_id': key_id, 'now': now},
+        columns=['k'],
+    )
+
+
 async def authenticate_api_key(
     db: graph.Graph,
     key: str,
@@ -407,11 +423,7 @@ async def authenticate_api_key(
         filtered = all_perms.intersection(set(scopes)) if scopes else all_perms
 
         # Update last_used only after all validation passes
-        now = datetime.datetime.now(datetime.UTC).isoformat()
-        update_query = (
-            'MATCH (k:APIKey {{key_id: {key_id}}}) SET k.last_used = {now}'
-        )
-        await db.execute(update_query, {'key_id': key_id, 'now': now})
+        await _stamp_api_key_last_used(db, key_id)
 
         return AuthContext(
             service_account=sa,
@@ -433,11 +445,7 @@ async def authenticate_api_key(
     identities = await _load_user_identities(db, user.id)
 
     # Update last_used only after all validation passes
-    now = datetime.datetime.now(datetime.UTC).isoformat()
-    update_query = (
-        'MATCH (k:APIKey {{key_id: {key_id}}}) SET k.last_used = {now}'
-    )
-    await db.execute(update_query, {'key_id': key_id, 'now': now})
+    await _stamp_api_key_last_used(db, key_id)
 
     return AuthContext(
         user=user,


### PR DESCRIPTION
## Summary

- Adds `RETURN k` to the `MATCH...SET k.last_used` Cypher query used when stamping an API key's last-used timestamp
- Extracts the duplicated update logic into a `_stamp_api_key_last_used()` helper (called from both the service-account and user code paths)

## Problem

Every authenticated request using an API key ended with a 500:

```
psycopg.errors.InternalError_: Entity failed to be updated: 3
```

Apache AGE's `cypher()` wrapper requires a `RETURN` clause to properly finalize a write operation. The `MATCH...SET` had no `RETURN`, so AGE couldn't complete the heap update. Every other write in the codebase (`merge`, `create`, `delete`) already ends with `RETURN n` — this was the only exception.

## Solution

Add `RETURN k` and pass `columns=['k']` to `db.execute()`. The result is discarded; the clause is only needed to satisfy AGE's write protocol.

## Test plan

- [ ] Authenticate with an API key and confirm the request no longer returns 500
- [ ] Confirm `last_used` is updated on the APIKey node after a successful request

Closes #314

🤖 Generated with [Claude Code](https://claude.com/claude-code)