### PR TITLE
Switch build_relationships to typed RelationshipSpec (L11)

### DIFF
--- a/src/imbi_api/endpoints/link_definitions.py
+++ b/src/imbi_api/endpoints/link_definitions.py
@@ -12,7 +12,7 @@ from imbi_common import blueprints, graph, models
 from imbi_api import patch as json_patch
 from imbi_api.auth import permissions
 from imbi_api.graph_sql import props_template, set_clause
-from imbi_api.relationships import build_relationships
+from imbi_api.relationships import RelationshipSpec, build_relationships
 
 LOGGER = logging.getLogger(__name__)
 
@@ -32,7 +32,7 @@ def _projects_relationship(
     """
     return build_relationships(
         '',
-        {'projects': ('', project_count)},
+        {'projects': RelationshipSpec('', project_count)},
     )
 
 

--- a/src/imbi_api/endpoints/organizations.py
+++ b/src/imbi_api/endpoints/organizations.py
@@ -11,7 +11,7 @@ from imbi_common import graph, models
 
 from imbi_api import patch as json_patch
 from imbi_api.auth import permissions
-from imbi_api.relationships import build_relationships
+from imbi_api.relationships import RelationshipSpec, build_relationships
 
 from .document_templates import document_templates_router
 from .documents import documents_project_router, documents_router
@@ -183,9 +183,9 @@ async def create_organization(
     result['relationships'] = build_relationships(
         request.app.url_path_for('get_organization', slug=slug),
         {
-            'teams': ('/teams', 0),
-            'members': ('/members', 0),
-            'projects': ('/projects', 0),
+            'teams': RelationshipSpec('/teams', 0),
+            'members': RelationshipSpec('/members', 0),
+            'projects': RelationshipSpec('/projects', 0),
         },
     )
     return result
@@ -235,9 +235,9 @@ async def list_organizations(
         org_data['relationships'] = build_relationships(
             request.app.url_path_for('get_organization', slug=slug),
             {
-                'teams': ('/teams', team_count),
-                'members': ('/members', member_count),
-                'projects': ('/projects', project_count),
+                'teams': RelationshipSpec('/teams', team_count),
+                'members': RelationshipSpec('/members', member_count),
+                'projects': RelationshipSpec('/projects', project_count),
             },
         )
         organizations.append(org_data)
@@ -296,15 +296,15 @@ async def get_organization(
     org_data['relationships'] = build_relationships(
         request.app.url_path_for('get_organization', slug=slug),
         {
-            'teams': (
+            'teams': RelationshipSpec(
                 '/teams',
                 graph.parse_agtype(records[0]['team_count']),
             ),
-            'members': (
+            'members': RelationshipSpec(
                 '/members',
                 graph.parse_agtype(records[0]['member_count']),
             ),
-            'projects': (
+            'projects': RelationshipSpec(
                 '/projects',
                 graph.parse_agtype(records[0]['project_count']),
             ),
@@ -386,15 +386,15 @@ async def _persist_organization(
     org_dict['relationships'] = build_relationships(
         request.app.url_path_for('get_organization', slug=org.slug),
         {
-            'teams': (
+            'teams': RelationshipSpec(
                 '/teams',
                 graph.parse_agtype(counts.get('team_count', 0)),
             ),
-            'members': (
+            'members': RelationshipSpec(
                 '/members',
                 graph.parse_agtype(counts.get('member_count', 0)),
             ),
-            'projects': (
+            'projects': RelationshipSpec(
                 '/projects',
                 graph.parse_agtype(counts.get('project_count', 0)),
             ),

--- a/src/imbi_api/endpoints/projects.py
+++ b/src/imbi_api/endpoints/projects.py
@@ -26,7 +26,7 @@ from imbi_api.plugins.lifecycle_dispatch import (
     LifecycleInvocation,
     dispatch_lifecycle,
 )
-from imbi_api.relationships import build_relationships
+from imbi_api.relationships import RelationshipSpec, build_relationships
 from imbi_api.scoring import OptionalValkeyClient
 from imbi_api.scoring import queue as score_queue
 
@@ -1005,8 +1005,8 @@ def _attach_project_relationships(
         build_relationships(
             '',
             {
-                'team': (team_url, 1 if team_slug else 0),
-                'environments': (
+                'team': RelationshipSpec(team_url, 1 if team_slug else 0),
+                'environments': RelationshipSpec(
                     f'{project_url}/environments',
                     len(project.get('environments') or []),
                 ),

--- a/src/imbi_api/endpoints/tags.py
+++ b/src/imbi_api/endpoints/tags.py
@@ -19,7 +19,7 @@ from imbi_common import graph, models
 
 from imbi_api import patch as json_patch
 from imbi_api.auth import permissions
-from imbi_api.relationships import build_relationships
+from imbi_api.relationships import RelationshipSpec, build_relationships
 
 LOGGER = logging.getLogger(__name__)
 
@@ -58,7 +58,7 @@ def _tag_relationships(
         request.app.url_path_for(
             'get_tag', org_slug=org_slug, tag_slug=tag_slug
         ),
-        {'documents': ('/documents', document_count)},
+        {'documents': RelationshipSpec('/documents', document_count)},
     )
 
 

--- a/src/imbi_api/relationships.py
+++ b/src/imbi_api/relationships.py
@@ -1,6 +1,22 @@
 """Utilities for building hypermedia-style relationship links."""
 
+import dataclasses
+
 from imbi_common.models import RelationshipLink
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class RelationshipSpec:
+    """Suffix + count pair consumed by :func:`build_relationships`.
+
+    A typed wrapper instead of a bare ``tuple[str, int]`` so call sites
+    can't accidentally swap the positional arguments and pass an int
+    where a str was expected. Frozen so it can live in dict literals
+    without surprise mutation.
+    """
+
+    suffix: str
+    count: int
 
 
 def relationship_link(href: str, count: int) -> RelationshipLink:
@@ -10,14 +26,16 @@ def relationship_link(href: str, count: int) -> RelationshipLink:
 
 def build_relationships(
     base_url: str,
-    links: dict[str, tuple[str, int]],
+    links: dict[str, RelationshipSpec],
 ) -> dict[str, RelationshipLink]:
-    """Build a relationships dict from name -> (path_suffix, count).
+    """Build a relationships dict from name -> RelationshipSpec.
 
     `base_url` is typically computed via `request.url_path_for(...)` so
     the configured API prefix is included automatically.
     """
     return {
-        name: RelationshipLink(href=f'{base_url}{suffix}', count=count)
-        for name, (suffix, count) in links.items()
+        name: RelationshipLink(
+            href=f'{base_url}{spec.suffix}', count=spec.count
+        )
+        for name, spec in links.items()
     }


### PR DESCRIPTION
## Summary
- Replaces `dict[str, tuple[str, int]]` parameter on `build_relationships` with a frozen `RelationshipSpec(suffix, count)` dataclass to prevent positional-argument swaps at call sites.
- Updates all five `build_relationships` call sites (`tags`, `organizations`, `link_definitions`, `projects`) to construct `RelationshipSpec` instances.

## Notes
- A `NamedTuple` was considered, but the `count` field collides with `tuple.count`, which triggers `reportIncompatibleMethodOverride` under basedpyright. Frozen dataclass with slots is the closest equivalent without that collision.
- No behavior change; `tag`, `organization`, `link_definition`, and `project` payloads remain byte-identical.

## Test plan
- [x] `uv run python -m unittest tests.endpoints.test_tags tests.endpoints.test_organizations tests.endpoints.test_link_definitions`
- [x] `uv run basedpyright` on touched files

Refs CODE_REVIEW_PUNCHLIST.md L11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)