### PR TITLE
Cascade-revoke refresh-token family on reuse (H1)

### DIFF
--- a/src/imbi_api/auth/tokens.py
+++ b/src/imbi_api/auth/tokens.py
@@ -33,6 +33,7 @@ _USER_CREATE: typing.LiteralString = (
     'id: {access_id}, '
     'jti: {access_jti}, '
     "token_type: 'access', "
+    'family_id: {family_id}, '
     'issued_at: {issued_at}, '
     'expires_at: {access_exp}, '
     'created_at: {issued_at}, '
@@ -42,6 +43,7 @@ _USER_CREATE: typing.LiteralString = (
     'id: {refresh_id}, '
     'jti: {refresh_jti}, '
     "token_type: 'refresh', "
+    'family_id: {family_id}, '
     'issued_at: {issued_at}, '
     'expires_at: {refresh_exp}, '
     'created_at: {issued_at}, '
@@ -55,6 +57,7 @@ _SERVICE_ACCOUNT_CREATE: typing.LiteralString = (
     'id: {access_id}, '
     'jti: {access_jti}, '
     "token_type: 'access', "
+    'family_id: {family_id}, '
     'issued_at: {issued_at}, '
     'expires_at: {access_exp}, '
     'created_at: {issued_at}, '
@@ -64,6 +67,7 @@ _SERVICE_ACCOUNT_CREATE: typing.LiteralString = (
     'id: {refresh_id}, '
     'jti: {refresh_jti}, '
     "token_type: 'refresh', "
+    'family_id: {family_id}, '
     'issued_at: {issued_at}, '
     'expires_at: {refresh_exp}, '
     'created_at: {issued_at}, '
@@ -93,6 +97,7 @@ async def issue_token_pair(
     principal_id: str,
     auth_settings: settings.Auth,
     extra_claims: dict[str, typing.Any] | None = None,
+    family_id: str | None = None,
 ) -> tuple[str, str, dict[str, typing.Any]]:
     """Mint an access+refresh pair and persist TokenMetadata nodes.
 
@@ -104,17 +109,27 @@ async def issue_token_pair(
     write (avoiding the TOCTOU gap of a separate existence query)
     and fails closed if a principal is removed mid-flight.
 
+    ``family_id`` ties an access+refresh pair to the refresh-token
+    chain it descends from. ``/auth/refresh`` passes the parent
+    refresh's ``family_id`` so the whole chain can be revoked when
+    reuse is detected (H1 in the code-review punchlist). Login,
+    OAuth, and client-credentials issuance pass ``None`` so each new
+    session starts a fresh chain.
+
     Args:
         db: Graph database connection.
         principal_type: ``'user'`` or ``'service_account'``.
         principal_id: Email for users, slug for service accounts.
         auth_settings: Auth settings for JWT configuration.
         extra_claims: Optional additional JWT claims.
+        family_id: Optional pre-assigned family id. ``None`` mints a
+            fresh chain.
 
     Returns:
         ``(access_token, refresh_token, meta)`` where ``meta``
-        contains ``access_jti``, ``refresh_jti``, ``issued_at``,
-        ``access_expires_at``, and ``refresh_expires_at``.
+        contains ``access_jti``, ``refresh_jti``, ``family_id``,
+        ``issued_at``, ``access_expires_at``, and
+        ``refresh_expires_at``.
 
     Raises:
         PrincipalNotFoundError: No principal matched ``principal_id``.
@@ -122,6 +137,8 @@ async def issue_token_pair(
 
     """
     create_query = _PRINCIPAL_QUERIES[principal_type]
+    if family_id is None:
+        family_id = nanoid.generate()
 
     access_token = core.create_access_token(
         principal_id,
@@ -153,6 +170,7 @@ async def issue_token_pair(
             'access_jti': access_claims['jti'],
             'refresh_id': nanoid.generate(),
             'refresh_jti': refresh_claims['jti'],
+            'family_id': family_id,
             'issued_at': now.isoformat(),
             'access_exp': access_expires_at.isoformat(),
             'refresh_exp': refresh_expires_at.isoformat(),
@@ -192,6 +210,7 @@ async def issue_token_pair(
         {
             'access_jti': access_claims['jti'],
             'refresh_jti': refresh_claims['jti'],
+            'family_id': family_id,
             'issued_at': now,
             'access_expires_at': access_expires_at,
             'refresh_expires_at': refresh_expires_at,

--- a/src/imbi_api/domain/models.py
+++ b/src/imbi_api/domain/models.py
@@ -258,6 +258,7 @@ class TokenMetadata(models.GraphModel):
 
     jti: str
     token_type: typing.Literal['access', 'refresh']
+    family_id: str | None = None
     issued_at: datetime.datetime
     expires_at: datetime.datetime
     revoked: bool = False

--- a/src/imbi_api/endpoints/auth.py
+++ b/src/imbi_api/endpoints/auth.py
@@ -442,6 +442,74 @@ async def login(
     )
 
 
+async def _handle_refresh_reuse(
+    db: graph.Graph, *, jti: str, revoked_at_iso: str
+) -> None:
+    """Detect and respond to refresh-token reuse.
+
+    Called from the refresh handler when the atomic ``MATCH ... WHERE
+    revoked = false ... SET revoked = true`` returned no rows. Two
+    cases:
+
+    1. The token doesn't exist — forged or expired-and-pruned jti.
+       Nothing to revoke; log and return.
+    2. The token exists with ``revoked = true`` — canonical
+       refresh-reuse signal. Revoke every un-revoked
+       ``TokenMetadata`` sharing the same ``family_id`` so an
+       attacker who already rotated tokens is logged out alongside
+       the victim.
+    """
+    lookup: typing.LiteralString = (
+        'MATCH (n:TokenMetadata {{jti: {jti}}}) '
+        'RETURN n.revoked AS revoked, n.family_id AS family_id'
+    )
+    rows = await db.execute(
+        lookup, {'jti': jti}, columns=['revoked', 'family_id']
+    )
+    if not rows:
+        LOGGER.warning('Token refresh failed: token not found (jti=%s)', jti)
+        return
+    revoked_val = graph.parse_agtype(rows[0].get('revoked'))
+    family_id_val = graph.parse_agtype(rows[0].get('family_id'))
+    if not revoked_val:
+        # Lost the race for some non-revoked reason (e.g. wrong
+        # token_type). Caller already logs; no cascade to fire.
+        return
+    if not isinstance(family_id_val, str) or not family_id_val:
+        # Legacy token issued before family_id existed. Without a
+        # family we can't trace the chain — log the reuse but skip
+        # the cascade so we never accidentally revoke unrelated
+        # tokens.
+        LOGGER.error(
+            'Refresh-token reuse detected for legacy token (no '
+            'family_id, jti=%s)',
+            jti,
+        )
+        return
+    cascade: typing.LiteralString = (
+        'MATCH (t:TokenMetadata {{family_id: {family_id}}}) '
+        'WHERE t.revoked = false '
+        'SET t.revoked = true, t.revoked_at = {revoked_at} '
+        'RETURN count(t) AS revoked_count'
+    )
+    cascade_rows = await db.execute(
+        cascade,
+        {'family_id': family_id_val, 'revoked_at': revoked_at_iso},
+        columns=['revoked_count'],
+    )
+    cascaded = 0
+    if cascade_rows:
+        raw = graph.parse_agtype(cascade_rows[0].get('revoked_count'))
+        cascaded = int(raw or 0)
+    LOGGER.error(
+        'Refresh-token reuse detected (jti=%s, family_id=%s); '
+        'revoked %d sibling tokens',
+        jti,
+        family_id_val,
+        cascaded,
+    )
+
+
 @auth_router.post('/token/refresh', response_model=auth_models.TokenResponse)
 @rate_limit.limiter.limit('10/minute')  # type: ignore[untyped-decorator]
 async def refresh_token(
@@ -491,40 +559,45 @@ async def refresh_token(
             status_code=401, detail='Invalid token type'
         )
 
-    # Atomically revoke the refresh token. Matching on
-    # ``revoked = false`` in the same statement as the SET closes
-    # the TOCTOU gap between the check and the write: when two
-    # refreshes race on the same token, only the first matches, so
-    # the second gets ``revoked_count = 0`` and a clean 401 instead
-    # of AGE raising ``Entity failed to be updated: 3`` on the
-    # concurrently-updated vertex.
+    # Atomically revoke the refresh token AND capture its family_id
+    # for the rotated pair. Matching on ``revoked = false`` in the
+    # same statement as the SET closes the TOCTOU gap between the
+    # check and the write: when two refreshes race on the same token
+    # only the first matches; the second gets an empty result and
+    # falls through to the reuse-detect branch below.
+    revoked_at_iso = datetime.datetime.now(datetime.UTC).isoformat()
     revoke_query: typing.LiteralString = (
         'MATCH (n:TokenMetadata {{jti: {jti}}}) '
         "WHERE n.revoked = false AND n.token_type = 'refresh' "
         'SET n.revoked = true, n.revoked_at = {revoked_at} '
-        'RETURN count(n) AS revoked_count'
+        'RETURN n.family_id AS family_id'
     )
     revoke_records = await db.execute(
         revoke_query,
         {
             'jti': payload['jti'],
-            'revoked_at': datetime.datetime.now(datetime.UTC).isoformat(),
+            'revoked_at': revoked_at_iso,
         },
-        columns=['revoked_count'],
+        columns=['family_id'],
     )
-    revoked = 0
-    if revoke_records:
-        raw = graph.parse_agtype(revoke_records[0].get('revoked_count'))
-        revoked = int(raw or 0)
-    if revoked == 0:
-        LOGGER.warning(
-            'Token refresh failed: token revoked or not found (jti=%s)',
-            payload['jti'],
+    if not revoke_records:
+        # Either the token doesn't exist, was already revoked, or has
+        # the wrong token_type. If it exists and was already revoked,
+        # that's refresh-token reuse — the canonical signal of a
+        # leaked/stolen refresh. Kill every un-revoked token in the
+        # same family so an attacker who already rotated tokens is
+        # logged out alongside the victim.
+        await _handle_refresh_reuse(
+            db, jti=payload['jti'], revoked_at_iso=revoked_at_iso
         )
         raise fastapi.HTTPException(
             status_code=401,
             detail='Refresh token has been revoked',
         )
+    family_id_raw = graph.parse_agtype(revoke_records[0].get('family_id'))
+    parent_family_id = (
+        family_id_raw if isinstance(family_id_raw, str) else None
+    )
 
     # Resolve principal (user or service account)
     subject = payload['sub']
@@ -563,13 +636,16 @@ async def refresh_token(
         principal_type = 'user'
         principal_id = user.email
 
-    # Mint rotated access+refresh pair
+    # Mint rotated access+refresh pair, inheriting the parent's
+    # family_id so a future reuse of any token in this chain can be
+    # detected and the whole chain revoked.
     access_token, new_refresh_token, _ = await tokens.issue_token_pair(
         db,
         principal_type=principal_type,
         principal_id=principal_id,
         auth_settings=auth_settings,
         extra_claims=extra_claims,
+        family_id=parent_family_id,
     )
 
     LOGGER.info(

--- a/tests/auth/test_authentication.py
+++ b/tests/auth/test_authentication.py
@@ -406,14 +406,21 @@ class TokenRefreshEndpointTestCase(unittest.TestCase):
         self.assertIn('type', response.json()['detail'].lower())
 
     def test_token_refresh_revoked(self) -> None:
-        """Test refresh with revoked token."""
+        """Test refresh with revoked token.
+
+        The atomic revoke returns no rows when the token is already
+        revoked; the reuse-detect handler then issues a lookup and a
+        family cascade.
+        """
         refresh_token = core.create_refresh_token(
             self.test_user.email, auth_settings=self.auth_settings
         )
 
-        # Atomic revoke returns 0 when the token is already revoked
-        # (or the jti doesn't match any TokenMetadata vertex).
-        self.mock_db.execute.return_value = [{'revoked_count': 0}]
+        self.mock_db.execute.side_effect = [
+            [],
+            [{'revoked': True, 'family_id': 'fam-test'}],
+            [{'revoked_count': 0}],
+        ]
 
         with mock.patch(
             'imbi_api.settings.get_auth_settings'

--- a/tests/endpoints/test_auth.py
+++ b/tests/endpoints/test_auth.py
@@ -1447,6 +1447,11 @@ class TokenRefreshTestCase(unittest.TestCase):
                 data['refresh_token'],
                 refresh_token,
             )
+            # The rotated pair must inherit the parent's family_id;
+            # otherwise the chain would split and a cascade revoke on
+            # reuse would miss every descendant minted from this call.
+            second_call_params = self.mock_db.execute.call_args_list[1][0][1]
+            self.assertEqual(second_call_params['family_id'], 'fam-test')
 
     def test_refresh_token_expired(self) -> None:
         """Test token refresh with expired token."""

--- a/tests/endpoints/test_auth.py
+++ b/tests/endpoints/test_auth.py
@@ -1421,11 +1421,12 @@ class TokenRefreshTestCase(unittest.TestCase):
         # only the user match remains.
         self.mock_db.match.return_value = [test_user]
         # execute() is called twice: first for the atomic revoke
-        # (revoked_count=1 means the row was unrevoked and is now
-        # revoked), then for the MATCH/CREATE inside issue_token_pair
-        # that persists token metadata and returns principal_count.
+        # (returns the parent's family_id so the rotated pair can
+        # inherit it), then for the MATCH/CREATE inside
+        # issue_token_pair that persists token metadata and returns
+        # principal_count.
         self.mock_db.execute.side_effect = [
-            [{'revoked_count': 1}],
+            [{'family_id': 'fam-test'}],
             [{'principal_count': 1}],
         ]
 
@@ -1556,9 +1557,16 @@ class TokenRefreshTestCase(unittest.TestCase):
             auth_settings=auth_settings,
         )
 
-        # Atomic revoke returns 0 when the token is already revoked
-        # (or the jti doesn't match any TokenMetadata vertex).
-        self.mock_db.execute.return_value = [{'revoked_count': 0}]
+        # Atomic revoke returns no rows when the token is already
+        # revoked or unknown. The reuse-detect handler then issues a
+        # lookup (returns the token's revoked/family_id) followed by
+        # the family cascade (returns the count of sibling tokens it
+        # revoked).
+        self.mock_db.execute.side_effect = [
+            [],
+            [{'revoked': True, 'family_id': 'fam-test'}],
+            [{'revoked_count': 0}],
+        ]
 
         with mock.patch(
             'imbi_api.settings.get_auth_settings',
@@ -1598,10 +1606,10 @@ class TokenRefreshTestCase(unittest.TestCase):
             auth_settings=auth_settings,
         )
 
-        # Atomic revoke succeeds (token is valid), then the user
-        # match returns the inactive user.
+        # Atomic revoke succeeds (returns the parent's family_id),
+        # then the user match returns the inactive user.
         self.mock_db.match.return_value = [test_user]
-        self.mock_db.execute.return_value = [{'revoked_count': 1}]
+        self.mock_db.execute.return_value = [{'family_id': 'fam-test'}]
 
         with mock.patch(
             'imbi_api.settings.get_auth_settings',
@@ -1617,6 +1625,53 @@ class TokenRefreshTestCase(unittest.TestCase):
                 'inactive',
                 response.json()['detail'].lower(),
             )
+
+    def test_refresh_token_reuse_cascades_family_revocation(self) -> None:
+        """Reusing a revoked refresh kills every sibling in the family.
+
+        Simulates the H1 reuse scenario: an attacker (or honest client
+        replaying a stale token) presents a refresh whose ``revoked =
+        false`` MATCH yields no rows. The handler then queries the
+        token's stored state, sees it's already revoked, and fans a
+        family-wide cascade SET that turns every un-revoked
+        ``TokenMetadata`` for the chain into revoked rows.
+        """
+        from imbi_common.auth import core
+
+        auth_settings = settings.Auth(
+            jwt_secret='test-secret-key-min-32-chars-long',
+        )
+        refresh_token = core.create_refresh_token(
+            'test@example.com',
+            auth_settings=auth_settings,
+        )
+
+        self.mock_db.execute.side_effect = [
+            # Atomic revoke matches nothing (already revoked).
+            [],
+            # Reuse lookup finds the row revoked w/ family_id.
+            [{'revoked': True, 'family_id': 'fam-leak'}],
+            # Family cascade reports the count of siblings revoked.
+            [{'revoked_count': 3}],
+        ]
+
+        with mock.patch(
+            'imbi_api.settings.get_auth_settings',
+            return_value=auth_settings,
+        ):
+            response = self.client.post(
+                '/auth/token/refresh',
+                json={'refresh_token': refresh_token},
+            )
+
+        self.assertEqual(response.status_code, 401)
+        self.assertIn('revoked', response.json()['detail'].lower())
+        # 3 execute() calls: atomic SET, reuse lookup, family cascade.
+        self.assertEqual(self.mock_db.execute.call_count, 3)
+        # The third call carries the family_id we returned from the
+        # lookup, proving the cascade fired with the right scope.
+        third_call_params = self.mock_db.execute.call_args_list[2][0][1]
+        self.assertEqual(third_call_params['family_id'], 'fam-leak')
 
 
 class LogoutTestCase(unittest.TestCase):


### PR DESCRIPTION
## Summary

The refresh endpoint already revoked the presented token atomically, but a reused (already-revoked) refresh just got a generic 401 — every rotated descendant in the chain stayed valid. So a stolen-and-leaked refresh that the attacker had already rotated would keep working after the victim's failing replay tripped the reuse signal.

This PR ties an access+refresh pair to a \`family_id\` and, on detected reuse, revokes every un-revoked sibling in that family:

- \`tokens.issue_token_pair\` accepts an optional \`family_id\`. \`/auth/refresh\` passes the parent's; login / OAuth / client_credentials pass \`None\` and the helper mints a fresh nanoid so each new session starts its own chain. Both \`TokenMetadata\` CREATE templates write \`family_id\`.

- The refresh handler's atomic revoke now returns \`n.family_id\` instead of a count. Empty result = race lost or reuse — both delegate to the new \`_handle_refresh_reuse\` helper, which looks up the row's \`revoked\` / \`family_id\`, and on confirmed reuse runs a single Cypher \`MATCH\` / \`WHERE revoked = false\` / \`SET revoked = true\` over every member of the family.

- A successful first refresh still inherits the parent \`family_id\` so the chain is preserved across rotations.

- Legacy \`TokenMetadata\` rows without \`family_id\` log an ERROR on reuse but skip the cascade (can't trace the chain without it).

## Test plan

- [x] Updated \`test_refresh_token_success\` / \`_user_inactive\` for the new \`family_id\` return shape
- [x] Updated \`test_refresh_token_revoked\` (both test files) to mock the three execute() round-trips
- [x] Added \`test_refresh_token_reuse_cascades_family_revocation\` that asserts the cascade fires with the right family_id
- [x] \`just lint\` clean (ruff + mypy + basedpyright)
- [x] 243 auth-domain tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)