### PR TITLE
Sign Valkey plugin-reload payloads with HMAC (C4)

### DIFF
--- a/src/imbi_api/plugins/reload.py
+++ b/src/imbi_api/plugins/reload.py
@@ -97,7 +97,10 @@ async def _subscribe_reload(
                 continue
             if msg is None:
                 continue
-            raw_data = typing.cast('object', msg.get('data'))  # pyright: ignore[reportUnknownMemberType]
+            raw_data = typing.cast(
+                'object',
+                msg.get('data'),  # pyright: ignore[reportUnknownMemberType]
+            )
             if isinstance(raw_data, (bytes, bytearray)):
                 data = bytes(raw_data).decode('utf-8', errors='replace')
             elif isinstance(raw_data, str):
@@ -172,4 +175,6 @@ async def publish_reload(
     ts = int(time.time())
     nonce = secrets.token_urlsafe(16)
     payload = f'{ts}:{nonce}:{_sign(ts, nonce, key)}'
-    await client.publish(_CHANNEL, payload)  # pyright: ignore[reportUnknownMemberType]
+    await client.publish(  # pyright: ignore[reportUnknownMemberType]
+        _CHANNEL, payload
+    )

--- a/src/imbi_api/plugins/reload.py
+++ b/src/imbi_api/plugins/reload.py
@@ -1,8 +1,25 @@
-"""Valkey pub/sub subscriber for cross-pod plugin reload."""
+"""Valkey pub/sub subscriber for cross-pod plugin reload.
+
+The ``imbi:plugins:reload`` channel triggers in-process
+``reload_plugins()`` on every subscriber. Anyone who can publish to
+that channel can therefore re-import every installed plugin module —
+so payloads are HMAC-signed with a key derived from ``jwt_secret``
+(already required to be shared across pods) and the subscriber
+rejects anything that doesn't verify or is older than
+:data:`_MAX_AGE_SECONDS`.
+
+Payload shape: ``"{unix_ts}:{nonce}:{hex_sig}"`` where ``hex_sig`` =
+HMAC-SHA256(derived_key, ``"{unix_ts}:{nonce}"``).
+"""
 
 import asyncio
 import contextlib
+import hashlib
+import hmac
 import logging
+import secrets
+import time
+import typing
 from collections.abc import AsyncGenerator
 
 from imbi_common import graph, valkey
@@ -16,6 +33,49 @@ from imbi_api.plugins.lifecycle import audit_unavailable
 LOGGER = logging.getLogger(__name__)
 
 _CHANNEL = 'imbi:plugins:reload'
+_HMAC_INFO = b'imbi-plugin-reload-v1'
+_MAX_AGE_SECONDS = 300
+
+
+def _get_reload_key() -> bytes | None:
+    """Derive the HMAC key from the auth ``jwt_secret``.
+
+    Returns None when settings aren't loadable (e.g. import-time
+    failures during test bootstrap), in which case publish/verify
+    short-circuit to a hard failure.
+    """
+    try:
+        from imbi_api.settings import get_auth_settings
+
+        jwt_secret = get_auth_settings().jwt_secret
+    except Exception:
+        LOGGER.exception('Plugin reload: failed to load auth settings')
+        return None
+    if not jwt_secret:
+        return None
+    return hmac.new(jwt_secret.encode(), _HMAC_INFO, hashlib.sha256).digest()
+
+
+def _sign(ts: int, nonce: str, key: bytes) -> str:
+    return hmac.new(key, f'{ts}:{nonce}'.encode(), hashlib.sha256).hexdigest()
+
+
+def _verify(
+    payload: str, key: bytes, *, max_age: int = _MAX_AGE_SECONDS
+) -> bool:
+    parts = payload.split(':', 2)
+    if len(parts) != 3:
+        return False
+    ts_str, nonce, sig = parts
+    if not nonce:
+        return False
+    try:
+        ts = int(ts_str)
+    except ValueError:
+        return False
+    if abs(int(time.time()) - ts) > max_age:
+        return False
+    return hmac.compare_digest(sig, _sign(ts, nonce, key))
 
 
 async def _subscribe_reload(
@@ -35,10 +95,33 @@ async def _subscribe_reload(
                 )
             except TimeoutError:
                 continue
-            if msg is not None:
-                LOGGER.info('Plugin reload triggered via pub/sub')
-                reload_plugins()
-                await audit_unavailable(db)
+            if msg is None:
+                continue
+            raw_data = typing.cast('object', msg.get('data'))  # pyright: ignore[reportUnknownMemberType]
+            if isinstance(raw_data, (bytes, bytearray)):
+                data = bytes(raw_data).decode('utf-8', errors='replace')
+            elif isinstance(raw_data, str):
+                data = raw_data
+            else:
+                LOGGER.warning(
+                    'Plugin reload: ignoring non-string payload type %r',
+                    type(raw_data).__name__,
+                )
+                continue
+            key = _get_reload_key()
+            if key is None:
+                LOGGER.error(
+                    'Plugin reload: HMAC key unavailable; dropping payload'
+                )
+                continue
+            if not _verify(data, key):
+                LOGGER.warning(
+                    'Plugin reload: payload failed HMAC verification; dropping'
+                )
+                continue
+            LOGGER.info('Plugin reload triggered via authenticated pub/sub')
+            reload_plugins()
+            await audit_unavailable(db)
     except asyncio.CancelledError:
         pass
     finally:
@@ -74,5 +157,19 @@ async def plugin_reload_hook(
 async def publish_reload(
     client: _valkey_asyncio.Valkey,
 ) -> None:
-    """Publish a reload notification to all pods."""
-    await client.publish(_CHANNEL, 'reload')  # pyright: ignore[reportUnknownMemberType]
+    """Publish a signed reload notification to all pods.
+
+    Raises:
+        RuntimeError: when the HMAC key cannot be derived (auth
+            settings unloadable or ``jwt_secret`` empty).
+    """
+    key = _get_reload_key()
+    if key is None:
+        raise RuntimeError(
+            'Cannot publish plugin-reload notification: '
+            'jwt_secret is unavailable'
+        )
+    ts = int(time.time())
+    nonce = secrets.token_urlsafe(16)
+    payload = f'{ts}:{nonce}:{_sign(ts, nonce, key)}'
+    await client.publish(_CHANNEL, payload)  # pyright: ignore[reportUnknownMemberType]

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -171,14 +171,33 @@ class ReloadHookTestCase(unittest.TestCase):
         asyncio.run(_run())
 
     def test_publish_reload(self) -> None:
-        from imbi_api.plugins.reload import publish_reload
+        from imbi_api.plugins import reload as reload_mod
 
         mock_client = mock.AsyncMock()
+        derived = b'k' * 32
 
-        asyncio.run(publish_reload(mock_client))
-        mock_client.publish.assert_called_once_with(
-            'imbi:plugins:reload', 'reload'
-        )
+        with mock.patch.object(
+            reload_mod, '_get_reload_key', return_value=derived
+        ):
+            asyncio.run(reload_mod.publish_reload(mock_client))
+
+        mock_client.publish.assert_awaited_once()
+        channel, payload = mock_client.publish.await_args.args
+        self.assertEqual(channel, 'imbi:plugins:reload')
+        self.assertTrue(reload_mod._verify(payload, derived))
+
+    def test_publish_reload_raises_without_key(self) -> None:
+        from imbi_api.plugins import reload as reload_mod
+
+        mock_client = mock.AsyncMock()
+        with (
+            mock.patch.object(
+                reload_mod, '_get_reload_key', return_value=None
+            ),
+            self.assertRaises(RuntimeError),
+        ):
+            asyncio.run(reload_mod.publish_reload(mock_client))
+        mock_client.publish.assert_not_awaited()
 
 
 class InstallerTestCase(unittest.TestCase):
@@ -941,6 +960,16 @@ class CredentialsTestCase(unittest.TestCase):
 class ReloadSubscriberTestCase(unittest.TestCase):
     """Test the pubsub subscriber loop in plugins.reload."""
 
+    def _make_signed_payload(self, key: bytes, *, age: int = 0) -> bytes:
+        import time
+
+        from imbi_api.plugins import reload as reload_mod
+
+        ts = int(time.time()) - age
+        nonce = 'abc123'
+        sig = reload_mod._sign(ts, nonce, key)
+        return f'{ts}:{nonce}:{sig}'.encode()
+
     def test_subscribe_processes_message_and_reloads(self) -> None:
         from imbi_api.plugins import reload as reload_mod
 
@@ -951,6 +980,8 @@ class ReloadSubscriberTestCase(unittest.TestCase):
         client.pubsub = mock.MagicMock(return_value=pubsub)
         mock_db = mock.AsyncMock()
         mock_db.execute.return_value = []
+        derived = b'k' * 32
+        payload = self._make_signed_payload(derived)
 
         async def _run() -> None:
             stop = asyncio.Event()
@@ -960,13 +991,16 @@ class ReloadSubscriberTestCase(unittest.TestCase):
                 calls.append(1)
                 # First call delivers a message; second iteration we stop.
                 if len(calls) == 1:
-                    return {'type': 'message', 'data': b'reload'}
+                    return {'type': 'message', 'data': payload}
                 stop.set()
                 raise TimeoutError()
 
             with (
                 mock.patch.object(
                     reload_mod.asyncio, 'wait_for', side_effect=_wait_for
+                ),
+                mock.patch.object(
+                    reload_mod, '_get_reload_key', return_value=derived
                 ),
                 mock.patch.object(reload_mod, 'reload_plugins') as reload_p,
                 mock.patch.object(
@@ -980,6 +1014,80 @@ class ReloadSubscriberTestCase(unittest.TestCase):
             pubsub.unsubscribe.assert_awaited()
 
         asyncio.run(_run())
+
+    def _run_subscribe_with_payload(
+        self,
+        payload: object,
+        *,
+        key: bytes | None = b'k' * 32,
+    ) -> tuple[mock.MagicMock, mock.AsyncMock]:
+        """Drive one iteration of the subscriber and return reload mocks."""
+        from imbi_api.plugins import reload as reload_mod
+
+        pubsub = mock.MagicMock()
+        pubsub.subscribe = mock.AsyncMock()
+        pubsub.unsubscribe = mock.AsyncMock()
+        client = mock.MagicMock()
+        client.pubsub = mock.MagicMock(return_value=pubsub)
+        mock_db = mock.AsyncMock()
+
+        async def _run() -> tuple[mock.MagicMock, mock.AsyncMock]:
+            stop = asyncio.Event()
+            calls: list[int] = []
+
+            async def _wait_for(*_a: object, **_k: object) -> object:
+                calls.append(1)
+                if len(calls) == 1:
+                    return {'type': 'message', 'data': payload}
+                stop.set()
+                raise TimeoutError()
+
+            with (
+                mock.patch.object(
+                    reload_mod.asyncio, 'wait_for', side_effect=_wait_for
+                ),
+                mock.patch.object(
+                    reload_mod, '_get_reload_key', return_value=key
+                ),
+                mock.patch.object(reload_mod, 'reload_plugins') as reload_p,
+                mock.patch.object(
+                    reload_mod, 'audit_unavailable', mock.AsyncMock()
+                ) as audit,
+            ):
+                await reload_mod._subscribe_reload(client, mock_db, stop)
+            return reload_p, audit
+
+        return asyncio.run(_run())
+
+    def test_subscribe_rejects_unsigned_payload(self) -> None:
+        reload_p, audit = self._run_subscribe_with_payload(b'reload')
+        reload_p.assert_not_called()
+        audit.assert_not_awaited()
+
+    def test_subscribe_rejects_bad_signature(self) -> None:
+        derived = b'k' * 32
+        payload = self._make_signed_payload(derived).replace(b'abc123', b'xxx')
+        reload_p, audit = self._run_subscribe_with_payload(
+            payload, key=derived
+        )
+        reload_p.assert_not_called()
+        audit.assert_not_awaited()
+
+    def test_subscribe_rejects_stale_timestamp(self) -> None:
+        derived = b'k' * 32
+        payload = self._make_signed_payload(derived, age=3600)
+        reload_p, audit = self._run_subscribe_with_payload(
+            payload, key=derived
+        )
+        reload_p.assert_not_called()
+        audit.assert_not_awaited()
+
+    def test_subscribe_drops_when_key_unavailable(self) -> None:
+        derived = b'k' * 32
+        payload = self._make_signed_payload(derived)
+        reload_p, audit = self._run_subscribe_with_payload(payload, key=None)
+        reload_p.assert_not_called()
+        audit.assert_not_awaited()
 
     def test_subscribe_handles_cancelled(self) -> None:
         from imbi_api.plugins import reload as reload_mod

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -141,36 +141,29 @@ class LifecycleTestCase(unittest.TestCase):
             asyncio.run(lifecycle.audit_unavailable(mock_db))
 
 
-class ReloadHookTestCase(unittest.TestCase):
-    def test_plugin_reload_hook_no_valkey(self) -> None:
+class ReloadHookTestCase(unittest.IsolatedAsyncioTestCase):
+    async def test_plugin_reload_hook_no_valkey(self) -> None:
         from imbi_api.plugins.reload import plugin_reload_hook
 
-        async def _run() -> None:
-            with mock.patch(
-                'imbi_api.plugins.reload.valkey.get_client',
-                side_effect=RuntimeError('no valkey'),
-            ):
-                async with plugin_reload_hook(db=None):
-                    pass
+        with mock.patch(
+            'imbi_api.plugins.reload.valkey.get_client',
+            side_effect=RuntimeError('no valkey'),
+        ):
+            async with plugin_reload_hook(db=None):
+                pass
 
-        asyncio.run(_run())
-
-    def test_plugin_reload_hook_no_db(self) -> None:
+    async def test_plugin_reload_hook_no_db(self) -> None:
         from imbi_api.plugins.reload import plugin_reload_hook
 
         mock_client = mock.MagicMock()
+        with mock.patch(
+            'imbi_api.plugins.reload.valkey.get_client',
+            return_value=mock_client,
+        ):
+            async with plugin_reload_hook(db=None):
+                pass
 
-        async def _run() -> None:
-            with mock.patch(
-                'imbi_api.plugins.reload.valkey.get_client',
-                return_value=mock_client,
-            ):
-                async with plugin_reload_hook(db=None):
-                    pass
-
-        asyncio.run(_run())
-
-    def test_publish_reload(self) -> None:
+    async def test_publish_reload(self) -> None:
         from imbi_api.plugins import reload as reload_mod
 
         mock_client = mock.AsyncMock()
@@ -179,14 +172,14 @@ class ReloadHookTestCase(unittest.TestCase):
         with mock.patch.object(
             reload_mod, '_get_reload_key', return_value=derived
         ):
-            asyncio.run(reload_mod.publish_reload(mock_client))
+            await reload_mod.publish_reload(mock_client)
 
         mock_client.publish.assert_awaited_once()
         channel, payload = mock_client.publish.await_args.args
         self.assertEqual(channel, 'imbi:plugins:reload')
         self.assertTrue(reload_mod._verify(payload, derived))
 
-    def test_publish_reload_raises_without_key(self) -> None:
+    async def test_publish_reload_raises_without_key(self) -> None:
         from imbi_api.plugins import reload as reload_mod
 
         mock_client = mock.AsyncMock()
@@ -196,7 +189,7 @@ class ReloadHookTestCase(unittest.TestCase):
             ),
             self.assertRaises(RuntimeError),
         ):
-            asyncio.run(reload_mod.publish_reload(mock_client))
+            await reload_mod.publish_reload(mock_client)
         mock_client.publish.assert_not_awaited()
 
 
@@ -957,7 +950,7 @@ class CredentialsTestCase(unittest.TestCase):
         self.assertIn('client_id or client_secret', str(ctx.exception))
 
 
-class ReloadSubscriberTestCase(unittest.TestCase):
+class ReloadSubscriberTestCase(unittest.IsolatedAsyncioTestCase):
     """Test the pubsub subscriber loop in plugins.reload."""
 
     def _make_signed_payload(self, key: bytes, *, age: int = 0) -> bytes:
@@ -970,7 +963,7 @@ class ReloadSubscriberTestCase(unittest.TestCase):
         sig = reload_mod._sign(ts, nonce, key)
         return f'{ts}:{nonce}:{sig}'.encode()
 
-    def test_subscribe_processes_message_and_reloads(self) -> None:
+    async def test_subscribe_processes_message_and_reloads(self) -> None:
         from imbi_api.plugins import reload as reload_mod
 
         pubsub = mock.MagicMock()
@@ -982,40 +975,36 @@ class ReloadSubscriberTestCase(unittest.TestCase):
         mock_db.execute.return_value = []
         derived = b'k' * 32
         payload = self._make_signed_payload(derived)
+        stop = asyncio.Event()
+        calls: list[int] = []
 
-        async def _run() -> None:
-            stop = asyncio.Event()
-            calls: list[int] = []
+        async def _wait_for(*_a: object, **_k: object) -> object:
+            calls.append(1)
+            # First call delivers a message; second iteration we stop.
+            if len(calls) == 1:
+                return {'type': 'message', 'data': payload}
+            stop.set()
+            raise TimeoutError()
 
-            async def _wait_for(*_a: object, **_k: object) -> object:
-                calls.append(1)
-                # First call delivers a message; second iteration we stop.
-                if len(calls) == 1:
-                    return {'type': 'message', 'data': payload}
-                stop.set()
-                raise TimeoutError()
+        with (
+            mock.patch.object(
+                reload_mod.asyncio, 'wait_for', side_effect=_wait_for
+            ),
+            mock.patch.object(
+                reload_mod, '_get_reload_key', return_value=derived
+            ),
+            mock.patch.object(reload_mod, 'reload_plugins') as reload_p,
+            mock.patch.object(
+                reload_mod, 'audit_unavailable', mock.AsyncMock()
+            ) as audit,
+        ):
+            await reload_mod._subscribe_reload(client, mock_db, stop)
 
-            with (
-                mock.patch.object(
-                    reload_mod.asyncio, 'wait_for', side_effect=_wait_for
-                ),
-                mock.patch.object(
-                    reload_mod, '_get_reload_key', return_value=derived
-                ),
-                mock.patch.object(reload_mod, 'reload_plugins') as reload_p,
-                mock.patch.object(
-                    reload_mod, 'audit_unavailable', mock.AsyncMock()
-                ) as audit,
-            ):
-                await reload_mod._subscribe_reload(client, mock_db, stop)
+        reload_p.assert_called_once()
+        audit.assert_awaited()
+        pubsub.unsubscribe.assert_awaited()
 
-            reload_p.assert_called_once()
-            audit.assert_awaited()
-            pubsub.unsubscribe.assert_awaited()
-
-        asyncio.run(_run())
-
-    def _run_subscribe_with_payload(
+    async def _run_subscribe_with_payload(
         self,
         payload: object,
         *,
@@ -1030,62 +1019,58 @@ class ReloadSubscriberTestCase(unittest.TestCase):
         client = mock.MagicMock()
         client.pubsub = mock.MagicMock(return_value=pubsub)
         mock_db = mock.AsyncMock()
+        stop = asyncio.Event()
+        calls: list[int] = []
 
-        async def _run() -> tuple[mock.MagicMock, mock.AsyncMock]:
-            stop = asyncio.Event()
-            calls: list[int] = []
+        async def _wait_for(*_a: object, **_k: object) -> object:
+            calls.append(1)
+            if len(calls) == 1:
+                return {'type': 'message', 'data': payload}
+            stop.set()
+            raise TimeoutError()
 
-            async def _wait_for(*_a: object, **_k: object) -> object:
-                calls.append(1)
-                if len(calls) == 1:
-                    return {'type': 'message', 'data': payload}
-                stop.set()
-                raise TimeoutError()
+        with (
+            mock.patch.object(
+                reload_mod.asyncio, 'wait_for', side_effect=_wait_for
+            ),
+            mock.patch.object(reload_mod, '_get_reload_key', return_value=key),
+            mock.patch.object(reload_mod, 'reload_plugins') as reload_p,
+            mock.patch.object(
+                reload_mod, 'audit_unavailable', mock.AsyncMock()
+            ) as audit,
+        ):
+            await reload_mod._subscribe_reload(client, mock_db, stop)
+        return reload_p, audit
 
-            with (
-                mock.patch.object(
-                    reload_mod.asyncio, 'wait_for', side_effect=_wait_for
-                ),
-                mock.patch.object(
-                    reload_mod, '_get_reload_key', return_value=key
-                ),
-                mock.patch.object(reload_mod, 'reload_plugins') as reload_p,
-                mock.patch.object(
-                    reload_mod, 'audit_unavailable', mock.AsyncMock()
-                ) as audit,
-            ):
-                await reload_mod._subscribe_reload(client, mock_db, stop)
-            return reload_p, audit
-
-        return asyncio.run(_run())
-
-    def test_subscribe_rejects_unsigned_payload(self) -> None:
-        reload_p, audit = self._run_subscribe_with_payload(b'reload')
+    async def test_subscribe_rejects_unsigned_payload(self) -> None:
+        reload_p, audit = await self._run_subscribe_with_payload(b'reload')
         reload_p.assert_not_called()
         audit.assert_not_awaited()
 
-    def test_subscribe_rejects_bad_signature(self) -> None:
+    async def test_subscribe_rejects_bad_signature(self) -> None:
         derived = b'k' * 32
         payload = self._make_signed_payload(derived).replace(b'abc123', b'xxx')
-        reload_p, audit = self._run_subscribe_with_payload(
+        reload_p, audit = await self._run_subscribe_with_payload(
             payload, key=derived
         )
         reload_p.assert_not_called()
         audit.assert_not_awaited()
 
-    def test_subscribe_rejects_stale_timestamp(self) -> None:
+    async def test_subscribe_rejects_stale_timestamp(self) -> None:
         derived = b'k' * 32
         payload = self._make_signed_payload(derived, age=3600)
-        reload_p, audit = self._run_subscribe_with_payload(
+        reload_p, audit = await self._run_subscribe_with_payload(
             payload, key=derived
         )
         reload_p.assert_not_called()
         audit.assert_not_awaited()
 
-    def test_subscribe_drops_when_key_unavailable(self) -> None:
+    async def test_subscribe_drops_when_key_unavailable(self) -> None:
         derived = b'k' * 32
         payload = self._make_signed_payload(derived)
-        reload_p, audit = self._run_subscribe_with_payload(payload, key=None)
+        reload_p, audit = await self._run_subscribe_with_payload(
+            payload, key=None
+        )
         reload_p.assert_not_called()
         audit.assert_not_awaited()
 


### PR DESCRIPTION
## Summary

The ``imbi:plugins:reload`` Valkey channel triggers in-process ``reload_plugins()`` on every subscribing pod — meaning anyone able to publish to that channel could re-import every installed plugin module across the cluster.

This PR HMAC-signs the payload with a key derived from ``jwt_secret`` (already required to be shared across pods) and the subscriber rejects anything that doesn't verify or is older than five minutes.

## Problem

``publish_reload`` sent the literal string ``'reload'``; the subscriber loop ran ``reload_plugins()`` on any received message. The installer.py allowlist / pinned ``--index-url`` / ``--no-deps`` work called out in C4 was already in place, but the pub/sub side was wide-open: anyone with Valkey publish access (or anything able to inject a message) could force a reload, which is the bridge a malicious plugin needs from disk into the process.

## Solution

- Payload format: ``"{ts}:{nonce}:{hex_sig}"`` where ``hex_sig = HMAC-SHA256(derived_key, "{ts}:{nonce}")``.
- ``derived_key = HMAC(jwt_secret, "imbi-plugin-reload-v1")`` — domain-separated from JWT signing so a leak in one doesn't directly compromise the other.
- ``publish_reload()`` raises ``RuntimeError`` when ``jwt_secret`` is empty (per C6, a future PR will refuse to boot at all in non-dev when the secret is unset).
- Subscriber drops messages that fail HMAC verification, are stale (±5 min window), or arrive while the derived key can't be loaded.

## Test plan

- [x] ``tests/test_plugins.py::ReloadHookTestCase`` and ``ReloadSubscriberTestCase`` — 12 passing (existing tests updated for the new payload shape, plus new coverage for unsigned/bad-signature/stale/key-unavailable rejection and publish-without-key error)
- [x] ``uv run basedpyright src/imbi_api/plugins/reload.py tests/test_plugins.py`` — clean
- [x] ``uv run pre-commit run --files …`` — ruff + mypy clean
- [x] Full ``uv run pytest tests/`` run: 1722 passed, 2 pre-existing infra failures in ``test_project_configuration`` (ClickHouse ``operations_log.plugin_slug`` column missing locally) confirmed to also fail on main.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>