### PR TITLE
Close login timing oracle and unblock event loop on Argon2 (H4, H5)

### DIFF
--- a/src/imbi_api/auth/permissions.py
+++ b/src/imbi_api/auth/permissions.py
@@ -1,5 +1,6 @@
 """Permission checking and authorization dependencies."""
 
+import asyncio
 import collections.abc
 import datetime
 import logging
@@ -429,7 +430,9 @@ async def authenticate_api_key(
             )
 
     # Verify key secret (hashed)
-    if not password.verify_password(key_secret, api_key_data['key_hash']):
+    if not await asyncio.to_thread(
+        password.verify_password, key_secret, api_key_data['key_hash']
+    ):
         raise fastapi.HTTPException(
             status_code=401, detail='Invalid or revoked API key'
         )

--- a/src/imbi_api/endpoints/api_keys.py
+++ b/src/imbi_api/endpoints/api_keys.py
@@ -5,6 +5,7 @@ access to the API. API keys support scoped permissions, expiration, rotation,
 and usage tracking via ClickHouse.
 """
 
+import asyncio
 import datetime
 import logging
 import secrets
@@ -126,7 +127,7 @@ async def create_api_key(
     # Generate key: format ik_<16chars>_<32chars>
     key_id = f'ik_{secrets.token_hex(16)}'
     key_secret = secrets.token_urlsafe(32)
-    key_hash = password.hash_password(key_secret)
+    key_hash = await asyncio.to_thread(password.hash_password, key_secret)
 
     # Validate expiration
     expires_at = None
@@ -371,7 +372,7 @@ async def rotate_api_key(
 
     # Generate new secret
     new_secret = secrets.token_urlsafe(32)
-    new_key_hash = password.hash_password(new_secret)
+    new_key_hash = await asyncio.to_thread(password.hash_password, new_secret)
     now_str = datetime.datetime.now(datetime.UTC).isoformat()
 
     # Update key in graph

--- a/src/imbi_api/endpoints/auth.py
+++ b/src/imbi_api/endpoints/auth.py
@@ -1,8 +1,10 @@
 """Authentication endpoints for login, token refresh, and logout."""
 
+import asyncio
 import datetime
 import json
 import logging
+import secrets
 import typing
 from urllib import parse as urlparse
 
@@ -32,6 +34,12 @@ from imbi_api.middleware import rate_limit
 from imbi_api.scoring import OptionalValkeyClient
 
 LOGGER = logging.getLogger(__name__)
+
+# Pre-computed dummy Argon2 hash used to keep login timing constant when
+# the supplied email does not match an authenticable user. Without this,
+# the existence of a user (vs. service-account, OAuth-only, or unknown
+# email) could be inferred from the response time.
+_DUMMY_PASSWORD_HASH = password_auth.hash_password(secrets.token_hex(32))
 
 auth_router = fastapi.APIRouter(prefix='/auth', tags=['Authentication'])
 
@@ -162,8 +170,10 @@ async def token(
             )
 
     # Verify secret
-    if not password_auth.verify_password(
-        client_secret, cred_data['client_secret_hash']
+    if not await asyncio.to_thread(
+        password_auth.verify_password,
+        client_secret,
+        cred_data['client_secret_hash'],
     ):
         raise fastapi.HTTPException(
             status_code=401,
@@ -274,49 +284,40 @@ async def login(
     results = await db.match(models.User, {'email': email})
     user = results[0] if results else None
 
-    if not user or not user.is_active:
-        LOGGER.warning(
-            'Login failed for email %s: user not found or inactive',
-            email,
-        )
+    # Always run Argon2 verification — against the real hash if the user
+    # is eligible for password login, otherwise against a fixed dummy
+    # hash. This collapses every failure mode (unknown email, inactive,
+    # service-account, OAuth-only, wrong password) to the same generic
+    # 401 with constant timing, eliminating the user-enumeration oracle.
+    eligible = bool(
+        user
+        and user.is_active
+        and not user.is_service_account
+        and user.password_hash
+    )
+    hash_to_check = (
+        user.password_hash
+        if eligible and user is not None and user.password_hash
+        else _DUMMY_PASSWORD_HASH
+    )
+    password_valid = await asyncio.to_thread(
+        password_auth.verify_password, password, hash_to_check
+    )
+
+    if not eligible or not password_valid or user is None:
+        LOGGER.warning('Login failed for email %s', email)
         raise fastapi.HTTPException(
             status_code=401,
             detail='Invalid credentials',
         )
 
-    if user.is_service_account:
-        LOGGER.warning(
-            'Login failed for email %s: service accounts '
-            'cannot use password login',
-            email,
-        )
-        raise fastapi.HTTPException(
-            status_code=403,
-            detail='Service accounts cannot use password login',
-        )
-
-    # Check if user has password authentication enabled
-    if not user.password_hash:
-        LOGGER.warning(
-            'Login failed for email %s: password authentication not enabled',
-            email,
-        )
-        raise fastapi.HTTPException(
-            status_code=401,
-            detail='Password authentication not available for this account',
-        )
-
-    # Verify password
-    if not password_auth.verify_password(password, user.password_hash):
-        LOGGER.warning('Login failed for email %s: invalid password', email)
-        raise fastapi.HTTPException(
-            status_code=401,
-            detail='Invalid credentials',
-        )
+    user_hash = typing.cast(str, user.password_hash)
 
     # Check if password needs rehashing
-    if password_auth.needs_rehash(user.password_hash):
-        user.password_hash = password_auth.hash_password(password)
+    if await asyncio.to_thread(password_auth.needs_rehash, user_hash):
+        user.password_hash = await asyncio.to_thread(
+            password_auth.hash_password, password
+        )
         await db.merge(user, match_on=['email'])
         LOGGER.info('Rehashed password for user %s', user.email)
 
@@ -388,7 +389,9 @@ async def login(
                 valid_backup = False
 
                 for i, hashed_code in enumerate(backup_codes):
-                    if password_auth.verify_password(mfa_code, hashed_code):
+                    if await asyncio.to_thread(
+                        password_auth.verify_password, mfa_code, hashed_code
+                    ):
                         # Remove used backup code
                         backup_codes.pop(i)
                         update_q2: typing.LiteralString = """

