### PR TITLE
Validate plugin label/edge names before Cypher interpolation

### DIFF
--- a/src/imbi_api/endpoints/plugin_edges.py
+++ b/src/imbi_api/endpoints/plugin_edges.py
@@ -6,6 +6,7 @@ generic across anchor types.
 
 import json
 import logging
+import re
 import typing
 
 import fastapi
@@ -15,6 +16,22 @@ from imbi_common.plugins.base import PluginEdgeLabel
 from imbi_common.plugins.registry import list_plugins
 
 LOGGER = logging.getLogger(__name__)
+
+# Cypher label and relationship-type identifiers are interpolated into
+# queries as f-strings, so each must be a simple identifier. A malformed
+# plugin manifest must not be able to break out of the label position
+# into arbitrary Cypher. Validated at the call site as defense-in-depth;
+# the manifest loader should reject these earlier.
+_CYPHER_IDENTIFIER = re.compile(r'^[A-Za-z][A-Za-z0-9_]*$')
+
+
+def _assert_cypher_identifier(value: str, kind: str) -> None:
+    """Reject any value that isn't a bare Cypher identifier."""
+    if not _CYPHER_IDENTIFIER.match(value):
+        raise fastapi.HTTPException(
+            status_code=400,
+            detail=f'Invalid {kind} {value!r}',
+        )
 
 
 class EdgePutBody(pydantic.BaseModel):
