### PR TITLE
Use MERGE for OWNED_BY and TYPE edges to avoid retry duplicates

### DIFF
--- a/src/imbi_api/domain/models.py
+++ b/src/imbi_api/domain/models.py
@@ -1156,7 +1156,7 @@ class WebhookResponse(pydantic.BaseModel):
                 config: dict[str, typing.Any] | list[typing.Any]
                 try:
                     config = json.loads(raw_config) if raw_config else {}
-                except json.JSONDecodeError, TypeError:
+                except (json.JSONDecodeError, TypeError):
                     config = {}
                 rules.append(
                     WebhookRuleResponse(

--- a/src/imbi_api/endpoints/auth_providers.py
+++ b/src/imbi_api/endpoints/auth_providers.py
@@ -43,7 +43,7 @@ def _parse_json_field(value: typing.Any, default: typing.Any) -> typing.Any:
     if isinstance(value, str):
         try:
             return json.loads(value)
-        except json.JSONDecodeError, TypeError:
+        except (json.JSONDecodeError, TypeError):
             return default
     return value
 

--- a/src/imbi_api/endpoints/projects.py
+++ b/src/imbi_api/endpoints/projects.py
@@ -1690,15 +1690,21 @@ def _build_update_clauses(
     """
     rel_clauses: str = ''
     if data.team_slug:
+        # MERGE (not CREATE) so the retry loop in
+        # _execute_project_update cannot accumulate duplicate edges
+        # if AGE rolls back the SET phase but not the edge write.
         rel_clauses += """
     WITH p, o
     MATCH (new_t:Team {{slug: {new_team_slug}}})
           -[:BELONGS_TO]->(o)
     OPTIONAL MATCH (p)-[old_own:OWNED_BY]->(:Team)
     DELETE old_own
-    CREATE (p)-[:OWNED_BY]->(new_t)
+    MERGE (p)-[:OWNED_BY]->(new_t)
     """
     if data.project_type_slugs is not None:
+        # MERGE (not CREATE) so the retry loop in
+        # _execute_project_update cannot accumulate duplicate edges
+        # if AGE rolls back the SET phase but not the edge write.
         rel_clauses += """
     WITH DISTINCT p, o
     OPTIONAL MATCH (p)-[old_type:TYPE]->(:ProjectType)
@@ -1707,7 +1713,7 @@ def _build_update_clauses(
     UNWIND {new_type_slugs} AS new_pt_slug
     MATCH (new_pt:ProjectType {{slug: new_pt_slug}})
           -[:BELONGS_TO]->(o)
-    CREATE (p)-[:TYPE]->(new_pt)
+    MERGE (p)-[:TYPE]->(new_pt)
     """
     new_env_entries = [
         {'slug': s, **ep} for s, ep in (data.environments or {}).items()

--- a/src/imbi_api/endpoints/releases.py
+++ b/src/imbi_api/endpoints/releases.py
@@ -518,7 +518,7 @@ async def list_releases(
     org_slug: str,
     project_id: str,
     db: graph.Pool,
-    auth: typing.Annotated[
+    _auth: typing.Annotated[
         permissions.AuthContext,
         fastapi.Depends(
             permissions.require_permission('project:read'),
@@ -546,7 +546,6 @@ async def list_releases(
     matched exactly. A null parameter is interpolated as Cypher ``null``
     and short-circuits the corresponding clause via ``null IS NULL``.
     """
-    del auth
     query: typing.LiteralString = """
     MATCH (p:Project {{id: {project_id}}})
           -[:OWNED_BY]->(:Team)
@@ -691,7 +690,7 @@ async def get_release(
     project_id: str,
     release_id: str,
     db: graph.Pool,
-    auth: typing.Annotated[
+    _auth: typing.Annotated[
         permissions.AuthContext,
         fastapi.Depends(
             permissions.require_permission('project:read'),
@@ -699,7 +698,6 @@ async def get_release(
     ],
 ) -> ReleaseResponse:
     """Get a single release by id."""
-    del auth
     data = await _fetch_release(db, org_slug, project_id, release_id)
     if data is None:
         raise fastapi.HTTPException(
@@ -718,7 +716,7 @@ async def patch_release(
     release_id: str,
     operations: list[json_patch.PatchOperation],
     db: graph.Pool,
-    auth: typing.Annotated[
+    _auth: typing.Annotated[
         permissions.AuthContext,
         fastapi.Depends(
             permissions.require_permission('project:write'),
@@ -726,7 +724,6 @@ async def patch_release(
     ],
 ) -> ReleaseResponse:
     """Apply a JSON Patch (RFC 6902) to a release."""
-    del auth
     data = await _fetch_release(db, org_slug, project_id, release_id)
     if data is None:
         raise fastapi.HTTPException(
@@ -1121,7 +1118,7 @@ async def record_deployment(
     env_slug: str,
     data: DeploymentEventInput,
     db: graph.Pool,
-    auth: typing.Annotated[
+    _auth: typing.Annotated[
         permissions.AuthContext,
         fastapi.Depends(
             permissions.require_permission('project:write'),
@@ -1129,7 +1126,6 @@ async def record_deployment(
     ],
 ) -> ReleaseEnvironmentEdgeResponse:
     """Record a deployment event for a release in an environment."""
-    del auth
     release = await _fetch_release(db, org_slug, project_id, release_id)
     if release is None:
         raise fastapi.HTTPException(
@@ -1222,7 +1218,7 @@ async def list_deployment_edges(
     project_id: str,
     release_id: str,
     db: graph.Pool,
-    auth: typing.Annotated[
+    _auth: typing.Annotated[
         permissions.AuthContext,
         fastapi.Depends(
             permissions.require_permission('project:read'),
@@ -1230,7 +1226,6 @@ async def list_deployment_edges(
     ],
 ) -> list[ReleaseEnvironmentEdgeResponse]:
     """List every environment edge for a release."""
-    del auth
     release = await _fetch_release(db, org_slug, project_id, release_id)
     if release is None:
         raise fastapi.HTTPException(
@@ -1280,7 +1275,7 @@ async def get_deployment_edge(
     release_id: str,
     env_slug: str,
     db: graph.Pool,
-    auth: typing.Annotated[
+    _auth: typing.Annotated[
         permissions.AuthContext,
         fastapi.Depends(
             permissions.require_permission('project:read'),
@@ -1288,7 +1283,6 @@ async def get_deployment_edge(
     ],
 ) -> ReleaseEnvironmentEdgeResponse:
     """Get a single deployment edge by environment slug."""
-    del auth
     release = await _fetch_release(db, org_slug, project_id, release_id)
     if release is None:
         raise fastapi.HTTPException(

--- a/src/imbi_api/endpoints/user_activity.py
+++ b/src/imbi_api/endpoints/user_activity.py
@@ -338,7 +338,7 @@ async def _graph_buckets(
 async def get_user_contributions(
     email: str,
     db: graph.Pool,
-    auth: typing.Annotated[
+    _auth: typing.Annotated[
         permissions.AuthContext,
         fastapi.Depends(permissions.require_permission('user:read')),
     ],
@@ -352,7 +352,6 @@ async def get_user_contributions(
     Release, Upload, Conversation) into one daily map keyed by the
     requested ``tz``.
     """
-    del auth
     email = urllib.parse.unquote(email)
     await _ensure_user_exists(db, email)
     zone = _resolve_tz(tz)
@@ -504,7 +503,7 @@ async def _projects_touched(
 async def get_user_stats(
     email: str,
     db: graph.Pool,
-    auth: typing.Annotated[
+    _auth: typing.Annotated[
         permissions.AuthContext,
         fastapi.Depends(permissions.require_permission('user:read')),
     ],
@@ -513,7 +512,6 @@ async def get_user_stats(
     tz: str = 'UTC',
 ) -> StatsResponse:
     """Return summary deployment / project tiles for the profile page."""
-    del auth
     _resolve_tz(tz)  # validate even though stats does not bucket by tz
     email = urllib.parse.unquote(email)
     await _ensure_user_exists(db, email)
@@ -589,13 +587,12 @@ async def get_user_stats(
 async def get_user_identities(
     email: str,
     db: graph.Pool,
-    auth: typing.Annotated[
+    _auth: typing.Annotated[
         permissions.AuthContext,
         fastapi.Depends(permissions.require_permission('user:read')),
     ],
 ) -> IdentitiesResponse:
     """Return the user's linked OAuth identities (no tokens)."""
-    del auth
     email = urllib.parse.unquote(email)
     await _ensure_user_exists(db, email)
 
@@ -995,7 +992,7 @@ async def get_user_activity(
     request: fastapi.Request,
     email: str,
     db: graph.Pool,
-    auth: typing.Annotated[
+    _auth: typing.Annotated[
         permissions.AuthContext,
         fastapi.Depends(permissions.require_permission('user:read')),
     ],
@@ -1003,7 +1000,6 @@ async def get_user_activity(
     cursor: str | None = None,
 ) -> fastapi.Response:
     """Cursor-paginated, mixed-source activity feed for the user."""
-    del auth
     if limit < 1 or limit > MAX_ACTIVITY_LIMIT:
         raise fastapi.HTTPException(
             status_code=400,

--- a/src/imbi_api/endpoints/users.py
+++ b/src/imbi_api/endpoints/users.py
@@ -368,7 +368,7 @@ async def get_user_by_identity(
     plugin_slug: str,
     subject: str,
     db: graph.Pool,
-    auth: typing.Annotated[
+    _auth: typing.Annotated[
         permissions.AuthContext,
         fastapi.Depends(permissions.require_permission('user:read')),
     ],
@@ -379,7 +379,6 @@ async def get_user_by_identity(
     (e.g. a GitHub deployment) to the corresponding Imbi user.
     Returns 404 when no active ``IdentityConnection`` matches.
     """
-    del auth
     user_id = await identity_repository.find_user_by_subject(
         db, plugin_slug=plugin_slug, subject=subject
     )

--- a/src/imbi_api/entrypoint.py
+++ b/src/imbi_api/entrypoint.py
@@ -214,12 +214,12 @@ async def _setup_async() -> None:
         password = getpass.getpass('  Password: ')
         if not password:
             typer.echo('✗ Password cannot be empty', err=True)
-            raise typer.Exit(code=1) from None
+            raise typer.Exit(code=1)
 
         password_confirm = getpass.getpass('  Confirm password: ')
         if password != password_confirm:
             typer.echo('✗ Passwords do not match', err=True)
-            raise typer.Exit(code=1) from None
+            raise typer.Exit(code=1)
 
         # Create admin user
         try:

--- a/src/imbi_api/patch.py
+++ b/src/imbi_api/patch.py
@@ -1,12 +1,13 @@
 """JSON Patch (RFC 6902) utilities."""
 
+import logging
 import typing
 
 import fastapi
 import jsonpatch  # type: ignore[import-untyped]
 import pydantic
 
-LOGGER = __import__('logging').getLogger(__name__)
+LOGGER = logging.getLogger(__name__)
 
 READONLY_PATHS: frozenset[str] = frozenset(
     ['/created_at', '/updated_at', '/relationships', '/id']

--- a/tests/endpoints/test_projects.py
+++ b/tests/endpoints/test_projects.py
@@ -739,6 +739,53 @@ class ProjectEndpointsTestCase(unittest.TestCase):
 
         self.assertEqual(response.status_code, 200)
 
+    def test_patch_project_team_and_type_use_merge(self) -> None:
+        """OWNED_BY and TYPE edges use MERGE so retries cannot duplicate."""
+        existing = self._project_data()
+        updated = self._project_data(name='Renamed API')
+
+        self.mock_db.execute.side_effect = [
+            [{'project': existing, 'outbound_count': 0, 'inbound_count': 0}],
+            [{'slug': 'backend'}],
+            [{'pt_slug': 'worker', 'found': True}],
+            [{'project': updated, 'outbound_count': 0, 'inbound_count': 0}],
+        ]
+
+        with (
+            mock.patch('imbi_common.blueprints.get_model') as mock_get_model,
+            mock.patch(
+                'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+            ),
+        ):
+            mock_get_model.return_value = models.Project
+            response = self.client.patch(
+                f'/organizations/engineering/projects/{PROJECT_ID}',
+                json=[
+                    {
+                        'op': 'replace',
+                        'path': '/team_slug',
+                        'value': 'backend',
+                    },
+                    {
+                        'op': 'replace',
+                        'path': '/project_type_slugs',
+                        'value': ['worker'],
+                    },
+                ],
+            )
+
+        self.assertEqual(response.status_code, 200)
+
+        update_query = next(
+            call.args[0]
+            for call in self.mock_db.execute.call_args_list
+            if 'old_own:OWNED_BY' in call.args[0]
+        )
+        self.assertIn('MERGE (p)-[:OWNED_BY]->(new_t)', update_query)
+        self.assertNotIn('CREATE (p)-[:OWNED_BY]', update_query)
+        self.assertIn('MERGE (p)-[:TYPE]->(new_pt)', update_query)
+        self.assertNotIn('CREATE (p)-[:TYPE]', update_query)
+
     def test_patch_project_invalid_team(self) -> None:
         """Patch with a non-existent team slug returns 422."""
         existing = self._project_data()


### PR DESCRIPTION
## Summary

- Mirrors #336 (DEPLOYED_IN). The project update path retries up to three times on AGE's non-deterministic *"Entity failed to be updated"* error; CREATE accumulates duplicate edges if AGE rolls back the SET phase but not the edge write. MERGE is idempotent under retry.
- Adds a regression test asserting the patched query uses MERGE for both OWNED_BY and TYPE, mirroring the existing DEPLOYED_IN coverage at `test_patch_project_environments_uses_merge`.

Addresses H10 in the in-tree code-review punchlist.

## Test plan

- [x] `just test tests/endpoints/test_projects.py` — 49 passed
- [x] Existing `test_patch_project_team_change` / `test_patch_project_team_change_with_types` still pass
- [x] New `test_patch_project_team_and_type_use_merge` asserts both edges use MERGE