### PR TITLE
Honor PluginRegistration.enabled in plugin resolution (M17)

### DIFF
--- a/src/imbi_api/plugins/resolution.py
+++ b/src/imbi_api/plugins/resolution.py
@@ -230,6 +230,16 @@ async def resolve_plugin(
     except PluginNotFoundError as exc:
         raise PluginUnavailableError(plugin_slug) from exc
 
+    # Treat a disabled PluginRegistration the same as a missing-from-
+    # registry plugin so admin-driven disable is honored at the resolve
+    # layer, not just by ``dispatch_lifecycle`` downstream. Importing
+    # lazily avoids a circular ``resolution -> lifecycle -> resolution``
+    # at module load.
+    from imbi_api.plugins.lifecycle import is_plugin_enabled
+
+    if not await is_plugin_enabled(db, plugin_slug):
+        raise PluginUnavailableError(plugin_slug)
+
     identity_plugin_id = _select_identity_plugin_id(chosen)
     env_payloads = _merge_env_payloads(
         chosen.get('pt_edge_env_payloads'),
@@ -335,11 +345,25 @@ async def resolve_all_plugins(
         else:
             merged[pid] = p
 
+    # Single query for admin-managed enabled flags so the fan-out below
+    # doesn't issue N round-trips. Imported lazily to avoid the
+    # ``resolution -> lifecycle -> resolution`` cycle at module load.
+    from imbi_api.plugins.lifecycle import get_enabled_map
+
+    enabled_map = await get_enabled_map(db)
+
     resolved: list[ResolvedPlugin] = []
     for chosen in merged.values():
         plugin_id = chosen.get('id')
         plugin_slug = chosen.get('slug')
         if not plugin_id or not plugin_slug:
+            continue
+        if not enabled_map.get(plugin_slug, False):
+            LOGGER.info(
+                'Skipping disabled plugin %r (id=%s) during fan-out',
+                plugin_slug,
+                plugin_id,
+            )
             continue
         plugin_defaults: dict[str, typing.Any] = parse_options(
             chosen.get('plugin_options')

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -431,8 +431,14 @@ class ResolutionTestCase(unittest.TestCase):
             }
         ]
         entry = _make_registry_entry('ssm')
-        with mock.patch(
-            'imbi_api.plugins.resolution.get_plugin', return_value=entry
+        with (
+            mock.patch(
+                'imbi_api.plugins.resolution.get_plugin', return_value=entry
+            ),
+            mock.patch(
+                'imbi_api.plugins.lifecycle.is_plugin_enabled',
+                new=mock.AsyncMock(return_value=True),
+            ),
         ):
             resolved = asyncio.run(
                 resolve_plugin(mock_db, 'proj1', 'configuration', None)
@@ -473,9 +479,15 @@ class ResolutionTestCase(unittest.TestCase):
                 ),
             }
         ]
-        with mock.patch(
-            'imbi_api.plugins.resolution.get_plugin',
-            return_value=_make_registry_entry('ssm'),
+        with (
+            mock.patch(
+                'imbi_api.plugins.resolution.get_plugin',
+                return_value=_make_registry_entry('ssm'),
+            ),
+            mock.patch(
+                'imbi_api.plugins.lifecycle.is_plugin_enabled',
+                new=mock.AsyncMock(return_value=True),
+            ),
         ):
             resolved = asyncio.run(
                 resolve_plugin(mock_db, 'proj1', 'configuration', None)
@@ -545,9 +557,15 @@ class ResolutionTestCase(unittest.TestCase):
                 ),
             }
         ]
-        with mock.patch(
-            'imbi_api.plugins.resolution.get_plugin',
-            return_value=_make_registry_entry('ssm'),
+        with (
+            mock.patch(
+                'imbi_api.plugins.resolution.get_plugin',
+                return_value=_make_registry_entry('ssm'),
+            ),
+            mock.patch(
+                'imbi_api.plugins.lifecycle.is_plugin_enabled',
+                new=mock.AsyncMock(return_value=True),
+            ),
         ):
             resolved = asyncio.run(
                 resolve_plugin(mock_db, 'proj1', 'configuration', None)
@@ -581,9 +599,15 @@ class ResolutionTestCase(unittest.TestCase):
                 ),
             }
         ]
