### PR TITLE
Redact email PII from login logs (M14)

### DIFF
--- a/src/imbi_api/endpoints/auth.py
+++ b/src/imbi_api/endpoints/auth.py
@@ -40,6 +40,22 @@ LOGGER = logging.getLogger(__name__)
 # email) could be inferred from the response time.
 _DUMMY_PASSWORD_HASH = password_auth.hash_password(secrets.token_hex(32))
 
+
+def _redact_email(email: str) -> str:
+    """Return a log-safe representation of an email address.
+
+    Preserves the domain and the first character of the local part so
+    failures can still be triaged (e.g. all-from-one-domain scans) while
+    keeping the local part — which is user-supplied PII on the failure
+    path — out of the log stream.
+    """
+    if not email or '@' not in email:
+        return '<redacted>'
+    local, _, domain = email.partition('@')
+    prefix = local[:1] if local else ''
+    return f'{prefix}***@{domain}'
+
+
 auth_router = fastapi.APIRouter(prefix='/auth', tags=['Authentication'])
 
 
@@ -304,7 +320,7 @@ async def login(
     )
 
     if not eligible or not password_valid or user is None:
-        LOGGER.warning('Login failed for email %s', email)
+        LOGGER.warning('Login failed for email %s', _redact_email(email))
         raise fastapi.HTTPException(
             status_code=401,
             detail='Invalid credentials',
@@ -318,7 +334,7 @@ async def login(
             password_auth.hash_password, password
         )
         await db.merge(user, match_on=['email'])
-        LOGGER.info('Rehashed password for user %s', user.email)
+        LOGGER.info('Rehashed password for user %s', _redact_email(user.email))
 
     # Phase 5: Check if MFA is enabled
     totp_query: typing.LiteralString = """
@@ -448,7 +464,7 @@ async def login(
     user.last_login = meta['issued_at']
     await db.merge(user, match_on=['email'])
 
-    LOGGER.info('User %s logged in successfully', user.email)
+    LOGGER.info('User %s logged in successfully', _redact_email(user.email))
 
     return auth_models.TokenResponse(
         access_token=access_token,

--- a/tests/endpoints/test_auth.py
+++ b/tests/endpoints/test_auth.py
@@ -86,6 +86,37 @@ def _patch_providers(
     )
 
 
+class RedactEmailTestCase(unittest.TestCase):
+    """Test cases for the _redact_email log helper."""
+
+    def test_keeps_first_char_and_domain(self) -> None:
+        from imbi_api.endpoints.auth import _redact_email
+
+        self.assertEqual(
+            _redact_email('admin@example.com'), 'a***@example.com'
+        )
+
+    def test_handles_single_char_local(self) -> None:
+        from imbi_api.endpoints.auth import _redact_email
+
+        self.assertEqual(_redact_email('x@example.com'), 'x***@example.com')
+
+    def test_handles_empty_local(self) -> None:
+        from imbi_api.endpoints.auth import _redact_email
+
+        self.assertEqual(_redact_email('@example.com'), '***@example.com')
+
+    def test_handles_no_at_sign(self) -> None:
+        from imbi_api.endpoints.auth import _redact_email
+
+        self.assertEqual(_redact_email('not-an-email'), '<redacted>')
+
+    def test_handles_empty_string(self) -> None:
+        from imbi_api.endpoints.auth import _redact_email
+
+        self.assertEqual(_redact_email(''), '<redacted>')
+
+
 class AuthProvidersEndpointTestCase(unittest.TestCase):
     """Test cases for GET /auth/providers endpoint."""
 


### PR DESCRIPTION
## Summary

Auth log calls were emitting full email addresses on login failure, password rehash, and successful login. The failure path is the highest risk — the email there is user-supplied input, so an attacker scanning for valid accounts could splatter PII through log aggregation, and even legitimate failed logins (typos, expired passwords) were exposing real addresses to anyone with log access.

## Problem

```python
LOGGER.warning('Login failed for email %s', email)        # raw PII
LOGGER.info('Rehashed password for user %s', user.email)  # raw PII
LOGGER.info('User %s logged in successfully', user.email) # raw PII
```

## Solution

Added an ``_redact_email()`` helper that returns ``"a***@example.com"`` — keeping the domain plus the first character of the local part so triage and per-domain volume analysis still work, but dropping the rest. All three log sites now go through it.

Edge cases covered by unit tests:
- normal address → ``a***@example.com``
- single-char local → ``x***@example.com``
- empty local (``@example.com``) → ``***@example.com``
- no ``@`` → ``<redacted>``
- empty string → ``<redacted>``

The punchlist mentioned four sites (lines 277/288/299/309); H4 had since collapsed those into the single failure-path log on line 307, which this PR redacts along with the two adjacent info-level lines that had the same exposure.

## Test plan

- [x] ``tests/endpoints/test_auth.py::RedactEmailTestCase`` — 5 new cases passing
- [x] ``tests/endpoints/test_auth.py::LoginPasswordRehashTestCase`` + ``LoginMFATestCase`` — 10 existing cases still passing (no log-string assertions to update)
- [x] ``uv run pre-commit run --files …`` — ruff + mypy clean
- [x] ``uv run basedpyright src/imbi_api/endpoints/auth.py tests/endpoints/test_auth.py`` — clean

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>