### PR TITLE
Retry AGE 'Entity failed to be updated' on project PATCH

### DIFF
--- a/src/imbi_api/endpoints/projects.py
+++ b/src/imbi_api/endpoints/projects.py
@@ -1722,24 +1722,43 @@ async def _execute_project_update(
         + _RETURN_FRAGMENT
     )
 
-    try:
-        updated = await db.execute(
-            update_query,
-            {
-                'project_id': project_id,
-                'org_slug': org_slug,
-                **props,
-                'new_team_slug': data.team_slug or '',
-                'new_type_slugs': data.project_type_slugs or [],
-                **new_env_params,
-            },
-            ['project', 'outbound_count', 'inbound_count'],
-        )
-    except psycopg.errors.UniqueViolation as e:
-        raise fastapi.HTTPException(
-            status_code=409,
-            detail=str(e),
-        ) from e
+    update_params: dict[str, typing.Any] = {
+        'project_id': project_id,
+        'org_slug': org_slug,
+        **props,
+        'new_team_slug': data.team_slug or '',
+        'new_type_slugs': data.project_type_slugs or [],
+        **new_env_params,
+    }
+    # AGE sporadically raises "Entity failed to be updated" on
+    # multi-stage MATCH/SET queries even when the entity exists.
+    # The error is non-deterministic and resolves on retry, so wrap
+    # the update in a short bounded retry loop.  ``UniqueViolation``
+    # is a real conflict and is surfaced as 409 immediately.
+    updated: list[dict[str, typing.Any]] = []
+    for attempt in range(3):
+        try:
+            updated = await db.execute(
+                update_query,
+                update_params,
+                ['project', 'outbound_count', 'inbound_count'],
+            )
+            break
+        except psycopg.errors.UniqueViolation as e:
+            raise fastapi.HTTPException(
+                status_code=409,
+                detail=str(e),
+            ) from e
+        except psycopg.errors.InternalError as e:
+            if 'Entity failed to be updated' not in str(e) or attempt == 2:
+                raise
+            LOGGER.warning(
+                'AGE update retry %d/3 for project %r: %s',
+                attempt + 1,
+                project_id,
+                e,
+            )
+            await asyncio.sleep(0.05 * (attempt + 1))
 
     if not updated:
         raise fastapi.HTTPException(

--- a/tests/endpoints/test_projects.py
+++ b/tests/endpoints/test_projects.py
@@ -721,7 +721,9 @@ class ProjectEndpointsTestCase(unittest.TestCase):
         ]
 
         with (
-            mock.patch('imbi_api.endpoints.projects.asyncio.sleep'),
+            mock.patch(
+                'imbi_api.endpoints.projects.asyncio.sleep'
+            ) as mock_sleep,
             mock.patch('imbi_common.blueprints.get_model') as mock_get_model,
             mock.patch(
                 'imbi_common.graph.parse_agtype', side_effect=lambda x: x
@@ -733,6 +735,9 @@ class ProjectEndpointsTestCase(unittest.TestCase):
                 f'/organizations/engineering/projects/{PROJECT_ID}',
                 json=[{'op': 'replace', 'path': '/name', 'value': 'Updated'}],
             )
+
+        self.assertEqual(self.mock_db.execute.call_count, 6)
+        self.assertEqual(mock_sleep.await_count, 2)
 
     def test_patch_project_other_internal_error_not_retried(self) -> None:
         """Non-AGE InternalError propagates without retry."""

--- a/tests/endpoints/test_projects.py
+++ b/tests/endpoints/test_projects.py
@@ -674,6 +674,89 @@ class ProjectEndpointsTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 409)
         self.assertIn('already exists', response.json()['detail'])
 
