### PR TITLE
Fix KeyError on missing Release.committish in current-releases endpoint

### DIFF
--- a/src/imbi_api/endpoints/releases.py
+++ b/src/imbi_api/endpoints/releases.py
@@ -87,7 +87,7 @@ class ReleaseResponse(pydantic.BaseModel):
     id: str
     project_id: str
     tag: str | None = None
-    committish: str
+    committish: str | None = None
     title: str
     description: str | None = None
     links: list[models.ReleaseLink] = []
@@ -204,7 +204,7 @@ def _release_to_response(
             'id': data['id'],
             'project_id': project_id,
             'tag': data.get('tag'),
-            'committish': data['committish'],
+            'committish': data.get('committish'),
             'title': data['title'],
             'description': data.get('description'),
             'links': raw_links,


### PR DESCRIPTION
## Summary

- ``_release_to_response`` accessed ``data['committish']`` against an
  AGE row dict. AGE's ``r{.*}`` projection only includes properties
  that are actually set, so any Release node missing ``committish``
  crashed ``GET /organizations/{org}/projects/{id}/releases/current``
  with a ``KeyError`` (Sentry IMBI-1P).
- Switches that single access to ``data.get('committish')`` and
  relaxes ``ReleaseResponse.committish`` from ``str`` to ``str | None``
  to match the dict shape. The release-train path at line ~311 already
  uses the defensive form.
- Surgical: doesn't touch the patch/conflict paths that have the same
  pattern (they fire on a different code path and aren't in the
  Sentry signal).

Fixes #320

## Test plan

- [x] ``just lint`` (basedpyright + mypy)
- [x] 39 tests in ``tests/endpoints/test_releases.py`` pass
- [ ] In prod-like data, verify ``GET .../releases/current`` returns
      Releases with ``committish: null`` rather than 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)