### PR TITLE
Surface IdP-side revoke failure in disconnect response (M18)

### DIFF
--- a/src/imbi_api/identity/endpoints.py
+++ b/src/imbi_api/identity/endpoints.py
@@ -271,10 +271,30 @@ async def disconnect(
             permissions.require_permission('me:identities:manage'),
         ),
     ],
-) -> fastapi.Response:
-    """Revoke + delete the actor's connection for ``plugin_id``."""
+) -> fastapi.responses.Response:
+    """Revoke + delete the actor's connection for ``plugin_id``.
+
+    Returns ``204 No Content`` when both local and IdP revocation
+    succeed (or no IdP call was needed). When the IdP-side revoke
+    fails the local state is still recorded as revoked, but the
+    response is ``200 OK`` with a JSON body so the UI can flag the
+    partial state — the user needs to know the IdP still has live
+    credentials and may need manual cleanup.
+    """
     user = auth.require_user
-    await flows.revoke_connection(
+    outcome = await flows.revoke_connection(
         db, plugin_id=plugin_id, actor_user_id=user.id
     )
+    if not outcome['idp_revoked']:
+        return fastapi.responses.JSONResponse(
+            status_code=200,
+            content={
+                'detail': (
+                    'Connection revoked locally, but the IdP rejected '
+                    'the revocation call. The remote credentials may '
+                    'still be valid until the IdP expires them.'
+                ),
+                'idp_error': outcome['idp_error'],
+            },
+        )
     return fastapi.Response(status_code=204)

--- a/src/imbi_api/identity/flows.py
+++ b/src/imbi_api/identity/flows.py
@@ -391,16 +391,36 @@ async def refresh_connection(
     return new_credentials
 
 
+class RevokeOutcome(typing.TypedDict):
+    """Outcome of :func:`revoke_connection`.
+
+    ``idp_revoked`` is False when the IdP-side revoke call raised; the
+    local connection is still revoked in that case but the caller
+    needs to surface the partial state so the user knows the IdP
+    still holds live credentials.
+    """
+
+    idp_revoked: bool
+    idp_error: str | None
+
+
 async def revoke_connection(
     db: graph.Graph,
     *,
     plugin_id: str,
     actor_user_id: str,
-) -> None:
+) -> RevokeOutcome:
     """First DELETE on an active connection: best-effort revoke at the
     IdP, then mark the connection revoked.  Subsequent DELETE on an
     already revoked / expired connection: hard-delete the node so the
     "Forget" action removes the row from the UI.
+
+    Returns a :class:`RevokeOutcome` so the caller can distinguish a
+    clean revoke from "we revoked locally but the IdP rejected our
+    call." Cases where there's nothing to revoke at the IdP (plugin
+    uninstalled, status was already non-active, no connection on
+    file) are reported as ``idp_revoked=True`` because nothing
+    *needed* IdP-side action.
     """
     try:
         (
@@ -414,19 +434,20 @@ async def revoke_connection(
         # Plugin uninstalled out from under us.  Nothing to revoke at
         # the IdP; just hard-delete whatever's left so the UI can clear.
         await repository.delete_connection(db, plugin_id, actor_user_id)
-        return
+        return {'idp_revoked': True, 'idp_error': None}
 
     status = await repository.connection_status(db, resolved_id, actor_user_id)
     if status is None:
-        return
+        return {'idp_revoked': True, 'idp_error': None}
     if status != 'active':
         # Already revoked / expired — second DELETE means "forget."
         await repository.delete_connection(db, resolved_id, actor_user_id)
-        return
+        return {'idp_revoked': True, 'idp_error': None}
 
     connection = await repository.load_connection(
         db, resolved_id, actor_user_id
     )
+    idp_error: str | None = None
     if connection is not None:
         try:
             ctx = PluginContext(
@@ -437,7 +458,7 @@ async def revoke_connection(
                 assignment_options=options,
             )
             await handler.revoke(ctx, creds, connection.access_token)
-        except Exception:  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
             LOGGER.warning(
                 'IdP revoke failed for plugin_id=%s user_id=%s; '
                 'marking connection revoked anyway',
@@ -445,4 +466,6 @@ async def revoke_connection(
                 actor_user_id,
                 exc_info=True,
             )
+            idp_error = f'{type(exc).__name__}: {exc}'
     await repository.revoke(db, resolved_id, actor_user_id)
+    return {'idp_revoked': idp_error is None, 'idp_error': idp_error}

--- a/tests/identity/test_endpoints.py
+++ b/tests/identity/test_endpoints.py
@@ -123,7 +123,7 @@ class RefreshEndpointTestCase(unittest.IsolatedAsyncioTestCase):
 
 
 class DisconnectEndpointTestCase(unittest.IsolatedAsyncioTestCase):
-    """Cover the disconnect endpoint's success path."""
+    """Cover the disconnect endpoint's success and partial-failure paths."""
 
     async def test_returns_204_after_revoke(self) -> None:
         db = mock.AsyncMock()
@@ -132,11 +132,35 @@ class DisconnectEndpointTestCase(unittest.IsolatedAsyncioTestCase):
         with mock.patch.object(
             endpoints.flows,
             'revoke_connection',
-            new=mock.AsyncMock(),
+            new=mock.AsyncMock(
+                return_value={'idp_revoked': True, 'idp_error': None}
+            ),
         ) as revoke:
             response = await endpoints.disconnect('p', db, auth)
         self.assertEqual(response.status_code, 204)
         revoke.assert_awaited_once()
+
+    async def test_returns_200_with_warning_on_idp_failure(self) -> None:
+        import json
+
+        db = mock.AsyncMock()
+        auth = mock.MagicMock()
+        auth.require_user = mock.MagicMock(id='user-1')
+        with mock.patch.object(
+            endpoints.flows,
+            'revoke_connection',
+            new=mock.AsyncMock(
+                return_value={
+                    'idp_revoked': False,
+                    'idp_error': 'RuntimeError: idp boom',
+                }
+            ),
+        ):
+            response = await endpoints.disconnect('p', db, auth)
+        self.assertEqual(response.status_code, 200)
+        body = json.loads(bytes(response.body))
+        self.assertIn('idp_error', body)
+        self.assertIn('idp boom', body['idp_error'])
 
 
 class StartConnectEndpointTestCase(unittest.IsolatedAsyncioTestCase):

--- a/tests/identity/test_flows.py
+++ b/tests/identity/test_flows.py
@@ -501,8 +501,13 @@ class RevokeConnectionTestCase(unittest.IsolatedAsyncioTestCase):
                 new=mock.AsyncMock(),
             ) as revoke,
         ):
-            await flows.revoke_connection(db, plugin_id='p', actor_user_id='u')
+            outcome = await flows.revoke_connection(
+                db, plugin_id='p', actor_user_id='u'
+            )
         revoke.assert_awaited_once_with(db, 'p', 'u')
+        self.assertFalse(outcome['idp_revoked'])
+        self.assertIn('idp boom', outcome['idp_error'] or '')
+        self.assertIn('RuntimeError', outcome['idp_error'] or '')
 
     async def test_happy_path_revokes_at_idp_and_locally(self) -> None:
         db = mock.AsyncMock()
@@ -528,6 +533,10 @@ class RevokeConnectionTestCase(unittest.IsolatedAsyncioTestCase):
                 new=mock.AsyncMock(),
             ) as revoke,
         ):
-            await flows.revoke_connection(db, plugin_id='p', actor_user_id='u')
+            outcome = await flows.revoke_connection(
+                db, plugin_id='p', actor_user_id='u'
+            )
         handler.revoke.assert_awaited_once()
         revoke.assert_awaited_once_with(db, 'p', 'u')
+        self.assertTrue(outcome['idp_revoked'])
+        self.assertIsNone(outcome['idp_error'])


### PR DESCRIPTION
## Summary

``revoke_connection`` logged a warning and returned ``None`` when the IdP-side ``handler.revoke()`` raised — the local connection was still marked revoked but the caller (and therefore the user) had no signal that the IdP still held live credentials.

## Solution

Return a structured ``RevokeOutcome(idp_revoked, idp_error)`` so the caller can distinguish a clean revoke from "we revoked locally but the IdP rejected the call." Cases where there's nothing to revoke at the IdP (plugin uninstalled, status was already non-active, no connection on file) are reported as ``idp_revoked=True`` because nothing *needed* IdP-side action.

The disconnect endpoint switches to ``200 OK`` with a JSON body in the partial-failure case (``204`` stays the happy path) so the UI can flag the partial state and tell the user they may need to revoke manually at the IdP:

```json
{
  "detail": "Connection revoked locally, but the IdP rejected the revocation call. The remote credentials may still be valid until the IdP expires them.",
  "idp_error": "RuntimeError: ..."
}
```

## Test plan

- [x] ``tests/identity/test_flows.py::RevokeConnectionTestCase`` — 3 cases passing (assertions extended to check the new outcome fields)
- [x] ``tests/identity/test_endpoints.py::DisconnectEndpointTestCase`` — 2 passing (existing 204 path + new 200-with-warning path)
- [x] ``tests/identity/`` full file — 119 passing
- [x] ``uv run pre-commit run --files …`` — ruff + mypy clean
- [x] ``uv run basedpyright …`` — clean

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>