### PR TITLE
Read projects-list current releases from AGE, not operations_log

### DIFF
--- a/src/imbi_api/endpoints/projects.py
+++ b/src/imbi_api/endpoints/projects.py
@@ -364,36 +364,49 @@ async def _resolve_display_names(
     }
 
 
-async def _fetch_current_releases(
-    db: graph.Graph,
-    project_ids: list[str],
-) -> dict[str, dict[str, ReleaseInfo]]:
-    """Return {project_id: {env_slug: ReleaseInfo}} for current releases.
+def _parse_deployment_events(
+    raw: typing.Any,
+) -> list[models.DeploymentEvent]:
+    """Parse the JSON-encoded ``deployments`` edge property."""
+    if not raw:
+        return []
+    data = json.loads(raw) if isinstance(raw, str) else raw
+    if not isinstance(data, list):
+        return []
+    items: list[typing.Any] = data  # type: ignore[assignment]
+    out: list[models.DeploymentEvent] = []
+    for item in items:
+        try:
+            out.append(models.DeploymentEvent.model_validate(item))
+        except pydantic.ValidationError:
+            continue
+    return out
 
-    ClickHouse tells us which release ``version`` string is currently
-    deployed per (project, environment). The Release node itself
-    carries the structured ``tag`` + ``committish`` fields, so we
-    join back to AGE with a single bulk query keyed on
-    ``(project_id, version)`` — matching ``r.tag = version`` for
-    tagged releases and ``r.committish = version`` for raw-SHA
-    deploys. The ops_log writer (see
-    ``project_deployments._record_deployment_audit``) stores
-    ``tag if tag else committish`` in ``version``, so the ``OR``
-    branch is exhaustive in normal data.
 
-    Errors are swallowed — release data is best-effort.
+async def _lookup_ops_log_performed_by(
+    targets: list[tuple[str, str, str]],
+) -> dict[tuple[str, str, str], str]:
+    """Map ``(project_id, environment_slug, version)`` → ``performed_by``.
+
+    Backfills the deployer for releases whose
+    ``DeploymentEvent.performed_by`` on the AGE edge is null.
+    The in-product deploy/promote handlers intentionally leave that
+    field empty because the audit row in ``operations_log`` already
+    carries the operator (see
+    ``project_deployments._record_deployment_audit``).
+
+    Errors are swallowed — performer attribution is best-effort.
     """
-    if not project_ids:
+    if not targets:
         return {}
+    project_ids = sorted({t[0] for t in targets})
     sql = (
-        'SELECT project_id, environment_slug,'
-        ' argMax(version, occurred_at) AS version,'
-        ' argMax(performed_by, occurred_at) AS performed_by,'
-        ' max(occurred_at) AS deployed_at'
+        'SELECT project_id, environment_slug, version,'
+        ' argMax(performed_by, occurred_at) AS performed_by'
         ' FROM operations_log FINAL'
         " WHERE entry_type = 'Deployed'"
         ' AND project_id IN {project_ids:Array(String)}'
-        ' GROUP BY project_id, environment_slug'
+        ' GROUP BY project_id, environment_slug, version'
     )
     try:
         rows = await ch_client.Clickhouse.get_instance().query(
@@ -401,101 +414,132 @@ async def _fetch_current_releases(
         )
     except Exception:  # noqa: BLE001
         LOGGER.warning(
-            'Failed to fetch current releases for projects', exc_info=True
+            'Failed to enrich performed_by from operations_log',
+            exc_info=True,
         )
         return {}
-    # First pass: collect rows and the (project_id, version) pairs we
-    # need to translate to (tag, committish).
-    rows_list = list(rows)
-    pairs = sorted(
-        {
-            (str(r['project_id']), str(r['version']))
-            for r in rows_list
-            if r.get('version')
-        }
-    )
-    identity_by_pair = await _resolve_release_identities(db, pairs)
-    result: dict[str, dict[str, ReleaseInfo]] = {}
-    for r in rows_list:
-        pid = str(r['project_id'])
-        env_slug = str(r['environment_slug'])
-        version_value = str(r['version']) if r.get('version') else ''
-        tag, committish = identity_by_pair.get(
-            (pid, version_value), (None, None)
+    target_keys = set(targets)
+    result: dict[tuple[str, str, str], str] = {}
+    for row in rows:
+        key = (
+            str(row.get('project_id') or ''),
+            str(row.get('environment_slug') or ''),
+            str(row.get('version') or ''),
         )
-        result.setdefault(pid, {})[env_slug] = ReleaseInfo(
-            tag=tag,
-            committish=committish,
-            performed_by=r.get('performed_by') or None,
-            deployed_at=r['deployed_at'],
-        )
+        performed_by = row.get('performed_by')
+        if performed_by and key in target_keys:
+            result[key] = str(performed_by)
     return result
 
 
-async def _resolve_release_identities(
+async def _fetch_current_releases(
     db: graph.Graph,
-    pairs: list[tuple[str, str]],
-) -> dict[tuple[str, str], tuple[str | None, str | None]]:
-    """Look up ``(tag, committish)`` for each ``(project_id, version)`` pair.
+    project_ids: list[str],
+) -> dict[str, dict[str, ReleaseInfo]]:
+    """Return {project_id: {env_slug: ReleaseInfo}} for current releases.
 
-    Fetches every release for the projects involved in one bulk
-    Cypher query, then joins against ``pairs`` in Python. Avoids
-    the cross-product scan that an inline UNWIND + ``OR`` filter
-    would force per pair (no tag/committish indexes exist, so each
-    pair would otherwise walk every Release for its project).
+    Reads from the AGE graph — the same source the project-detail
+    ``/releases/current`` endpoint uses — so both views agree.  For
+    each project we walk every
+    ``(p)-[:HAS_RELEASE]->(r:Release)-[d:DEPLOYED_TO]->(e:Environment)``
+    edge and pick the release whose latest ``DeploymentEvent``
+    has the most recent ``timestamp`` per environment.
 
-    When a ``(project_id, version)`` matches both a release's
-    ``tag`` and another release's ``committish``, the tag match
-    wins so the human-readable label stays canonical.
+    ``performed_by`` on each ``DeploymentEvent`` is populated for
+    resync-sourced events but is intentionally null for in-product
+    deploy/promote actions (which capture the operator on the
+    ``operations_log`` audit row instead).  For those rows we look
+    up the deployer in ``operations_log`` keyed on
+    ``(project_id, environment_slug, version)`` — where ``version``
+    is ``tag if tag else committish``, matching the audit writer.
+
+    Errors are swallowed — release data is best-effort.
     """
