### PR TITLE
Bump version to 2.6.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "imbi-api"
-version = "2.5.2"
+version = "2.6.0"
 description = "Imbi is a DevOps Service Management Platform designed to provide an efficient way to manage a large environment that contains many services and applications."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -220,9 +220,14 @@ max-complexity = 15
 [tool.ruff.lint.per-file-ignores]
 "tests/**/*.py" = ["S"]
 
+[tool.uv]
+exclude-newer = "7 days"
+exclude-newer-package = { "clickhouse-connect" = false, "imbi-common" = false, "imbi-plugin-aws" = false, "imbi-plugin-github" = false, "imbi-plugin-logzio" = false, "imbi-plugin-oidc" = false, "imbi-plugin-pagerduty" = false, "imbi-plugin-sentry" = false, "imbi-plugin-sonarqube" = false }
+
 [[tool.uv.index]]
 url = "https://pypi.org/simple"
 default = true
 
 [tool.uv.sources]
+imbi-common = { path = "../imbi-common", editable = true }
 imbi-plugin-github = { path = "../imbi-plugin-github", editable = true }

--- a/uv.lock
+++ b/uv.lock
@@ -959,7 +959,7 @@ wheels = [
 
 [[package]]
 name = "imbi-api"
-version = "2.5.1"
+version = "2.6.0"
 source = { editable = "." }
 dependencies = [
   { name = "aioboto3" },
@@ -1143,7 +1143,7 @@ wheels = [
 
 [[package]]
 name = "imbi-plugin-github"
-version = "1.2.0"
+version = "1.3.0"
 source = { editable = "../imbi-plugin-github" }
 dependencies = [
   { name = "httpx" },


### PR DESCRIPTION
## Summary

Release 2.6.0 — backwards-compatible additions since 2.5.2.

### Changes

- #326 — Read projects-list current releases from AGE, not operations_log (fix)
- #327 — Throttle last_used / last_activity stamps on auth (perf/fix)
- #328 — Add non-admin plugin manifest endpoint (`GET /plugins/{slug}/manifest`)
- #329 — Split single-project rescore from rescore-all permission
- #330 — Add slim variant to projects list endpoint (`?slim=true`)

### Bump

- ``pyproject.toml``: 2.5.2 → 2.6.0
- ``uv.lock``: regenerated (also picks up ``imbi-plugin-github`` 1.3.0 from upstream)