### PR TITLE
Preserve original deployer on resync

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
   "fastapi",
   "filetype",
   "httpx>=0.28.1,<1",
-  "imbi-common[databases,llm,sentry,server]>=2.5.3",
+  "imbi-common[databases,llm,sentry,server]>=2.5.5",
   "jinja2",
   "jsonpatch>=1.33",
   "nanoid>=2.0.0",

--- a/src/imbi_api/endpoints/project_deployments.py
+++ b/src/imbi_api/endpoints/project_deployments.py
@@ -621,7 +621,6 @@ async def resync_for_project(
                 db,
                 org_slug=org_slug,
                 project_id=project_id,
-                project_slug=ctx.project_slug,
                 plugin_slug=resolved.plugin_slug,
                 recorded_by=auth.principal_name,
                 observed=observed,
@@ -655,14 +654,20 @@ async def _apply_remote_deployment(
     *,
     org_slug: str,
     project_id: str,
-    project_slug: str,
     plugin_slug: str,
     recorded_by: str,
     observed: RemoteDeployment,
     summary: ResyncSummary,
     seen_identities: set[tuple[str, str | None]],
 ) -> None:
-    """Persist one observed remote deployment + audit row.
+    """Persist one observed remote deployment.
+
+    Writes the ``Release`` node + ``DeploymentEvent`` on the
+    ``DEPLOYED_TO`` edge.  No ``operations_log`` audit row is written
+    here -- resync backfills historical activity, and attributing it to
+    the resync operator poisons ``argMax(performed_by, occurred_at)``
+    queries.  The edge's ``DeploymentEvent.performed_by`` carries the
+    original deployer when the plugin can resolve one.
 
     ``seen_identities`` is mutated to track which
     ``(committish, tag)`` pairs have already been counted against
@@ -710,6 +715,7 @@ async def _apply_remote_deployment(
         external_run_id=observed.external_run_id,
         external_run_url=observed.run_url,
         timestamp=observed.created_at,
+        performed_by=observed.creator,
     )
     if result is None:
         # Either the Release upsert didn't take or the env slug isn't
@@ -738,19 +744,13 @@ async def _apply_remote_deployment(
         summary.events_skipped += 1
     else:
         summary.events_recorded += 1
-    await _record_deployment_audit(
-        project_id=project_id,
-        project_slug=project_slug,
-        environment_slug=observed.environment,
-        recorded_by=recorded_by,
-        action='resync',
-        tag=tag,
-        committish=committish,
-        plugin_slug=plugin_slug,
-        run_url=observed.run_url,
-        external_run_id=observed.external_run_id,
-        release_url=observed.deployment_url,
-    )
+    # Intentionally no operations_log audit row here: resync backfills
+    # historical remote deployments, so attributing them to the resync
+    # operator poisons ``argMax(performed_by, occurred_at)`` lookups
+    # (e.g. the "Current Deployments" column on /projects). The
+    # ``DEPLOYED_TO`` edge already carries the original creator via
+    # ``DeploymentEvent.performed_by``; in-product deploy/promote
+    # actions still get their own audit row written by their handlers.
 
 
 # ---------------------------------------------------------------------------

--- a/src/imbi_api/endpoints/releases.py
+++ b/src/imbi_api/endpoints/releases.py
@@ -885,6 +885,7 @@ async def append_deployment_event(
     external_run_id: str | None = None,
     external_run_url: str | None = None,
     timestamp: datetime.datetime | None = None,
+    performed_by: str | None = None,
 ) -> tuple[ReleaseEnvironmentEdgeResponse, AppendOutcome] | None:
     """Append a ``DeploymentEvent`` to ``Release -[:DEPLOYED_TO]-> Env``.
 
@@ -909,6 +910,12 @@ async def append_deployment_event(
 
     ``timestamp`` lets the resync flow record the remote's deployment
     creation time rather than ``now()``; defaults to now when omitted.
+
+    ``performed_by`` records the original deployer when the event is
+    being backfilled from a remote (e.g. ``deployment.creator.login``
+    from GitHub during resync). Deploy/promote flows can leave this
+    ``None`` -- those code paths already attribute the operator via
+    ``operations_log``.
     """
     release = await _fetch_release(db, org_slug, project_id, release_id)
     if release is None:
@@ -931,6 +938,7 @@ async def append_deployment_event(
                     candidate.status == status
                     and candidate.note == note
                     and candidate.external_run_url == external_run_url
+                    and candidate.performed_by == performed_by
                 ):
                     return _edge_to_response(env, existing), 'noop'
                 refreshed = candidate.model_copy(
@@ -940,6 +948,7 @@ async def append_deployment_event(
                         'external_run_url': external_run_url,
                         'timestamp': timestamp
                         or datetime.datetime.now(datetime.UTC),
+                        'performed_by': performed_by,
                     }
                 )
                 updated_list = [
@@ -962,6 +971,7 @@ async def append_deployment_event(
         note=note,
         external_run_id=external_run_id,
         external_run_url=external_run_url,
+        performed_by=performed_by,
     )
     deployments = [*existing, event]
     if existing:

--- a/tests/endpoints/test_project_deployments.py
+++ b/tests/endpoints/test_project_deployments.py
@@ -1117,6 +1117,7 @@ class ResyncProjectDeploymentsTestCase(ProjectDeploymentsTestCase):
         sha: str = '2668cd0abcdef',
         status: str = 'success',
         external_run_id: str = '12345',
+        creator: str | None = 'octocat',
     ) -> RemoteDeployment:
         return RemoteDeployment(
             environment=environment,
@@ -1132,6 +1133,7 @@ class ResyncProjectDeploymentsTestCase(ProjectDeploymentsTestCase):
                 'https://api.github.com/repos/octo/demo/deployments/12345'
             ),
             description='Bump foo',
+            creator=creator,
         )
 
     def test_resync_persists_release_and_event_for_sha(self) -> None:
@@ -1225,7 +1227,16 @@ class ResyncProjectDeploymentsTestCase(ProjectDeploymentsTestCase):
         )
         self.assertEqual(data['events_recorded'], 0)
 
