### PR TITLE
Enforce single-use semantics on identity state JWT nonces

### DIFF
--- a/src/imbi_api/endpoints/auth.py
+++ b/src/imbi_api/endpoints/auth.py
@@ -14,6 +14,7 @@ import pyotp
 from imbi_common import graph
 from imbi_common.auth import core, encryption
 from imbi_common.plugins import errors as plugin_errors
+from valkey import asyncio as valkey_module
 
 from imbi_api import models, settings
 from imbi_api.auth import (
@@ -28,6 +29,7 @@ from imbi_api.auth import password as password_auth
 from imbi_api.identity import flows as identity_flows
 from imbi_api.identity import repository as identity_repository
 from imbi_api.middleware import rate_limit
+from imbi_api.scoring import OptionalValkeyClient
 
 LOGGER = logging.getLogger(__name__)
 
@@ -817,6 +819,7 @@ async def oauth_login(
 async def oauth_callback(
     db: graph.Pool,
     provider: str,
+    valkey_client: OptionalValkeyClient,
     code: str | None = fastapi.Query(default=None),
     state: str | None = fastapi.Query(default=None),
     error: str | None = fastapi.Query(default=None),
@@ -874,6 +877,7 @@ async def oauth_callback(
                 code,
                 state,
                 auth_settings,
+                valkey_client,
             )
 
         # Verify state parameter
@@ -994,6 +998,7 @@ async def _identity_plugin_login_callback(
     code: str,
     state: str,
     auth_settings: settings.Auth,
+    valkey_client: valkey_module.Valkey | None,
 ) -> fastapi.responses.RedirectResponse:
     """Complete a login-intent flow handled by an identity plugin.
 
@@ -1009,7 +1014,10 @@ async def _identity_plugin_login_callback(
         plugin_id,
         return_to,
     ) = await identity_flows.complete_login_flow(
-        db, code=code, state_token=state
+        db,
+        code=code,
+        state_token=state,
+        valkey_client=valkey_client,
     )
     if not profile.email:
         raise ValueError(

--- a/src/imbi_api/identity/endpoints.py
+++ b/src/imbi_api/identity/endpoints.py
@@ -21,6 +21,7 @@ from imbi_api.identity import (
     models,
     repository,
 )
+from imbi_api.scoring import OptionalValkeyClient
 
 LOGGER = logging.getLogger(__name__)
 
@@ -194,17 +195,24 @@ async def callback(
     code: str,
     state: str,
     db: graph.Pool,
+    valkey_client: OptionalValkeyClient,
 ) -> fastapi.responses.Response:
     """Browser callback handler — exchanges ``code`` and persists the
-    connection.  Trusts the state JWT for actor identity (the user may
-    not have a session yet during a login flow)."""
+    connection.  The state JWT carries the actor identity (the user may
+    not have a session yet during a login flow) and its nonce is
+    enforced single-use via Valkey to prevent replay."""
     try:
         (
             _profile,
             _credentials,
             _returned_plugin_id,
             return_to,
-        ) = await flows.complete_flow(db, code=code, state_token=state)
+        ) = await flows.complete_flow(
+            db,
+            code=code,
+            state_token=state,
+            valkey_client=valkey_client,
+        )
     except ValueError as exc:
         raise fastapi.HTTPException(
             status_code=400, detail=f'Invalid state: {exc}'

--- a/src/imbi_api/identity/flows.py
+++ b/src/imbi_api/identity/flows.py
@@ -14,6 +14,7 @@ from imbi_common.plugins.base import (
 )
 from imbi_common.plugins.errors import PluginNotFoundError
 from imbi_common.plugins.registry import RegistryEntry, get_plugin
+from valkey import asyncio as valkey
 
 from imbi_api.identity import errors, repository, state
 from imbi_api.plugins import credentials as plugin_credentials
@@ -196,17 +197,24 @@ async def complete_flow(
     *,
     code: str,
     state_token: str,
+    valkey_client: valkey.Valkey | None,
 ) -> tuple[IdentityProfile, IdentityCredentials, str, str | None]:
     """Exchange ``code`` for tokens and persist the connection.
 
     Returns ``(profile, credentials, plugin_id, return_to)``.  The caller
     decides whether to also create / refresh a session (login intent) or
     just record the IdentityConnection (identity intent).
+
+    Enforces single-use semantics on the state JWT's nonce via
+    :func:`state.consume_identity_nonce` so a leaked / logged state
+    cannot be replayed within its 10-minute TTL.
     """
     state_data = state.decode_identity_state(state_token)
     plugin_id = state_data.plugin_id
     if not plugin_id:
         raise ValueError('state token missing plugin_id')
+    if not await state.consume_identity_nonce(valkey_client, state_data.nonce):
+        raise ValueError('state token has already been used')
 
     resolved_id, _entry, handler, creds, options = await _load_plugin_handler(
         db, plugin_id
@@ -296,6 +304,7 @@ async def complete_login_flow(
     *,
     code: str,
     state_token: str,
+    valkey_client: valkey.Valkey | None,
 ) -> tuple[IdentityProfile, IdentityCredentials, str, str | None]:
     """Exchange a code from an ``intent='login'`` flow.
 
@@ -304,11 +313,16 @@ async def complete_login_flow(
     :class:`IdentityConnection` — the caller must provision the local
     user first and then call :func:`repository.upsert_connection` with
     that user's id.
+
+    The state JWT's nonce is enforced single-use via Valkey to prevent
+    replay of a leaked or logged login state.
     """
     state_data = state.decode_login_state(state_token)
     plugin_id = state_data.plugin_id
     if not plugin_id:
         raise ValueError('state token missing plugin_id')
+    if not await state.consume_identity_nonce(valkey_client, state_data.nonce):
+        raise ValueError('state token has already been used')
 
     resolved_id, _entry, handler, creds, options = await _load_plugin_handler(
         db, plugin_id

--- a/src/imbi_api/identity/state.py
+++ b/src/imbi_api/identity/state.py
@@ -6,13 +6,25 @@ state-token format.  ``intent='identity'`` discriminates the identity
 flow path.
 """
 
+import logging
 import secrets
 import time
 
 import jwt
+from valkey import asyncio as valkey
 
 from imbi_api import settings
 from imbi_api.auth import models
+
+LOGGER = logging.getLogger(__name__)
+
+# Identity state JWTs are short-lived (10 min by default), but the
+# JWT alone has no single-use semantics: anyone who replays the
+# state token within its lifetime would otherwise re-trigger the
+# callback and persist (or overwrite) the IdentityConnection again.
+# A Valkey ``SET NX EX`` on the per-token nonce gives single-use
+# guarantees with the same TTL as the JWT itself.
+_NONCE_KEY_PREFIX = 'identity:state:nonce:'
 
 
 def encode_identity_state(
@@ -103,6 +115,30 @@ def decode_identity_state(
         auth_settings=auth_settings,
         max_age_seconds=max_age_seconds,
     )
+
+
+async def consume_identity_nonce(
+    valkey_client: valkey.Valkey | None,
+    nonce: str,
+    *,
+    ttl_seconds: int = 600,
+) -> bool:
+    """Atomically mark ``nonce`` as consumed.
+
+    Returns ``True`` if the nonce was newly recorded (first use),
+    ``False`` if it had already been consumed within ``ttl_seconds``.
+    Raises :class:`RuntimeError` when no Valkey client is available
+    — replay protection requires Valkey, and identity flows must fail
+    closed rather than silently lose the guarantee.
+    """
+    if valkey_client is None:
+        raise RuntimeError(
+            'Identity replay protection requires Valkey; '
+            'no client is configured'
+        )
+    key = f'{_NONCE_KEY_PREFIX}{nonce}'
+    result = await valkey_client.set(key, '1', nx=True, ex=ttl_seconds)
+    return bool(result)
 
 
 def decode_login_state(

--- a/tests/identity/test_endpoints.py
+++ b/tests/identity/test_endpoints.py
@@ -228,7 +228,9 @@ class CallbackEndpointTestCase(unittest.IsolatedAsyncioTestCase):
                 )
             ),
         ):
-            response = await endpoints.callback('plugin-1', 'code', 'st', db)
+            response = await endpoints.callback(
+                'plugin-1', 'code', 'st', db, mock.AsyncMock()
+            )
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response.headers['location'], '/projects/x')
 
@@ -251,7 +253,9 @@ class CallbackEndpointTestCase(unittest.IsolatedAsyncioTestCase):
                 )
             ),
         ):
-            response = await endpoints.callback('plugin-1', 'code', 'st', db)
+            response = await endpoints.callback(
+                'plugin-1', 'code', 'st', db, mock.AsyncMock()
+            )
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response.headers['location'], '/settings/connections')
 
@@ -263,7 +267,9 @@ class CallbackEndpointTestCase(unittest.IsolatedAsyncioTestCase):
             new=mock.AsyncMock(side_effect=ValueError('expired')),
         ):
             with self.assertRaises(fastapi.HTTPException) as ctx:
-                await endpoints.callback('plugin-1', 'code', 'st', db)
+                await endpoints.callback(
+                    'plugin-1', 'code', 'st', db, mock.AsyncMock()
+                )
         self.assertEqual(ctx.exception.status_code, 400)
 
     async def test_maps_plugin_not_found_to_404(self) -> None:
@@ -276,7 +282,9 @@ class CallbackEndpointTestCase(unittest.IsolatedAsyncioTestCase):
             new=mock.AsyncMock(side_effect=PluginNotFoundError('plugin-1')),
         ):
             with self.assertRaises(fastapi.HTTPException) as ctx:
-                await endpoints.callback('plugin-1', 'code', 'st', db)
+                await endpoints.callback(
+                    'plugin-1', 'code', 'st', db, mock.AsyncMock()
+                )
         self.assertEqual(ctx.exception.status_code, 404)
 
 

--- a/tests/identity/test_flows.py
+++ b/tests/identity/test_flows.py
@@ -17,6 +17,13 @@ def _parse_agtype_stub(v: typing.Any) -> typing.Any:
     return v.strip('"') if isinstance(v, str) else v
 
 
+def _fresh_nonce_valkey() -> mock.AsyncMock:
+    """A Valkey mock whose ``set`` returns truthy (nonce never seen)."""
+    client = mock.AsyncMock()
+    client.set = mock.AsyncMock(return_value=True)
+    return client
+
+
 def _patch_load_handler(
     handler: object,
     creds: dict[str, str] | None = None,
@@ -204,7 +211,10 @@ class CompleteFlowTestCase(unittest.IsolatedAsyncioTestCase):
             ) as upsert,
         ):
             result = await flows.complete_flow(
-                db, code='auth-code', state_token='state-token'
+                db,
+                code='auth-code',
+                state_token='state-token',
+                valkey_client=_fresh_nonce_valkey(),
             )
         upsert.assert_awaited_once()
         self.assertEqual(result[0], profile)
@@ -240,7 +250,10 @@ class CompleteFlowTestCase(unittest.IsolatedAsyncioTestCase):
             ) as upsert,
         ):
             await flows.complete_flow(
-                db, code='auth-code', state_token='state-token'
+                db,
+                code='auth-code',
+                state_token='state-token',
+                valkey_client=_fresh_nonce_valkey(),
             )
         upsert.assert_not_called()
 
@@ -254,7 +267,41 @@ class CompleteFlowTestCase(unittest.IsolatedAsyncioTestCase):
             return_value=state_data,
         ):
             with self.assertRaises(ValueError):
-                await flows.complete_flow(db, code='c', state_token='s')
+                await flows.complete_flow(
+                    db,
+                    code='c',
+                    state_token='s',
+                    valkey_client=_fresh_nonce_valkey(),
+                )
+
+    async def test_rejects_replayed_state_token(self) -> None:
+        db = mock.AsyncMock()
+        state_data = mock.MagicMock()
+        state_data.plugin_id = 'plugin-1'
+        state_data.actor_user_id = 'user-1'
+        state_data.nonce = 'nonce-abc'
+
+        handler = mock.MagicMock(spec=flows.IdentityPlugin)
+        handler.exchange_code = mock.AsyncMock()
+        replayed = mock.AsyncMock()
+        replayed.set = mock.AsyncMock(return_value=None)
+
+        with (
+            mock.patch.object(
+                flows.state,
+                'decode_identity_state',
+                return_value=state_data,
+            ),
+            _patch_load_handler(handler),
+        ):
+            with self.assertRaisesRegex(ValueError, 'already been used'):
+                await flows.complete_flow(
+                    db,
+                    code='c',
+                    state_token='s',
+                    valkey_client=replayed,
+                )
+        handler.exchange_code.assert_not_called()
 
 
 class CompleteLoginFlowTestCase(unittest.IsolatedAsyncioTestCase):
@@ -292,7 +339,12 @@ class CompleteLoginFlowTestCase(unittest.IsolatedAsyncioTestCase):
                 returned_creds,
                 plugin_id,
                 return_to,
-            ) = await flows.complete_login_flow(db, code='c', state_token='s')
+            ) = await flows.complete_login_flow(
+                db,
+                code='c',
+                state_token='s',
+                valkey_client=_fresh_nonce_valkey(),
+            )
         upsert.assert_not_called()
         self.assertEqual(returned_profile, profile)
         self.assertEqual(returned_creds, credentials)
@@ -309,7 +361,12 @@ class CompleteLoginFlowTestCase(unittest.IsolatedAsyncioTestCase):
             return_value=state_data,
         ):
             with self.assertRaises(ValueError):
-                await flows.complete_login_flow(db, code='c', state_token='s')
+                await flows.complete_login_flow(
+                    db,
+                    code='c',
+                    state_token='s',
+                    valkey_client=_fresh_nonce_valkey(),
+                )
 
 
 class RefreshConnectionTestCase(unittest.IsolatedAsyncioTestCase):

--- a/tests/identity/test_state.py
+++ b/tests/identity/test_state.py
@@ -169,3 +169,36 @@ class DecodeLoginStateTestCase(unittest.TestCase):
         wrong = settings.Auth(jwt_secret='different-secret')
         with self.assertRaises(ValueError):
             state.decode_login_state(token, auth_settings=wrong)
+
+
+class ConsumeIdentityNonceTestCase(unittest.IsolatedAsyncioTestCase):
+    """Verify the Valkey-backed nonce replay cache."""
+
+    async def test_returns_true_on_first_use(self) -> None:
+        client = mock.AsyncMock()
+        client.set = mock.AsyncMock(return_value=True)
+        result = await state.consume_identity_nonce(client, 'nonce-x')
+        self.assertTrue(result)
+        client.set.assert_awaited_once_with(
+            'identity:state:nonce:nonce-x', '1', nx=True, ex=600
+        )
+
+    async def test_returns_false_on_replay(self) -> None:
+        client = mock.AsyncMock()
+        client.set = mock.AsyncMock(return_value=None)
+        result = await state.consume_identity_nonce(client, 'nonce-y')
+        self.assertFalse(result)
+
+    async def test_raises_when_valkey_is_none(self) -> None:
+        with self.assertRaisesRegex(RuntimeError, 'requires Valkey'):
+            await state.consume_identity_nonce(None, 'nonce-z')
+
+    async def test_respects_ttl_argument(self) -> None:
+        client = mock.AsyncMock()
+        client.set = mock.AsyncMock(return_value=True)
+        await state.consume_identity_nonce(
+            client, 'nonce-ttl', ttl_seconds=120
+        )
+        client.set.assert_awaited_once_with(
+            'identity:state:nonce:nonce-ttl', '1', nx=True, ex=120
+        )


### PR DESCRIPTION
## Summary

Addresses the **nonce-replay subset of C3** from the in-tree code-review punchlist.

A leaked or logged identity state JWT could be replayed within its 10-minute TTL to re-trigger the OAuth callback — either overwriting the existing `IdentityConnection` (identity intent) or potentially re-issuing tokens during a login-intent flow. This PR wires a Valkey-backed nonce-replay cache (`SET NX EX 600`) into `complete_flow` and `complete_login_flow`. `poll_flow` is intentionally left alone — device-code polling is repeatedly idempotent against the same state token by design.

Replay protection fails closed: if no Valkey client is configured, `consume_identity_nonce` raises a `RuntimeError` rather than silently dropping the guarantee.

## What this PR does **not** do

The reviewer's other C3 suggestion — adding `Depends(require_auth)` to the callback and asserting `auth.user.id == state.actor_user_id` — does not fit the Bearer-token architecture: the IdP-driven cross-origin redirect strips the `Authorization` header, so there is no session to check on this path. The state JWT continues to carry the actor identity. A real fix for that piece would require switching the callback to a cookie session (separate architectural change, out of scope here).

## Test plan

- [x] `just test tests/identity/` — 114 passed
- [x] `just test tests/endpoints/test_auth.py` — 55 passed
- [x] `just lint` — clean
- [x] New `ConsumeIdentityNonceTestCase` covers: first-use returns True, replay returns False, raises when Valkey is None, TTL argument respected.
- [x] New `CompleteFlowTestCase.test_rejects_replayed_state_token` covers the full flow path with a replayed nonce.

## Notes

The 2 failing tests on `main` (`tests/endpoints/test_project_configuration.py::*`) are a pre-existing ClickHouse schema-migration issue unrelated to this PR — verified by running them with `git stash`.