-    if not pairs:
+    if not project_ids:
         return {}
-    project_ids = sorted({pid for pid, _ in pairs})
     query: typing.LiteralString = """
     MATCH (p:Project)-[:HAS_RELEASE]->(r:Release)
+                    -[d:DEPLOYED_TO]->(e:Environment)
     WHERE p.id IN {project_ids}
-    RETURN p.id AS project_id, r.tag AS tag, r.committish AS committish
+    RETURN p.id AS project_id,
+           e.slug AS env_slug,
+           r.tag AS tag,
+           r.committish AS committish,
+           d.deployments AS deployments
     """
     try:
         rows = await db.execute(
             query,
             {'project_ids': project_ids},
-            ['project_id', 'tag', 'committish'],
+            ['project_id', 'env_slug', 'tag', 'committish', 'deployments'],
         )
     except Exception:  # noqa: BLE001
         LOGGER.warning(
-            'Failed to resolve release identities from the graph',
-            exc_info=True,
+            'Failed to fetch current releases for projects', exc_info=True
         )
         return {}
 
-    # Build two indexes per project: tag → (tag, committish) and
-    # committish → (tag, committish). The tag index wins for lookup
-    # so a ``version`` that happens to match both indexes resolves
-    # to the tagged release.
-    by_tag: dict[tuple[str, str], tuple[str | None, str | None]] = {}
-    by_committish: dict[tuple[str, str], tuple[str | None, str | None]] = {}
+    # For each (project_id, env_slug), keep the (release, event) pair
+    # with the latest event timestamp.
+    latest: dict[
+        tuple[str, str],
+        tuple[str | None, str | None, datetime.datetime, str | None],
+    ] = {}
     for row in rows:
         pid = graph.parse_agtype(row.get('project_id'))