-    def test_resync_writes_audit_per_environment(self) -> None:
+    def test_resync_does_not_write_operations_log_audit(self) -> None:
+        """Resync must not poison ``argMax(performed_by, occurred_at)``.
+
+        Backfilling historical remote deployments through the
+        ``operations_log`` would attribute every event to whoever
+        clicked "Resync", overriding the v1-migrated rows that already
+        carry the real deployer.  The ``DEPLOYED_TO`` edge alone
+        carries the event during resync; in-product deploy / promote
+        flows still write their own audit rows.
+        """
         self._arm([self._observed()])
         with testclient.TestClient(self.test_app) as client:
             response = client.post(
@@ -1233,18 +1244,18 @@ class ResyncProjectDeploymentsTestCase(ProjectDeploymentsTestCase):
             )
         self.assertEqual(response.status_code, 200, response.text)
         ch = self.mocks['clickhouse'].return_value
-        ch.insert.assert_awaited_once()
-        args, _kwargs = ch.insert.call_args
-        cols = args[2]
-        row = dict(zip(cols, args[1][0], strict=False))
-        self.assertEqual(row['entry_type'], 'Deployed')
-        self.assertEqual(row['environment_slug'], 'infrastructure-testing')
-        self.assertEqual(row['version'], '2668cd0')
-        description = row['description']
-        if isinstance(description, str):
-            import json as _json
+        ch.insert.assert_not_awaited()
 
