### PR TITLE
Make OAuth state JWT single-use via Valkey nonce (M31)

### DIFF
--- a/src/imbi_api/auth/oauth.py
+++ b/src/imbi_api/auth/oauth.py
@@ -14,9 +14,12 @@ import httpx
 import jwt
 from imbi_common import graph
 from imbi_common.auth import encryption
+from valkey import asyncio as valkey_module
 
 from imbi_api import settings
 from imbi_api.auth import login_providers, models
+
+_OAUTH_STATE_NONCE_PREFIX = 'imbi:oauth:state-nonce:'
 
 LOGGER = logging.getLogger(__name__)
 
@@ -192,22 +195,34 @@ def generate_oauth_state(
     return state_token, state_data
 
 
-def verify_oauth_state(
-    state_token: str, auth_settings: settings.Auth, max_age_seconds: int = 600
+async def verify_oauth_state(
+    state_token: str,
+    auth_settings: settings.Auth,
+    *,
+    valkey_client: valkey_module.Valkey | None,
+    max_age_seconds: int = 600,
 ) -> models.OAuthStateData:
-    """Verify and decode OAuth state parameter.
+    """Verify, decode, and single-use-consume an OAuth state parameter.
+
+    Verifies the JWT signature and the 10-minute timestamp window, then
+    atomically marks the embedded nonce as consumed in Valkey (SET NX
+    EX) so a captured token cannot be replayed inside its TTL.
 
     Args:
         state_token: State token from OAuth callback
         auth_settings: Auth settings instance
+        valkey_client: Valkey client used for the nonce consume.
+            ``None`` means OAuth replay protection is unavailable and
+            verification fails closed.
         max_age_seconds: Maximum age for state token (default 10 minutes)
 
     Returns:
         Decoded state data
 
     Raises:
-        ValueError: If state is invalid or expired
-
+        ValueError: If state is invalid, expired, or already consumed.
+        RuntimeError: If no Valkey client is configured (replay
+            protection must fail closed).
     """
     try:
         payload = jwt.decode(
@@ -222,6 +237,19 @@ def verify_oauth_state(
     age = int(time.time()) - state_data.timestamp
     if age > max_age_seconds:
         raise ValueError(f'OAuth state expired (age: {age}s)')
+
+    if valkey_client is None:
+        raise RuntimeError(
+            'OAuth replay protection requires Valkey; no client is configured'
+        )
+    key = f'{_OAUTH_STATE_NONCE_PREFIX}{state_data.nonce}'
+    fresh = await valkey_client.set(  # pyright: ignore[reportUnknownMemberType]
+        key, '1', nx=True, ex=max_age_seconds
+    )
+    if not fresh:
+        raise ValueError(
+            'OAuth state already consumed; possible replay attempt'
+        )
 
     return state_data
 

--- a/src/imbi_api/endpoints/auth.py
+++ b/src/imbi_api/endpoints/auth.py
@@ -974,8 +974,13 @@ async def oauth_callback(
                 valkey_client,
             )
 
-        # Verify state parameter
-        state_data = oauth.verify_oauth_state(state, auth_settings)
+        # Verify state parameter + atomically mark the nonce consumed
+        # so a captured state cannot be replayed within its TTL.
+        state_data = await oauth.verify_oauth_state(
+            state,
+            auth_settings,
+            valkey_client=valkey_client,
+        )
 
         if state_data.provider != provider:
             raise ValueError('Provider mismatch')

--- a/src/imbi_api/endpoints/auth.py
+++ b/src/imbi_api/endpoints/auth.py
@@ -1084,6 +1084,11 @@ async def oauth_callback(
         jwt.InvalidTokenError,
         httpx.HTTPError,
         fastapi.HTTPException,
+        # verify_oauth_state raises RuntimeError when the Valkey replay-
+        # protection backend is unavailable; surface that as the normal
+        # auth-failed redirect so a missing dependency doesn't return a
+        # bare 500.
+        RuntimeError,
     ) as err:
         LOGGER.exception('OAuth callback failed: %s', err)
         return fastapi.responses.RedirectResponse(

--- a/tests/auth/test_oauth.py
+++ b/tests/auth/test_oauth.py
@@ -52,14 +52,17 @@ def _patch_encryptor() -> typing.Any:
     )
 
 
-class OAuthStateTestCase(unittest.TestCase):
+class OAuthStateTestCase(unittest.IsolatedAsyncioTestCase):
     """Test cases for OAuth state generation and verification."""
 
     def setUp(self) -> None:
-        """Set up test auth settings."""
+        """Set up test auth settings and a fresh-nonce Valkey stub."""
         self.auth_settings = settings.Auth(
             jwt_secret='test-secret-key-for-oauth-state'
         )
+        # Default: ``set`` returns truthy, meaning nonce was newly recorded.
+        self.valkey = mock.AsyncMock()
+        self.valkey.set = mock.AsyncMock(return_value=True)
 
     def test_generate_oauth_state(self) -> None:
         """Test generating OAuth state token."""
@@ -77,7 +80,7 @@ class OAuthStateTestCase(unittest.TestCase):
         self.assertTrue(len(state_data.nonce) > 0)
         self.assertIsInstance(state_data.timestamp, int)
 
-    def test_verify_oauth_state_success(self) -> None:
+    async def test_verify_oauth_state_success(self) -> None:
         """Test verifying valid OAuth state token."""
         # Generate state
         state_token, original_data = oauth.generate_oauth_state(
@@ -85,8 +88,8 @@ class OAuthStateTestCase(unittest.TestCase):
         )
 
         # Verify state
-        verified_data = oauth.verify_oauth_state(
-            state_token, self.auth_settings
+        verified_data = await oauth.verify_oauth_state(
+            state_token, self.auth_settings, valkey_client=self.valkey
         )
 
         # Should match original data
@@ -96,8 +99,13 @@ class OAuthStateTestCase(unittest.TestCase):
         )
         self.assertEqual(verified_data.nonce, original_data.nonce)
         self.assertEqual(verified_data.timestamp, original_data.timestamp)
+        # Nonce was consumed via SET NX EX.
+        self.valkey.set.assert_awaited_once()
+        args, kwargs = self.valkey.set.await_args
+        self.assertTrue(args[0].startswith('imbi:oauth:state-nonce:'))
+        self.assertEqual(kwargs.get('nx'), True)
 
-    def test_verify_oauth_state_expired(self) -> None:
+    async def test_verify_oauth_state_expired(self) -> None:
         """Test verifying expired OAuth state token."""
         # Generate state with old timestamp
         state_data = models.OAuthStateData(
@@ -113,30 +121,59 @@ class OAuthStateTestCase(unittest.TestCase):
             algorithm=self.auth_settings.jwt_algorithm,
         )
 
-        # Verify should fail due to age
+        # Verify should fail due to age, before any nonce consume.
         with self.assertRaises(ValueError) as context:
-            oauth.verify_oauth_state(state_token, self.auth_settings)
+            await oauth.verify_oauth_state(
+                state_token, self.auth_settings, valkey_client=self.valkey
+            )
 
         self.assertIn('expired', str(context.exception).lower())
+        self.valkey.set.assert_not_awaited()
 
-    def test_verify_oauth_state_invalid_signature(self) -> None:
+    async def test_verify_oauth_state_invalid_signature(self) -> None:
         """Test verifying OAuth state with wrong secret."""
-        # Generate state with different secret
         wrong_settings = settings.Auth(jwt_secret='wrong-secret')
         state_token, _ = oauth.generate_oauth_state(
             'google', '/dashboard', wrong_settings
         )
 
-        # Verify with correct secret should fail
         with self.assertRaises(ValueError) as context:
-            oauth.verify_oauth_state(state_token, self.auth_settings)
+            await oauth.verify_oauth_state(
+                state_token, self.auth_settings, valkey_client=self.valkey
+            )
 
         self.assertIn('invalid', str(context.exception).lower())
 
-    def test_verify_oauth_state_malformed(self) -> None:
+    async def test_verify_oauth_state_malformed(self) -> None:
         """Test verifying malformed OAuth state token."""
         with self.assertRaises(ValueError):
-            oauth.verify_oauth_state('not-a-valid-jwt', self.auth_settings)
+            await oauth.verify_oauth_state(
+                'not-a-valid-jwt',
+                self.auth_settings,
+                valkey_client=self.valkey,
+            )
+
+    async def test_verify_oauth_state_replay_rejected(self) -> None:
+        """Second use of the same state token must be rejected."""
+        self.valkey.set = mock.AsyncMock(return_value=None)
+        state_token, _ = oauth.generate_oauth_state(
+            'google', '/dashboard', self.auth_settings
+        )
+        with self.assertRaises(ValueError) as context:
+            await oauth.verify_oauth_state(
+                state_token, self.auth_settings, valkey_client=self.valkey
+            )
+        self.assertIn('replay', str(context.exception).lower())
+
+    async def test_verify_oauth_state_requires_valkey(self) -> None:
+        """No Valkey client -> fail closed."""
+        state_token, _ = oauth.generate_oauth_state(
+            'google', '/dashboard', self.auth_settings
+        )
+        with self.assertRaises(RuntimeError):
+            await oauth.verify_oauth_state(
+                state_token, self.auth_settings, valkey_client=None
+            )
 
 
 class OAuthProfileNormalizationTestCase(unittest.TestCase):

--- a/tests/endpoints/test_auth.py
+++ b/tests/endpoints/test_auth.py
@@ -926,7 +926,7 @@ class OAuthCallbackSuccessTestCase(unittest.TestCase):
             _patch_providers([_stub_provider('google')]),
             mock.patch(
                 'imbi_api.auth.oauth.verify_oauth_state',
-                return_value=mock_state_data,
+                new=mock.AsyncMock(return_value=mock_state_data),
             ),
             mock.patch(
                 'imbi_api.auth.oauth.exchange_oauth_code',
@@ -1024,7 +1024,7 @@ class OAuthCallbackSuccessTestCase(unittest.TestCase):
             _patch_providers([_stub_provider('google')]),
             mock.patch(
                 'imbi_api.auth.oauth.verify_oauth_state',
-                return_value=mock_state_data,
+                new=mock.AsyncMock(return_value=mock_state_data),
             ),
             mock.patch(
                 'imbi_api.auth.oauth.exchange_oauth_code',
@@ -1111,7 +1111,7 @@ class OAuthCallbackSuccessTestCase(unittest.TestCase):
             ),
             mock.patch(
                 'imbi_api.auth.oauth.verify_oauth_state',
-                return_value=mock_state_data,
+                new=mock.AsyncMock(return_value=mock_state_data),
             ),
             mock.patch(
                 'imbi_api.auth.oauth.exchange_oauth_code',
@@ -1215,7 +1215,7 @@ class OAuthCallbackSuccessTestCase(unittest.TestCase):
             _patch_providers([_stub_provider('google')]),
             mock.patch(
                 'imbi_api.auth.oauth.verify_oauth_state',
-                return_value=mock_state_data,
+                new=mock.AsyncMock(return_value=mock_state_data),
             ),
             mock.patch(
                 'imbi_api.auth.oauth.exchange_oauth_code',
@@ -1289,7 +1289,7 @@ class OAuthCallbackSuccessTestCase(unittest.TestCase):
             _patch_providers([_stub_provider('google')]),
             mock.patch(
                 'imbi_api.auth.oauth.verify_oauth_state',
-                return_value=mock_state_data,
+                new=mock.AsyncMock(return_value=mock_state_data),
             ),
             mock.patch(
                 'imbi_api.auth.oauth.exchange_oauth_code',
@@ -1328,7 +1328,7 @@ class OAuthCallbackSuccessTestCase(unittest.TestCase):
             _patch_providers([_stub_provider('google')]),
             mock.patch(
                 'imbi_api.auth.oauth.verify_oauth_state',
-                return_value=mock_state_data,
+                new=mock.AsyncMock(return_value=mock_state_data),
             ),
             mock.patch(
                 'imbi_api.auth.oauth.exchange_oauth_code',
@@ -1402,7 +1402,7 @@ class OAuthCallbackSuccessTestCase(unittest.TestCase):
         with (
             mock.patch(
                 'imbi_api.auth.oauth.verify_oauth_state',
-                return_value=mock_state_data,
+                new=mock.AsyncMock(return_value=mock_state_data),
             ),
             mock.patch(
                 'imbi_api.auth.oauth.exchange_oauth_code',


### PR DESCRIPTION
## Summary

The OAuth state JWT was signed and time-bounded but reusable — an attacker who captured a state token via logs, referer-leak, or a proxy could replay the OAuth callback inside the 10-minute TTL and ride a real user's redirect.

## Problem

``verify_oauth_state`` checked signature + age only. The embedded nonce was just CSRF padding; nothing recorded that a particular state had been seen, so re-presenting it always passed.

## Solution

Mirror the identity-flow pattern (``consume_identity_nonce``): on every callback ``verify_oauth_state`` now atomically marks the embedded nonce as consumed via Valkey ``SET NX EX``. The second attempt to verify the same token raises ``ValueError`` (``'OAuth state already consumed; possible replay attempt'``).

Replay protection is required, not optional. ``verify_oauth_state`` takes a keyword-only ``valkey_client`` and fails closed with ``RuntimeError`` when no client is configured — matches identity-flow semantics.

``verify_oauth_state`` is now async; the only production caller (``/auth/oauth/{provider}/callback`` in ``endpoints/auth.py``) already had a Valkey client in scope.

## Test plan

- [x] ``tests/auth/test_oauth.py::OAuthStateTestCase`` — 7 passing (now under ``IsolatedAsyncioTestCase``; existing 5 cases adapted, 2 new: replay rejection and "Valkey required")
- [x] ``tests/endpoints/test_auth.py::OAuthCallbackSuccessTestCase`` — 6 passing (mocks switched to ``AsyncMock``)
- [x] ``tests/endpoints/test_auth.py`` full file — 58 passing
- [x] ``uv run pre-commit run --files …`` — ruff + mypy clean
- [x] ``uv run basedpyright …`` — clean

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>