### PR TITLE
Serialize OpenAPI schema regeneration with threading.Lock (H16)

### DIFF
--- a/src/imbi_api/openapi.py
+++ b/src/imbi_api/openapi.py
@@ -17,6 +17,7 @@ Usage:
 """
 
 import logging
+import threading
 import typing
 
 import fastapi.openapi.utils
@@ -43,6 +44,16 @@ _edge_models: dict[str, type[pydantic.BaseModel]] = {}
 
 # Cache for the generated OpenAPI schema
 _schema_cache: dict[str, typing.Any] | None = None
+
+# Lock serializing schema regeneration. ``custom_openapi`` is sync and
+# called from FastAPI's openapi route handler; within a single worker
+# the event loop already serializes sync code, but FastAPI also
+# exposes ``app.openapi`` to tooling that may call it from a thread
+# pool (Stoplight rendering, schema export scripts, custom routes).
+# The lock keeps the build path single-threaded so two cold callers
+# don't both pay the full regeneration cost — and protects against
+# half-built schemas being observed mid-population.
+_schema_cache_lock = threading.Lock()
 
 # Mapping of API paths to their model types
 PATH_MODEL_MAPPING: dict[str, str] = {
@@ -205,81 +216,96 @@ def create_custom_openapi(
         if _schema_cache is not None:
             return _schema_cache
 
-        openapi_schema = fastapi.openapi.utils.get_openapi(
-            title=app.title,
-            version=app.version,
-            openapi_version=app.openapi_version,
-            summary=app.summary,
-            description=app.description,
-            routes=app.routes,
-            tags=app.openapi_tags,
-            servers=app.servers,
-            terms_of_service=app.terms_of_service,
-            contact=app.contact,
-            license_info=app.license_info,
-        )
+        with _schema_cache_lock:
+            # Double-check under the lock: a concurrent caller may have
+            # populated the cache while we were waiting.
+            if _schema_cache is not None:
+                return _schema_cache
+            _schema_cache = _build_schema(app)
+            return _schema_cache
 
-        if 'components' not in openapi_schema:
-            openapi_schema['components'] = {}
-        if 'schemas' not in openapi_schema['components']:
-            openapi_schema['components']['schemas'] = {}
+    return custom_openapi
 
-        schemas = typing.cast(
-            dict[str, typing.Any],
-            openapi_schema['components']['schemas'],
-        )
 
-        if _blueprint_models:
-            for model_name in _blueprint_models:
-                write_model = _blueprint_models[model_name]
-                resp_model = _response_models[model_name]
+def _build_schema(app: fastapi.FastAPI) -> dict[str, typing.Any]:
+    """Generate the OpenAPI schema with blueprint-enhanced models.
 