-            self.assertEqual(_json.loads(description)['action'], 'resync')
+    def test_resync_threads_creator_to_performed_by(self) -> None:
+        """``observed.creator`` becomes ``DeploymentEvent.performed_by``."""
+        self._arm([self._observed(creator='octocat')])
+        with testclient.TestClient(self.test_app) as client:
+            response = client.post(
+                '/organizations/myorg/projects/proj1/deployments/resync'
+            )
+        self.assertEqual(response.status_code, 200, response.text)
+        append_call = self.mocks['append_deployment_event'].call_args
+        self.assertEqual(append_call.kwargs['performed_by'], 'octocat')
 
     def test_resync_requires_write_permission(self) -> None:
         non_admin = models.User(

--- a/tests/endpoints/test_releases.py
+++ b/tests/endpoints/test_releases.py
@@ -727,6 +727,7 @@ class AppendDeploymentEventDedupeTestCase(_ReleasesTestBase):
         external_run_id: str | None,
         status: str = 'success',
         note: str | None = None,
+        performed_by: str | None = None,
     ) -> typing.Any:
         import asyncio
 
@@ -757,6 +758,7 @@ class AppendDeploymentEventDedupeTestCase(_ReleasesTestBase):
                     note=note,
                     external_run_id=external_run_id,
                     external_run_url='https://gh/runs/42',
+                    performed_by=performed_by,
                 )
             )
 
@@ -830,6 +832,53 @@ class AppendDeploymentEventDedupeTestCase(_ReleasesTestBase):
         )
         self.assertEqual(outcome, 'appended')
         self.assertEqual(len(edge.deployments), 2)
+
+    def test_performed_by_change_refreshes_in_place(self) -> None:
+        """A new ``performed_by`` for the same run triggers a refresh.
+
+        Resync replaying a deployment after a plugin upgrade can now
+        supply a creator login it didn't have before; the dedupe path
+        must treat that as a change so the edge picks up the new
+        attribution rather than no-op'ing on identical-looking rows.
+        """
+        existing = [
+            {
+                'timestamp': '2026-05-13T14:00:00+00:00',
+                'status': 'success',
+                'note': None,
+                'external_run_id': '42',
+                'external_run_url': 'https://gh/runs/42',
+                'performed_by': None,
+            }
+        ]
+        edge, outcome = self._call(
+            existing,
+            external_run_id='42',
+            status='success',
+            performed_by='octocat',
+        )
+        self.assertEqual(outcome, 'updated')
+        self.assertEqual(edge.deployments[0].performed_by, 'octocat')
+
+    def test_performed_by_match_is_no_op(self) -> None:
+        existing = [
+            {
+                'timestamp': '2026-05-13T14:00:00+00:00',
+                'status': 'success',
+                'note': None,
+                'external_run_id': '42',
+                'external_run_url': 'https://gh/runs/42',
+                'performed_by': 'octocat',
+            }
+        ]
+        edge, outcome = self._call(
+            existing,
+            external_run_id='42',
+            status='success',
+            performed_by='octocat',
+        )
+        self.assertEqual(outcome, 'noop')
+        self.assertEqual(edge.deployments[0].performed_by, 'octocat')
 
 
 class CurrentReleasesTestCase(_ReleasesTestBase):

