### PR TITLE
Stop leaking internal node fields in API responses (M12)

### DIFF
--- a/src/imbi_api/domain/models.py
+++ b/src/imbi_api/domain/models.py
@@ -683,7 +683,7 @@ class ThirdPartyServiceUpdate(pydantic.BaseModel):
 class ThirdPartyServiceResponse(pydantic.BaseModel):
     """Response model for a third-party service."""
 
-    model_config = pydantic.ConfigDict(extra='allow')
+    model_config = pydantic.ConfigDict(extra='ignore')
 
     name: str
     slug: str
@@ -926,7 +926,7 @@ class ConfigKeyValueResponse(ConfigKeyResponse):
 class LogEntryResponse(pydantic.BaseModel):
     """Response model for a single log entry."""
 
-    model_config = pydantic.ConfigDict(extra='allow')
+    model_config = pydantic.ConfigDict(extra='ignore')
 
     timestamp: datetime.datetime
     message: str
@@ -1130,7 +1130,7 @@ class WebhookRuleResponse(pydantic.BaseModel):
 class WebhookResponse(pydantic.BaseModel):
     """Response model for a webhook."""
 
-    model_config = pydantic.ConfigDict(extra='allow')
+    model_config = pydantic.ConfigDict(extra='ignore')
 
     id: str
     name: str


### PR DESCRIPTION
## Summary

``ThirdPartyServiceResponse``, ``LogEntryResponse``, and ``WebhookResponse`` all opted into ``extra='allow'``, so any extra key on the underlying graph record (AGE-internal identifiers, half-migrated columns, anything a plugin manifest tacks on) round-tripped straight into the JSON response.

## Problem

``ThirdPartyServiceResponse`` is the loudest case — ``_build_service_response`` does ``models.ThirdPartyServiceResponse(**service)`` against the full AGE node dict, so every property attached to a Service node ended up in the public response. The contract is supposed to be the declared fields; anything else is implementation detail or, worse, future credential storage that someone forgot to scrub.

## Solution

Switch all three to ``extra='ignore'`` so undeclared fields are dropped instead of serialized. The builders explicitly construct from named fields, so nothing downstream relied on the leak.

## Test plan

- [x] ``uv run pytest -k "third_party or webhook or log or tps"`` — 274 passing
- [x] ``uv run pre-commit run --files src/imbi_api/domain/models.py`` — ruff + mypy clean
- [x] ``uv run basedpyright src/imbi_api/domain/models.py`` — clean

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>