--- a/src/imbi_api/endpoints/client_credentials.py
+++ b/src/imbi_api/endpoints/client_credentials.py
@@ -5,6 +5,7 @@ that enable service accounts to authenticate using the client
 credentials grant flow.
 """
 
+import asyncio
 import datetime
 import logging
 import secrets
@@ -102,7 +103,9 @@ async def create_client_credential(
     # Generate client_id and secret
     client_id = f'cc_{secrets.token_urlsafe(16)}'
     client_secret = secrets.token_urlsafe(32)
-    secret_hash = password.hash_password(client_secret)
+    secret_hash = await asyncio.to_thread(
+        password.hash_password, client_secret
+    )
 
     # Validate expiration
     expires_at = None
@@ -351,7 +354,7 @@ async def rotate_client_credential(
 
     # Generate new secret and update atomically with ownership
     new_secret = secrets.token_urlsafe(32)
-    new_hash = password.hash_password(new_secret)
+    new_hash = await asyncio.to_thread(password.hash_password, new_secret)
     now_str = datetime.datetime.now(datetime.UTC).isoformat()
 
     update_query: typing.LiteralString = """

--- a/src/imbi_api/endpoints/mfa.py
+++ b/src/imbi_api/endpoints/mfa.py
@@ -5,6 +5,7 @@ apps like Google Authenticator, Authy, 1Password, etc. Includes backup codes
 for account recovery.
 """
 
+import asyncio
 import base64
 import datetime
 import io
@@ -161,9 +162,12 @@ async def setup_mfa(
 
     # Generate 10 backup codes (8-character hex strings)
     backup_codes = [secrets.token_hex(4) for _ in range(10)]
-    hashed_backup_codes = [
-        password.hash_password(code) for code in backup_codes
-    ]
+    hashed_backup_codes = await asyncio.gather(
+        *(
+            asyncio.to_thread(password.hash_password, code)
+            for code in backup_codes
+        )
+    )
 
     # First, delete any existing TOTP secret
     delete_query: typing.LiteralString = """