--- a/uv.lock
+++ b/uv.lock
@@ -959,7 +959,7 @@ wheels = [
 
 [[package]]
 name = "imbi-api"
-version = "2.4.0"
+version = "2.5.1"
 source = { editable = "." }
 dependencies = [
   { name = "aioboto3" },
@@ -1034,7 +1034,7 @@ requires-dist = [
   { name = "fastapi" },
   { name = "filetype" },
   { name = "httpx", specifier = ">=0.28.1,<1" },
-  { name = "imbi-common", extras = ["databases", "llm", "sentry", "server"], specifier = ">=2.5.3" },
+  { name = "imbi-common", extras = ["databases", "llm", "sentry", "server"], specifier = ">=2.5.5" },
   { name = "jinja2" },
   { name = "jsonpatch", specifier = ">=1.33" },
   { name = "nanoid", specifier = ">=2.0.0" },
@@ -1087,7 +1087,7 @@ plugins = [
 
 [[package]]
 name = "imbi-common"
-version = "2.5.3"
+version = "2.5.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
   { name = "cryptography" },
@@ -1103,9 +1103,9 @@ dependencies = [
   { name = "python-slugify" },
   { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3a/a4/925d4524170a451c4ec109af083191c5bffed64086e33f171b17eeca458d/imbi_common-2.5.3.tar.gz", hash = "sha256:ee7500e8787008c831232b804a0fa7d2373b3e329aa7b7b736a1713082bd32c1", size = 276944, upload-time = "2026-05-19T18:27:33.638Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/b7/6dab7155b281f9c075d3434e3f234ef217fe49db840b14e59e3e5a75faa2/imbi_common-2.5.5.tar.gz", hash = "sha256:56751efe31fdc1fcb1d1be19e6b3f073d5b3e4fda3c89c0bcdec5c7943549477", size = 277481, upload-time = "2026-05-20T02:10:09.044Z" }
 wheels = [
-  { url = "https://files.pythonhosted.org/packages/b3/4b/bcd5c211fd04c294c077ed9ade6be8b8ffd3872414d2b720bbdf496efb7c/imbi_common-2.5.3-py3-none-any.whl", hash = "sha256:5f7573717d34953369b6b8d1b300dfdbe95319c7e2880d3401994c1ef2acbf64", size = 90672, upload-time = "2026-05-19T18:27:32.184Z" },
+  { url = "https://files.pythonhosted.org/packages/48/04/69e72ec3a1968a9dd8b91df38e6a7be16e1399a054a953777a23f34c60ca/imbi_common-2.5.5-py3-none-any.whl", hash = "sha256:19ffa23d9cdb0b8065af1d3a9166f819c15414fc4b5707d089adaf64b932ebf1", size = 91154, upload-time = "2026-05-20T02:10:07.448Z" },
 ]
 
 [package.optional-dependencies]
@@ -1154,7 +1154,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
   { name = "httpx", specifier = ">=0.27" },
-  { name = "imbi-common", specifier = ">=2.3.0" },
+  { name = "imbi-common", specifier = ">=2.5.5" },
   { name = "pydantic", specifier = ">=2" },
 ]
 


### PR DESCRIPTION
## Summary
- `append_deployment_event` takes a new optional `performed_by` kwarg and persists it on the `DeploymentEvent` written to the `DEPLOYED_TO` edge.
- `_apply_remote_deployment` passes `RemoteDeployment.creator` (the GitHub deployment creator) into that new kwarg, and **no longer writes an `operations_log` audit row** during resync.
- `project_slug` is dropped from `_apply_remote_deployment` (only the removed audit call used it).

## Why
The "Current Deployments" column on `/projects` reads `performed_by` from `operations_log` via `argMax(performed_by, occurred_at)`. The github-deployment-ec plugin's resync was inserting one fresh `Deployed` audit row per observed deployment, attributing every historical event to whoever clicked "Resync" — so every project ended up displaying the resync operator instead of the actual deployer. Removing the audit row keeps the v1-migrated rows as the latest entry; capturing `performed_by` on the `DeploymentEvent` preserves the original deployer on the edge itself for future surfaces. In-product `deploy` / `promote` actions still write their own audit rows (and those code paths already attribute the operator correctly).

## Dependencies
- **imbi-common 2.5.5** (`DeploymentEvent.performed_by`, `RemoteDeployment.creator`) — PR: AWeber-Imbi/imbi-common#126
- **imbi-plugin-github** (extracts `deployment.creator.login`) — PR: AWeber-Imbi/imbi-plugin-github#17

This PR should land after the imbi-common release and the lock bump.

## Test plan
- [ ] CI passes once imbi-common 2.5.5 is in the lockfile
- [ ] Trigger a resync against a project with non-`gavinr` recent deployments and confirm the `Current Deployments` column on `/projects` shows the original deployers
- [ ] Inspect `operations_log` after resync: zero new `Deployed` rows from the resync action; v1-migrated `argMax` results remain latest
- [ ] An in-product deploy still writes one `Deployed` audit row attributed to the clicker

## Cleanup
Three legacy `action: resync` rows remain in production operations_log. Drop them with:
```sql
ALTER TABLE operations_log DELETE
WHERE entry_type = 'Deployed'
  AND id NOT LIKE 'v1-%'
  AND JSONExtractString(description, 'action') = 'resync';
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)