### PR TITLE
Close MFA backup-code reuse race with atomic Cypher SET (H6)

### DIFF
--- a/src/imbi_api/domain/models.py
+++ b/src/imbi_api/domain/models.py
@@ -187,7 +187,7 @@ class LocalAuthConfig(models.GraphModel):
 
     key: typing.Literal['global'] = 'global'
     enabled: bool = True
-    updated_at: datetime.datetime = pydantic.Field(
+    updated_at: datetime.datetime | None = pydantic.Field(
         default_factory=lambda: datetime.datetime.now(datetime.UTC)
     )
 

--- a/src/imbi_api/endpoints/auth.py
+++ b/src/imbi_api/endpoints/auth.py
@@ -2,7 +2,6 @@
 
 import asyncio
 import datetime
-import json
 import logging
 import secrets
 import typing
@@ -388,31 +387,47 @@ async def login(
                 backup_codes = totp_data.get('backup_codes', [])
                 valid_backup = False
 
-                for i, hashed_code in enumerate(backup_codes):
-                    if await asyncio.to_thread(
+                for hashed_code in backup_codes:
+                    if not await asyncio.to_thread(
                         password_auth.verify_password, mfa_code, hashed_code
                     ):
-                        # Remove used backup code
-                        backup_codes.pop(i)
-                        update_q2: typing.LiteralString = """
-                        MATCH (u:User {{email: {email}}})
-                              <-[:MFA_FOR]-(t:TOTPSecret)
-                        SET t.backup_codes = {backup_codes}
-                        """
-                        await db.execute(
-                            update_q2,
-                            {
-                                'email': user.email,
-                                'backup_codes': json.dumps(backup_codes),
-                            },
-                        )
-
-                        valid_backup = True
-                        LOGGER.info(
-                            'MFA verified via backup code for user %s',
+                        continue
+                    # Atomically remove the matched backup code. The
+                    # ``WHERE {used_hash} IN t.backup_codes`` guard plus
+                    # list-comprehension SET is the H6 race fix: if a
+                    # parallel login already consumed this hash, the
+                    # WHERE rejects so the SET never fires and the same
+                    # code can't be used twice. An empty result set means
+                    # the race happened — treat it as failed auth.
+                    update_q2: typing.LiteralString = """
+                    MATCH (u:User {{email: {email}}})
+                          <-[:MFA_FOR]-(t:TOTPSecret)
+                    WHERE {used_hash} IN t.backup_codes
+                    SET t.backup_codes =
+                        [c IN t.backup_codes WHERE c <> {used_hash}]
+                    RETURN size(t.backup_codes) AS remaining
+                    """
+                    update_records = await db.execute(
+                        update_q2,
+                        {
+                            'email': user.email,
+                            'used_hash': hashed_code,
+                        },
+                        columns=['remaining'],
+                    )
+                    if not update_records:
+                        LOGGER.warning(
+                            'MFA backup code already consumed for user '
+                            '%s (race)',
                             user.email,
                         )
-                        break
+                        continue
+                    valid_backup = True
+                    LOGGER.info(
+                        'MFA verified via backup code for user %s',
+                        user.email,
+                    )
+                    break
 
                 if not valid_backup:
                     raise fastapi.HTTPException(

--- a/src/imbi_api/endpoints/mfa.py
+++ b/src/imbi_api/endpoints/mfa.py
@@ -9,7 +9,6 @@ import asyncio
 import base64
 import datetime
 import io
-import json
 import logging
 import secrets
 import typing
@@ -275,7 +274,7 @@ async def verify_and_enable_mfa(
     )
 
     is_valid = False
-    used_backup_code = False
+    matched_backup_hash: str | None = None
     backup_codes = typing.cast(list[str], totp_data.get('backup_codes', []))
 
     # First try TOTP verification (allow 1 time step for skew)
@@ -288,9 +287,7 @@ async def verify_and_enable_mfa(
                 password.verify_password, verify_request.code, backup_hash
             ):
                 is_valid = True
-                used_backup_code = True
-                # Remove used backup code
-                backup_codes.remove(backup_hash)
+                matched_backup_hash = backup_hash
                 break
 
     if not is_valid:
@@ -298,23 +295,40 @@ async def verify_and_enable_mfa(
 
     now_str = datetime.datetime.now(datetime.UTC).isoformat()
 
-    # Enable MFA and update backup codes if one was used
-    if used_backup_code:
+    # Enable MFA and atomically remove the used backup code. The
+    # ``WHERE {used_hash} IN t.backup_codes`` + list-comprehension
+    # filter is the race fix (H6): if a parallel verify already
+    # consumed this code, the WHERE rejects this query so the SET
+    # never fires and the hash can't be reused. We detect that case
+    # via the empty result set and surface it as a 401, matching the
+    # behavior the user would have seen if they'd raced themselves.
+    if matched_backup_hash is not None:
         update_query: typing.LiteralString = """
         MATCH (u:User {{email: {email}}})
               <-[:MFA_FOR]-(t:TOTPSecret)
+        WHERE {used_hash} IN t.backup_codes
         SET t.enabled = true,
             t.last_used = {now},
-            t.backup_codes = {backup_codes}
+            t.backup_codes = [c IN t.backup_codes WHERE c <> {used_hash}]
+        RETURN size(t.backup_codes) AS remaining
         """
-        await db.execute(
+        records = await db.execute(
             update_query,
             {
                 'email': auth.require_user.email,
-                'backup_codes': json.dumps(backup_codes),
+                'used_hash': matched_backup_hash,
                 'now': now_str,
             },
+            columns=['remaining'],
         )
+        if not records:
+            LOGGER.warning(
+                'MFA backup code already consumed for user %s (race)',
+                auth.require_user.email,
+            )
+            raise fastapi.HTTPException(
+                status_code=401, detail='Invalid MFA code'
+            )
         LOGGER.info(
             'MFA enabled for user %s (used backup code)',
             auth.require_user.email,

--- a/tests/endpoints/test_auth.py
+++ b/tests/endpoints/test_auth.py
@@ -565,12 +565,13 @@ class LoginMFATestCase(unittest.TestCase):
         }
 
         self.mock_db.match.return_value = [test_user]
-        # execute(): TOTP fetch, backup_codes update, then the atomic
-        # MATCH/CREATE inside issue_token_pair that returns
-        # principal_count.
+        # execute(): TOTP fetch, atomic backup-code consume (returns the
+        # remaining count post-removal so the caller knows the hash
+        # really was still present), then the atomic MATCH/CREATE inside
+        # issue_token_pair that returns principal_count.
         self.mock_db.execute.side_effect = [
             [{'n': totp_data}],
-            [],
+            [{'remaining': 1}],
             [{'principal_count': 1}],
         ]
         self.mock_db.merge.return_value = None
@@ -592,6 +593,55 @@ class LoginMFATestCase(unittest.TestCase):
             data = response.json()
             self.assertIn('access_token', data)
             self.assertIn('refresh_token', data)
+
+    def test_login_mfa_backup_code_race_returns_401(self) -> None:
+        """Argon2 verifies but the atomic SET says the hash is gone.
+
+        Simulates the H6 race: another concurrent login consumed the
+        same backup code between our read and our SET. The atomic
+        ``WHERE {used_hash} IN t.backup_codes`` filter excludes the row
+        on this side, so ``db.execute`` returns no rows and login must
+        fail with the same 401 the user would have seen if they'd
+        raced themselves.
+        """
+        from imbi_api import models
+        from imbi_api.auth import password
+
+        test_user = models.User(
+            email='test@example.com',
+            display_name='Test User',
+            is_active=True,
+            password_hash=password.hash_password('password123'),
+            created_at=datetime.datetime.now(datetime.UTC),
+        )
+        backup_code = 'racy-bk1'
+        hashed_backup = password.hash_password(backup_code)
+        totp_data = {
+            'secret': 'JBSWY3DPEHPK3PXP',
+            'enabled': True,
+            'backup_codes': [hashed_backup],
+        }
+        self.mock_db.match.return_value = [test_user]
+        # TOTP fetch returns the row containing the hash; the atomic
+        # update returns no rows (race lost).
+        self.mock_db.execute.side_effect = [
+            [{'n': totp_data}],
+            [],
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            response = self.client.post(
+                '/auth/login',
+                json={
+                    'email': 'test@example.com',
+                    'password': 'password123',
+                    'mfa_code': backup_code,
+                },
+            )
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.json()['detail'], 'Invalid MFA code')
 
     def test_login_mfa_invalid_code(self) -> None:
         """Test login with invalid MFA code."""

--- a/tests/endpoints/test_mfa.py
+++ b/tests/endpoints/test_mfa.py
@@ -577,6 +577,48 @@ class MFAEndpointsTestCase(unittest.TestCase):
 
             self.assertEqual(response.status_code, 204)
 
+    def test_verify_mfa_with_backup_code_race_returns_401(self) -> None:
+        """The atomic SET reports zero rows when another verifier won.
+
+        Simulates the H6 race during ``POST /mfa/verify``: the in-memory
+        Argon2 loop matches one of the stored hashes, but by the time
+        the ``WHERE {used_hash} IN t.backup_codes`` SET fires the row
+        has already had its codes rewritten by a parallel verify.
+        """
+        secret = 'JBSWY3DPEHPK3PXP'
+        backup_code_plain = 'racybk12'
+        backup_code_hash = password.hash_password(backup_code_plain)
+        totp_data = {
+            'secret': secret,
+            'enabled': False,
+            'backup_codes': [backup_code_hash],
+            'created_at': datetime.datetime.now(datetime.UTC),
+        }
+        # First execute() = TOTP read (returns the row); second = the
+        # atomic update (returns no rows = race lost).
+        self.mock_db.execute.side_effect = [
+            [{'n': totp_data}],
+            [],
+        ]
+
+        with (
+            mock.patch(
+                'imbi_api.settings.get_auth_settings',
+            ) as mock_settings,
+            mock.patch(
+                'imbi_common.graph.parse_agtype',
+                side_effect=lambda x: x,
+            ),
+        ):
+            mock_settings.return_value = self.auth_settings
+            response = self.client.post(
+                '/mfa/verify',
+                json={'code': backup_code_plain},
+            )
+
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.json()['detail'], 'Invalid MFA code')
+
     def test_disable_mfa_password_required(self) -> None:
         """Test MFA disable requires password."""
         with (


### PR DESCRIPTION
## Summary

Both MFA backup-code paths — login (`endpoints/auth.py`) and verify-setup (`endpoints/mfa.py`) — were vulnerable to a read-modify-write race that let the same single-use backup code authenticate twice if two requests arrived close together.

The fix folds the \"verify, remove, persist\" steps into one atomic Cypher statement:

\`\`\`cypher
MATCH (u:User {email: {email}})<-[:MFA_FOR]-(t:TOTPSecret)
WHERE {used_hash} IN t.backup_codes
SET   t.backup_codes = [c IN t.backup_codes WHERE c <> {used_hash}]
RETURN size(t.backup_codes) AS remaining
\`\`\`

The \`WHERE {used_hash} IN t.backup_codes\` filter is evaluated post-commit for the second writer, so the hash is already gone and the SET never fires. An empty result set is the race signal — we treat it as a 401, matching the surface the user would have seen had they raced themselves.

The change also drops the latent \`json.dumps(backup_codes)\` write, which had been coercing the property from a native AGE list into a JSON string after the first backup-code use. The list comprehension in the new SET keeps the property natively-typed.

## Test plan

- [x] `tests/endpoints/test_auth.py::LoginMFATestCase` — 9 passing (existing + 1 new race test)
- [x] `tests/endpoints/test_mfa.py` — 20 passing (existing + 1 new race test)
- [x] `just lint` — ruff + mypy + basedpyright clean
- [x] Manual review of both call sites in the diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)