+        env_slug = graph.parse_agtype(row.get('env_slug'))
+        if not isinstance(pid, str) or not isinstance(env_slug, str):
+            continue
+        events = _parse_deployment_events(
+            graph.parse_agtype(row.get('deployments'))
+        )
+        if not events:
+            continue
+        event = max(events, key=lambda e: e.timestamp)
         tag_val = graph.parse_agtype(row.get('tag'))
         committish_val = graph.parse_agtype(row.get('committish'))
-        if not isinstance(pid, str):
-            continue
         tag = str(tag_val) if tag_val else None
         committish = str(committish_val) if committish_val else None
-        identity = (tag, committish)
-        if tag:
-            by_tag.setdefault((pid, tag), identity)
-        if committish:
-            by_committish.setdefault((pid, committish), identity)
+        key = (pid, env_slug)
+        existing = latest.get(key)
+        if existing is None or event.timestamp > existing[2]:
+            latest[key] = (
+                tag,
+                committish,
+                event.timestamp,
+                event.performed_by,
+            )
 
-    result: dict[tuple[str, str], tuple[str | None, str | None]] = {}
-    for pid, version in pairs:
-        key = (pid, version)
-        if key in by_tag:
-            result[key] = by_tag[key]
-        elif key in by_committish:
-            result[key] = by_committish[key]
+    # Backfill performed_by from operations_log for events whose
+    # AGE edge left it null (in-product deploy/promote path).
+    enrich_targets = [
+        (pid, env_slug, str(tag or committish or ''))
+        for (pid, env_slug), (
+            tag,
+            committish,
+            _ts,
+            performed_by,
+        ) in latest.items()
+        if performed_by is None and (tag or committish)
+    ]
+    performed_by_by_key = await _lookup_ops_log_performed_by(enrich_targets)
+    if performed_by_by_key:
+        for key, (tag, committish, ts, performed_by) in list(latest.items()):
+            if performed_by is not None:
+                continue
+            version = str(tag or committish or '')
+            looked_up = performed_by_by_key.get((key[0], key[1], version))
+            if looked_up:
+                latest[key] = (tag, committish, ts, looked_up)
+
+    result: dict[str, dict[str, ReleaseInfo]] = {}
+    for (pid, env_slug), (tag, committish, ts, performed_by) in latest.items():
+        result.setdefault(pid, {})[env_slug] = ReleaseInfo(
+            tag=tag,
+            committish=committish,
+            performed_by=performed_by,
+            deployed_at=ts,
+        )
     return result
 
 

--- a/tests/endpoints/test_projects_helpers.py
+++ b/tests/endpoints/test_projects_helpers.py
@@ -2,10 +2,11 @@
 
 Covers the private helpers added in the release-committish work:
 ``_fetch_pr_counts``, ``_resolve_display_names``,