+    def test_patch_project_retries_age_entity_update_error(self) -> None:
+        """AGE 'Entity failed to be updated' is retried, eventually
+        succeeds."""
+        existing = self._project_data()
+        updated_row = {
+            'project': existing,
+            'outbound_count': 0,
+            'inbound_count': 0,
+        }
+        self.mock_db.execute.side_effect = [
+            [{'project': existing, 'outbound_count': 0, 'inbound_count': 0}],
+            [{'slug': 'platform'}],
+            [{'pt_slug': 'api-service', 'found': True}],
+            psycopg.errors.InternalError('Entity failed to be updated: 3'),
+            [updated_row],  # retry succeeds
+        ]
+
+        with (
+            mock.patch('imbi_api.endpoints.projects.asyncio.sleep'),
+            mock.patch('imbi_common.blueprints.get_model') as mock_get_model,
+            mock.patch(
+                'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+            ),
+        ):
+            mock_get_model.return_value = models.Project
+
+            response = self.client.patch(
+                f'/organizations/engineering/projects/{PROJECT_ID}',
+                json=[{'op': 'replace', 'path': '/name', 'value': 'Updated'}],
+            )
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_patch_project_age_update_error_exhausted(self) -> None:
+        """AGE 'Entity failed to be updated' that persists is raised after
+        three attempts."""
+        existing = self._project_data()
+        self.mock_db.execute.side_effect = [
+            [{'project': existing, 'outbound_count': 0, 'inbound_count': 0}],
+            [{'slug': 'platform'}],
+            [{'pt_slug': 'api-service', 'found': True}],
+            psycopg.errors.InternalError('Entity failed to be updated: 3'),
+            psycopg.errors.InternalError('Entity failed to be updated: 3'),
+            psycopg.errors.InternalError('Entity failed to be updated: 3'),
+        ]
+
+        with (
+            mock.patch('imbi_api.endpoints.projects.asyncio.sleep'),
+            mock.patch('imbi_common.blueprints.get_model') as mock_get_model,
+            mock.patch(
+                'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+            ),
+            self.assertRaises(psycopg.errors.InternalError),
+        ):
+            mock_get_model.return_value = models.Project
+            self.client.patch(
+                f'/organizations/engineering/projects/{PROJECT_ID}',
+                json=[{'op': 'replace', 'path': '/name', 'value': 'Updated'}],
+            )
+
+    def test_patch_project_other_internal_error_not_retried(self) -> None:
+        """Non-AGE InternalError propagates without retry."""
+        existing = self._project_data()
+        self.mock_db.execute.side_effect = [
+            [{'project': existing, 'outbound_count': 0, 'inbound_count': 0}],
+            [{'slug': 'platform'}],
+            [{'pt_slug': 'api-service', 'found': True}],
+            psycopg.errors.InternalError('some other error'),
+        ]
+
+        with (
+            mock.patch('imbi_common.blueprints.get_model') as mock_get_model,
+            mock.patch(
+                'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+            ),
+            self.assertRaises(psycopg.errors.InternalError),
+        ):
+            mock_get_model.return_value = models.Project
+            self.client.patch(
+                f'/organizations/engineering/projects/{PROJECT_ID}',
+                json=[{'op': 'replace', 'path': '/name', 'value': 'Updated'}],
+            )
+
     def test_patch_project_concurrent_delete(self) -> None:
         """Patch when update query returns empty returns 404."""
         existing = self._project_data()


### PR DESCRIPTION
## Summary

- ``PATCH /organizations/{org}/projects/{id}`` sporadically 500s
  with ``psycopg.InternalError: Entity failed to be updated: 3``
  (Sentry IMBI-1Q / #322). The error is non-deterministic AGE
  behavior on multi-stage MATCH/SET queries — the same root cause
  that ``_stamp_api_key_last_used`` worked around in commit
  ``bbda477``.
- Here the write is load-bearing, so the swallow trick from #321
  doesn't apply. Instead, wraps the ``db.execute`` call in
  ``_execute_project_update`` in a bounded 3-attempt retry with
  short backoff (50 / 100 / — ms), matched specifically on the
  ``"Entity failed to be updated"`` message substring. Any other
  ``InternalError`` propagates on the first attempt.
- ``psycopg.errors.UniqueViolation`` continues to surface as 409
  immediately — it is a real conflict, not a flake.

Fixes #322

## Test plan

- [x] ``just lint`` (basedpyright + mypy) clean
- [x] ``tests/endpoints/test_projects.py`` — 45 tests pass, including
      three new cases:
  - ``test_patch_project_retries_age_entity_update_error`` — retry
    succeeds on second attempt
  - ``test_patch_project_age_update_error_exhausted`` — exhausts
    after 3 attempts and re-raises
  - ``test_patch_project_other_internal_error_not_retried`` —
    non-AGE ``InternalError`` propagates without retry
- [ ] Monitor Sentry IMBI-1Q rate after deploy; if it keeps firing
      with this fingerprint despite retries, the root cause is more
      severe than a transient flake and the AGE upgrade path becomes
      the next step

## Notes

- Issue #321 (same error class in ``_stamp_api_key_last_used``)
  is already fixed by ``bbda477``/``eb6ce68``, both in 2.5.1+. That
  Sentry event came from a 2.5.0 deploy and should not reappear
  once 2.5.1+ is running.
- If this retry pattern proves valuable on other write paths
  (releases, deployments), it can be lifted into a small helper
  later — keeping it inline for now to avoid premature abstraction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)