### PR TITLE
Stop exposing version on unauthenticated /status (L6)

### DIFF
--- a/src/imbi_api/endpoints/status.py
+++ b/src/imbi_api/endpoints/status.py
@@ -3,8 +3,6 @@ import typing
 import fastapi
 import pydantic
 
-from imbi_api import version
-
 status_router = fastapi.APIRouter()
 
 
@@ -12,7 +10,6 @@ class StatusResponse(pydantic.BaseModel):
     """Service operational status"""
 
     service: str = 'imbi'
-    version: str = version
     status: typing.Literal['ok', 'initializing', 'error']
 
 

--- a/tests/endpoints/test_status.py
+++ b/tests/endpoints/test_status.py
@@ -3,7 +3,7 @@ import unittest
 
 from fastapi import testclient
 
-from imbi_api import app, version
+from imbi_api import app
 from imbi_api.endpoints import status
 
 _StatusLiteral = typing.Literal['ok', 'initializing', 'error']
@@ -16,8 +16,10 @@ class StatusResponseModelTestCase(unittest.TestCase):
         """Test creating a StatusResponse model."""
         response = status.StatusResponse(status='ok')
         self.assertEqual(response.service, 'imbi')
-        self.assertEqual(response.version, version)
         self.assertEqual(response.status, 'ok')
+        # Version is no longer exposed on the unauthenticated /status
+        # response surface (L6); confirm the model has no such field.
+        self.assertFalse(hasattr(response, 'version'))
 
     def test_status_response_with_different_status(self) -> None:
         """Test StatusResponse with different status values."""
@@ -46,8 +48,9 @@ class StatusEndpointTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         data = response.json()
         self.assertEqual(data['service'], 'imbi')
-        self.assertEqual(data['version'], version)
         self.assertEqual(data['status'], 'ok')
+        # Unauthenticated /status must not expose the build version (L6).
+        self.assertNotIn('version', data)
 
     def test_get_status_response_model(self) -> None:
         """Test GET /status endpoint returns valid StatusResponse."""


### PR DESCRIPTION
## Summary

``/status`` is wired to k8s liveness / readiness probes so it has to stay unauthenticated, but it was leaking the API version string into every unauth response. Version disclosure is a low-grade infosec gift — it lets an attacker target known CVEs against the deployed build before they've even authenticated.

## Solution

Drop the ``version`` field from ``StatusResponse``. The UI doesn't consume it (only the generated OpenAPI type referenced it). Anyone who needs version info for ops can read it from the build metadata or an authenticated endpoint.

## Test plan

- [x] ``tests/test_lifespans.py`` + ``tests/test_app.py`` — 15 passing, no tests assert on the dropped field
- [x] ``uv run pre-commit run --files src/imbi_api/endpoints/status.py`` — ruff + mypy clean
- [x] ``uv run basedpyright src/imbi_api/endpoints/status.py`` — clean

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>