### PR TITLE
Mark parse_scopes as deprecated (L4)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,6 +121,11 @@ config-file = "mkdocs.yml"
 deprecateTypingAliases = true
 reportMissingSuperCall = "hint"
 typeCheckingMode = "strict"
+# ``@warnings.deprecated`` markers are intentional signals that a
+# helper is on its way out; we want IDE / type-checker visibility but
+# don't want every legacy call site to block CI until the migration
+# is complete. See CODE_REVIEW_PUNCHLIST entry L4 (parse_scopes).
+reportDeprecated = "warning"
 
 [[tool.pyright.executionEnvironments]]
 root = "src/imbi_api/assistant"

--- a/src/imbi_api/models.py
+++ b/src/imbi_api/models.py
@@ -9,6 +9,7 @@ from imbi_api.domain for a single import path:
 
 import json
 import typing
+import warnings
 
 from imbi_common import models as _common
 
@@ -79,6 +80,15 @@ UserCreate = _domain.UserCreate
 UserResponse = _domain.UserResponse
 
 
+@warnings.deprecated(
+    'parse_scopes is a compatibility shim for legacy AGE rows that '
+    "stored list properties as PostgreSQL-array strings (e.g. '{a,b}')."
+    ' Cypher writes have stored lists as JSON since the list-'
+    'serialization fix; callers should switch to ``graph.parse_agtype``'
+    ' once every legacy scope row has been rewritten. Plan to remove '
+    'this helper alongside that backfill -- see CODE_REVIEW_PUNCHLIST '
+    'L4 for the open migration deadline.'
+)
 def parse_scopes(value: typing.Any) -> list[str]:
     """Convert AGE scope values to a Python list.
 


### PR DESCRIPTION
## Summary

``parse_scopes`` is a compatibility shim for legacy AGE rows that stored list properties as PostgreSQL-array strings (e.g. ``'{a,b}'``); new writes have gone through Cypher's JSON-list serialization for a while. Once every legacy scope row has been rewritten by the v1→v2 backfill, callers can switch to ``graph.parse_agtype`` and we can delete the helper.

## Solution

Decorate with ``warnings.deprecated`` (PEP 702) so the deprecation is machine-readable (type checkers, IDEs) without forcing a Python-side rename right now. The deprecation message points at the punchlist entry that tracks the actual removal deadline.

Default Python filters silence ``DeprecationWarning`` outside of ``__main__`` / unit-test contexts, so production callers don't get flooded with messages.

## Test plan

- [x] ``tests/endpoints/test_auth.py`` — 58 passing
- [x] ``uv run pre-commit run --files src/imbi_api/models.py`` — ruff + mypy clean
- [x] ``uv run basedpyright src/imbi_api/models.py`` — clean

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>