### PR TITLE
Add non-admin plugin manifest endpoint

### DIFF
--- a/src/imbi_api/endpoints/__init__.py
+++ b/src/imbi_api/endpoints/__init__.py
@@ -18,6 +18,7 @@ from .mfa import mfa_router
 from .operations_log import operations_log_router
 from .organizations import organizations_router
 from .plugin_entities import plugin_entities_router
+from .plugins import plugins_router
 from .roles import roles_router
 from .sa_api_keys import sa_api_keys_router
 from .scoring import scoring_router
@@ -42,6 +43,7 @@ prefixed_routers: list[fastapi.APIRouter] = [
     operations_log_router,
     organizations_router,
     plugin_entities_router,
+    plugins_router,
     roles_router,
     sa_api_keys_router,
     scoring_policies_router,

--- a/src/imbi_api/endpoints/plugins.py
+++ b/src/imbi_api/endpoints/plugins.py
@@ -1,0 +1,65 @@
+"""Non-admin plugin metadata endpoints.
+
+Exposes the static plugin manifest (option + credential schemas) so
+project editors with ``project:write`` can render a typed form for
+per-project plugin option overrides without needing the admin
+``admin:plugins:read`` permission. Only schema metadata is returned —
+nothing about install state, package details, or per-org overrides.
+"""
+
+import typing
+
+import fastapi
+import pydantic
+from imbi_common.plugins.base import CredentialField, PluginOption
+from imbi_common.plugins.errors import PluginNotFoundError
+from imbi_common.plugins.registry import get_plugin
+
+from imbi_api.auth import permissions
+
+plugins_router = fastapi.APIRouter(tags=['Plugins'])
+
+
+class PluginManifestResponse(pydantic.BaseModel):
+    """Minimal plugin manifest for option-editor rendering."""
+
+    slug: str
+    name: str
+    description: str | None = None
+    plugin_type: str
+    options: list[PluginOption]
+    credentials: list[CredentialField]
+
+
+@plugins_router.get('/plugins/{slug}/manifest')
+async def get_plugin_manifest(
+    slug: str,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(permissions.get_current_user),
+    ],
+) -> PluginManifestResponse:
+    """Return the option and credential schemas for a plugin.
+
+    Gated on authentication only — the manifest is static metadata
+    shipped in the plugin's Python package and is not sensitive.
+    Project editors need this to render a typed form for per-project
+    option overrides on the ``USES_PLUGIN`` edge.
+    """
+    _ = auth
+    try:
+        entry = get_plugin(slug)
+    except PluginNotFoundError as exc:
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail=f'Plugin {slug!r} is not installed',
+        ) from exc
+    manifest = entry.manifest
+    return PluginManifestResponse(
+        slug=manifest.slug,
+        name=manifest.name,
+        description=manifest.description,
+        plugin_type=manifest.plugin_type,
+        options=list(manifest.options),
+        credentials=list(manifest.credentials),
+    )

