### PR TITLE
Add committish/tag filters to list_releases

### DIFF
--- a/src/imbi_api/endpoints/releases.py
+++ b/src/imbi_api/endpoints/releases.py
@@ -524,20 +524,47 @@ async def list_releases(
             permissions.require_permission('project:read'),
         ),
     ],
+    committish: typing.Annotated[
+        str | None,
+        fastapi.Query(
+            description=(
+                'Optional 7-character committish to filter releases by.'
+            ),
+        ),
+    ] = None,
+    tag: typing.Annotated[
+        str | None,
+        fastapi.Query(
+            description='Optional tag to filter releases by.',
+        ),
+    ] = None,
 ) -> list[ReleaseResponse]:
-    """List all releases for a project, newest first."""
+    """List releases for a project, newest first.
+
+    Optional ``committish`` and ``tag`` query parameters filter the
+    result; when both are omitted every release is returned. Both are
+    matched exactly. A null parameter is interpolated as Cypher ``null``
+    and short-circuits the corresponding clause via ``null IS NULL``.
+    """
     del auth
     query: typing.LiteralString = """
     MATCH (p:Project {{id: {project_id}}})
           -[:OWNED_BY]->(:Team)
           -[:BELONGS_TO]->(:Organization {{slug: {org_slug}}})
     MATCH (p)-[:HAS_RELEASE]->(r:Release)
+    WHERE ({committish} IS NULL OR r.committish = {committish})
+      AND ({tag} IS NULL OR r.tag = {tag})
     RETURN r{{.*}} AS release
     ORDER BY r.created_at DESC
     """
     rows = await db.execute(
         query,
-        {'project_id': project_id, 'org_slug': org_slug},
+        {
+            'project_id': project_id,
+            'org_slug': org_slug,
+            'committish': committish,
+            'tag': tag,
+        },
         ['release'],
     )
     return [

--- a/tests/endpoints/test_releases.py
+++ b/tests/endpoints/test_releases.py
@@ -297,6 +297,76 @@ class ListGetReleaseTestCase(_ReleasesTestBase):
         self.assertEqual(len(data), 2)
         self.assertEqual(data[0]['tag'], '1.0.0')
         self.assertEqual(data[0]['project_id'], PROJECT_ID)
+        passed_params = self.mock_db.execute.await_args_list[0].args[1]
+        self.assertIsNone(passed_params['committish'])
+        self.assertIsNone(passed_params['tag'])
+
+    def test_list_releases_filter_by_committish(self) -> None:
+        self.mock_db.execute.return_value = [
+            {'release': _release_row(committish=DEFAULT_COMMITTISH)},
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            response = self.client.get(
+                self._url('/'),
+                params={'committish': DEFAULT_COMMITTISH},
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.json()), 1)
+        passed_params = self.mock_db.execute.await_args_list[0].args[1]
+        self.assertEqual(passed_params['committish'], DEFAULT_COMMITTISH)
+        self.assertIsNone(passed_params['tag'])
+
+    def test_list_releases_filter_by_tag(self) -> None:
+        self.mock_db.execute.return_value = [
+            {'release': _release_row(tag='1.2.3')},
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            response = self.client.get(
+                self._url('/'),
+                params={'tag': '1.2.3'},
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.json()), 1)
+        passed_params = self.mock_db.execute.await_args_list[0].args[1]
+        self.assertEqual(passed_params['tag'], '1.2.3')
+        self.assertIsNone(passed_params['committish'])
+
+    def test_list_releases_filter_by_both(self) -> None:
+        self.mock_db.execute.return_value = [
+            {
+                'release': _release_row(
+                    committish=DEFAULT_COMMITTISH, tag='1.2.3'
+                )
+            },
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            response = self.client.get(
+                self._url('/'),
+                params={'committish': DEFAULT_COMMITTISH, 'tag': '1.2.3'},
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.json()), 1)
+        passed_params = self.mock_db.execute.await_args_list[0].args[1]
+        self.assertEqual(passed_params['committish'], DEFAULT_COMMITTISH)
+        self.assertEqual(passed_params['tag'], '1.2.3')
+
+    def test_list_releases_filter_no_matches(self) -> None:
+        self.mock_db.execute.return_value = []
+        response = self.client.get(
+            self._url('/'),
+            params={'committish': 'deadbee'},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), [])
 
     def test_get_release_success(self) -> None:
         self.mock_db.execute.return_value = [{'release': _release_row()}]


### PR DESCRIPTION
## Summary

Add optional `committish` and `tag` query parameters to the project releases list endpoint so callers can resolve a `(committish, tag)` identity to a release nano-id.

## Problem

The gateway's `record_deployment` flow can produce a `(committish, tag)` pair from a webhook payload, but the API's deployment-event path requires the release's nano-id. There was no read-side endpoint to translate one to the other; the only way to find a release by its natural key was to enumerate every release for a project and filter client-side.

## Solution

- `GET /organizations/{org}/projects/{id}/releases/` now accepts `committish` and `tag` query parameters.
- Both are exact-match. Either may be omitted; when omitted, the corresponding `WHERE` clause short-circuits via `null IS NULL`, preserving the unfiltered behavior.
- Tests cover: no filters, committish only, tag only, both together, and an empty-result case.

## Test plan

- [x] `just test` — 1665 passed, 1 skipped. `endpoints/releases.py` at 91% coverage.
- [x] `just lint` — ruff, basedpyright, mypy all clean.

## Companion PRs

- imbi-gateway: AWeber-Imbi/imbi-gateway#30 — consumes the new filters to look up a release by `(committish, tag)` before posting a deployment event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)