### PR TITLE
Bump version to 2.7.0 and add uv 7-day holdback

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "imbi-api"
-version = "2.5.2"
+version = "2.7.0"
 description = "Imbi is a DevOps Service Management Platform designed to provide an efficient way to manage a large environment that contains many services and applications."
 readme = "README.md"
 requires-python = ">=3.14"
@@ -220,6 +220,10 @@ max-complexity = 15
 
 [tool.ruff.lint.per-file-ignores]
 "tests/**/*.py" = ["S"]
+
+[tool.uv]
+exclude-newer = "7 days"
+exclude-newer-package = { "clickhouse-connect" = false, "imbi-common" = false, "imbi-plugin-aws" = false, "imbi-plugin-github" = false, "imbi-plugin-logzio" = false, "imbi-plugin-oidc" = false, "imbi-plugin-pagerduty" = false, "imbi-plugin-sentry" = false, "imbi-plugin-sonarqube" = false }
 
 [[tool.uv.index]]
 url = "https://pypi.org/simple"

--- a/uv.lock
+++ b/uv.lock
@@ -6,6 +6,21 @@ resolution-markers = [
   "python_full_version < '3.15'",
 ]
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z"  # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P7D"
+
+[options.exclude-newer-package]
+imbi-common = false
+imbi-plugin-pagerduty = false
+imbi-plugin-github = false
+imbi-plugin-logzio = false
+imbi-plugin-aws = false
+imbi-plugin-sonarqube = false
+clickhouse-connect = false
+imbi-plugin-sentry = false
+imbi-plugin-oidc = false
+
 [[package]]
 name = "aioboto3"
 version = "15.5.0"
@@ -959,7 +974,7 @@ wheels = [
 
 [[package]]
 name = "imbi-api"
-version = "2.5.2"
+version = "2.7.0"
 source = { editable = "." }
 dependencies = [
   { name = "aioboto3" },


### PR DESCRIPTION
## Summary

- Bump `imbi-api` version from 2.5.2 → 2.7.0.
- Add `[tool.uv]` with `exclude-newer = "7 days"` plus an `exclude-newer-package` exemption list for internal imbi packages and `clickhouse-connect`.

## Problem

`tool.uv.exclude-newer` was previously added in #333 but got overwritten by #332's squash merge (which dropped the entire `[tool.uv]` and `[tool.uv.sources]` blocks). The supply-chain holdback never made it onto `main`.

## Solution

Re-add the same `[tool.uv]` block from #331/#333 with one deliberate difference: **no `imbi-common = { path = "../imbi-common", editable = true }` source line**. That keeps `uv.lock` resolving `imbi-common` from PyPI by default, which is what #332 was intentionally aiming for. Forward-looking exemptions for `imbi-plugin-sentry`, `imbi-plugin-pagerduty`, and `imbi-plugin-sonarqube` are preserved so cross-repo work on those plugins isn't blocked.

The version skips 2.6.0 (the closed #331 had planned that) and goes straight to 2.7.0 to reflect everything that has merged since 2.5.2:
- #329 — single-project rescore permission split
- #330 — slim projects-list variant
- #332 — plugins as optional dependencies
- #333 — uv holdback (overwritten, re-applied here)
- #334 — release-notes prompt tightening
- #335 — committish/tag filters on list_releases
- #336 — MERGE for DEPLOYED_IN edges

## Test plan

- [x] `uv lock` resolved cleanly — only the imbi-api self-version changed; no transitive dep shifts.
- [x] `just test tests/endpoints/test_projects.py` — 48/48 pass locally.
- [ ] CI green on the PR.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>