### PR TITLE
Throttle last_used / last_activity stamps on auth

### DIFF
--- a/src/imbi_api/auth/permissions.py
+++ b/src/imbi_api/auth/permissions.py
@@ -304,23 +304,41 @@ async def authenticate_jwt(
     )
 
 
-async def _stamp_api_key_last_used(db: graph.Graph, key_id: str) -> None:
+async def _stamp_api_key_last_used(
+    db: graph.Graph,
+    key_id: str,
+    auth_settings: settings.Auth,
+) -> None:
     """Set last_used on the APIKey node identified by key_id.
+
+    Skips the write atomically when the existing ``last_used`` is
+    newer than ``auth_settings.last_used_throttle_seconds`` ago. The
+    value only needs to be accurate to the nearest minute or so; we
+    don't need to spend a graph write on every authenticated
+    request. A throttle of ``0`` disables this and always writes.
 
     AGE's cypher() wrapper requires a RETURN clause to properly
     finalize a write operation — omitting it causes an internal
     "Entity failed to be updated" error. Failures are logged and
     swallowed: the stamp is best-effort and must not fail authentication.
     """
-    now = datetime.datetime.now(datetime.UTC).isoformat()
+    now = datetime.datetime.now(datetime.UTC)
+    threshold = now - datetime.timedelta(
+        seconds=max(0, auth_settings.last_used_throttle_seconds)
+    )
     query: typing.LiteralString = (
         'MATCH (k:APIKey {{key_id: {key_id}}})'
+        ' WHERE k.last_used IS NULL OR k.last_used < {threshold}'
         ' SET k.last_used = {now} RETURN k'
     )
     try:
         await db.execute(
             query,
-            {'key_id': key_id, 'now': now},
+            {
+                'key_id': key_id,
+                'now': now.isoformat(),
+                'threshold': threshold.isoformat(),
+            },
             columns=['k'],
         )
     except Exception:  # noqa: BLE001
