### PR TITLE
Split single-project rescore from rescore-all permission

### DIFF
--- a/src/imbi_api/auth/seed.py
+++ b/src/imbi_api/auth/seed.py
@@ -285,6 +285,12 @@ STANDARD_PERMISSIONS: list[tuple[str, str, str, str]] = [
         'Delete scoring policies',
     ),
     (
+        'scoring_policy:rescore',
+        'scoring_policy',
+        'rescore',
+        'Trigger rescore for a single project',
+    ),
+    (
         'scoring_policy:rescore_all',
         'scoring_policy',
         'rescore_all',
@@ -425,6 +431,7 @@ DEFAULT_ROLES: list[tuple[str, str, str, int, list[str], bool]] = [
             'organization:read',
             'organization:update',
             'project_type:read',
+            'scoring_policy:rescore',
             'team:read',
             'team:update',
             'user:read',
@@ -464,6 +471,7 @@ DEFAULT_ROLES: list[tuple[str, str, str, int, list[str], bool]] = [
             'project:read',
             'project_type:read',
             'role:read',
+            'scoring_policy:rescore',
             'search:read',
             'tag:read',
             'team:read',

--- a/src/imbi_api/endpoints/scoring.py
+++ b/src/imbi_api/endpoints/scoring.py
@@ -508,13 +508,25 @@ async def rescore(
     valkey_client: OptionalValkeyClient,
     auth: typing.Annotated[
         permissions.AuthContext,
-        fastapi.Depends(
-            permissions.require_permission('scoring_policy:rescore_all')
-        ),
+        fastapi.Depends(permissions.get_current_user),
     ],
     body: scoring_models.RescoreRequest | None = None,
 ) -> scoring_models.RescoreResponse:
     body = body or scoring_models.RescoreRequest()
+    # Single-project rescore only needs scoring_policy:rescore; any wider
+    # scope (policy, blueprint, project_type, or global) requires
+    # scoring_policy:rescore_all.
+    if body.project_id and not (
+        body.policy_slug or body.blueprint_slug or body.project_type_slug
+    ):
+        required = 'scoring_policy:rescore'
+    else:
+        required = 'scoring_policy:rescore_all'
+    if not auth.is_admin and required not in auth.permissions:
+        raise fastapi.HTTPException(
+            status_code=403,
+            detail=f'Permission denied: {required} required',
+        )
     project_ids: list[str] = []
     if body.project_id:
         project_ids = [body.project_id]

--- a/tests/endpoints/test_scoring.py
+++ b/tests/endpoints/test_scoring.py
@@ -252,6 +252,51 @@ class ScoringEndpointsTestCase(unittest.TestCase):
         args = self.mock_valkey.xadd.call_args.args
         self.assertEqual(args[1]['project_id'], 'proj-abc')
 
+    def test_rescore_single_project_requires_only_rescore_perm(self) -> None:
+        """Non-admin with ``scoring_policy:rescore`` can rescore one project.
+
+        The wider permission ``scoring_policy:rescore_all`` is not
+        required for the single-project case.
+        """
+        self.auth.user = self.user.model_copy(update={'is_admin': False})
+        self.auth.permissions = {'scoring_policy:rescore'}
+        response = self.client.post(
+            '/scoring/rescore', json={'project_id': 'proj-abc'}
+        )
+        self.assertEqual(response.status_code, 200, response.text)
+        self.assertEqual(response.json()['enqueued'], 1)
+
+    def test_rescore_single_project_rejects_without_perm(self) -> None:
+        """Non-admin with neither rescore permission is rejected (403)."""
+        self.auth.user = self.user.model_copy(update={'is_admin': False})
+        self.auth.permissions = set()
+        response = self.client.post(
+            '/scoring/rescore', json={'project_id': 'proj-abc'}
+        )
+        self.assertEqual(response.status_code, 403, response.text)
+        self.assertIn('scoring_policy:rescore', response.json()['detail'])
+
+    def test_rescore_wider_scope_requires_rescore_all(self) -> None:
+        """``rescore`` alone is not enough for blueprint / policy scope."""
+        self.auth.user = self.user.model_copy(update={'is_admin': False})
+        self.auth.permissions = {'scoring_policy:rescore'}
+        response = self.client.post(
+            '/scoring/rescore', json={'policy_slug': 'python-version'}
+        )
+        self.assertEqual(response.status_code, 403, response.text)
+        self.assertIn('scoring_policy:rescore_all', response.json()['detail'])
+
+    def test_rescore_all_requires_rescore_all_for_non_admin(self) -> None:
+        """A non-admin with ``rescore_all`` runs the empty-body bulk path."""
+        self.auth.user = self.user.model_copy(update={'is_admin': False})
+        self.auth.permissions = {'scoring_policy:rescore_all'}
+        self.mock_db.execute = mock.AsyncMock(
+            return_value=[{'id': 'p1'}, {'id': 'p2'}]
+        )
+        response = self.client.post('/scoring/rescore', json={})
+        self.assertEqual(response.status_code, 200, response.text)
+        self.assertEqual(response.json()['enqueued'], 2)
+
     def test_score_trend_returns_delta(self) -> None:
         self.mock_db.execute = mock.AsyncMock(
             return_value=[{'score': 90.0}],


### PR DESCRIPTION
## Summary

`POST /scoring/rescore` previously required `scoring_policy:rescore_all` for every request shape — including the single-project case (`{"project_id": "..."}`) that drives the "Recompute Score" button on the project Settings → Utility Functions card. Non-admin users who can otherwise see and edit their project couldn't trigger a rescore for it without org-wide rescore privileges.

## Changes

- New `scoring_policy:rescore` permission added to `STANDARD_PERMISSIONS` and granted to the `developer` and `default` roles in `seed.py`.
- `POST /scoring/rescore` resolves auth via `get_current_user` and now picks the required permission per request body:
  - Single-project (`project_id` only) → `scoring_policy:rescore`
  - Anything wider (`policy_slug`, `blueprint_slug`, `project_type_slug`, or empty-body bulk) → `scoring_policy:rescore_all`
- Admins continue to bypass both checks.

## Companion UI work

`imbi-ui` is updated separately to render the "Recompute Score" button when `isAdmin || permissions.includes('scoring_policy:rescore')` (vs admin-only today). The "Sync Deployments" button gating is unchanged.

## Test plan

- [x] `pytest tests/endpoints/test_scoring.py --no-cov` — 29 pass (4 new tests)
- [x] New coverage: single-project rescore with only `rescore` succeeds; without it 403s with the right detail; `policy_slug` request with only `rescore` is rejected with `rescore_all` detail; non-admin with `rescore_all` runs the empty-body bulk path.
- [x] `ruff format`, `mypy` — clean
- [ ] Smoke test with a developer user: load a project, click "Recompute Score" — should enqueue without 403.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>