### PR TITLE
Harden runtime plugin installer surface

### DIFF
--- a/src/imbi_api/plugins/installer.py
+++ b/src/imbi_api/plugins/installer.py
@@ -1,8 +1,22 @@
-"""Runtime plugin installation via uv pip."""
+"""Runtime plugin installation via uv pip.
+
+Plugin installation invokes ``uv pip install`` against a package name
+supplied by the caller. To keep that surface narrow we:
+
+* allow only package names matching ``^imbi-plugin-[a-z0-9_-]+$`` — no
+  general PyPI specifiers, no ``pkg --index-url=…`` injection;
+* require the version string (when provided) to match a normal PEP-440
+  release shape so it cannot smuggle arguments through the spec;
+* pin the index URL via ``IMBI_PLUGINS_INDEX_URL`` (defaults to PyPI)
+  rather than inheriting whatever the host environment configured;
+* pass ``--no-deps`` so installation can never pull transitive
+  packages that aren't themselves allowlisted.
+"""
 
 import asyncio
 import logging
 import os
+import re
 
 from imbi_common.plugins.registry import (
     LoadResult,
@@ -15,10 +29,41 @@ _INSTALL_TIMEOUT = int(os.environ.get('IMBI_PLUGINS_INSTALL_TIMEOUT', '120'))
 _INSTALL_ENABLED = (
     os.environ.get('IMBI_PLUGINS_INSTALL_ENABLED', 'true').lower() != 'false'
 )
+_INDEX_URL = os.environ.get(
+    'IMBI_PLUGINS_INDEX_URL',
+    'https://pypi.org/simple',
+)
+
+_PACKAGE_NAME = re.compile(r'^imbi-plugin-[a-z0-9_-]+$')
+# Lenient PEP 440 release-segment match — `1`, `1.2`, `1.2.3`,
+# `1.2.3.post4`, `1.2.3a1`, `1.2.3rc2`, `1.2.3+local.tag`. Rejects
+# whitespace and shell metacharacters that could change the meaning
+# of the resulting spec passed to uv.
+_VERSION = re.compile(r'^[A-Za-z0-9.+!_-]+$')
 
 
 class InstallError(Exception):
     """Raised when uv pip install fails."""
+
+
+def _validate_name(name: str) -> str:
+    if not _PACKAGE_NAME.match(name):
+        raise InstallError(
+            f'Refusing to install package {name!r}: not in the '
+            "'imbi-plugin-*' allowlist"
+        )
+    return name
+
+
+def _validate_version(version: str | None) -> str | None:
+    if version is None:
+        return None
+    if not _VERSION.match(version):
+        raise InstallError(
+            f'Refusing to install with version {version!r}: '
+            'must match PEP 440 release shape'
+        )
+    return version
 
 
 async def install_package(name: str, version: str | None = None) -> LoadResult:
@@ -28,11 +73,16 @@ async def install_package(name: str, version: str | None = None) -> LoadResult:
             'Runtime plugin installation is disabled '
             '(IMBI_PLUGINS_INSTALL_ENABLED=false)'
         )