-``_fetch_current_releases`` and ``_resolve_release_identities``.
+``_fetch_current_releases`` and ``_lookup_ops_log_performed_by``.
 """
 
 import datetime
+import json
 import unittest
 from unittest import mock
 
@@ -125,116 +126,80 @@ class ResolveDisplayNamesTestCase(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result, {})
 
 
-class ResolveReleaseIdentitiesTestCase(unittest.IsolatedAsyncioTestCase):
-    """Coverage for ``_resolve_release_identities``."""
+def _event(
+    timestamp: datetime.datetime,
+    *,
+    status: str = 'success',
+    performed_by: str | None = None,
+) -> dict[str, object]:
+    payload: dict[str, object] = {
+        'timestamp': timestamp.isoformat(),
+        'status': status,
+    }
+    if performed_by is not None:
+        payload['performed_by'] = performed_by
+    return payload
 
-    async def test_empty_pairs_short_circuits(self) -> None:
-        db = mock.AsyncMock()
-        result = await projects._resolve_release_identities(db, [])
-        self.assertEqual(result, {})
-        db.execute.assert_not_called()
 
-    async def test_resolves_tag_and_committish(self) -> None:
-        db = mock.AsyncMock()
-        db.execute.return_value = [
-            {'project_id': 'p1', 'tag': '1.0.0', 'committish': 'abcdef0'},
-            {'project_id': 'p1', 'tag': None, 'committish': '1234567'},
-            {'project_id': 'p2', 'tag': '2.0.0', 'committish': 'fedcba9'},
-        ]
-        with mock.patch(
-            'imbi_api.endpoints.projects.graph.parse_agtype',
-            side_effect=lambda v: v,
-        ):
-            result = await projects._resolve_release_identities(
-                db,
-                [
-                    ('p1', '1.0.0'),  # matches by tag
-                    ('p1', '1234567'),  # matches by committish only
-                    ('p2', 'fedcba9'),  # matches by committish (has tag too)
-                    ('p2', 'not-there'),  # no match — omitted
-                ],
-            )
-        self.assertEqual(result[('p1', '1.0.0')], ('1.0.0', 'abcdef0'))
-        self.assertEqual(result[('p1', '1234567')], (None, '1234567'))
-        self.assertEqual(result[('p2', 'fedcba9')], ('2.0.0', 'fedcba9'))
-        self.assertNotIn(('p2', 'not-there'), result)
-
-    async def test_tag_wins_when_version_matches_both(self) -> None:
-        # A version equal to one release's tag AND another release's
-        # committish must resolve to the tagged release.
-        db = mock.AsyncMock()
-        db.execute.return_value = [
-            # Release A: has tag 'shared'
-            {'project_id': 'p1', 'tag': 'shared', 'committish': 'aaaaaaa'},
-            # Release B: has committish 'shared'
-            {'project_id': 'p1', 'tag': '1.2.3', 'committish': 'shared'},
-        ]
-        with mock.patch(
-            'imbi_api.endpoints.projects.graph.parse_agtype',
-            side_effect=lambda v: v,
-        ):
-            result = await projects._resolve_release_identities(
-                db, [('p1', 'shared')]
-            )
-        self.assertEqual(result[('p1', 'shared')], ('shared', 'aaaaaaa'))
-
-    async def test_skips_rows_with_non_string_project_id(self) -> None:
-        db = mock.AsyncMock()
-        db.execute.return_value = [
-            {'project_id': 12345, 'tag': '1.0.0', 'committish': 'abc'},
-        ]
-        with mock.patch(
-            'imbi_api.endpoints.projects.graph.parse_agtype',
-            side_effect=lambda v: v,
-        ):
-            result = await projects._resolve_release_identities(
-                db, [('12345', '1.0.0')]
-            )
-        self.assertEqual(result, {})
-
-    async def test_swallows_db_errors(self) -> None:
-        db = mock.AsyncMock()
-        db.execute.side_effect = RuntimeError('graph down')
-        result = await projects._resolve_release_identities(
-            db, [('p1', '1.0.0')]
-        )
-        self.assertEqual(result, {})
+def _row(
+    *,
+    project_id: str,
+    env_slug: str,
+    tag: str | None,
+    committish: str | None,
+    events: list[dict[str, object]],
+) -> dict[str, object]:
+    return {
+        'project_id': project_id,
+        'env_slug': env_slug,
+        'tag': tag,
+        'committish': committish,
+        'deployments': json.dumps(events),
+    }
 
 
 class FetchCurrentReleasesTestCase(unittest.IsolatedAsyncioTestCase):
-    """Coverage for ``_fetch_current_releases``."""
+    """Coverage for ``_fetch_current_releases`` reading from AGE."""
 
     async def test_empty_project_ids_short_circuits(self) -> None:
         db = mock.AsyncMock()
         result = await projects._fetch_current_releases(db, [])
         self.assertEqual(result, {})
+        db.execute.assert_not_called()
 
     async def test_returns_release_info_per_env(self) -> None:
-        deployed = datetime.datetime(2026, 4, 1, 12, 0, 0, tzinfo=datetime.UTC)
-        ch_rows = [
-            {
-                'project_id': 'p1',
-                'environment_slug': 'prod',
-                'version': '1.0.0',
-                'performed_by': 'alice@example.com',
-                'deployed_at': deployed,
-            },
-            {
-                'project_id': 'p1',
-                'environment_slug': 'stage',
-                'version': '7654321',
-                'performed_by': None,
-                'deployed_at': deployed,
-            },
-        ]
-        ch = mock.MagicMock()
-        ch.query = mock.AsyncMock(return_value=ch_rows)
-
+        older = datetime.datetime(2026, 4, 1, 12, 0, 0, tzinfo=datetime.UTC)
+        newer = datetime.datetime(2026, 4, 2, 12, 0, 0, tzinfo=datetime.UTC)
         db = mock.AsyncMock()
         db.execute.return_value = [
-            {'project_id': 'p1', 'tag': '1.0.0', 'committish': 'abcdef0'},
-            {'project_id': 'p1', 'tag': None, 'committish': '7654321'},
+            # An older release also deployed to prod — must not win.
+            _row(
+                project_id='p1',
+                env_slug='prod',
+                tag='0.9.0',
+                committish='abc1234',
+                events=[_event(older, performed_by='legacy@example.com')],
+            ),
+            # The current prod release: latest event wins.
+            _row(
+                project_id='p1',
+                env_slug='prod',
+                tag='1.0.0',
+                committish='abcdef0',
+                events=[_event(newer, performed_by='alice@example.com')],
+            ),
+            # Stage release with a null performer (in-product deploy).
+            _row(
+                project_id='p1',
+                env_slug='stage',
+                tag=None,
+                committish='7654321',
+                events=[_event(newer)],
+            ),
         ]
+
+        ch = mock.MagicMock()
+        ch.query = mock.AsyncMock(return_value=[])
 
         with (
             mock.patch(
@@ -254,27 +219,34 @@ class FetchCurrentReleasesTestCase(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(prod.tag, '1.0.0')
         self.assertEqual(prod.committish, 'abcdef0')
         self.assertEqual(prod.performed_by, 'alice@example.com')
-        self.assertEqual(prod.deployed_at, deployed)
+        self.assertEqual(prod.deployed_at, newer)
         self.assertIsNone(stage.tag)
         self.assertEqual(stage.committish, '7654321')
         self.assertIsNone(stage.performed_by)
 
-    async def test_missing_version_omits_release_identity(self) -> None:
+    async def test_enriches_performed_by_from_ops_log(self) -> None:
         deployed = datetime.datetime(2026, 4, 1, 12, 0, 0, tzinfo=datetime.UTC)
-        ch_rows = [
-            {
-                'project_id': 'p1',
-                'environment_slug': 'prod',
-                'version': '',
-                'performed_by': 'bob@example.com',
-                'deployed_at': deployed,
-            },
+        db = mock.AsyncMock()
+        db.execute.return_value = [
+            _row(
+                project_id='p1',
+                env_slug='prod',
+                tag='1.0.0',
+                committish='abcdef0',
+                events=[_event(deployed)],
+            ),
         ]
         ch = mock.MagicMock()
-        ch.query = mock.AsyncMock(return_value=ch_rows)
-
-        db = mock.AsyncMock()
-        db.execute.return_value = []
+        ch.query = mock.AsyncMock(
+            return_value=[
+                {
+                    'project_id': 'p1',
+                    'environment_slug': 'prod',
+                    'version': '1.0.0',
+                    'performed_by': 'bob@example.com',
+                },
+            ]
+        )
 
         with (
             mock.patch(
@@ -288,18 +260,92 @@ class FetchCurrentReleasesTestCase(unittest.IsolatedAsyncioTestCase):
             ),
         ):
             result = await projects._fetch_current_releases(db, ['p1'])
-        info = result['p1']['prod']
-        self.assertIsNone(info.tag)
-        self.assertIsNone(info.committish)
-        self.assertEqual(info.performed_by, 'bob@example.com')
 
-    async def test_swallows_clickhouse_errors(self) -> None:
-        ch = mock.MagicMock()
-        ch.query = mock.AsyncMock(side_effect=RuntimeError('boom'))
+        self.assertEqual(result['p1']['prod'].performed_by, 'bob@example.com')
+
+    async def test_skips_environments_with_no_events(self) -> None:
         db = mock.AsyncMock()
+        db.execute.return_value = [
+            _row(
+                project_id='p1',
+                env_slug='prod',
+                tag='1.0.0',
+                committish='abcdef0',
+                events=[],
+            ),
+        ]
+        ch = mock.MagicMock()
+        ch.query = mock.AsyncMock(return_value=[])
+        with (
+            mock.patch(
+                'imbi_api.endpoints.projects.ch_client.Clickhouse.'
+                'get_instance',
+                return_value=ch,
+            ),
+            mock.patch(
+                'imbi_api.endpoints.projects.graph.parse_agtype',
+                side_effect=lambda v: v,
+            ),
+        ):
+            result = await projects._fetch_current_releases(db, ['p1'])
+        self.assertEqual(result, {})
+
+    async def test_swallows_graph_errors(self) -> None:
+        db = mock.AsyncMock()
+        db.execute.side_effect = RuntimeError('graph down')
+        result = await projects._fetch_current_releases(db, ['p1'])
+        self.assertEqual(result, {})
+
+
+class LookupOpsLogPerformedByTestCase(unittest.IsolatedAsyncioTestCase):
+    """Coverage for ``_lookup_ops_log_performed_by``."""
+
+    async def test_empty_targets_short_circuits(self) -> None:
+        with mock.patch(
+            'imbi_api.endpoints.projects.ch_client.Clickhouse.get_instance'
+        ) as gi:
+            result = await projects._lookup_ops_log_performed_by([])
+        self.assertEqual(result, {})
+        gi.assert_not_called()
+
+    async def test_filters_to_requested_keys(self) -> None:
+        ch = mock.MagicMock()
+        ch.query = mock.AsyncMock(
+            return_value=[
+                {
+                    'project_id': 'p1',
+                    'environment_slug': 'prod',
+                    'version': '1.0.0',
+                    'performed_by': 'alice@example.com',
+                },
+                # Stale row for a version we no longer need — must be dropped.
+                {
+                    'project_id': 'p1',
+                    'environment_slug': 'prod',
+                    'version': '0.9.0',
+                    'performed_by': 'legacy@example.com',
+                },
+            ]
+        )
         with mock.patch(
             'imbi_api.endpoints.projects.ch_client.Clickhouse.get_instance',
             return_value=ch,
         ):
-            result = await projects._fetch_current_releases(db, ['p1'])
+            result = await projects._lookup_ops_log_performed_by(
+                [('p1', 'prod', '1.0.0')]
+            )
+        self.assertEqual(
+            result, {('p1', 'prod', '1.0.0'): 'alice@example.com'}
+        )
+
+    async def test_swallows_clickhouse_errors(self) -> None:
+        ch = mock.MagicMock()
+        ch.query = mock.AsyncMock(side_effect=RuntimeError('boom'))
+        with mock.patch(
+            'imbi_api.endpoints.projects.ch_client.Clickhouse.get_instance',
+            return_value=ch,
+        ):
+            result = await projects._lookup_ops_log_performed_by(
+                [('p1', 'prod', '1.0.0')]
+            )
         self.assertEqual(result, {})


### PR DESCRIPTION
## Summary

- `GET /organizations/{org}/projects/` was sourcing `current_releases` from ClickHouse `operations_log` via `argMax(version, occurred_at)`. The project detail page (`GET .../releases/current`) reads the AGE graph directly. Any environment whose most-recent deploy landed via the resync/webhook path showed a **stale older release** on the projects list while the detail page showed the correct one.
- Resync intentionally skips writing an `operations_log` audit row (see `project_deployments._fetch_one` and the comment at `project_deployments.py:747-753`) so it doesn't poison `argMax(performed_by, occurred_at)`. That's the asymmetry that caused the divergence.
- Switch `_fetch_current_releases` to read from AGE — same query shape as `/releases/current` — so the list and detail pages share a single source of truth.
- `DeploymentEvent.performed_by` is null on the AGE edge for in-product deploy/promote actions (the audit row carries the operator instead). For those rows we now back-fill `performed_by` from `operations_log` keyed on `(project_id, env_slug, version)`. Resync events already carry the original deployer on the edge and skip the lookup.
- Removed the now-unused `_resolve_release_identities` helper and its tests.

## Reproduction

Project with two recent deploys to `infrastructure-testing`:
- old `065474d` via in-product deploy (writes ops_log)
- new `1e7780f` via webhook/resync (no ops_log row)

Before: list page shows `065474d`, detail page shows `1e7780f`.
After: both show `1e7780f`.

## Test plan

- [x] `pytest tests/endpoints/test_projects_helpers.py` — 16/16 pass, including new coverage for latest-event-wins, performed_by enrichment, empty-events skip, and ops-log error swallowing
- [x] `ruff format` clean
- [x] `mypy` strict + `basedpyright` strict — no issues
- [ ] Smoke-test against a live Imbi where at least one env's latest deploy came via webhook/resync — confirm the list page chip now matches the detail page chip

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>