### PR TITLE
Use MERGE for DEPLOYED_IN edges to avoid retry duplicates

### DIFF
--- a/src/imbi_api/endpoints/projects.py
+++ b/src/imbi_api/endpoints/projects.py
@@ -272,14 +272,16 @@ def _env_entries_template(
     return '[' + ', '.join(maps) + ']', params
 
 
-def _edge_create_props(
+def _edge_props_map(
     entries: list[dict[str, typing.Any]],
 ) -> str:
-    """Build a Cypher property map for DEPLOYED_IN edge creation.
+    """Build a Cypher property map for DEPLOYED_IN edge writes.
 
-    Returns a string like ``{{`url`: entry.`url`}}`` derived from
-    the union of all entries' keys (excluding ``slug``).  Returns
-    an empty string when there are no edge properties.
+    Used for both ``CREATE … []`` (project creation) and
+    ``MERGE … SET r =`` (project update).  Returns a string like
+    ``{{`url`: entry.`url`}}`` derived from the union of all entries'
+    keys (excluding ``slug``).  Returns an empty string when there are
+    no edge properties.
 
     """
     if not entries:
@@ -913,7 +915,7 @@ async def create_project(
     create_tpl = props_template(props)
     env_entries = [{'slug': s, **ep} for s, ep in data.environments.items()]
     env_tpl, env_params = _env_entries_template(env_entries)
-    edge_props_tpl = _edge_create_props(env_entries)
+    edge_props_tpl = _edge_props_map(env_entries)
 
     query: str = (
         '\nMATCH (o:Organization {{slug: {org_slug}}})'
@@ -1711,9 +1713,12 @@ def _build_update_clauses(
         {'slug': s, **ep} for s, ep in (data.environments or {}).items()
     ]
     new_env_tpl, new_env_params = _env_entries_template(new_env_entries)
-    new_edge_props_tpl = _edge_create_props(new_env_entries)
+    new_edge_props_tpl = _edge_props_map(new_env_entries)
 
     if data.environments is not None:
+        # MERGE (not CREATE) so the retry loop in
+        # _execute_project_update cannot accumulate duplicate edges
+        # if AGE rolls back the SET phase but not the edge write.
         rel_clauses += (
             ' WITH DISTINCT p, o'
             ' OPTIONAL MATCH'
@@ -1721,12 +1726,15 @@ def _build_update_clauses(
             ' DELETE old_env'
         )
         if new_env_entries:
+            merge_set = (
+                ' SET r =' + new_edge_props_tpl if new_edge_props_tpl else ''
+            )
             rel_clauses += (
                 ' WITH DISTINCT p, o'
                 f' UNWIND {new_env_tpl} AS entry'
                 ' MATCH (e:Environment'
                 ' {{slug: entry.slug}})-[:BELONGS_TO]->(o)'
-                ' CREATE (p)-[:DEPLOYED_IN' + new_edge_props_tpl + ']->(e)'
+                ' MERGE (p)-[r:DEPLOYED_IN]->(e)' + merge_set
             )
 
     return rel_clauses, new_env_params

--- a/tests/endpoints/test_projects.py
+++ b/tests/endpoints/test_projects.py
@@ -646,6 +646,53 @@ class ProjectEndpointsTestCase(unittest.TestCase):
 
         self.assertEqual(response.status_code, 200)
 
+    def test_patch_project_environments_uses_merge(self) -> None:
+        """Env edges use MERGE so retries cannot duplicate them."""
+        existing = self._project_data(
+            environments=[
+                {
+                    'slug': 'staging',
+                    'name': 'Staging',
+                    'id': 'env-1',
+                    'created_at': '2026-01-01T00:00:00Z',
+                    'updated_at': '2026-01-01T00:00:00Z',
+                }
+            ]
+        )
+        updated = self._project_data(name='Renamed API')
+
+        self.mock_db.execute.side_effect = [
+            [{'project': existing, 'outbound_count': 0, 'inbound_count': 0}],
+            [{'slug': 'platform'}],
+            [{'pt_slug': 'api-service', 'found': True}],
+            [{'env_slug': 'staging', 'found': True}],
+            [{'project': updated, 'outbound_count': 0, 'inbound_count': 0}],
+        ]
+
+        with (
+            mock.patch('imbi_common.blueprints.get_model') as mock_get_model,
+            mock.patch(
+                'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+            ),
+        ):
+            mock_get_model.return_value = models.Project
+            response = self.client.patch(
+                f'/organizations/engineering/projects/{PROJECT_ID}',
+                json=[
+                    {'op': 'replace', 'path': '/name', 'value': 'Renamed API'},
+                ],
+            )
+
+        self.assertEqual(response.status_code, 200)
+
+        update_query = next(
+            call.args[0]
+            for call in self.mock_db.execute.call_args_list
+            if 'old_env:DEPLOYED_IN' in call.args[0]
+        )
+        self.assertIn('MERGE (p)-[r:DEPLOYED_IN]->(e)', update_query)
+        self.assertNotIn('CREATE (p)-[:DEPLOYED_IN', update_query)
+
     def test_patch_project_team_change(self) -> None:
         """Patch a project to change its team."""
         existing = self._project_data()


### PR DESCRIPTION
## Summary

- Switch the env-edge fan-out in `_build_update_clauses` from `CREATE` to `MERGE (p)-[r:DEPLOYED_IN]->(e) SET r = <props>` so the per-entry write is idempotent under the `_execute_project_update` retry loop.
- The `DELETE old_env` sweep stays — it now also self-heals any pre-existing duplicate edges the next time a project is PATCHed with an `environments` field, so no backfill script is needed.
- Rename `_edge_create_props` → `_edge_props_map` (both call sites updated) since the helper is now used for both the CREATE and MERGE…SET paths.

## Problem

`_build_update_clauses` rewrote the env fan-out with `DELETE old_env … CREATE (p)-[:DEPLOYED_IN]->(e)`. When the retry loop introduced in #324 fires (AGE rolls back the SET phase but not the relationship write), the second attempt's DELETE doesn't see the first attempt's CREATEs, and we end up with two edges per environment. Renaming a project via the UI surfaced this for `aws-privateca-issuer` — every environment chip rendered twice (12 `DEPLOYED_IN` edges instead of 6).

## Solution

`MERGE (p)-[r:DEPLOYED_IN]->(e) SET r = {...}` is idempotent: a retry never adds a second edge for the same (project, environment) pair. The sweep + MERGE pattern also means a single PATCH on each previously-affected project collapses the duplicates back to one edge per environment — no backfill script required. For `aws-privateca-issuer`, one PATCH with the current env list returns the edge count to 6.

## Test plan

- [x] `just test tests/endpoints/test_projects.py` — 48/48 pass, including the new regression test `test_patch_project_environments_uses_merge` which asserts the rendered Cypher uses MERGE and never `CREATE (p)-[:DEPLOYED_IN`.
- [ ] After merge + deploy, PATCH `aws-privateca-issuer` (any PATCH whose body includes `environments`) and verify the edge count returns to 6.

## Follow-ups (out of scope for this PR)

- `Environment.slug` is not indexed in `imbi-common`'s `schemata.toml`; every per-entry `MATCH (e:Environment {slug: ...})` does a label scan. Belongs in a separate imbi-common PR.
- `_build_update_clauses` runs the sweep + MERGE unconditionally whenever `data.environments is not None`. A name-only PATCH still re-writes every edge because the PATCH handler populates `data.environments` from the existing project. Cheap fix in a follow-up: compare against `existing_p` and set `data.environments = None` when they match.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>