@@ -280,7 +284,9 @@ async def verify_and_enable_mfa(
     else:
         # Try backup codes
         for backup_hash in backup_codes:
-            if password.verify_password(verify_request.code, backup_hash):
+            if await asyncio.to_thread(
+                password.verify_password, verify_request.code, backup_hash
+            ):
                 is_valid = True
                 used_backup_code = True
                 # Remove used backup code
@@ -371,7 +377,8 @@ async def disable_mfa(
                 status_code=401,
                 detail='Password required to disable MFA',
             )
-        if not password.verify_password(
+        if not await asyncio.to_thread(
+            password.verify_password,
             current_password,
             auth.require_user.password_hash,
         ):
@@ -433,7 +440,9 @@ async def disable_mfa(
             # Try backup codes
             backup_codes = totp_data.get('backup_codes', [])
             for backup_hash in backup_codes:
-                if password.verify_password(mfa_code, backup_hash):
+                if await asyncio.to_thread(
+                    password.verify_password, mfa_code, backup_hash
+                ):
                     is_valid = True
                     break
 

--- a/src/imbi_api/endpoints/sa_api_keys.py
+++ b/src/imbi_api/endpoints/sa_api_keys.py
@@ -5,6 +5,7 @@ accounts. It mirrors the user API key endpoints but associates keys
 with a ServiceAccount node instead of a User node.
 """
 
+import asyncio
 import datetime
 import logging
 import secrets
@@ -103,7 +104,7 @@ async def create_sa_api_key(
     # Generate key: format ik_<16chars>_<32chars>
     key_id = f'ik_{secrets.token_hex(16)}'
     key_secret = secrets.token_urlsafe(32)
-    key_hash = password.hash_password(key_secret)
+    key_hash = await asyncio.to_thread(password.hash_password, key_secret)
 
     # Validate expiration
     expires_at = None
@@ -342,7 +343,7 @@ async def rotate_sa_api_key(
 
     # Generate new secret and update atomically
     new_secret = secrets.token_urlsafe(32)
-    new_key_hash = password.hash_password(new_secret)
+    new_key_hash = await asyncio.to_thread(password.hash_password, new_secret)
     now_str = datetime.datetime.now(datetime.UTC).isoformat()
 
     update_query: typing.LiteralString = """

--- a/src/imbi_api/endpoints/users.py
+++ b/src/imbi_api/endpoints/users.py
@@ -1,5 +1,6 @@
 """User management endpoints."""
 
+import asyncio
 import logging
 import typing
 from urllib import parse as urlparse
@@ -200,7 +201,9 @@ async def create_user(
     # Hash password if provided
     password_hash = None
     if user_create.password:
-        password_hash = password.hash_password(user_create.password)
+        password_hash = await asyncio.to_thread(
+            password.hash_password, user_create.password
+        )
 
     # Prevent non-admins from creating admin users
     if user_create.is_admin and not auth.require_user.is_admin:
@@ -744,8 +747,10 @@ async def change_password(
                 status_code=400,
                 detail='Current password is required',
             )
-        if not user.password_hash or not password.verify_password(
-            password_change.current_password, user.password_hash
+        if not user.password_hash or not await asyncio.to_thread(
+            password.verify_password,
+            password_change.current_password,
+            user.password_hash,
         ):
             raise fastapi.HTTPException(
                 status_code=401,
@@ -753,8 +758,8 @@ async def change_password(
             )
 
     # Update password
-    user.password_hash = password.hash_password(
-        password_change.new_password,
+    user.password_hash = await asyncio.to_thread(
+        password.hash_password, password_change.new_password
     )
     await db.merge(user, match_on=['email'])
 

--- a/tests/auth/test_authentication.py
+++ b/tests/auth/test_authentication.py
@@ -149,8 +149,8 @@ class LoginEndpointTestCase(unittest.TestCase):
         self.client = fastapi.testclient.TestClient(self.application)
         self.mock_db = mock.AsyncMock()
         # Override graph dependency
-        self.application.dependency_overrides[graph._inject_graph] = (
-            lambda: self.mock_db
+        self.application.dependency_overrides[graph._inject_graph] = lambda: (
+            self.mock_db
         )
         # Reset rate limiter to avoid 429 errors across tests
         rate_limit.limiter.reset()
@@ -257,7 +257,11 @@ class LoginEndpointTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 401)
 
     def test_login_no_password_hash(self) -> None:
-        """Test login for user without password authentication."""
+        """Test login for user without password authentication.
+
+        Returns a generic 401 so the response doesn't distinguish
+        OAuth-only accounts from other failure modes (H4).
+        """
         oauth_user = models.User(
             email='oauth@example.com',
             display_name='OAuth User',
@@ -279,7 +283,7 @@ class LoginEndpointTestCase(unittest.TestCase):
         )
 
         self.assertEqual(response.status_code, 401)
-        self.assertIn('not available', response.json()['detail'])
+        self.assertIn('Invalid credentials', response.json()['detail'])
 
 
 class TokenRefreshEndpointTestCase(unittest.TestCase):
@@ -290,8 +294,8 @@ class TokenRefreshEndpointTestCase(unittest.TestCase):
         self.application = app.create_app()
         self.client = fastapi.testclient.TestClient(self.application)
         self.mock_db = mock.AsyncMock()
-        self.application.dependency_overrides[graph._inject_graph] = (
-            lambda: self.mock_db
+        self.application.dependency_overrides[graph._inject_graph] = lambda: (
+            self.mock_db
         )
         # Reset rate limiter to avoid 429 errors across tests
         rate_limit.limiter.reset()
@@ -432,8 +436,8 @@ class LogoutEndpointTestCase(unittest.TestCase):
         self.application = app.create_app()
         self.client = fastapi.testclient.TestClient(self.application)
         self.mock_db = mock.AsyncMock()
-        self.application.dependency_overrides[graph._inject_graph] = (
-            lambda: self.mock_db
+        self.application.dependency_overrides[graph._inject_graph] = lambda: (
+            self.mock_db
         )
         # Reset rate limiter to avoid 429 errors across tests
         rate_limit.limiter.reset()

--- a/tests/endpoints/test_auth.py
+++ b/tests/endpoints/test_auth.py
@@ -94,8 +94,8 @@ class AuthProvidersEndpointTestCase(unittest.TestCase):
         settings._auth_settings = None
         self.test_app = app.create_app()
         self.mock_db = mock.AsyncMock(spec=graph.Graph)
-        self.test_app.dependency_overrides[graph._inject_graph] = (
-            lambda: self.mock_db
+        self.test_app.dependency_overrides[graph._inject_graph] = lambda: (
+            self.mock_db
         )
         self.client = testclient.TestClient(self.test_app)
         login_providers.invalidate_cache()
@@ -198,8 +198,8 @@ class OAuthFlowTestCase(unittest.TestCase):
         self.test_app = app.create_app()
 
         self.mock_db = mock.AsyncMock(spec=graph.Graph)
-        self.test_app.dependency_overrides[graph._inject_graph] = (
-            lambda: self.mock_db
+        self.test_app.dependency_overrides[graph._inject_graph] = lambda: (
+            self.mock_db
         )
 
         self.client = testclient.TestClient(self.test_app)
@@ -332,8 +332,8 @@ class LoginPasswordRehashTestCase(unittest.TestCase):
         self.test_app = app.create_app()
 
         self.mock_db = mock.AsyncMock(spec=graph.Graph)
-        self.test_app.dependency_overrides[graph._inject_graph] = (
-            lambda: self.mock_db
+        self.test_app.dependency_overrides[graph._inject_graph] = lambda: (
+            self.mock_db
         )
 
         self.client = testclient.TestClient(self.test_app)
@@ -411,8 +411,8 @@ class LoginMFATestCase(unittest.TestCase):
         self.test_app = app.create_app()
 
         self.mock_db = mock.AsyncMock(spec=graph.Graph)
-        self.test_app.dependency_overrides[graph._inject_graph] = (
-            lambda: self.mock_db
+        self.test_app.dependency_overrides[graph._inject_graph] = lambda: (
+            self.mock_db
         )
 
         self.client = testclient.TestClient(self.test_app)
@@ -654,8 +654,40 @@ class LoginMFATestCase(unittest.TestCase):
             response.json()['detail'],
         )
 
+    def test_login_unknown_user_still_runs_argon2(self) -> None:
+        """H4: verify_password runs against the dummy hash on unknown email.
+
+        Without this, response time leaks user existence.
+        """
+        self.mock_db.match.return_value = []
+
+        with mock.patch(
+            'imbi_api.auth.password.verify_password',
+            return_value=False,
+        ) as mock_verify:
+            response = self.client.post(
+                '/auth/login',
+                json={
+                    'email': 'unknown@example.com',
+                    'password': 'whatever',
+                },
+            )
+
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(mock_verify.call_count, 1)
+        # The supplied password is verified against *some* hash (the
+        # module-level dummy) so timing matches the real-user path.
+        called_password, called_hash = mock_verify.call_args.args
+        self.assertEqual(called_password, 'whatever')
+        self.assertTrue(called_hash.startswith('$argon2'))
+
     def test_login_oauth_only_user(self) -> None:
-        """Test login for OAuth-only user (no password)."""
+        """Test login for OAuth-only user (no password).
+
+        Returns a generic 401 instead of leaking that the user exists
+        but has no password configured (H4 — login timing/user-existence
+        oracle defense).
+        """
         from imbi_api import models
 
         oauth_user = models.User(
@@ -678,7 +710,7 @@ class LoginMFATestCase(unittest.TestCase):
 
         self.assertEqual(response.status_code, 401)
         self.assertIn(
-            'Password authentication not available',
+            'Invalid credentials',
             response.json()['detail'],
         )
 
@@ -721,8 +753,8 @@ class OAuthCallbackSuccessTestCase(unittest.TestCase):
         self.test_app = app.create_app()
 
         self.mock_db = mock.AsyncMock(spec=graph.Graph)
-        self.test_app.dependency_overrides[graph._inject_graph] = (
-            lambda: self.mock_db
+        self.test_app.dependency_overrides[graph._inject_graph] = lambda: (
+            self.mock_db
         )
 
         self.client = testclient.TestClient(self.test_app)
@@ -1352,8 +1384,8 @@ class TokenRefreshTestCase(unittest.TestCase):
         self.test_app = app.create_app()
 
         self.mock_db = mock.AsyncMock(spec=graph.Graph)
-        self.test_app.dependency_overrides[graph._inject_graph] = (
-            lambda: self.mock_db
+        self.test_app.dependency_overrides[graph._inject_graph] = lambda: (
+            self.mock_db
         )
 
         self.client = testclient.TestClient(self.test_app)
@@ -1597,8 +1629,8 @@ class LogoutTestCase(unittest.TestCase):
         self.test_app = app.create_app()
 
         self.mock_db = mock.AsyncMock(spec=graph.Graph)
-        self.test_app.dependency_overrides[graph._inject_graph] = (
-            lambda: self.mock_db
+        self.test_app.dependency_overrides[graph._inject_graph] = lambda: (
+            self.mock_db
         )
 
         self.client = testclient.TestClient(self.test_app)
@@ -1765,8 +1797,8 @@ class ServiceAccountAuthTestCase(unittest.TestCase):
         self.test_app = app.create_app()
 
         self.mock_db = mock.AsyncMock(spec=graph.Graph)
-        self.test_app.dependency_overrides[graph._inject_graph] = (
-            lambda: self.mock_db
+        self.test_app.dependency_overrides[graph._inject_graph] = lambda: (
+            self.mock_db
         )
 
         self.client = testclient.TestClient(self.test_app)
@@ -1795,7 +1827,12 @@ class ServiceAccountAuthTestCase(unittest.TestCase):
     def test_service_account_blocked_from_password_login(
         self,
     ) -> None:
-        """POST /auth/login with SA returns 403."""
+        """POST /auth/login with a service account returns generic 401.
+
+        After H4 we collapse every login failure mode to a single 401
+        with constant timing so an attacker can't distinguish service
+        accounts (or any other category) from unknown emails.
+        """
         self.mock_db.match.return_value = [self.sa_user]
 
         response = self.client.post(
@@ -1806,9 +1843,9 @@ class ServiceAccountAuthTestCase(unittest.TestCase):
             },
         )
 
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, 401)
         self.assertIn(
-            'Service accounts cannot use password login',
+            'Invalid credentials',
             response.json()['detail'],
         )
 
@@ -2129,8 +2166,8 @@ class IdentityPluginLoginFlowTestCase(unittest.TestCase):
         settings._auth_settings = None
         self.test_app = app.create_app()
         self.mock_db = mock.AsyncMock(spec=graph.Graph)
-        self.test_app.dependency_overrides[graph._inject_graph] = (
-            lambda: self.mock_db
+        self.test_app.dependency_overrides[graph._inject_graph] = lambda: (
+            self.mock_db
         )
         self.client = testclient.TestClient(self.test_app)
 


### PR DESCRIPTION
## Summary

Two security/perf items from the code review punchlist:

- **H4 — login timing/user-existence oracle.** Every login failure path now runs Argon2 (against the real hash when the user is password-eligible, otherwise against a fixed dummy hash computed at import time). Unknown email, inactive user, service account, OAuth-only account, and wrong password all return the same generic 401 \`Invalid credentials\` — neither response time nor message distinguishes them.
- **H5 — Argon2 blocking the event loop.** Every production Argon2 call site is now wrapped in \`asyncio.to_thread\`: login (verify + needs_rehash + rehash + MFA backup-code check), client credentials grant verify, API-key auth (runs on every authenticated request), MFA setup/verify/disable, password change, user create, API key + SA API key + client credential create/rotate. The 10 backup-code hashes during MFA setup now run via \`asyncio.gather\`, turning ~1–3s of serial blocking into a single parallel batch.

## Behavior changes worth flagging

- \`POST /auth/login\` no longer returns \`403 Service accounts cannot use password login\` or \`401 Password authentication not available\` — both are now \`401 Invalid credentials\` to remove the user-enumeration channel. The provider list (\`GET /auth/providers\`) is still available to drive UI hints client-side.

## Test plan

- [x] \`tests/endpoints/test_auth.py\` — login success, invalid password, user not found, OAuth-only, service-account paths
- [x] \`tests/auth/test_authentication.py\` — login no-password-hash test updated for new generic message
- [x] New regression: \`test_login_unknown_user_still_runs_argon2\` asserts \`verify_password\` is invoked even when the email is unknown, with a real \`\$argon2…\` hash argument
- [x] Full suite: 1703 passed (the 2 \`test_project_configuration\` failures are the pre-existing ClickHouse \`plugin_slug\` migration failures on \`main\`, unrelated to this branch)
- [x] \`ruff check\` + \`ruff format\` + \`mypy\` + \`basedpyright\` clean on touched files