### PR TITLE
Make _stamp_api_key_last_used best-effort to prevent auth failures

### DIFF
--- a/src/imbi_api/auth/permissions.py
+++ b/src/imbi_api/auth/permissions.py
@@ -324,7 +324,11 @@ async def _stamp_api_key_last_used(db: graph.Graph, key_id: str) -> None:
             columns=['k'],
         )
     except Exception:  # noqa: BLE001
-        LOGGER.warning('Failed to stamp last_used for API key %s', key_id)
+        LOGGER.warning(
+            'Failed to stamp last_used for API key %s',
+            key_id,
+            exc_info=True,
+        )
 
 
 async def authenticate_api_key(

--- a/src/imbi_api/auth/permissions.py
+++ b/src/imbi_api/auth/permissions.py
@@ -309,18 +309,22 @@ async def _stamp_api_key_last_used(db: graph.Graph, key_id: str) -> None:
 
     AGE's cypher() wrapper requires a RETURN clause to properly
     finalize a write operation — omitting it causes an internal
-    "Entity failed to be updated" error.
+    "Entity failed to be updated" error. Failures are logged and
+    swallowed: the stamp is best-effort and must not fail authentication.
     """
     now = datetime.datetime.now(datetime.UTC).isoformat()
     query: typing.LiteralString = (
         'MATCH (k:APIKey {{key_id: {key_id}}})'
         ' SET k.last_used = {now} RETURN k'
     )
-    await db.execute(
-        query,
-        {'key_id': key_id, 'now': now},
-        columns=['k'],
-    )
+    try:
+        await db.execute(
+            query,
+            {'key_id': key_id, 'now': now},
+            columns=['k'],
+        )
+    except Exception:  # noqa: BLE001
+        LOGGER.warning('Failed to stamp last_used for API key %s', key_id)
 
 
 async def authenticate_api_key(


### PR DESCRIPTION
## Summary
- `_stamp_api_key_last_used` now catches and logs exceptions rather than propagating them
- AGE sporadically raises `psycopg.errors.InternalError_: Entity failed to be updated` on the SET query even with a RETURN clause, which was crashing every API key authenticated request
- The stamp is audit-only (recording `last_used` timestamp) — authentication has already fully passed by the time it runs, so a failure here should never break the request

## Problem
After deploying 2.5.0, all API key auth requests were failing with:
```
psycopg.errors.InternalError_: Entity failed to be updated: 3
```
The exception propagated out of `_stamp_api_key_last_used` and surfaced as a 500 to callers.

## Solution
Wrap the AGE write in a `try/except` and log a warning on failure, matching the same pattern already used in `_load_user_identities`. The `last_used` timestamp is best-effort observability data, not a correctness requirement.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)