--- a/tests/endpoints/test_plugins.py
+++ b/tests/endpoints/test_plugins.py
@@ -1,0 +1,137 @@
+"""Tests for non-admin plugin manifest endpoint."""
+
+import datetime
+import unittest
+from unittest import mock
+
+from fastapi import testclient
+from imbi_common import graph
+
+from imbi_api import app, models
+from imbi_api.auth import password, permissions
+
+
+class PluginManifestEndpointTestCase(unittest.TestCase):
+    """Test cases for ``GET /plugins/{slug}/manifest``."""
+
+    def setUp(self) -> None:
+        self.test_app = app.create_app()
+        self.test_user = models.User(
+            email='editor@example.com',
+            display_name='Project Editor',
+            is_active=True,
+            is_admin=False,
+            password_hash=password.hash_password('testpassword123'),
+            created_at=datetime.datetime.now(datetime.UTC),
+        )
+        # Note: deliberately no ``admin:plugins:read`` -- this endpoint
+        # must work for any authenticated user.
+        self.auth_context = permissions.AuthContext(
+            user=self.test_user,
+            session_id='test-session',
+            auth_method='jwt',
+            permissions={'project:read', 'project:write'},
+        )
+
+        async def mock_get_current_user() -> permissions.AuthContext:
+            return self.auth_context
+
+        self.test_app.dependency_overrides[permissions.get_current_user] = (
+            mock_get_current_user
+        )
+        self.mock_db = mock.AsyncMock(spec=graph.Graph)
+        self.mock_db.execute.return_value = []
+        self.test_app.dependency_overrides[graph._inject_graph] = lambda: (
+            self.mock_db
+        )
+
+    def _entry(self) -> object:
+        from imbi_common.plugins.base import (
+            ConfigurationPlugin,
+            CredentialField,
+            PluginManifest,
+            PluginOption,
+        )
+        from imbi_common.plugins.registry import RegistryEntry
+
+        class _Fake(ConfigurationPlugin):
+            manifest = PluginManifest(
+                slug='logzio',
+                name='Logz.io',
+                description='Logz.io log search',
+                plugin_type='logs',
+                options=[
+                    PluginOption(
+                        name='base_query',
+                        label='Base Query Template',
+                        type='string',
+                        description='Elasticsearch query_string clause.',
+                    ),
+                    PluginOption(
+                        name='region',
+                        label='Region',
+                        type='string',
+                        choices=['us', 'eu'],
+                        default='us',
+                    ),
+                ],
+                credentials=[
+                    CredentialField(
+                        name='api_token',
+                        label='API Token',
+                    ),
+                ],
+            )
+
+        return RegistryEntry(
+            handler_cls=_Fake,
+            manifest=_Fake.manifest,
+            package_name='imbi-plugin-logzio',
+            package_version='0.1.0',
+        )
+
+    def test_returns_manifest(self) -> None:
+        with (
+            mock.patch(
+                'imbi_api.endpoints.plugins.get_plugin',
+                return_value=self._entry(),
+            ),
+            testclient.TestClient(self.test_app) as client,
+        ):
+            response = client.get('/plugins/logzio/manifest')
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data['slug'], 'logzio')
+        self.assertEqual(data['name'], 'Logz.io')
+        self.assertEqual(data['plugin_type'], 'logs')
+        self.assertEqual(len(data['options']), 2)
+        self.assertEqual(data['options'][0]['name'], 'base_query')
+        self.assertEqual(data['options'][0]['label'], 'Base Query Template')
+        self.assertEqual(data['options'][1]['choices'], ['us', 'eu'])
+        self.assertEqual(len(data['credentials']), 1)
+        self.assertEqual(data['credentials'][0]['name'], 'api_token')
+
+    def test_returns_404_for_unknown_slug(self) -> None:
+        from imbi_common.plugins.errors import PluginNotFoundError
+
+        with (
+            mock.patch(
+                'imbi_api.endpoints.plugins.get_plugin',
+                side_effect=PluginNotFoundError('no-such-plugin'),
+            ),
+            testclient.TestClient(self.test_app) as client,
+        ):
+            response = client.get('/plugins/no-such-plugin/manifest')
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_requires_authentication(self) -> None:
+        # Without the override, get_current_user runs its real flow and
+        # rejects the unauthenticated request.
+        self.test_app.dependency_overrides.pop(
+            permissions.get_current_user, None
+        )
+        with testclient.TestClient(self.test_app) as client:
+            response = client.get('/plugins/logzio/manifest')
+        self.assertIn(response.status_code, {401, 403})


### PR DESCRIPTION
## Summary

- The backend has supported per-project plugin option overrides all along — `PluginAssignmentCreate.options: dict[str, Any]` rides on the project's `USES_PLUGIN` edge, and `imbi_api.plugins.resolution.resolve_plugin` applies a three-tier merge with project-level overrides winning. But the UI can't render an option editor because the existing manifest endpoint (`GET /admin/plugins/{slug}`) requires `admin:plugins:read`, which a project editor with `project:write` doesn't have.
- Add `GET /plugins/{slug}/manifest` returning just the static schema: `slug`, `name`, `description`, `plugin_type`, `options[]`, `credentials[]`. Gated on authentication only — the manifest ships in the plugin's Python package and is not sensitive.
- Companion UI work in imbi-ui will land in a separate PR; this endpoint is the dependency.

## Test plan

- [x] `pytest tests/endpoints/test_plugins.py --no-cov` — 3/3 pass (returns manifest for a non-admin user with `project:read`/`project:write`, 404 for unknown slug, rejects unauthenticated request)
- [x] `ruff format`, `mypy` strict, `basedpyright` strict — clean
- [ ] Smoke-test against a live Imbi: as a non-admin, `curl /api/plugins/logzio/manifest` should return the manifest including `base_query` as an option

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>