-        with mock.patch(
-            'imbi_api.plugins.resolution.get_plugin',
-            return_value=_make_registry_entry('ssm'),
+        with (
+            mock.patch(
+                'imbi_api.plugins.resolution.get_plugin',
+                return_value=_make_registry_entry('ssm'),
+            ),
+            mock.patch(
+                'imbi_api.plugins.lifecycle.is_plugin_enabled',
+                new=mock.AsyncMock(return_value=True),
+            ),
         ):
             resolved = asyncio.run(
                 resolve_plugin(mock_db, 'proj1', 'configuration', 'p2')
@@ -652,6 +676,85 @@ class ResolutionTestCase(unittest.TestCase):
                     resolve_plugin(mock_db, 'proj1', 'configuration', None)
                 )
 
+    def test_disabled_plugin_raises_unavailable(self) -> None:
+        from imbi_common.plugins.errors import PluginUnavailableError
+
+        from imbi_api.plugins.resolution import resolve_plugin
+
+        mock_db = mock.AsyncMock()
+        mock_db.execute.return_value = [
+            {
+                'proj_plugins': '[]',
+                'pt_plugins': json.dumps(
+                    [
+                        {
+                            'id': 'p1',
+                            'slug': 'ssm',
+                            'options': '{}',
+                            'default': True,
+                            'src': 'project_type',
+                        }
+                    ]
+                ),
+            }
+        ]
+        with (
+            mock.patch(
+                'imbi_api.plugins.resolution.get_plugin',
+                return_value=_make_registry_entry('ssm'),
+            ),
+            mock.patch(
+                'imbi_api.plugins.lifecycle.is_plugin_enabled',
+                new=mock.AsyncMock(return_value=False),
+            ),
+        ):
+            with self.assertRaises(PluginUnavailableError):
+                asyncio.run(
+                    resolve_plugin(mock_db, 'proj1', 'configuration', None)
+                )
+
+    def test_resolve_all_skips_disabled_plugins(self) -> None:
+        from imbi_api.plugins.resolution import resolve_all_plugins
+
+        mock_db = mock.AsyncMock()
+        mock_db.execute.return_value = [
+            {
+                'proj_plugins': '[]',
+                'pt_plugins': json.dumps(
+                    [
+                        {
+                            'id': 'p1',
+                            'slug': 'on',
+                            'options': '{}',
+                            'default': True,
+                            'src': 'project_type',
+                        },
+                        {
+                            'id': 'p2',
+                            'slug': 'off',
+                            'options': '{}',
+                            'default': True,
+                            'src': 'project_type',
+                        },
+                    ]
+                ),
+            }
+        ]
+        with (
+            mock.patch(
+                'imbi_api.plugins.resolution.get_plugin',
+                side_effect=lambda slug: _make_registry_entry(slug),
+            ),
+            mock.patch(
+                'imbi_api.plugins.lifecycle.get_enabled_map',
+                new=mock.AsyncMock(return_value={'on': True, 'off': False}),
+            ),
+        ):
+            resolved = asyncio.run(
+                resolve_all_plugins(mock_db, 'proj1', 'configuration')
+            )
+        self.assertEqual({r.plugin_slug for r in resolved}, {'on'})
+
 
 class ResolveAllPluginsTestCase(unittest.TestCase):
     """Branch coverage for ``resolve_all_plugins`` (lifecycle fan-out)."""
@@ -706,9 +809,20 @@ class ResolveAllPluginsTestCase(unittest.TestCase):
         entry_a = _make_registry_entry('github-lifecycle')
         entry_b = _make_registry_entry('aws-lifecycle')
         entries = {'github-lifecycle': entry_a, 'aws-lifecycle': entry_b}
-        with mock.patch(
-            'imbi_api.plugins.resolution.get_plugin',
-            side_effect=lambda slug: entries[slug],
+        with (
+            mock.patch(
+                'imbi_api.plugins.resolution.get_plugin',
+                side_effect=lambda slug: entries[slug],
+            ),
+            mock.patch(
+                'imbi_api.plugins.lifecycle.get_enabled_map',
+                new=mock.AsyncMock(
+                    return_value={
+                        'github-lifecycle': True,
+                        'aws-lifecycle': True,
+                    }
+                ),
+            ),
         ):
             result = asyncio.run(
                 resolve_all_plugins(mock_db, 'proj1', 'lifecycle')
@@ -755,9 +869,17 @@ class ResolveAllPluginsTestCase(unittest.TestCase):
                 return entry
             raise PluginNotFoundError(slug)
 
-        with mock.patch(
-            'imbi_api.plugins.resolution.get_plugin',
-            side_effect=_get,
+        with (
+            mock.patch(
+                'imbi_api.plugins.resolution.get_plugin',
+                side_effect=_get,
+            ),
+            mock.patch(
+                'imbi_api.plugins.lifecycle.get_enabled_map',
+                new=mock.AsyncMock(
+                    return_value={'present': True, 'gone': True}
+                ),
+            ),
         ):
             result = asyncio.run(
                 resolve_all_plugins(mock_db, 'proj1', 'lifecycle')
@@ -798,8 +920,14 @@ class ResolveAllPluginsTestCase(unittest.TestCase):
             }
         ]
         entry = _make_registry_entry('github-lifecycle')
-        with mock.patch(
-            'imbi_api.plugins.resolution.get_plugin', return_value=entry
+        with (
+            mock.patch(
+                'imbi_api.plugins.resolution.get_plugin', return_value=entry
+            ),
+            mock.patch(
+                'imbi_api.plugins.lifecycle.get_enabled_map',
+                new=mock.AsyncMock(return_value={'github-lifecycle': True}),
+            ),
         ):
             result = asyncio.run(
                 resolve_all_plugins(mock_db, 'proj1', 'lifecycle')


### PR DESCRIPTION
## Summary

``dispatch_lifecycle`` and every other resolver call site silently invoked plugins whose admin-managed ``PluginRegistration`` row was disabled. The enable/disable toggle existed in the UI but stopped short of actually preventing dispatch — the only thing it gated was the assignment-edit UI.

## Problem

A disabled plugin would still run on lifecycle events (archive/unarchive), still answer ``resolve_plugin`` for log / deployment / configuration tabs, and still receive credentials. The ``enabled`` flag was load-bearing only at edge-creation time.

## Solution

Move the check into the resolver so it applies everywhere:

- ``resolve_plugin`` raises ``PluginUnavailableError`` when the chosen plugin's registration is disabled, mirroring the slug-not-in-registry path that callers already handle.
- ``resolve_all_plugins`` issues a single ``get_enabled_map`` round-trip and skips disabled plugins with an INFO log so a half-disabled set still fans out to the enabled members.

Disabled is intentionally treated as "unavailable" rather than "unassigned" so the admin toggle preserves the assignment edge for re-enable.

## Test plan

- [x] ``tests/test_plugins.py::ResolutionTestCase`` + ``ResolveAllPluginsTestCase`` — 11 passing (existing 8 updated to mock the enabled lookup, plus 2 new: ``test_disabled_plugin_raises_unavailable`` and ``test_resolve_all_skips_disabled_plugins``)
- [x] Full ``uv run pytest tests/`` — 1719 passing, 2 pre-existing ClickHouse infra failures (``operations_log.plugin_slug`` column missing locally) that also fail on main.
- [x] ``uv run pre-commit run --files …`` — ruff + mypy clean
- [x] ``uv run basedpyright …`` — clean

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>