### PR TITLE
Add uv 7-day holdback for third-party packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -220,9 +220,14 @@ max-complexity = 15
 [tool.ruff.lint.per-file-ignores]
 "tests/**/*.py" = ["S"]
 
+[tool.uv]
+exclude-newer = "7 days"
+exclude-newer-package = { "imbi-common" = false, "imbi-plugin-aws" = false, "imbi-plugin-github" = false, "imbi-plugin-logzio" = false, "imbi-plugin-oidc" = false, "imbi-plugin-pagerduty" = false, "imbi-plugin-sentry" = false, "imbi-plugin-sonarqube" = false }
+
 [[tool.uv.index]]
 url = "https://pypi.org/simple"
 default = true
 
 [tool.uv.sources]
+imbi-common = { path = "../imbi-common", editable = true }
 imbi-plugin-github = { path = "../imbi-plugin-github", editable = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -222,7 +222,7 @@ max-complexity = 15
 
 [tool.uv]
 exclude-newer = "7 days"
-exclude-newer-package = { "imbi-common" = false, "imbi-plugin-aws" = false, "imbi-plugin-github" = false, "imbi-plugin-logzio" = false, "imbi-plugin-oidc" = false, "imbi-plugin-pagerduty" = false, "imbi-plugin-sentry" = false, "imbi-plugin-sonarqube" = false }
+exclude-newer-package = { "clickhouse-connect" = false, "imbi-common" = false, "imbi-plugin-aws" = false, "imbi-plugin-github" = false, "imbi-plugin-logzio" = false, "imbi-plugin-oidc" = false, "imbi-plugin-pagerduty" = false, "imbi-plugin-sentry" = false, "imbi-plugin-sonarqube" = false }
 
 [[tool.uv.index]]
 url = "https://pypi.org/simple"


### PR DESCRIPTION
## Summary
- Sets `tool.uv.exclude-newer = "7 days"` to defer installing recently-published versions, as supply-chain hardening
- Exempts internal imbi packages (imbi-common, imbi-plugin-*) including forthcoming sentry/pagerduty/sonarqube plugins so cross-repo work isn't blocked

## Test plan
- [ ] `uv sync` succeeds against the lockfile
- [ ] No unintended dependency downgrades