### PR TITLE
Close rate-limit gaps on MFA verify / logout / OAuth callback (M32)

### DIFF
--- a/src/imbi_api/endpoints/auth.py
+++ b/src/imbi_api/endpoints/auth.py
@@ -676,7 +676,9 @@ async def refresh_token(
 
 
 @auth_router.post('/logout', status_code=204)
+@rate_limit.limiter.limit('30/minute')  # type: ignore[untyped-decorator]
 async def logout(
+    request: fastapi.Request,
     db: graph.Pool,
     auth: typing.Annotated[
         permissions.AuthContext,
@@ -910,7 +912,9 @@ async def oauth_login(
 
 
 @auth_router.get('/oauth/{provider}/callback')
+@rate_limit.limiter.limit('10/minute')  # type: ignore[untyped-decorator]
 async def oauth_callback(
+    request: fastapi.Request,
     db: graph.Pool,
     provider: str,
     valkey_client: OptionalValkeyClient,

--- a/src/imbi_api/endpoints/mfa.py
+++ b/src/imbi_api/endpoints/mfa.py
@@ -22,6 +22,7 @@ from imbi_common.auth import encryption
 
 from imbi_api import models, settings
 from imbi_api.auth import password, permissions
+from imbi_api.middleware import rate_limit
 
 LOGGER = logging.getLogger(__name__)
 
@@ -209,7 +210,9 @@ async def setup_mfa(
 
 
 @mfa_router.post('/verify', status_code=204)
+@rate_limit.limiter.limit('5/minute')  # type: ignore[untyped-decorator]
 async def verify_and_enable_mfa(
+    request: fastapi.Request,
     verify_request: MFAVerifyRequest,
     db: graph.Pool,
     auth: typing.Annotated[

--- a/tests/endpoints/test_mfa.py
+++ b/tests/endpoints/test_mfa.py
@@ -11,6 +11,7 @@ from imbi_common import graph
 
 from imbi_api import app, models, settings
 from imbi_api.auth import password, permissions
+from imbi_api.middleware import rate_limit
 
 
 class MFAEndpointsTestCase(unittest.TestCase):
@@ -18,6 +19,10 @@ class MFAEndpointsTestCase(unittest.TestCase):
 
     def setUp(self) -> None:
         """Set up test fixtures."""
+        # Reset the slowapi limiter so the new /mfa/verify 5/min cap
+        # doesn't bleed across tests in this suite (TestClient reuses
+        # 127.0.0.1, which is the limiter key).
+        rate_limit.limiter.reset()
         self.test_app = app.create_app()
 
         # Create test user


### PR DESCRIPTION
## Summary

Three endpoints had no slowapi decorator and were either obvious brute-force targets or amplification routes:

- ``POST /mfa/verify`` is checked against the six-digit TOTP code, so it is the canonical brute target. Cap at **5/minute** per IP (same as ``/auth/login``).
- ``POST /auth/logout`` is cheap but should not be a free-fire endpoint either. Cap at **30/minute**.
- ``GET /auth/oauth/{provider}/callback`` triggers an outbound token exchange and a userinfo fetch per call — an attacker hammering the callback URL turns the imbi process into an amplifier against the IdP. Cap at **10/minute**.

``/auth/token`` already carries a 10/minute limit, so the client-id-scanning note on the punchlist is already covered.

## Test plan

- [x] ``tests/endpoints/test_mfa.py`` + ``tests/endpoints/test_auth.py`` — 78 passing.
- The new ``/mfa/verify`` limit was bleeding across tests because slowapi keys on the TestClient's ``127.0.0.1``. Added a ``rate_limit.limiter.reset()`` in ``MFAEndpointsTestCase.setUp`` matching the pattern in ``test_auth`` and ``test_authentication``.
- [x] ``uv run pre-commit run --files …`` — ruff + mypy clean
- [x] ``uv run basedpyright …`` — clean

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>