@@ -127,9 +144,13 @@ def resolve_edge_for(anchor_label: str, rel_type: str) -> PluginEdgeLabel:
         an anchor whose label is in ``from_labels``.
 
     """
+    _assert_cypher_identifier(anchor_label, 'anchor label')
+    _assert_cypher_identifier(rel_type, 'relationship type')
     for entry in list_plugins():
         for edge in entry.manifest.edge_labels:
             if edge.name == rel_type and anchor_label in edge.from_labels:
+                for target in edge.to_labels:
+                    _assert_cypher_identifier(target, 'target label')
                 return edge
     raise fastapi.HTTPException(
         status_code=404,

--- a/src/imbi_api/endpoints/plugin_entities.py
+++ b/src/imbi_api/endpoints/plugin_entities.py
@@ -8,6 +8,7 @@ import functools
 import importlib
 import json
 import logging
+import re
 import types
 import typing
 
@@ -23,6 +24,13 @@ from imbi_api.auth import permissions
 from imbi_api.graph_sql import props_template, set_clause
 
 LOGGER = logging.getLogger(__name__)
+
+# Cypher label identifiers are interpolated into queries as f-strings,
+# so each label must be a simple identifier. A malformed plugin
+# manifest must not be able to break out of the label position into
+# arbitrary Cypher. Validated at the call site as defense-in-depth;
+# the manifest loader should reject these earlier.
+_CYPHER_IDENTIFIER = re.compile(r'^[A-Za-z][A-Za-z0-9_]*$')
 
 plugin_entities_router = fastapi.APIRouter(
     prefix='/admin/plugins/{slug}/entities',
@@ -77,6 +85,19 @@ def _resolve_label(
         ) from exc
     for vlabel in entry.manifest.vertex_labels:
         if vlabel.name == label:
+            if not _CYPHER_IDENTIFIER.match(vlabel.name):
+                LOGGER.error(
+                    'Plugin %r declares invalid vertex label %r',
+                    slug,
+                    vlabel.name,
+                )
+                raise fastapi.HTTPException(
+                    status_code=500,
+                    detail=(
+                        f'Plugin {slug!r} declares invalid vertex label '
+                        f'{vlabel.name!r}'
+                    ),
+                )
             return _import_model(vlabel.model_ref), vlabel.name
     raise fastapi.HTTPException(
         status_code=404,

--- a/tests/endpoints/test_plugin_label_validation.py
+++ b/tests/endpoints/test_plugin_label_validation.py
@@ -55,7 +55,7 @@ def _registry_entry(
     )
 
 
-class ResolveLabelValidationTests(unittest.TestCase):
+class ResolveLabelValidationTests(unittest.IsolatedAsyncioTestCase):
     def test_valid_label_resolves(self) -> None:
         entry = _registry_entry(
             vertex_labels=[
@@ -108,7 +108,7 @@ class ResolveLabelValidationTests(unittest.TestCase):
         self.assertEqual(ctx.exception.status_code, 500)
 
 
-class ResolveEdgeValidationTests(unittest.TestCase):
+class ResolveEdgeValidationTests(unittest.IsolatedAsyncioTestCase):
     def test_malicious_rel_type_is_rejected(self) -> None:
         with self.assertRaises(fastapi.HTTPException) as ctx:
             plugin_edges.resolve_edge_for(

--- a/tests/endpoints/test_plugin_label_validation.py
+++ b/tests/endpoints/test_plugin_label_validation.py
@@ -1,0 +1,158 @@
+"""Verify plugin label/edge names are validated before Cypher interpolation.
+
+The endpoints in :mod:`imbi_api.endpoints.plugin_entities` and
+:mod:`imbi_api.endpoints.plugin_edges` interpolate label and
+relationship-type strings directly into Cypher queries. A malformed
+plugin manifest must not be able to break out of the label position.
+"""
+
+import unittest
+from unittest import mock
+
+import fastapi
+from imbi_common.plugins.base import (
+    ConfigurationPlugin,
+    PluginEdgeLabel,
+    PluginManifest,
+    PluginVertexLabel,
+)
+from imbi_common.plugins.registry import RegistryEntry
+
+from imbi_api.endpoints import plugin_edges, plugin_entities
+
+
+def _registry_entry(
+    *,
+    vertex_labels: list[PluginVertexLabel] | None = None,
+    edge_labels: list[PluginEdgeLabel] | None = None,
+) -> RegistryEntry:
+    class _Fake(ConfigurationPlugin):
+        manifest = PluginManifest(
+            slug='evil',
+            name='Evil Plugin',
+            plugin_type='configuration',
+            vertex_labels=vertex_labels or [],
+            edge_labels=edge_labels or [],
+        )
+
+        async def list_keys(self, ctx, credentials):  # type: ignore[override]
+            return []
+
+        async def get_values(self, ctx, credentials, keys=None):  # type: ignore[override]
+            return []
+
+        async def set_value(self, ctx, credentials, key, value):  # type: ignore[override]
+            raise NotImplementedError
+
+        async def delete_key(self, ctx, credentials, key):  # type: ignore[override]
+            return None
+
+    return RegistryEntry(
+        handler_cls=_Fake,
+        manifest=_Fake.manifest,
+        package_name='imbi-plugin-evil',
+        package_version='1.0.0',
+    )
+
+
+class ResolveLabelValidationTests(unittest.TestCase):
+    def test_valid_label_resolves(self) -> None:
+        entry = _registry_entry(
+            vertex_labels=[
+                PluginVertexLabel(
+                    name='AwsAccount',
+                    model_ref='imbi_common.models:Organization',
+                )
+            ]
+        )
+        with mock.patch.object(
+            plugin_entities, 'get_plugin', return_value=entry
+        ):
+            _model, vlabel = plugin_entities._resolve_label(
+                'evil', 'AwsAccount'
+            )
+        self.assertEqual(vlabel, 'AwsAccount')
+
+    def test_malicious_label_with_space_is_rejected(self) -> None:
+        entry = _registry_entry(
+            vertex_labels=[
+                PluginVertexLabel(
+                    name='Node) DETACH DELETE n MATCH (x',
+                    model_ref='imbi_common.models:Organization',
+                )
+            ]
+        )
+        with mock.patch.object(
+            plugin_entities, 'get_plugin', return_value=entry
+        ):
+            with self.assertRaises(fastapi.HTTPException) as ctx:
+                plugin_entities._resolve_label(
+                    'evil', 'Node) DETACH DELETE n MATCH (x'
+                )
+        self.assertEqual(ctx.exception.status_code, 500)
+
+    def test_label_starting_with_digit_is_rejected(self) -> None:
+        entry = _registry_entry(
+            vertex_labels=[
+                PluginVertexLabel(
+                    name='1Bad',
+                    model_ref='imbi_common.models:Organization',
+                )
+            ]
+        )
+        with mock.patch.object(
+            plugin_entities, 'get_plugin', return_value=entry
+        ):
+            with self.assertRaises(fastapi.HTTPException) as ctx:
+                plugin_entities._resolve_label('evil', '1Bad')
+        self.assertEqual(ctx.exception.status_code, 500)
+
+
+class ResolveEdgeValidationTests(unittest.TestCase):
+    def test_malicious_rel_type_is_rejected(self) -> None:
+        with self.assertRaises(fastapi.HTTPException) as ctx:
+            plugin_edges.resolve_edge_for(
+                'Environment',
+                'MAPS_TO]->() DETACH DELETE x MATCH (a:Environment',
+            )
+        self.assertEqual(ctx.exception.status_code, 400)
+
+    def test_malicious_anchor_label_is_rejected(self) -> None:
+        with self.assertRaises(fastapi.HTTPException) as ctx:
+            plugin_edges.resolve_edge_for(
+                'Environment) DETACH DELETE x MATCH (y', 'MAPS_TO'
+            )
+        self.assertEqual(ctx.exception.status_code, 400)
+
+    def test_malicious_target_label_in_manifest_is_rejected(self) -> None:
+        entry = _registry_entry(
+            edge_labels=[
+                PluginEdgeLabel(
+                    name='MAPS_TO',
+                    from_labels=['Environment'],
+                    to_labels=['Foo) DETACH DELETE n MATCH (x'],
+                )
+            ]
+        )
+        with mock.patch.object(
+            plugin_edges, 'list_plugins', return_value=[entry]
+        ):
+            with self.assertRaises(fastapi.HTTPException) as ctx:
+                plugin_edges.resolve_edge_for('Environment', 'MAPS_TO')
+        self.assertEqual(ctx.exception.status_code, 400)
+
+    def test_valid_edge_resolves(self) -> None:
+        entry = _registry_entry(
+            edge_labels=[
+                PluginEdgeLabel(
+                    name='MAPS_TO',
+                    from_labels=['Environment'],
+                    to_labels=['AwsAccount'],
+                )
+            ]
+        )
+        with mock.patch.object(
+            plugin_edges, 'list_plugins', return_value=[entry]
+        ):
+            edge = plugin_edges.resolve_edge_for('Environment', 'MAPS_TO')
+        self.assertEqual(edge.name, 'MAPS_TO')


### PR DESCRIPTION
## Summary

Addresses **C5** in the in-tree code-review punchlist.

The generic plugin-entity and plugin-edge endpoints interpolate label and relationship-type identifiers directly into Cypher queries via f-strings (e.g. `f'MATCH (n:{vlabel})'`, `f'-[r:{rel_type}]->'`). A plugin manifest that declares a vertex label, edge name, or target label containing whitespace or closing brackets could break out of the label position and execute arbitrary Cypher.

This PR is the **call-site (defense-in-depth)** half of the fix — every identifier interpolated into a Cypher query is now validated against `^[A-Za-z][A-Za-z0-9_]*$` before use:

- `plugin_entities._resolve_label()` — raises **500** (the configured manifest is bad, not a client error).
- `plugin_edges.resolve_edge_for()` — raises **400** for `rel_type` / `anchor_label` (callers may pass user-controlled values via query params) and **400** for any malformed `to_labels` entry in the matched manifest.

The matching **manifest-time** validation belongs in `imbi_common` (the punchlist asks for both ends) and will land separately so this PR stays surgical.

## Test plan

- [x] `just test tests/endpoints/test_admin_plugins.py tests/endpoints/test_plugin_label_validation.py` — 15 passed
- [x] New `tests/endpoints/test_plugin_label_validation.py` covers: valid label resolves; whitespace-bearing label rejected; digit-leading label rejected; malicious `rel_type` rejected; malicious `anchor_label` rejected; malicious `target_label` in matched manifest rejected.

## Notes / Follow-up

- Defense-in-depth: even with this in place, a malicious package that reaches the install path is still arbitrary code execution (see C4). C5 + C4 should land together; pairing this with the upcoming C4 PR.