+    name = _validate_name(name)
+    version = _validate_version(version)
     spec = f'{name}=={version}' if version else name
     proc = await asyncio.create_subprocess_exec(
         'uv',
         'pip',
         'install',
+        '--no-deps',
+        '--index-url',
+        _INDEX_URL,
         spec,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
@@ -61,6 +111,7 @@ async def uninstall_package(name: str) -> LoadResult:
     """Uninstall a plugin package at runtime."""
     if not _INSTALL_ENABLED:
         raise InstallError('Runtime plugin installation is disabled')
+    name = _validate_name(name)
     proc = await asyncio.create_subprocess_exec(
         'uv',
         'pip',

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -1,0 +1,107 @@
+"""Verify the runtime plugin installer hardening.
+
+Targets the input-validation surface added in fix/plugin-installer-hardening:
+package-name allowlist, version-string shape, and the resulting uv pip
+argv (``--no-deps``, pinned ``--index-url``).
+"""
+
+import unittest
+from unittest import mock
+
+from imbi_api.plugins import installer
+
+
+class ValidateNameTestCase(unittest.TestCase):
+    def test_accepts_imbi_plugin_prefix(self) -> None:
+        self.assertEqual(
+            installer._validate_name('imbi-plugin-github'),
+            'imbi-plugin-github',
+        )
+
+    def test_accepts_letters_digits_underscores_hyphens(self) -> None:
+        self.assertEqual(
+            installer._validate_name('imbi-plugin-aws_iam_ic-2'),
+            'imbi-plugin-aws_iam_ic-2',
+        )
+
+    def test_rejects_bare_pypi_name(self) -> None:
+        with self.assertRaisesRegex(installer.InstallError, 'allowlist'):
+            installer._validate_name('requests')
+
+    def test_rejects_uppercase(self) -> None:
+        with self.assertRaisesRegex(installer.InstallError, 'allowlist'):
+            installer._validate_name('Imbi-Plugin-GitHub')
+
+    def test_rejects_index_url_injection(self) -> None:
+        with self.assertRaisesRegex(installer.InstallError, 'allowlist'):
+            installer._validate_name('imbi-plugin-x --index-url=http://evil/')
+
+    def test_rejects_path_traversal(self) -> None:
+        with self.assertRaisesRegex(installer.InstallError, 'allowlist'):
+            installer._validate_name('../etc/passwd')
+
+
+class ValidateVersionTestCase(unittest.TestCase):
+    def test_accepts_simple_release(self) -> None:
+        self.assertEqual(installer._validate_version('1.2.3'), '1.2.3')
+
+    def test_accepts_pre_release(self) -> None:
+        self.assertEqual(installer._validate_version('1.2.3rc1'), '1.2.3rc1')
+
+    def test_accepts_local_segment(self) -> None:
+        self.assertEqual(
+            installer._validate_version('1.2.3+local.tag'),
+            '1.2.3+local.tag',
+        )
+
+    def test_none_passes_through(self) -> None:
+        self.assertIsNone(installer._validate_version(None))
+
+    def test_rejects_whitespace(self) -> None:
+        with self.assertRaisesRegex(installer.InstallError, 'PEP 440'):
+            installer._validate_version('1.2.3 --index-url=http://evil/')
+
+    def test_rejects_shell_metacharacters(self) -> None:
+        with self.assertRaisesRegex(installer.InstallError, 'PEP 440'):
+            installer._validate_version('1.2.3;rm -rf /')
+
+
+class InstallPackageArgvTestCase(unittest.IsolatedAsyncioTestCase):
+    """Confirm the uv invocation pins --index-url and includes --no-deps."""
+
+    async def test_install_uses_no_deps_and_pinned_index(self) -> None:
+        fake_proc = mock.AsyncMock()
+        fake_proc.communicate.return_value = (b'installed', b'')
+        fake_proc.returncode = 0
+        with (
+            mock.patch.object(
+                installer.asyncio,
+                'create_subprocess_exec',
+                new=mock.AsyncMock(return_value=fake_proc),
+            ) as spawn,
+            mock.patch.object(
+                installer, 'reload_plugins', return_value=mock.MagicMock()
+            ),
+        ):
+            await installer.install_package('imbi-plugin-github', '1.2.3')
+
+        spawn.assert_awaited_once()
+        argv = spawn.await_args.args
+        self.assertEqual(
+            argv[:5], ('uv', 'pip', 'install', '--no-deps', '--index-url')
+        )
+        self.assertEqual(argv[6], 'imbi-plugin-github==1.2.3')
+
+    async def test_install_rejects_non_allowlisted_name(self) -> None:
+        with self.assertRaises(installer.InstallError):
+            await installer.install_package('requests')
+
+    async def test_install_rejects_malformed_version(self) -> None:
+        with self.assertRaises(installer.InstallError):
+            await installer.install_package(
+                'imbi-plugin-x', '1.0 --index-url=http://evil/'
+            )
+
+    async def test_uninstall_rejects_non_allowlisted_name(self) -> None:
+        with self.assertRaises(installer.InstallError):
+            await installer.uninstall_package('requests')


### PR DESCRIPTION
## Summary

Addresses the contained half of **C4** in the in-tree code-review punchlist. The HMAC-signed reload-payload piece is left for a follow-up that picks where the shared secret lives.

Today the installer concatenates a caller-supplied package name into the `uv pip install` spec untouched. A caller could:

- smuggle additional uv arguments (`pkg --index-url=http://evil/`);
- install transitive packages that aren't themselves allowlisted;
- pull from whatever index the host environment happens to have configured.

This PR tightens that surface:

- package name must match `^imbi-plugin-[a-z0-9_-]+$` — no general PyPI specifiers, no flag injection;
- version (when supplied) must match the PEP 440 release shape — rejects whitespace, `;`, and other shell metacharacters that could change the spec's meaning;
- pass `--no-deps` so install can't pull transitive packages;
- pin `--index-url` via `IMBI_PLUGINS_INDEX_URL` (defaults to PyPI) rather than inheriting the host environment.

## Test plan

- [x] `just test tests/test_installer.py` — 16 passed
- [x] `just lint` — clean
- [x] New `tests/test_installer.py` covers: name allowlist (accepts/rejects including `--index-url` injection and path traversal); version shape (accepts `1.2.3`, `1.2.3rc1`, `1.2.3+local`; rejects whitespace and `;`); uv argv (asserts `--no-deps` and `--index-url` are present and the spec is last).

## Follow-up

- HMAC-signed reload-payload check in `src/imbi_api/plugins/reload.py` — punted pending a decision on the shared-secret source.
- An `imbi-common` PR for C5's manifest-time half (`^[A-Za-z][A-Za-z0-9_]*$` validator on `PluginVertexLabel.name` / `PluginEdgeLabel.name`).