### PR TITLE
Make plugin disambiguation explicit in _load_plugin_handler (M44)

### DIFF
--- a/src/imbi_api/identity/flows.py
+++ b/src/imbi_api/identity/flows.py
@@ -22,9 +22,14 @@ from imbi_api.plugins import credentials as plugin_credentials
 LOGGER = logging.getLogger(__name__)
 
 
+PluginRefKind = typing.Literal['auto', 'id', 'slug']
+
+
 async def _load_plugin_handler(
     db: graph.Graph,
     plugin_id: str,
+    *,
+    lookup: PluginRefKind = 'auto',
 ) -> tuple[
     str, RegistryEntry, IdentityPlugin, dict[str, str], dict[str, typing.Any]
 ]:
@@ -34,6 +39,15 @@ async def _load_plugin_handler(
     service-attached plugin instance) or a manifest slug (the
     user-driven Connections page sends the slug because the catalog
     surface doesn't expose node ids).
+
+    ``lookup`` declares which form the caller is providing:
+
+    * ``'id'`` — match only the ``:Plugin.id`` property;
+    * ``'slug'`` — match only the ``:Plugin.plugin_slug`` property;
+    * ``'auto'`` (default, for back-compat) — try ``id`` first, then
+      ``slug``. Emits an INFO log when the fallback fires so a caller
+      that's silently relying on the implicit disambiguation is
+      visible in production logs (M44).
 
     When a ``:Plugin`` node matches, its ``options`` JSON is parsed and
     returned for the caller to thread through ``PluginContext``.
@@ -49,15 +63,23 @@ async def _load_plugin_handler(
         'RETURN p.id AS id, p.plugin_slug AS slug, p.options AS options '
         'LIMIT 1'
     )
-    rows = await db.execute(
-        by_id, {'plugin_id': plugin_id}, ['id', 'slug', 'options']
+    by_slug: typing.LiteralString = (
+        'MATCH (p:Plugin {{plugin_slug: {plugin_id}}}) '
+        'RETURN p.id AS id, p.plugin_slug AS slug, p.options AS options '
+        'LIMIT 1'
     )
-    if not rows:
-        by_slug: typing.LiteralString = (
-            'MATCH (p:Plugin {{plugin_slug: {plugin_id}}}) '
-            'RETURN p.id AS id, p.plugin_slug AS slug, p.options AS options '
-            'LIMIT 1'
+    rows: list[dict[str, typing.Any]] = []
+    if lookup in ('auto', 'id'):
+        rows = await db.execute(
+            by_id, {'plugin_id': plugin_id}, ['id', 'slug', 'options']
         )
+    if not rows and lookup in ('auto', 'slug'):
+        if lookup == 'auto':
+            LOGGER.info(
+                'Plugin lookup fell back from id to slug match for %r;'
+                ' caller should pass lookup="slug" if this is expected',
+                plugin_id,
+            )
         rows = await db.execute(
             by_slug, {'plugin_id': plugin_id}, ['id', 'slug', 'options']
         )

--- a/tests/identity/test_flows.py
+++ b/tests/identity/test_flows.py
@@ -121,8 +121,14 @@ class LoadPluginHandlerTestCase(unittest.IsolatedAsyncioTestCase):
         """M44: ``lookup='slug'`` must skip the by-id query entirely."""
         db = mock.AsyncMock()
         db.execute.return_value = []
+        # Use a slug that's guaranteed unregistered in any environment
+        # so the post-lookup ``get_plugin`` raises before reaching
+        # ``get_plugin_credentials`` (CI has real plugins loaded that
+        # would otherwise surface a different error first).
         with self.assertRaises(PluginNotFoundError):
-            await flows._load_plugin_handler(db, 'oidc', lookup='slug')
+            await flows._load_plugin_handler(
+                db, 'nonexistent-test-slug-xyz', lookup='slug'
+            )
         self.assertEqual(db.execute.await_count, 1)
 
 

--- a/tests/identity/test_flows.py
+++ b/tests/identity/test_flows.py
@@ -107,6 +107,24 @@ class LoadPluginHandlerTestCase(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result[3], {'client_id': 'cid'})
         self.assertEqual(result[4], {})
 
+    async def test_lookup_id_skips_slug_fallback(self) -> None:
+        """M44: ``lookup='id'`` must not fall back to the slug query."""
+        db = mock.AsyncMock()
+        db.execute.return_value = []
+        with self.assertRaises(PluginNotFoundError):
+            await flows._load_plugin_handler(db, 'plugin-1', lookup='id')
+        # Only the by-id query should have run; with 'auto' there would
+        # be a second call against ``plugin_slug``.
+        self.assertEqual(db.execute.await_count, 1)
+
+    async def test_lookup_slug_skips_id_query(self) -> None:
+        """M44: ``lookup='slug'`` must skip the by-id query entirely."""
+        db = mock.AsyncMock()
+        db.execute.return_value = []
+        with self.assertRaises(PluginNotFoundError):
+            await flows._load_plugin_handler(db, 'oidc', lookup='slug')
+        self.assertEqual(db.execute.await_count, 1)
+
 
 class StartFlowTestCase(unittest.IsolatedAsyncioTestCase):
     """Verify start_flow returns auth URL + state token."""


### PR DESCRIPTION
## Summary
``_load_plugin_handler`` was silently falling back from ``MATCH ... {id: ...}`` to ``MATCH ... {plugin_slug: ...}`` whenever the by-id query came up empty. Callers couldn't declare whether they were passing a node id or a manifest slug, and the implicit fallback masked the difference — a renamed slug that happens to collide with an old node id (or vice versa) would silently resolve to the wrong handler.

## Changes
Adds a keyword-only ``lookup: Literal['auto', 'id', 'slug']`` parameter:
- ``'id'`` — query only ``:Plugin.id`` (one round trip).
- ``'slug'`` — query only ``:Plugin.plugin_slug``.
- ``'auto'`` (default, back-compat) — try id, then slug, and log ``INFO`` when the fallback fires so production logs reveal callers that are silently relying on it.

Existing call sites stay on ``'auto'`` so no behavior changes for in-flight identity flows.

## Tests
- Added ``test_lookup_id_skips_slug_fallback`` and ``test_lookup_slug_skips_id_query`` (assert exactly one ``db.execute`` call per explicit mode).
- ``tests.identity.test_flows`` 25/25.

## Test plan
- [x] ``uv run python -m unittest tests.identity.test_flows``

Refs CODE_REVIEW_PUNCHLIST.md M44.

🤖 Generated with [Claude Code](https://claude.com/claude-code)