### PR TITLE
Refuse non-HTTPS authorization URLs in _replace_state (L17)

### DIFF
--- a/src/imbi_api/identity/flows.py
+++ b/src/imbi_api/identity/flows.py
@@ -180,9 +180,24 @@ async def start_flow(
     return authorization_url, state_token, request.polling
 
 
+_LOCAL_HOSTS = frozenset({'localhost', '127.0.0.1', '::1'})
+
+
 def _replace_state(url: str, state_token: str) -> str:
-    """Return ``url`` with its ``state`` param set to ``state_token``."""
+    """Return ``url`` with its ``state`` param set to ``state_token``.
+
+    Refuses to rewrite non-HTTPS authorization URLs (except for the
+    local-loopback hosts that dev / test fixtures legitimately use).
+    The state JWT carries signed flow context we don't want round-
+    tripped over an unencrypted redirect, and a misconfigured plugin
+    manifest pointing at ``http://idp.example.com`` would otherwise
+    silently expose it to anyone on the network path.
+    """
     parts = urllib.parse.urlsplit(url)
+    if parts.scheme != 'https' and parts.hostname not in _LOCAL_HOSTS:
+        raise ValueError(
+            f'Identity-flow authorization URL must use https; got {url!r}'
+        )
     query = urllib.parse.parse_qsl(parts.query, keep_blank_values=True)
     rewritten = [(k, state_token if k == 'state' else v) for k, v in query]
     if not any(k == 'state' for k, _ in query):

--- a/tests/identity/test_flows.py
+++ b/tests/identity/test_flows.py
@@ -178,6 +178,45 @@ class StartFlowTestCase(unittest.IsolatedAsyncioTestCase):
         self.assertIs(polling, request.polling)
 
 
+class ReplaceStateTestCase(unittest.TestCase):
+    """Verify _replace_state enforces HTTPS on non-loopback hosts."""
+
+    def test_https_url_is_rewritten(self) -> None:
+        url = flows._replace_state(
+            'https://idp.example.com/auth?client_id=cid&state=nonce',
+            'state-token',
+        )
+        self.assertEqual(
+            url,
+            'https://idp.example.com/auth?client_id=cid&state=state-token',
+        )
+
+    def test_appends_state_when_absent(self) -> None:
+        url = flows._replace_state(
+            'https://idp.example.com/auth?client_id=cid', 'state-token'
+        )
+        self.assertIn('state=state-token', url)
+
+    def test_localhost_http_allowed_for_dev(self) -> None:
+        url = flows._replace_state(
+            'http://localhost:8080/auth?state=x', 'state-token'
+        )
+        self.assertEqual(url, 'http://localhost:8080/auth?state=state-token')
+
+    def test_loopback_ip_http_allowed(self) -> None:
+        url = flows._replace_state(
+            'http://127.0.0.1:8080/auth?state=x', 'state-token'
+        )
+        self.assertIn('state=state-token', url)
+
+    def test_non_https_remote_rejected(self) -> None:
+        with self.assertRaises(ValueError) as ctx:
+            flows._replace_state(
+                'http://idp.example.com/auth?state=x', 'state-token'
+            )
+        self.assertIn('must use https', str(ctx.exception))
+
+
 class CompleteFlowTestCase(unittest.IsolatedAsyncioTestCase):
     """Verify complete_flow persists the connection on success."""
 


### PR DESCRIPTION
## Summary

``_replace_state`` rewrites the ``state`` query parameter on an OAuth / identity-provider authorization URL to inject our signed flow JWT. The JWT carries plugin id, intent, ``return_to``, ``code_verifier``, and the actor user id — all signed but readable. Sending it over an unencrypted redirect is bad enough that we should refuse to do it.

## Problem

A misconfigured plugin manifest pointing at ``http://idp.example.com/auth`` would silently send the state JWT to the IdP in cleartext. Nothing in the rewrite path validated the scheme.

## Solution

Raise ``ValueError`` on any non-HTTPS scheme unless the host is a local loopback (``localhost``, ``127.0.0.1``, ``::1``) so dev/test fixtures legitimately using ``http://localhost:port`` still work.

## Test plan

- [x] ``tests/identity/test_flows.py::ReplaceStateTestCase`` — 5 new cases (https rewrite, append-when-missing, localhost http, loopback IP, non-loopback http rejected)
- [x] ``tests/identity/test_flows.py`` full file — 23 passing (existing tests already use ``https://``)
- [x] ``uv run pre-commit run --files …`` — ruff + mypy clean
- [x] ``uv run basedpyright …`` — clean

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>