@@ -434,7 +452,7 @@ async def authenticate_api_key(
         filtered = all_perms.intersection(set(scopes)) if scopes else all_perms
 
         # Update last_used only after all validation passes
-        await _stamp_api_key_last_used(db, key_id)
+        await _stamp_api_key_last_used(db, key_id, auth_settings)
 
         return AuthContext(
             service_account=sa,
@@ -456,7 +474,7 @@ async def authenticate_api_key(
     identities = await _load_user_identities(db, user.id)
 
     # Update last_used only after all validation passes
-    await _stamp_api_key_last_used(db, key_id)
+    await _stamp_api_key_last_used(db, key_id, auth_settings)
 
     return AuthContext(
         user=user,

--- a/src/imbi_api/auth/sessions.py
+++ b/src/imbi_api/auth/sessions.py
@@ -6,6 +6,7 @@ concurrent session limits, and tracking session activity.
 
 import datetime
 import logging
+import typing
 
 from imbi_common import graph
 
@@ -82,7 +83,7 @@ async def update_session_activity(
     threshold = now - datetime.timedelta(
         seconds=max(0, auth_settings.last_used_throttle_seconds)
     )
-    query = (
+    query: typing.LiteralString = (
         'MATCH (s:Session {{session_id: {session_id}}}) '
         'WHERE s.last_activity IS NULL OR s.last_activity < {threshold} '
         'SET s.last_activity = {now} RETURN s'

--- a/src/imbi_api/auth/sessions.py
+++ b/src/imbi_api/auth/sessions.py
@@ -58,20 +58,44 @@ async def enforce_session_limit(
         )
 
 
-async def update_session_activity(db: graph.Graph, session_id: str) -> None:
+async def update_session_activity(
+    db: graph.Graph,
+    session_id: str,
+    auth_settings: settings.Auth,
+) -> None:
     """Update last activity timestamp for session.
+
+    Skips the write atomically when the existing ``last_activity`` is
+    newer than ``auth_settings.last_used_throttle_seconds`` ago.
+    Authentication runs on every request, so without throttling this
+    would book a graph write per request even though we only need
+    minute-scale accuracy.
 
     Args:
         db: Graph database connection.
         session_id: Session ID to update.
+        auth_settings: Auth settings (reads
+            ``last_used_throttle_seconds``).
 
     """
-    now = datetime.datetime.now(datetime.UTC).isoformat()
+    now = datetime.datetime.now(datetime.UTC)
+    threshold = now - datetime.timedelta(
+        seconds=max(0, auth_settings.last_used_throttle_seconds)
+    )
     query = (
         'MATCH (s:Session {{session_id: {session_id}}}) '
-        'SET s.last_activity = {now}'
+        'WHERE s.last_activity IS NULL OR s.last_activity < {threshold} '
+        'SET s.last_activity = {now} RETURN s'
     )
-    await db.execute(query, {'session_id': session_id, 'now': now})
+    await db.execute(
+        query,
+        {
+            'session_id': session_id,
+            'now': now.isoformat(),
+            'threshold': threshold.isoformat(),
+        },
+        columns=['s'],
+    )
 
 
 async def delete_expired_sessions(db: graph.Graph) -> int:

--- a/src/imbi_api/settings.py
+++ b/src/imbi_api/settings.py
@@ -106,6 +106,13 @@ class Auth(settings.Auth):  # type: ignore[misc]
     # API Key Configuration
     api_key_max_lifetime_days: int = 365
 
+    # Throttle interval for ``last_used`` / ``last_activity`` stamps.
+    # Authentication runs on every request, but persisting the stamp
+    # every time spikes graph write pressure for no UX benefit -- the
+    # value only needs to be accurate to the nearest minute or so.
+    # Set to 0 to disable throttling.
+    last_used_throttle_seconds: int = 60
+
     # MFA Configuration (Phase 5)
     mfa_issuer_name: str = 'Imbi'
     mfa_totp_period: int = 30  # seconds

--- a/tests/auth/test_api_key_auth.py
+++ b/tests/auth/test_api_key_auth.py
@@ -420,3 +420,63 @@ class GetCurrentUserTestCase(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(auth_context.user.email, 'test@example.com')
         self.assertEqual(auth_context.session_id, self.key_id)
         self.assertEqual(auth_context.auth_method, 'api_key')
+
+
+class StampApiKeyLastUsedTestCase(unittest.IsolatedAsyncioTestCase):
+    """Test ``_stamp_api_key_last_used`` throttling behavior."""
+
+    async def test_query_carries_throttle_threshold(self) -> None:
+        """Stamp query filters on the configured throttle interval."""
+        mock_db = mock.AsyncMock()
+        mock_db.execute.return_value = []
+        auth_settings = settings.Auth(
+            jwt_secret='test-secret-key-min-32-chars-long',
+            last_used_throttle_seconds=60,
+        )
+
+        await permissions._stamp_api_key_last_used(
+            mock_db, 'ik_abc', auth_settings
+        )
+
+        mock_db.execute.assert_awaited_once()
+        call_args = mock_db.execute.await_args
+        assert call_args is not None
+        query = call_args[0][0]
+        params = call_args[0][1] if len(call_args[0]) > 1 else {}
+        self.assertEqual('ik_abc', params.get('key_id'))
+        self.assertIn('threshold', params)
+        self.assertIn('k.last_used IS NULL', query)
+        self.assertIn('k.last_used < {threshold}', query)
+        now_dt = datetime.datetime.fromisoformat(params['now'])
+        threshold_dt = datetime.datetime.fromisoformat(params['threshold'])
+        self.assertEqual(60.0, (now_dt - threshold_dt).total_seconds())
+
+    async def test_zero_throttle_uses_now_as_threshold(self) -> None:
+        """A 0-second throttle disables the filter (threshold == now)."""
+        mock_db = mock.AsyncMock()
+        mock_db.execute.return_value = []
+        auth_settings = settings.Auth(
+            jwt_secret='test-secret-key-min-32-chars-long',
+            last_used_throttle_seconds=0,
+        )
+
+        await permissions._stamp_api_key_last_used(
+            mock_db, 'ik_abc', auth_settings
+        )
+
+        call_args = mock_db.execute.await_args
+        assert call_args is not None
+        params = call_args[0][1] if len(call_args[0]) > 1 else {}
+        self.assertEqual(params['now'], params['threshold'])
+
+    async def test_swallows_db_errors(self) -> None:
+        """Stamp failures are logged but never propagate."""
+        mock_db = mock.AsyncMock()
+        mock_db.execute.side_effect = RuntimeError('graph down')
+        auth_settings = settings.Auth(
+            jwt_secret='test-secret-key-min-32-chars-long',
+        )
+
+        await permissions._stamp_api_key_last_used(
+            mock_db, 'ik_abc', auth_settings
+        )

--- a/tests/auth/test_sessions.py
+++ b/tests/auth/test_sessions.py
@@ -1,5 +1,6 @@
 """Tests for session management."""
 
+import datetime
 import unittest
 from unittest import mock
 
@@ -70,18 +71,49 @@ class UpdateSessionActivityTestCase(
 ):
     """Test update_session_activity function."""
 
+    def setUp(self) -> None:
+        """Set up test fixtures."""
+        self.auth_settings = settings.Auth(last_used_throttle_seconds=60)
+
     async def test_update_session_activity(self) -> None:
-        """Test update_session_activity updates timestamp."""
+        """Test update_session_activity issues a throttled SET query."""
         mock_db = mock.AsyncMock()
         mock_db.execute.return_value = []
 
-        await sessions.update_session_activity(mock_db, 'session123')
+        await sessions.update_session_activity(
+            mock_db, 'session123', self.auth_settings
+        )
 
-        # Verify execute was called with correct session_id
-        mock_db.execute.assert_called_once()
-        call_args = mock_db.execute.call_args
+        # Verify execute was called with the expected params and the
+        # query carries the throttling guard.
+        mock_db.execute.assert_awaited_once()
+        call_args = mock_db.execute.await_args
+        assert call_args is not None
+        query = call_args[0][0]
         params = call_args[0][1] if len(call_args[0]) > 1 else {}
         self.assertEqual('session123', params.get('session_id'))
+        self.assertIn('threshold', params)
+        self.assertIn('s.last_activity IS NULL', query)
+        self.assertIn('s.last_activity < {threshold}', query)
+        # ``now`` and ``threshold`` should be 60 seconds apart.
+        now_dt = datetime.datetime.fromisoformat(params['now'])
+        threshold_dt = datetime.datetime.fromisoformat(params['threshold'])
+        self.assertEqual(60.0, (now_dt - threshold_dt).total_seconds())
+
+    async def test_zero_throttle_uses_now_as_threshold(self) -> None:
+        """With throttle=0 the WHERE filter never blocks the write."""
+        mock_db = mock.AsyncMock()
+        mock_db.execute.return_value = []
+        zero_settings = settings.Auth(last_used_throttle_seconds=0)
+
+        await sessions.update_session_activity(
+            mock_db, 'session123', zero_settings
+        )
+
+        call_args = mock_db.execute.await_args
+        assert call_args is not None
+        params = call_args[0][1] if len(call_args[0]) > 1 else {}
+        self.assertEqual(params['now'], params['threshold'])
 
 
 class DeleteExpiredSessionsTestCase(


### PR DESCRIPTION
## Summary

- Both ``_stamp_api_key_last_used`` (per API-key-authenticated request) and ``update_session_activity`` (per session-authenticated request) issued an unconditional ``SET`` against AGE on every authentication. The value only needs minute-scale accuracy, so we were paying a graph write per request for no UX benefit.
- Add ``Auth.last_used_throttle_seconds`` (default ``60``) to ``imbi_api.settings.Auth``. ``0`` disables throttling.
- Guard both helpers atomically in Cypher: ``WHERE k.last_used IS NULL OR k.last_used < {threshold}`` (and the analogous clause on ``s.last_activity``). The ``SET`` is skipped when the existing stamp is newer than the threshold. Doing it in Cypher keeps the check atomic under concurrent auth.
- Thread ``auth_settings`` into ``_stamp_api_key_last_used`` and ``update_session_activity`` so they can read the throttle interval.

ISO 8601 timestamps written with a consistent ``+00:00`` offset sort lexicographically, so the string comparison on ``last_used`` / ``last_activity`` in AGE is correct.

## Test plan

- [x] ``pytest tests/auth/test_sessions.py tests/auth/test_api_key_auth.py`` — 21/21 pass
- [x] New ``StampApiKeyLastUsedTestCase`` covers: throttle threshold present in query/params, ``throttle_seconds=0`` collapses ``now == threshold``, errors are swallowed
- [x] ``UpdateSessionActivityTestCase`` updated with the same coverage
- [x] ``ruff format``, ``mypy`` strict, ``basedpyright`` strict — all clean
- [ ] Smoke-test against a live Imbi: with ``last_used_throttle_seconds=60``, repeated authenticated requests within a minute should leave ``last_used`` / ``last_activity`` unchanged

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>