### PR TITLE
Replace brittle resource_type to label conversion with explicit map (M36)

### DIFF
--- a/src/imbi_api/auth/permissions.py
+++ b/src/imbi_api/auth/permissions.py
@@ -581,6 +581,49 @@ def require_permission(
     return check_permission
 
 
+# Explicit map from a permission ``resource_type`` (the snake-case
+# slug used in permission strings like ``project:read``) to the AGE
+# vertex label that identifies the node in the graph. Kept explicit
+# rather than derived from ``''.join(w.capitalize() ...)`` because
+# the naive conversion would map e.g. ``project_logs`` → ``ProjectLogs``
+# even though no such label exists, silently denying every request
+# instead of surfacing a configuration bug.
+_RESOURCE_LABEL_MAP: dict[str, str] = {
+    'blueprint': 'Blueprint',
+    'document': 'Document',
+    'document_template': 'DocumentTemplate',
+    'environment': 'Environment',
+    'identity_connection': 'IdentityConnection',
+    'link_definition': 'LinkDefinition',
+    'organization': 'Organization',
+    'plugin': 'Plugin',
+    'project': 'Project',
+    'project_type': 'ProjectType',
+    'release': 'Release',
+    'role': 'Role',
+    'service_application': 'ServiceApplication',
+    'tag': 'Tag',
+    'team': 'Team',
+    'third_party_service': 'ThirdPartyService',
+}
+
+
+def _resolve_resource_label(resource_type: str) -> str:
+    """Return the AGE label for a permission resource type.
+
+    Raises ``KeyError`` so a missing mapping shows up as a 500 on the
+    affected endpoint instead of a silent 403 — the latter would be a
+    classic "works on the dev's box, denied in prod" footgun.
+    """
+    try:
+        return _RESOURCE_LABEL_MAP[resource_type]
+    except KeyError as exc:
+        raise KeyError(
+            f'Unknown resource_type {resource_type!r}: add it to'
+            ' _RESOURCE_LABEL_MAP'
+        ) from exc
+
+
 async def check_resource_permission(
     db: graph.Graph,
     email: str,
@@ -678,9 +721,7 @@ def require_resource_access(
 
         # Check resource-level permission (users only)
         if auth.user:
-            label = ''.join(
-                word.capitalize() for word in resource_type.split('_')
-            )
+            label = _resolve_resource_label(resource_type)
             has_access = await check_resource_permission(
                 db, auth.user.email, label, slug, action
             )

--- a/tests/auth/test_authorization.py
+++ b/tests/auth/test_authorization.py
@@ -569,3 +569,23 @@ class ResourceAccessDependencyTestCase(
 
         self.assertEqual(ctx.exception.status_code, 403)
         self.assertIn('Access denied', str(ctx.exception.detail))
+
+    async def test_require_resource_access_unknown_resource_type(
+        self,
+    ) -> None:
+        """M36: unmapped resource_type surfaces as a hard KeyError."""
+        user_context = permissions.AuthContext(
+            user=self.regular_user,
+            session_id='test-session',
+            auth_method='jwt',
+            permissions=set(),
+        )
+        mock_db = mock.AsyncMock()
+
+        check_fn = permissions.require_resource_access('bogus_type', 'read')
+
+        with self.assertRaises(KeyError) as ctx:
+            await check_fn('test-slug', user_context, mock_db)
+
+        self.assertIn('bogus_type', str(ctx.exception))
+        self.assertIn('_RESOURCE_LABEL_MAP', str(ctx.exception))


### PR DESCRIPTION
## Summary
- ``require_resource_access`` was deriving the AGE vertex label from the permission ``resource_type`` by title-casing each underscore segment (``project_logs`` → ``ProjectLogs``). That convention has no single source of truth — the auto-conversion can produce labels that don't exist on any node (e.g. ``ProjectLogs`` vs. the singular form), which silently 403s every request instead of surfacing a configuration bug.
- Replaces the conversion with an explicit ``_RESOURCE_LABEL_MAP`` dict and a ``_resolve_resource_label`` helper that raises ``KeyError`` for any unmapped type. This turns a "works on dev, denied in prod" footgun into a hard 500 surfaced at the affected endpoint.

## Tests
- Added ``test_require_resource_access_unknown_resource_type`` to lock in the new behavior.
- ``ResourceAccessDependencyTestCase`` 5/5 pass.

## Test plan
- [x] ``uv run python -m unittest tests.auth.test_authorization.ResourceAccessDependencyTestCase``
- [x] ``basedpyright`` clean on ``permissions.py`` (the parse_scopes deprecation warning is pre-existing — see L4)

Refs CODE_REVIEW_PUNCHLIST.md M36.

🤖 Generated with [Claude Code](https://claude.com/claude-code)