-                # Write schema (for request bodies)
-                write_name = f'{model_name}Request'
-                try:
-                    schemas[write_name] = write_model.model_json_schema(
-                        ref_template=('#/components/schemas/{model}')
-                    )
-                except Exception:
-                    LOGGER.exception(
-                        'Failed to generate write schema for %s',
-                        model_name,
-                    )
+    Pulled out of ``custom_openapi`` so the locked build path is a
+    single straight-line function — easier to reason about than a
+    nested closure straddling the lock.
+    """
+    openapi_schema = fastapi.openapi.utils.get_openapi(
+        title=app.title,
+        version=app.version,
+        openapi_version=app.openapi_version,
+        summary=app.summary,
+        description=app.description,
+        routes=app.routes,
+        tags=app.openapi_tags,
+        servers=app.servers,
+        terms_of_service=app.terms_of_service,
+        contact=app.contact,
+        license_info=app.license_info,
+    )
 
-                # Response schema (with relationships)
-                resp_name = f'{model_name}Response'
-                try:
-                    schemas[resp_name] = resp_model.model_json_schema(
-                        ref_template=('#/components/schemas/{model}')
-                    )
-                except Exception:
-                    LOGGER.exception(
-                        'Failed to generate response schema for %s',
-                        model_name,
-                    )
+    if 'components' not in openapi_schema:
+        openapi_schema['components'] = {}
+    if 'schemas' not in openapi_schema['components']:
+        openapi_schema['components']['schemas'] = {}
 
-            _hoist_defs_to_components(schemas)
-            _rewrite_path_schemas(openapi_schema)
+    schemas = typing.cast(
+        dict[str, typing.Any],
+        openapi_schema['components']['schemas'],
+    )
 
-        for edge_name, edge_model in _edge_models.items():
-            schema_name = f'{edge_name}EdgeProperties'
+    if _blueprint_models:
+        for model_name in _blueprint_models:
+            write_model = _blueprint_models[model_name]
+            resp_model = _response_models[model_name]
+
+            # Write schema (for request bodies)
+            write_name = f'{model_name}Request'
             try:
-                schemas[schema_name] = edge_model.model_json_schema(
+                schemas[write_name] = write_model.model_json_schema(
                     ref_template=('#/components/schemas/{model}')
                 )
             except Exception:
                 LOGGER.exception(
-                    'Failed to generate edge schema for %s',
-                    edge_name,
+                    'Failed to generate write schema for %s',
+                    model_name,
                 )
 
-        if _edge_models:
-            _hoist_defs_to_components(schemas)
+            # Response schema (with relationships)
+            resp_name = f'{model_name}Response'
+            try:
+                schemas[resp_name] = resp_model.model_json_schema(
+                    ref_template=('#/components/schemas/{model}')
+                )
+            except Exception:
+                LOGGER.exception(
+                    'Failed to generate response schema for %s',
+                    model_name,
+                )
 
-        _schema_cache = openapi_schema
-        return openapi_schema
+        _hoist_defs_to_components(schemas)
+        _rewrite_path_schemas(openapi_schema)
 
-    return custom_openapi
+    for edge_name, edge_model in _edge_models.items():
+        schema_name = f'{edge_name}EdgeProperties'
+        try:
+            schemas[schema_name] = edge_model.model_json_schema(
+                ref_template=('#/components/schemas/{model}')
+            )
+        except Exception:
+            LOGGER.exception(
+                'Failed to generate edge schema for %s',
+                edge_name,
+            )
+
+    if _edge_models:
+        _hoist_defs_to_components(schemas)
+
+    return openapi_schema
 
 
 def _hoist_defs_to_components(
@@ -407,9 +433,14 @@ def _rewrite_response_schemas(
 
 
 def clear_schema_cache() -> None:
-    """Clear the cached OpenAPI schema."""
+    """Clear the cached OpenAPI schema.
+
+    Acquires ``_schema_cache_lock`` so a concurrent in-flight build
+    cannot win the race and re-populate the cache after we clear it.
+    """
     global _schema_cache
-    _schema_cache = None
+    with _schema_cache_lock:
+        _schema_cache = None
     LOGGER.debug('Cleared OpenAPI schema cache')
 
 

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -272,6 +272,46 @@ class CreateCustomOpenapiTestCase(unittest.TestCase):
 
         self.assertIs(schema1, schema2)
 
+    def test_concurrent_cold_calls_build_once(self) -> None:
+        """H16: two threads hitting a cold cache must build only once."""
+        import threading
+
+        openapi._blueprint_models = {}
+        openapi._schema_cache = None
+
+        app = fastapi.FastAPI(title='Test', version='1.0.0')
+        custom_openapi_fn = openapi.create_custom_openapi(app)
+
+        build_count = 0
+        original_build = openapi._build_schema
+
+        def counting_build(a: fastapi.FastAPI) -> dict:
+            nonlocal build_count
+            build_count += 1
+            return original_build(a)
+
+        results: list[dict] = []
+        barrier = threading.Barrier(4)
+
+        def worker() -> None:
+            barrier.wait()
+            results.append(custom_openapi_fn())
+
+        with unittest.mock.patch.object(
+            openapi, '_build_schema', side_effect=counting_build
+        ):
+            threads = [threading.Thread(target=worker) for _ in range(4)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
+
+        self.assertEqual(build_count, 1)
+        self.assertEqual(len(results), 4)
+        # All callers observe the same cached schema instance.
+        for r in results[1:]:
+            self.assertIs(r, results[0])
+
     def test_path_schema_rewriting(self) -> None:
         """Test list endpoints get array response schemas."""
         import fastapi


### PR DESCRIPTION
## Summary
``custom_openapi`` did a naive ``if _schema_cache is None: build`` check-then-act. Within a single async worker the event loop serializes sync code so the race window is narrow, but ``app.openapi`` is also called from thread pools (Stoplight rendering, custom export scripts, tooling running on ``asyncio.to_thread``) — and a half-built schema escaping the build is worse than the duplicate work itself.

## Changes
- Wraps the cache check + build in a ``threading.Lock`` with a double-check pattern: two cold callers wait on the lock, the winner builds, the loser observes the populated cache and returns it.
- ``clear_schema_cache`` now acquires the lock so an in-flight build can't re-populate after we've cleared.
- Extracted the build body into ``_build_schema(app)`` so the locked section is a single straight-line function — easier to audit than a nested closure straddling the lock.

## Tests
- Added ``test_concurrent_cold_calls_build_once`` — 4 threads race a cold cache; expect exactly 1 ``_build_schema`` call and all callers observing the same instance.
- ``tests.test_openapi`` 14/14.

## Test plan
- [x] ``uv run python -m unittest tests.test_openapi``

Refs CODE_REVIEW_PUNCHLIST.md H16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)