### PR TITLE
Bound OIDC discovery cache to 64 entries (M30)

### DIFF
--- a/src/imbi_api/auth/oauth.py
+++ b/src/imbi_api/auth/oauth.py
@@ -20,10 +20,25 @@ from imbi_api.auth import login_providers, models
 
 LOGGER = logging.getLogger(__name__)
 
-# Cache for OIDC discovery documents with TTL
-# Format: {issuer_url: (discovery_data, timestamp)}
+# Cache for OIDC discovery documents with TTL.
+# Format: {issuer_url: (discovery_data, timestamp)}.
+# Bounded to ``_OIDC_CACHE_MAX_ENTRIES`` so a deployment with many
+# configured IdPs (or a misbehaving caller passing junk issuers) can't
+# grow the cache without limit. When full, the oldest entry by insertion
+# timestamp is evicted on the next miss.
 _oidc_discovery_cache: dict[str, tuple[dict[str, typing.Any], float]] = {}
 _OIDC_CACHE_TTL_SECONDS = 86400  # 24 hours
+_OIDC_CACHE_MAX_ENTRIES = 64
+
+
+def _bound_oidc_cache() -> None:
+    """Drop the oldest cache entry while over the size cap."""
+    while len(_oidc_discovery_cache) > _OIDC_CACHE_MAX_ENTRIES:
+        oldest_key = min(
+            _oidc_discovery_cache,
+            key=lambda k: _oidc_discovery_cache[k][1],
+        )
+        del _oidc_discovery_cache[oldest_key]
 
 
 def _insecure_urls_allowed() -> bool:
@@ -159,6 +174,7 @@ async def _discover_oidc_endpoints(issuer_url: str) -> dict[str, typing.Any]:
     )
 
     _oidc_discovery_cache[issuer_url] = (discovery_data, time.time())
+    _bound_oidc_cache()
     return discovery_data
 
 

--- a/tests/auth/test_oauth.py
+++ b/tests/auth/test_oauth.py
@@ -537,6 +537,43 @@ class OIDCDiscoveryTestCase(unittest.IsolatedAsyncioTestCase):
 
         self.assertIn('userinfo_endpoint', str(context.exception).lower())
 
+    @mock.patch('imbi_api.auth.oauth.httpx.AsyncClient')
+    async def test_discover_oidc_cache_is_bounded(
+        self, mock_client_class: mock.Mock
+    ) -> None:
+        """Test that the OIDC discovery cache evicts oldest entries."""
+        fresh = {
+            'token_endpoint': 'https://new.example.com/token',
+            'userinfo_endpoint': 'https://new.example.com/userinfo',
+        }
+        mock_response = mock.Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = fresh
+        mock_client = mock.AsyncMock()
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.__aexit__.return_value = None
+        mock_client.get.return_value = mock_response
+        mock_client_class.return_value = mock_client
+
+        # Pre-load the cache with one more than the max so the next
+        # successful discovery has to evict.
+        max_entries = oauth._OIDC_CACHE_MAX_ENTRIES
+        for i in range(max_entries):
+            oauth._oidc_discovery_cache[f'https://idp-{i}.example.com'] = (
+                {'token_endpoint': 't', 'userinfo_endpoint': 'u'},
+                time.time() - (max_entries - i),  # idp-0 is the oldest
+            )
+        self.assertEqual(len(oauth._oidc_discovery_cache), max_entries)
+
+        await oauth._discover_oidc_endpoints('https://new.example.com')
+
+        self.assertEqual(len(oauth._oidc_discovery_cache), max_entries)
+        # The oldest pre-loaded entry should have been evicted.
+        self.assertNotIn(
+            'https://idp-0.example.com', oauth._oidc_discovery_cache
+        )
+        self.assertIn('https://new.example.com', oauth._oidc_discovery_cache)
+
 
 class _DBProviderTestBase(unittest.IsolatedAsyncioTestCase):
     """Base class for tests that need a stub DB returning provider rows."""


### PR DESCRIPTION
## Summary

``_oidc_discovery_cache`` grew without limit, keyed by issuer URL. A deployment with many configured IdPs — or a misbehaving caller passing junk issuers — would slowly accumulate dead entries until process restart. Cache entries are small (one discovery dict per IdP) so the actual memory risk is mild, but unbounded process-local state is the kind of thing that bites at the worst time.

## Solution

Cap the cache at 64 entries via ``_OIDC_CACHE_MAX_ENTRIES`` and evict the oldest entry on each successful insertion (``_bound_oidc_cache``). TTL behavior is preserved — expired entries are still purged on lookup — the bound just protects against the "never-evicted" failure mode.

## Test plan

- [x] ``tests/auth/test_oauth.py::OIDCDiscoveryTestCase`` — 8 passing (existing 7 + new ``test_discover_oidc_cache_is_bounded``)
- [x] ``uv run pre-commit run --files …`` — ruff + mypy clean
- [x] ``uv run basedpyright …`` — clean

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>