### PR TITLE
Suppress deploy audit row when no Release matched (L24)

### DIFF
--- a/src/imbi_api/endpoints/project_deployments.py
+++ b/src/imbi_api/endpoints/project_deployments.py
@@ -1096,18 +1096,27 @@ async def _handle_deploy(
         if result is not None:
             matched_tag = try_tag
             break
-    await _record_deployment_audit(
-        project_id=project_id,
-        project_slug=ctx.project_slug,
-        environment_slug=body.environment,
-        recorded_by=auth.principal_name,
-        action=body.action,
-        tag=matched_tag if result is not None else candidate_tag,
-        committish=committish_short,
-        plugin_slug=resolved.plugin_slug,
-        run_url=run.run_url,
-        external_run_id=str(run.run_id) if run.run_id else None,
-    )
+    if result is None:
+        LOGGER.warning(
+            'Deploy triggered for project=%s committish=%s tag=%s but no'
+            ' matching Release node was found; audit row suppressed',
+            project_id,
+            committish_short,
+            candidate_tag,
+        )
+    else:
+        await _record_deployment_audit(
+            project_id=project_id,
+            project_slug=ctx.project_slug,
+            environment_slug=body.environment,
+            recorded_by=auth.principal_name,
+            action=body.action,
+            tag=matched_tag,
+            committish=committish_short,
+            plugin_slug=resolved.plugin_slug,
+            run_url=run.run_url,
+            external_run_id=str(run.run_id) if run.run_id else None,
+        )
     return DeploymentTriggerResponse(
         run=run,
         plugin_id=resolved.plugin_id,

--- a/tests/endpoints/test_project_deployments.py
+++ b/tests/endpoints/test_project_deployments.py
@@ -997,6 +997,16 @@ class ProjectDeploymentsTestCase(unittest.TestCase):
         )
 
     def test_deploy_writes_operations_log_audit(self) -> None:
+        self.mocks['append_deployment_event'].return_value = mock.Mock()
+        # Mock _release_id_for so the deploy flow finds a Release node —
+        # the audit row is only written when a deploy ties back to a
+        # known Release (see L24).
+        self._start(
+            mock.patch(
+                f'{_MODULE}._release_id_for',
+                return_value='matched-release-id',
+            )
+        )
         with testclient.TestClient(self.test_app) as client:
             response = client.post(
                 '/organizations/myorg/projects/proj1/deployments',
@@ -1049,6 +1059,25 @@ class ProjectDeploymentsTestCase(unittest.TestCase):
         self.assertEqual(row['environment_slug'], 'staging')
         self.assertEqual(row['version'], 'v6.4.0')
         self.assertEqual(row['plugin_slug'], 'github-deployment')
+
+    def test_deploy_suppresses_audit_when_no_release_matches(self) -> None:
+        # L24: when ``_release_id_for`` returns no match, the workflow
+        # was still dispatched but we cannot tie it to a Release node,
+        # so the audit row is suppressed to keep operations_log clean.
+        with testclient.TestClient(self.test_app) as client:
+            response = client.post(
+                '/organizations/myorg/projects/proj1/deployments',
+                json={
+                    'action': 'deploy',
+                    'environment': 'testing',
+                    'committish': 'abc1234',
+                    'ref_label': 'main',
+                },
+            )
+        self.assertEqual(response.status_code, 202)
+        self.assertFalse(response.json()['recorded'])
+        ch = self.mocks['clickhouse'].return_value
+        ch.insert.assert_not_called()
 
 
 class ResyncProjectDeploymentsTestCase(ProjectDeploymentsTestCase):


### PR DESCRIPTION
## Summary
- ``_handle_deploy`` was unconditionally writing a row to ``operations_log`` even when ``_release_id_for`` produced no matching Release node and ``append_deployment_event`` was never called — leaving a misleading trail (workflow dispatched externally, internal release history untouched).
- The fix skips ``_record_deployment_audit`` on the no-match path and logs a warning instead. The response still returns ``recorded=False`` so the UI can distinguish a fully-recorded deploy from one that was only dispatched.

## Test updates
- ``test_deploy_writes_operations_log_audit`` was relying on the no-match path producing an audit row; updated it to mock ``_release_id_for`` so it tests the happy-path audit shape.
- Added ``test_deploy_suppresses_audit_when_no_release_matches`` to lock in the new behavior.

## Test plan
- [x] ``uv run python -m unittest tests.endpoints.test_project_deployments`` (85/85)

Refs CODE_REVIEW_PUNCHLIST.md L24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)