### PR TITLE
Drop unused change_reason='' filter from score history feed (L18)

### DIFF
--- a/src/imbi_api/endpoints/scoring.py
+++ b/src/imbi_api/endpoints/scoring.py
@@ -459,7 +459,6 @@ async def score_history_feed(
         return []
     where: list[str] = [
         'project_id IN {project_ids:Array(String)}',
-        "change_reason != ''",
     ]
     params: dict[str, typing.Any] = {'project_ids': list(project_info)}
     if from_ is not None:


### PR DESCRIPTION
## Summary
- Removes the ``change_reason != ''`` predicate from ``score_history_feed`` — every caller of ``record_score_change`` already passes a non-empty reason (``scoring/queue.py:151`` falls back to ``'attribute_change'``), so the filter excluded rows that never get written.
- Aligns with the sibling ``/scores/{project_id}/history`` endpoint, which never carried the filter.

## Notes
- The read-side ``str(row.get('change_reason') or '') or None`` conversion stays so any legacy row with an empty string surfaces as ``change_reason=null`` rather than being silently dropped.

## Test plan
- [x] ``uv run python -m unittest tests.endpoints.test_scoring`` (29/29)

Refs CODE_REVIEW_PUNCHLIST.md L18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)