### PR TITLE
Close OIDC/OAuth SSRF channel via URL allow-list (H2)

### DIFF
--- a/src/imbi_api/auth/oauth.py
+++ b/src/imbi_api/auth/oauth.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import ipaddress
+import logging
 import os
 import secrets
 import socket
@@ -17,6 +18,8 @@ from imbi_common.auth import encryption
 from imbi_api import settings
 from imbi_api.auth import login_providers, models
 
+LOGGER = logging.getLogger(__name__)
+
 # Cache for OIDC discovery documents with TTL
 # Format: {issuer_url: (discovery_data, timestamp)}
 _oidc_discovery_cache: dict[str, tuple[dict[str, typing.Any], float]] = {}
@@ -27,7 +30,8 @@ def _insecure_urls_allowed() -> bool:
     """True iff the dev escape hatch ``IMBI_OAUTH_ALLOW_INSECURE_URLS`` is on.
 
     When set, ``_validate_external_url`` skips its scheme and IP-range
-    checks. Intended only for local dev against mock OIDC providers on
+    checks *only* for hostnames in ``{'localhost', '127.0.0.1', '::1'}``.
+    Intended only for local dev against mock OIDC providers on
     ``http://localhost``; never set in production.
     """
     return os.environ.get('IMBI_OAUTH_ALLOW_INSECURE_URLS', '').lower() in {
@@ -42,19 +46,24 @@ async def _validate_external_url(url: str, *, field: str) -> None:
 
     Used on every URL that this module is about to fetch (OIDC issuer,
     discovered token/userinfo endpoints) to close the SSRF channel an
-    admin-configurable ``issuer_url`` would otherwise open. Disable with
-    ``IMBI_OAUTH_ALLOW_INSECURE_URLS=true`` for dev against localhost
-    mocks.
+    admin-configurable ``issuer_url`` would otherwise open. The
+    ``IMBI_OAUTH_ALLOW_INSECURE_URLS=true`` dev escape hatch only
+    bypasses validation for ``localhost``/``127.0.0.1``/``::1``; every
+    other host is still validated normally.
 
     Raises:
         ValueError: If scheme is not ``https`` or hostname resolves to a
             loopback, link-local, private (RFC1918), multicast, or
             reserved address.
     """
-    if _insecure_urls_allowed():
+    parsed = urlparse.urlparse(url)
+    if _insecure_urls_allowed() and parsed.hostname in {
+        'localhost',
+        '127.0.0.1',
+        '::1',
+    }:
         return
 
-    parsed = urlparse.urlparse(url)
     if parsed.scheme != 'https':
         raise ValueError(
             f'{field} must use https:// (got scheme {parsed.scheme!r})'

--- a/src/imbi_api/auth/oauth.py
+++ b/src/imbi_api/auth/oauth.py
@@ -1,8 +1,13 @@
 """OAuth2/OIDC integration helpers."""
 
+import asyncio
+import ipaddress
+import os
 import secrets
+import socket
 import time
 import typing
+from urllib import parse as urlparse
 
 import httpx
 import jwt
@@ -18,6 +23,76 @@ _oidc_discovery_cache: dict[str, tuple[dict[str, typing.Any], float]] = {}
 _OIDC_CACHE_TTL_SECONDS = 86400  # 24 hours
 
 
+def _insecure_urls_allowed() -> bool:
+    """True iff the dev escape hatch ``IMBI_OAUTH_ALLOW_INSECURE_URLS`` is on.
+
+    When set, ``_validate_external_url`` skips its scheme and IP-range
+    checks. Intended only for local dev against mock OIDC providers on
+    ``http://localhost``; never set in production.
+    """
+    return os.environ.get('IMBI_OAUTH_ALLOW_INSECURE_URLS', '').lower() in {
+        '1',
+        'true',
+        'yes',
+    }
+
+
+async def _validate_external_url(url: str, *, field: str) -> None:
+    """Reject URLs that point at non-HTTPS or private network addresses.
+
+    Used on every URL that this module is about to fetch (OIDC issuer,
+    discovered token/userinfo endpoints) to close the SSRF channel an
+    admin-configurable ``issuer_url`` would otherwise open. Disable with
+    ``IMBI_OAUTH_ALLOW_INSECURE_URLS=true`` for dev against localhost
+    mocks.
+
+    Raises:
+        ValueError: If scheme is not ``https`` or hostname resolves to a
+            loopback, link-local, private (RFC1918), multicast, or
+            reserved address.
+    """
+    if _insecure_urls_allowed():
+        return
+
+    parsed = urlparse.urlparse(url)
+    if parsed.scheme != 'https':
+        raise ValueError(
+            f'{field} must use https:// (got scheme {parsed.scheme!r})'
+        )
+    if not parsed.hostname:
+        raise ValueError(f'{field} is missing a hostname')
+
+    try:
+        infos = await asyncio.to_thread(
+            socket.getaddrinfo,
+            parsed.hostname,
+            None,
+            0,
+            socket.SOCK_STREAM,
+        )
+    except socket.gaierror as err:
+        raise ValueError(
+            f'{field} hostname does not resolve: {parsed.hostname}'
+        ) from err
+
+    for info in infos:
+        sockaddr = info[4]
+        ip_str = sockaddr[0]
+        ip = ipaddress.ip_address(ip_str)
+        if (
+            ip.is_loopback
+            or ip.is_link_local
+            or ip.is_private
+            or ip.is_multicast
+            or ip.is_reserved
+            or ip.is_unspecified
+        ):
+            raise ValueError(
+                f'{field} resolves to a non-public address '
+                f'({parsed.hostname} -> {ip_str})'
+            )
+
+
 async def _discover_oidc_endpoints(issuer_url: str) -> dict[str, typing.Any]:
     """Discover OIDC endpoints via .well-known/openid-configuration.
 
@@ -28,7 +103,8 @@ async def _discover_oidc_endpoints(issuer_url: str) -> dict[str, typing.Any]:
         Discovery document with token_endpoint, userinfo_endpoint, etc.
 
     Raises:
-        ValueError: If discovery fails
+        ValueError: If discovery fails or any URL involved would target
+            a non-public network address (SSRF defense).
 
     """
     if issuer_url in _oidc_discovery_cache:
@@ -38,11 +114,15 @@ async def _discover_oidc_endpoints(issuer_url: str) -> dict[str, typing.Any]:
             return discovery_data
         del _oidc_discovery_cache[issuer_url]
 
+    await _validate_external_url(issuer_url, field='OIDC issuer URL')
+
     issuer = issuer_url.rstrip('/')
     discovery_url = f'{issuer}/.well-known/openid-configuration'
 
     try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
+        async with httpx.AsyncClient(
+            timeout=10.0, follow_redirects=False
+        ) as client:
             response = await client.get(discovery_url)
     except httpx.HTTPError as e:
         raise ValueError(f'OIDC discovery request failed: {e}') from e
@@ -58,6 +138,16 @@ async def _discover_oidc_endpoints(issuer_url: str) -> dict[str, typing.Any]:
         raise ValueError('OIDC discovery missing token_endpoint')
     if 'userinfo_endpoint' not in discovery_data:
         raise ValueError('OIDC discovery missing userinfo_endpoint')
+
+    # The discovered endpoints can be set by whoever controls the
+    # issuer's discovery document; revalidate so an HTTPS issuer cannot
+    # point token/userinfo at an internal host.
+    await _validate_external_url(
+        discovery_data['token_endpoint'], field='OIDC token_endpoint'
+    )
+    await _validate_external_url(
+        discovery_data['userinfo_endpoint'], field='OIDC userinfo_endpoint'
+    )
 
     _oidc_discovery_cache[issuer_url] = (discovery_data, time.time())
     return discovery_data
@@ -150,7 +240,11 @@ async def exchange_oauth_code(
     """
     token_url, client_id, client_secret = await _get_provider_config(slug, db)
 
-    async with httpx.AsyncClient(timeout=30.0) as client:
+    await _validate_external_url(token_url, field='OAuth token_url')
+
+    async with httpx.AsyncClient(
+        timeout=30.0, follow_redirects=False
+    ) as client:
         response = await client.post(
             token_url,
             data={
@@ -194,7 +288,11 @@ async def fetch_oauth_profile(
     app = await _load_active_login_app(slug, db)
     userinfo_url = await _get_userinfo_url(slug, db)
 
-    async with httpx.AsyncClient(timeout=30.0) as client:
+    await _validate_external_url(userinfo_url, field='OAuth userinfo_url')
+
+    async with httpx.AsyncClient(
+        timeout=30.0, follow_redirects=False
+    ) as client:
         response = await client.get(
             userinfo_url,
             headers={'Authorization': f'Bearer {access_token}'},

--- a/tests/auth/test_oauth.py
+++ b/tests/auth/test_oauth.py
@@ -311,8 +311,19 @@ class OIDCDiscoveryTestCase(unittest.IsolatedAsyncioTestCase):
     """Test cases for OIDC discovery."""
 
     def setUp(self) -> None:
-        """Clear OIDC discovery cache before each test."""
+        """Clear cache and short-circuit SSRF validation for fake hostnames.
+
+        ``_validate_external_url`` does a real DNS lookup, which fails
+        for ``*.example.com`` fixtures used here. The standalone
+        ``URLValidationTestCase`` below exercises the validator itself.
+        """
         oauth._oidc_discovery_cache.clear()
+        self._validate_patcher = mock.patch(
+            'imbi_api.auth.oauth._validate_external_url',
+            new=mock.AsyncMock(return_value=None),
+        )
+        self._validate_patcher.start()
+        self.addCleanup(self._validate_patcher.stop)
 
     @mock.patch('imbi_api.auth.oauth.httpx.AsyncClient')
     async def test_discover_oidc_endpoints_success(
@@ -551,9 +562,15 @@ class _DBProviderTestBase(unittest.IsolatedAsyncioTestCase):
             list_login_apps=_fake_list,
         )
         self._patch.start()
+        self._validate_patcher = mock.patch(
+            'imbi_api.auth.oauth._validate_external_url',
+            new=mock.AsyncMock(return_value=None),
+        )
+        self._validate_patcher.start()
 
     def tearDown(self) -> None:
         self._patch.stop()
+        self._validate_patcher.stop()
 
     def seed(self, slug: str, **kwargs: typing.Any) -> None:
         self.providers_by_slug[slug] = _stub_provider(slug, **kwargs)
@@ -853,3 +870,123 @@ class OAuthProfileFetchTestCase(_DBProviderTestBase):
         with self.assertRaises(ValueError) as context:
             await oauth._get_provider_config('oidc', self.db)
         self.assertIn('not enabled', str(context.exception).lower())
+
+
+class URLValidationTestCase(unittest.IsolatedAsyncioTestCase):
+    """H2: SSRF defense around OIDC/OAuth URL fetches."""
+
+    async def test_rejects_non_https_scheme(self) -> None:
+        with self.assertRaises(ValueError) as ctx:
+            await oauth._validate_external_url(
+                'http://auth.example.com', field='issuer'
+            )
+        self.assertIn('https://', str(ctx.exception))
+
+    async def test_rejects_missing_hostname(self) -> None:
+        with self.assertRaises(ValueError) as ctx:
+            await oauth._validate_external_url('https://', field='issuer')
+        self.assertIn('hostname', str(ctx.exception))
+
+    async def test_rejects_loopback(self) -> None:
+        with mock.patch(
+            'imbi_api.auth.oauth.socket.getaddrinfo',
+            return_value=[
+                (0, 0, 0, '', ('127.0.0.1', 0)),
+            ],
+        ):
+            with self.assertRaises(ValueError) as ctx:
+                await oauth._validate_external_url(
+                    'https://localhost-aliased.example', field='issuer'
+                )
+        self.assertIn('non-public', str(ctx.exception))
+
+    async def test_rejects_link_local(self) -> None:
+        with mock.patch(
+            'imbi_api.auth.oauth.socket.getaddrinfo',
+            return_value=[
+                (0, 0, 0, '', ('169.254.169.254', 0)),
+            ],
+        ):
+            with self.assertRaises(ValueError) as ctx:
+                await oauth._validate_external_url(
+                    'https://metadata.attacker.example', field='issuer'
+                )
+        self.assertIn('non-public', str(ctx.exception))
+
+    async def test_rejects_rfc1918(self) -> None:
+        for private_ip in ('10.0.0.1', '172.16.0.1', '192.168.1.1'):
+            with mock.patch(
+                'imbi_api.auth.oauth.socket.getaddrinfo',
+                return_value=[
+                    (0, 0, 0, '', (private_ip, 0)),
+                ],
+            ):
+                with self.assertRaises(ValueError) as ctx:
+                    await oauth._validate_external_url(
+                        'https://internal.attacker.example', field='issuer'
+                    )
+            self.assertIn(
+                'non-public', str(ctx.exception), f'failed for {private_ip}'
+            )
+
+    async def test_rejects_ipv6_loopback(self) -> None:
+        with mock.patch(
+            'imbi_api.auth.oauth.socket.getaddrinfo',
+            return_value=[
+                (0, 0, 0, '', ('::1', 0, 0, 0)),
+            ],
+        ):
+            with self.assertRaises(ValueError) as ctx:
+                await oauth._validate_external_url(
+                    'https://v6.attacker.example', field='issuer'
+                )
+        self.assertIn('non-public', str(ctx.exception))
+
+    async def test_rejects_unresolvable_host(self) -> None:
+        import socket as _socket
+
+        with mock.patch(
+            'imbi_api.auth.oauth.socket.getaddrinfo',
+            side_effect=_socket.gaierror('no such host'),
+        ):
+            with self.assertRaises(ValueError) as ctx:
+                await oauth._validate_external_url(
+                    'https://nope.example.invalid', field='issuer'
+                )
+        self.assertIn('does not resolve', str(ctx.exception))
+
+    async def test_allows_public_address(self) -> None:
+        with mock.patch(
+            'imbi_api.auth.oauth.socket.getaddrinfo',
+            return_value=[
+                (0, 0, 0, '', ('8.8.8.8', 0)),
+            ],
+        ):
+            await oauth._validate_external_url(
+                'https://auth.example.com', field='issuer'
+            )
+
+    async def test_dev_escape_hatch_skips_validation(self) -> None:
+        with mock.patch.dict(
+            'os.environ',
+            {'IMBI_OAUTH_ALLOW_INSECURE_URLS': 'true'},
+            clear=False,
+        ):
+            await oauth._validate_external_url(
+                'http://localhost:9000', field='issuer'
+            )
+
+    async def test_rejects_one_bad_ip_in_multi_result(self) -> None:
+        """If any resolved IP is private, fail closed."""
+        with mock.patch(
+            'imbi_api.auth.oauth.socket.getaddrinfo',
+            return_value=[
+                (0, 0, 0, '', ('8.8.8.8', 0)),
+                (0, 0, 0, '', ('127.0.0.1', 0)),
+            ],
+        ):
+            with self.assertRaises(ValueError) as ctx:
+                await oauth._validate_external_url(
+                    'https://dns-rebinding.example', field='issuer'
+                )
+        self.assertIn('non-public', str(ctx.exception))

--- a/tests/auth/test_oauth.py
+++ b/tests/auth/test_oauth.py
@@ -322,7 +322,7 @@ class OIDCDiscoveryTestCase(unittest.IsolatedAsyncioTestCase):
             'imbi_api.auth.oauth._validate_external_url',
             new=mock.AsyncMock(return_value=None),
         )
-        self._validate_patcher.start()
+        self._validate_mock = self._validate_patcher.start()
         self.addCleanup(self._validate_patcher.stop)
 
     @mock.patch('imbi_api.auth.oauth.httpx.AsyncClient')
@@ -363,6 +363,10 @@ class OIDCDiscoveryTestCase(unittest.IsolatedAsyncioTestCase):
 
         # Verify cache was populated
         self.assertIn('https://auth.example.com', oauth._oidc_discovery_cache)
+
+        # SSRF defense was invoked on the happy path; removal would fail
+        # this test rather than silently disabling the hook.
+        self._validate_mock.assert_awaited()
 
     @mock.patch('imbi_api.auth.oauth.httpx.AsyncClient')
     async def test_discover_oidc_endpoints_cached(
@@ -566,7 +570,7 @@ class _DBProviderTestBase(unittest.IsolatedAsyncioTestCase):
             'imbi_api.auth.oauth._validate_external_url',
             new=mock.AsyncMock(return_value=None),
         )
-        self._validate_patcher.start()
+        self._validate_mock = self._validate_patcher.start()
 
     def tearDown(self) -> None:
         self._patch.stop()
@@ -647,6 +651,10 @@ class OAuthProviderConfigTestCase(_DBProviderTestBase):
         self.assertEqual(token_url, 'https://auth.example.com/oauth/token')
         self.assertEqual(client_id, 'oidc-client-id')
         self.assertEqual(client_secret, 'oidc-client-secret')
+
+        # SSRF defense was invoked on the happy path; removal would fail
+        # this test rather than silently disabling the hook.
+        self._validate_mock.assert_awaited()
 
     async def test_get_provider_config_disabled(self) -> None:
         self.seed('google', enabled=False)
@@ -990,3 +998,36 @@ class URLValidationTestCase(unittest.IsolatedAsyncioTestCase):
                     'https://dns-rebinding.example', field='issuer'
                 )
         self.assertIn('non-public', str(ctx.exception))
+
+    async def test_rejects_multicast_reserved_and_unspecified(self) -> None:
+        """Multicast, reserved, and unspecified IP categories fail closed."""
+        for blocked_ip in ('224.0.0.1', '240.0.0.1', '0.0.0.0'):
+            with self.subTest(blocked_ip=blocked_ip):
+                with mock.patch(
+                    'imbi_api.auth.oauth.socket.getaddrinfo',
+                    return_value=[(0, 0, 0, '', (blocked_ip, 0))],
+                ):
+                    with self.assertRaises(ValueError) as ctx:
+                        await oauth._validate_external_url(
+                            'https://blocked.example', field='issuer'
+                        )
+                self.assertIn('non-public', str(ctx.exception))
+
+    async def test_dev_escape_hatch_does_not_bypass_non_localhost(
+        self,
+    ) -> None:
+        """Escape hatch must only short-circuit ``localhost``-style hosts.
+
+        For any other hostname the regular scheme/IP-range checks still
+        apply even when ``IMBI_OAUTH_ALLOW_INSECURE_URLS`` is set.
+        """
+        with mock.patch.dict(
+            'os.environ',
+            {'IMBI_OAUTH_ALLOW_INSECURE_URLS': 'true'},
+            clear=False,
+        ):
+            with self.assertRaises(ValueError) as ctx:
+                await oauth._validate_external_url(
+                    'http://auth.example.com', field='issuer'
+                )
+        self.assertIn('https://', str(ctx.exception))


### PR DESCRIPTION
## Summary

Closes H2 from the code review punchlist — SSRF in OIDC discovery.

An admin who configures an OIDC login provider could previously point \`issuer_url\` at any reachable address: cloud metadata services (\`169.254.169.254\`), internal RFC1918 hosts, or \`localhost\`. The newly added \`_validate_external_url\` runs before every outbound HTTP request in \`auth/oauth.py\`:

1. \`issuer_url\` before discovery
2. \`token_endpoint\` and \`userinfo_endpoint\` returned by the discovery doc (the issuer can rewrite these even if its own URL is public — fail closed)
3. \`token_url\` used by \`exchange_oauth_code\` (admin-set \`app.token_endpoint\` bypasses discovery)
4. \`userinfo_url\` used by \`fetch_oauth_profile\`

The validator enforces \`https://\` and rejects loopback, link-local, RFC1918, multicast, reserved, and unspecified addresses. Multi-result resolutions fail closed if any one IP is private.

Dev escape hatch: \`IMBI_OAUTH_ALLOW_INSECURE_URLS=true\` for local mock providers on \`http://localhost\`. Never set in production.

Also explicitly passes \`follow_redirects=False\` on every \`httpx.AsyncClient\` in this module. That's already the httpx default, but pinning it locks the contract against future client-default drift.

## Test plan

- [x] New \`URLValidationTestCase\` covers 10 cases: scheme, missing hostname, IPv4 loopback, link-local, RFC1918 (x3), IPv6 loopback, NXDOMAIN, public address, dev escape hatch, mixed-result fail-closed
- [x] Existing \`OIDCDiscoveryTestCase\` setUp patches the validator so fixture hostnames don't need to resolve
- [x] \`_DBProviderTestBase\` also patches the validator since its callers feed the mocked token/userinfo URLs through the new check
- [x] Full suite: 264 auth tests passing, ruff + mypy + basedpyright clean