### PR TITLE
Validate credential scopes against seeded Permission set (L27)

### DIFF
--- a/src/imbi_api/auth/permissions.py
+++ b/src/imbi_api/auth/permissions.py
@@ -87,6 +87,53 @@ _ALLOWED_PRINCIPAL_SELECTORS: frozenset[
 )
 
 
+async def load_all_permission_names(db: graph.Graph) -> set[str]:
+    """Return the set of seeded ``Permission.name`` values.
+
+    Used to validate API-key / SA-key / client-credential scope lists
+    at creation time — a scope that doesn't correspond to a seeded
+    permission would silently grant nothing (the auth path
+    intersects scopes with the principal's actual permissions), but
+    persisting bogus scopes pollutes the audit trail and hides
+    typos.
+    """
+    records = await db.execute(
+        'MATCH (p:Permission) RETURN p.name AS name',
+        {},
+        columns=['name'],
+    )
+    names: set[str] = set()
+    for row in records:
+        raw = graph.parse_agtype(row.get('name'))
+        if isinstance(raw, str) and raw:
+            names.add(raw)
+    return names
+
+
+async def validate_scopes(
+    db: graph.Graph, scopes: collections.abc.Iterable[str]
+) -> None:
+    """Raise ``HTTPException(400)`` if any scope isn't a seeded Permission.
+
+    An empty / all-scopes list (``[]``) is treated as "no restriction"
+    by callers and passes validation trivially.
+    """
+    requested = {s for s in scopes if s}
+    if not requested:
+        return
+    known = await load_all_permission_names(db)
+    unknown = sorted(requested - known)
+    if unknown:
+        raise fastapi.HTTPException(
+            status_code=400,
+            detail=(
+                'Unknown scope(s): '
+                + ', '.join(unknown)
+                + '. Scopes must match seeded Permission names.'
+            ),
+        )
+
+
 async def load_principal_permissions(
     db: graph.Graph,
     label: PrincipalLabel,

--- a/src/imbi_api/endpoints/api_keys.py
+++ b/src/imbi_api/endpoints/api_keys.py
@@ -124,6 +124,10 @@ async def create_api_key(
     """
     auth_settings = settings.get_auth_settings()
 
+    # L27: reject bogus scopes at write time so audit logs and the
+    # /api-keys UI never show typos that silently grant nothing.
+    await permissions.validate_scopes(db, key_request.scopes)
+
     # Generate key: format ik_<16chars>_<32chars>
     key_id = f'ik_{secrets.token_hex(16)}'
     key_secret = secrets.token_urlsafe(32)

--- a/src/imbi_api/endpoints/client_credentials.py
+++ b/src/imbi_api/endpoints/client_credentials.py
@@ -100,6 +100,10 @@ async def create_client_credential(
 
     auth_settings = settings.get_auth_settings()
 
+    # L27: reject bogus scopes at write time so audit logs and the
+    # client-credentials UI never show typos that silently grant nothing.
+    await permissions.validate_scopes(db, credential_request.scopes)
+
     # Generate client_id and secret
     client_id = f'cc_{secrets.token_urlsafe(16)}'
     client_secret = secrets.token_urlsafe(32)

--- a/src/imbi_api/endpoints/sa_api_keys.py
+++ b/src/imbi_api/endpoints/sa_api_keys.py
@@ -101,6 +101,10 @@ async def create_sa_api_key(
 
     auth_settings = settings.get_auth_settings()
 
+    # L27: reject bogus scopes at write time so audit logs and the
+    # SA key UI never show typos that silently grant nothing.
+    await permissions.validate_scopes(db, key_request.scopes)
+
     # Generate key: format ik_<16chars>_<32chars>
     key_id = f'ik_{secrets.token_hex(16)}'
     key_secret = secrets.token_urlsafe(32)

--- a/tests/endpoints/test_api_keys.py
+++ b/tests/endpoints/test_api_keys.py
@@ -125,7 +125,12 @@ class APIKeysEndpointsTestCase(unittest.TestCase):
     def test_create_api_key_with_scopes(self) -> None:
         """Test API key creation with scopes."""
         self.mock_db.merge.return_value = None
-        self.mock_db.execute.return_value = []
+        # validate_scopes (L27) queries Permission nodes; return the
+        # requested scopes as known so creation succeeds.
+        self.mock_db.execute.side_effect = [
+            [{'name': 'project:read'}, {'name': 'project:write'}],
+            [],
+        ]
 
         with mock.patch(
             'imbi_api.settings.get_auth_settings',
@@ -137,8 +142,8 @@ class APIKeysEndpointsTestCase(unittest.TestCase):
                 json={
                     'name': 'Scoped Key',
                     'scopes': [
-                        'read:projects',
-                        'write:projects',
+                        'project:read',
+                        'project:write',
                     ],
                 },
             )
@@ -147,8 +152,31 @@ class APIKeysEndpointsTestCase(unittest.TestCase):
             data = response.json()
             self.assertEqual(
                 data['scopes'],
-                ['read:projects', 'write:projects'],
+                ['project:read', 'project:write'],
             )
+
+    def test_create_api_key_rejects_unknown_scope(self) -> None:
+        """L27: unknown scopes are rejected with 400."""
+        self.mock_db.merge.return_value = None
+        # Only ``project:read`` is seeded; ``bogus:scope`` is not.
+        self.mock_db.execute.return_value = [{'name': 'project:read'}]
+
+        with mock.patch(
+            'imbi_api.settings.get_auth_settings',
+        ) as mock_settings:
+            mock_settings.return_value = self.auth_settings
+
+            response = self.client.post(
+                '/api-keys',
+                json={
+                    'name': 'Bogus Key',
+                    'scopes': ['project:read', 'bogus:scope'],
+                },
+            )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('bogus:scope', response.json()['detail'])
+        self.assertIn('Unknown scope', response.json()['detail'])
 
     def test_create_api_key_expiration_exceeds_max(
         self,


### PR DESCRIPTION
## Summary
Scope lists supplied at credential-creation time were persisted without validation. A typo (e.g. ``project:reead`` instead of ``project:read``) would survive the round-trip — the auth path silently intersects scopes with the principal's actual permissions, so a typo grants nothing and never surfaces.

## Changes
- ``load_all_permission_names(db)`` returns the seeded ``Permission.name`` set.
- ``validate_scopes(db, scopes)`` raises ``HTTPException(400, 'Unknown scope(s): ...')`` when any requested scope isn't seeded; empty list short-circuits.
- ``validate_scopes`` call added at the top of three credential-create endpoints (``api_keys``, ``sa_api_keys``, ``client_credentials``).

## Tests
- Updated ``test_create_api_key_with_scopes`` to mock the new permission query and use real permission names.
- Added ``test_create_api_key_rejects_unknown_scope`` to lock in 400 + descriptive error.
- ``tests.endpoints.test_api_keys`` 13/13, ``tests.endpoints.test_sa_api_keys`` 7/7, ``tests.endpoints.test_client_credentials`` 9/9.

## Test plan
- [x] ``uv run python -m unittest tests.endpoints.test_api_keys tests.endpoints.test_sa_api_keys tests.endpoints.test_client_credentials``

Refs CODE_REVIEW_PUNCHLIST.md L27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)