### PR TITLE
Fail fast when admin setup can't grant membership (H21)

### DIFF
--- a/src/imbi_api/entrypoint.py
+++ b/src/imbi_api/entrypoint.py
@@ -458,10 +458,18 @@ async def _create_admin_user(
         "SET m.role = 'admin' "
         'RETURN m'
     )
-    await db.execute(
+    membership_records = await db.execute(
         membership_query,
         {'email': email, 'org_slug': org_slug},
         columns=['m'],
     )
+    if not membership_records:
+        # Empty result = the User/Organization MATCH didn't bind, so the
+        # MERGE never fired. Fail fast rather than leaving an admin with
+        # no organization membership.
+        raise RuntimeError(
+            f'Failed to grant {email!r} admin membership in '
+            f'organization {org_slug!r}: organization not found'
+        )
 
     return user

--- a/tests/test_entrypoint.py
+++ b/tests/test_entrypoint.py
@@ -378,3 +378,63 @@ class BackfillNodeIdsTestCase(unittest.TestCase):
         self.assertIn('Failed to connect to PostgreSQL', result.output)
         # Should not have attempted any queries.
         self.mock_graph.execute.assert_not_awaited()
+
+
+class CreateAdminUserTestCase(unittest.IsolatedAsyncioTestCase):
+    """Test cases for the _create_admin_user helper."""
+
+    def _make_db(
+        self, *, user_rows: list[dict], membership_rows: list[dict]
+    ) -> mock.AsyncMock:
+        db = mock.AsyncMock()
+        db.execute.side_effect = [user_rows, membership_rows]
+        return db
+
+    async def test_user_create_failure_raises(self) -> None:
+        db = self._make_db(user_rows=[], membership_rows=[])
+        with self.assertRaises(RuntimeError) as ctx:
+            await entrypoint._create_admin_user(
+                db,
+                email='admin@example.com',
+                display_name='Admin',
+                password='s3cret',
+                org_slug='default',
+            )
+        self.assertIn('Failed to create user', str(ctx.exception))
+        # MERGE for the user fired, membership query never ran.
+        self.assertEqual(db.execute.await_count, 1)
+
+    async def test_membership_failure_raises(self) -> None:
+        db = self._make_db(
+            user_rows=[{'n': 'user-row'}],
+            membership_rows=[],
+        )
+        with self.assertRaises(RuntimeError) as ctx:
+            await entrypoint._create_admin_user(
+                db,
+                email='admin@example.com',
+                display_name='Admin',
+                password='s3cret',
+                org_slug='missing',
+            )
+        msg = str(ctx.exception)
+        self.assertIn("'admin@example.com'", msg)
+        self.assertIn("'missing'", msg)
+        self.assertIn('organization not found', msg)
+        self.assertEqual(db.execute.await_count, 2)
+
+    async def test_happy_path_returns_user(self) -> None:
+        db = self._make_db(
+            user_rows=[{'n': 'user-row'}],
+            membership_rows=[{'m': 'edge-row'}],
+        )
+        user = await entrypoint._create_admin_user(
+            db,
+            email='admin@example.com',
+            display_name='Admin',
+            password='s3cret',
+            org_slug='default',
+        )
+        self.assertEqual(user.email, 'admin@example.com')
+        self.assertTrue(user.is_admin)
+        self.assertEqual(db.execute.await_count, 2)


### PR DESCRIPTION
## Summary

The membership ``MERGE`` in ``_create_admin_user`` matched on ``(User, Organization)`` first; if either node was missing the MERGE never fired and ``execute()`` returned ``[]``. The previous code ignored that result, leaving the freshly-created admin without any org membership and the operator with no signal that setup had silently misfired.

## Problem

``just setup`` (and ``uv run imbi-api setup``) reported "Created admin user" even when the admin landed in zero organizations. Diagnosing later was hard: the user node existed and login worked, but every permission check failed because there was no ``MEMBER_OF`` edge.

## Solution

Capture the membership row count and raise ``RuntimeError`` when it's empty. The message surfaces the email and org slug so the operator can see which assumption broke (typically a missing or mistyped ``--org-slug``):

```
Failed to grant 'admin@example.com' admin membership in organization 'missing': organization not found
```

Added focused unit tests for ``_create_admin_user`` covering the user-MERGE-failed path (already raising), the new membership-MERGE-failed path, and the happy path. The existing ``SetupTestCase`` continues to mock ``_create_admin_user`` so the new behavior doesn't ripple into the CLI suite.

## Test plan

- [x] ``tests/test_entrypoint.py`` — 18 passing (3 new cases under ``CreateAdminUserTestCase``)
- [x] ``uv run pre-commit run --files …`` — ruff + mypy clean
- [x] ``uv run basedpyright src/imbi_api/entrypoint.py tests/test_entrypoint.py`` — clean

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>