### PR TITLE
Close three authz gaps from the code review (H7, H8, H9)

### DIFF
--- a/src/imbi_api/auth/seed.py
+++ b/src/imbi_api/auth/seed.py
@@ -397,6 +397,13 @@ STANDARD_PERMISSIONS: list[tuple[str, str, str, str]] = [
         'identities:revoke',
         "Force-revoke another user's identity connection",
     ),
+    # Cross-organization event feed
+    (
+        'admin:events:read',
+        'admin',
+        'events:read',
+        'List events across every organization (audit / support)',
+    ),
 ]
 
 # Default role definitions.

--- a/src/imbi_api/endpoints/events.py
+++ b/src/imbi_api/endpoints/events.py
@@ -201,10 +201,10 @@ async def _list_impl(
 @events_router.get('/', response_model=EventsPage)
 async def list_events(
     request: fastapi.Request,
-    auth: typing.Annotated[
+    _auth: typing.Annotated[
         permissions.AuthContext,
         fastapi.Depends(
-            permissions.require_permission('project:read'),
+            permissions.require_permission('admin:events:read'),
         ),
     ],
     limit: int = DEFAULT_LIMIT,
@@ -215,7 +215,13 @@ async def list_events(
     since: str | None = None,
     until: str | None = None,
 ) -> fastapi.Response:
-    """List events (newest first, keyset paginated)."""
+    """List events across every organization (admin / audit feed).
+
+    Per-project event access lives on the org-scoped router; this
+    endpoint is gated on ``admin:events:read`` because the unscoped
+    cursor would otherwise expose events for projects the caller has
+    no permission on.
+    """
     return await _list_impl(
         request=request,
         limit=limit,

--- a/src/imbi_api/endpoints/roles.py
+++ b/src/imbi_api/endpoints/roles.py
@@ -475,6 +475,14 @@ async def grant_permission(
             status_code=404,
             detail=f'Role with slug {slug!r} not found',
         )
+    if role.is_system:
+        raise fastapi.HTTPException(
+            status_code=403,
+            detail=(
+                f'Role {slug!r} is a system role; its permissions are '
+                'managed by the seed and cannot be changed via the API'
+            ),
+        )
 
     # Check if permission exists
     perm_results = await db.match(
@@ -538,6 +546,14 @@ async def revoke_permission(
         raise fastapi.HTTPException(
             status_code=404,
             detail=f'Role with slug {slug!r} not found',
+        )
+    if role.is_system:
+        raise fastapi.HTTPException(
+            status_code=403,
+            detail=(
+                f'Role {slug!r} is a system role; its permissions are '
+                'managed by the seed and cannot be changed via the API'
+            ),
         )
 
     # Delete GRANTS relationship

--- a/src/imbi_api/endpoints/uploads.py
+++ b/src/imbi_api/endpoints/uploads.py
@@ -194,6 +194,10 @@ async def get_upload(
     upload_id: str,
     storage_client: storage.InjectStorageClient,
     db: graph.Pool,
+    _auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(permissions.require_permission('upload:read')),
+    ],
 ) -> fastapi.responses.Response:
     """Serve the uploaded file.
 
@@ -242,6 +246,10 @@ async def get_upload(
 async def get_upload_meta(
     upload_id: str,
     db: graph.Pool,
+    _auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(permissions.require_permission('upload:read')),
+    ],
 ) -> UploadResponse:
     """Return upload metadata as JSON.
 
@@ -267,6 +275,10 @@ async def get_upload_thumbnail(
     upload_id: str,
     storage_client: storage.InjectStorageClient,
     db: graph.Pool,
+    _auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(permissions.require_permission('upload:read')),
+    ],
 ) -> fastapi.responses.Response:
     """Serve the upload thumbnail.
 

--- a/tests/endpoints/test_events.py
+++ b/tests/endpoints/test_events.py
@@ -212,6 +212,25 @@ class GlobalListTests(_EventsTestBase):
         response = self.client.get('/events/', params={'since': 'garbage'})
         self.assertEqual(response.status_code, 400)
 
+    def test_non_admin_without_event_permission_denied(self) -> None:
+        """Non-admin users without admin:events:read get 403."""
+        non_admin = api_models.User(
+            email='basic@example.com',
+            display_name='Basic',
+            is_active=True,
+            is_admin=False,
+            is_service_account=False,
+            created_at=datetime.datetime.now(datetime.UTC),
+        )
+        self.auth = api_permissions.AuthContext(
+            user=non_admin,
+            session_id='s',
+            auth_method='jwt',
+            permissions={'project:read'},
+        )
+        response = self.client.get('/events/')
+        self.assertEqual(response.status_code, 403)
+
     def test_list_with_invalid_limit_returns_400(self) -> None:
         response = self.client.get('/events/', params={'limit': 0})
         self.assertEqual(response.status_code, 400)

--- a/tests/endpoints/test_roles.py
+++ b/tests/endpoints/test_roles.py
@@ -298,6 +298,41 @@ class RoleEndpointsTestCase(unittest.TestCase):
             response.json()['detail'],
         )
 
+    def test_grant_permission_on_system_role_denied(self) -> None:
+        """Grant against a system role is rejected with 403."""
+        system_role = models.Role(
+            name='Administrator',
+            slug='admin',
+            priority=1000,
+            is_system=True,
+        )
+        self.mock_db.match.return_value = [system_role]
+
+        response = self.client.post(
+            '/roles/admin/permissions',
+            json={'permission_name': 'blueprint:read'},
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertIn('system role', response.json()['detail'])
+
+    def test_revoke_permission_on_system_role_denied(self) -> None:
+        """Revoke against a system role is rejected with 403."""
+        system_role = models.Role(
+            name='Administrator',
+            slug='admin',
+            priority=1000,
+            is_system=True,
+        )
+        self.mock_db.match.return_value = [system_role]
+
+        response = self.client.delete(
+            '/roles/admin/permissions/blueprint:read'
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertIn('system role', response.json()['detail'])
+
     def test_revoke_permission_success(self) -> None:
         """Test revoking permission from role."""
         self.mock_db.match.return_value = [self.test_role]

--- a/tests/endpoints/test_uploads.py
+++ b/tests/endpoints/test_uploads.py
@@ -372,6 +372,50 @@ class UploadEndpointsTestCase(unittest.TestCase):
 
         self.assertEqual(response.status_code, 404)
 
+    def test_read_paths_require_upload_read_permission(self) -> None:
+        """GET / GET-meta / GET-thumbnail all require upload:read."""
+        from imbi_api.auth import permissions
+
+        non_admin_user = models.User(
+            email='basic@example.com',
+            display_name='Basic User',
+            is_active=True,
+            is_admin=False,
+            is_service_account=False,
+            created_at=datetime.datetime.now(datetime.UTC),
+        )
+        non_admin_ctx = permissions.AuthContext(
+            user=non_admin_user,
+            session_id='test-session',
+            auth_method='jwt',
+            permissions=set(),
+        )
+
+        async def _non_admin():
+            return non_admin_ctx
+
+        self.test_app.dependency_overrides[permissions.get_current_user] = (
+            _non_admin
+        )
+        try:
+            for path in (
+                '/uploads/test-uuid-1234',
+                '/uploads/test-uuid-1234/meta',
+                '/uploads/test-uuid-1234/thumbnail',
+            ):
+                response = self.client.get(path)
+                self.assertEqual(
+                    response.status_code, 403, f'expected 403 for {path}'
+                )
+        finally:
+
+            async def _restore():
+                return self.auth_context
+
+            self.test_app.dependency_overrides[
+                permissions.get_current_user
+            ] = _restore
+
     def test_requires_authentication(self) -> None:
         """Test that upload endpoints reject unauthenticated."""
         from imbi_api.auth import permissions


### PR DESCRIPTION
## Summary

Three contained authz fixes from the in-tree code-review punchlist.

**H8** — `get_upload`, `get_upload_meta`, and `get_upload_thumbnail` in `src/imbi_api/endpoints/uploads.py:192-262` were reachable by any authenticated caller. Each now requires `upload:read`. The list / create / delete paths in this router already enforced the matching permission, so this brings the read paths into line.

**H7** — `roles.grant_permission` and `revoke_permission` did not check `is_system`. An operator with `role:update` could mutate the seed roles — e.g. revoke permissions from `admin` or grant arbitrary permissions to `default`. Both now refuse system roles with **403**, matching the existing pattern in `delete_role` and `patch_role`.

**H9** — `GET /events` was gated on `project:read`, but the global cursor returned events for every project the caller had no permission on. A new seeded permission `admin:events:read` (admin-only) now gates the cross-org endpoint. The org-scoped variant at `/organizations/{slug}/projects/{id}/events/` stays on `project:read` because the URL itself scopes the result.

## Operator impact

Existing callers of `GET /events` without admin will start receiving **403**. The org-scoped per-project endpoint is unaffected, so per-project event feeds in the UI keep working. The `admin:events:read` permission is automatically picked up by the seeded `admin` role on next `seed_permissions` run.

## Test plan

- [x] `just test tests/endpoints/test_uploads.py tests/endpoints/test_events.py tests/endpoints/test_roles.py tests/auth/test_seed.py` — 81 passed
- [x] `just lint` — clean
- [x] New regression tests:
  - `test_uploads.py::test_read_paths_require_upload_read_permission` — non-admin without `upload:read` gets 403 on `/`, `/meta`, `/thumbnail`.
  - `test_roles.py::test_grant_permission_on_system_role_denied` and `test_revoke_permission_on_system_role_denied` — 403 on system roles.
  - `test_events.py::test_non_admin_without_event_permission_denied` — non-admin holding only `project:read` gets 403 on the global feed.

## Notes

The H1-H6 auth items are still open; this PR was scoped to the three contained authz gaps that didn't need design discussion.