### PR TITLE
Capture previous_slugs on org rename (L9)

### DIFF
--- a/src/imbi_api/endpoints/organizations.py
+++ b/src/imbi_api/endpoints/organizations.py
@@ -334,15 +334,56 @@ async def _persist_organization(
         HTTPException 404: Organization vanished between fetch and update.
 
     """
-    update_query: typing.LiteralString = (
-        'MATCH (n:Organization {{slug: {original_slug}}})'
-        ' SET n.name = {name},'
-        ' n.slug = {slug},'
-        ' n.description = {description},'
-        ' n.icon = {icon},'
-        ' n.updated_at = {updated_at}'
-        ' RETURN n'
-    )
+    # L9: when the slug changes, capture the old one so future lookups
+    # can redirect the stale URL. Fetched here as a pre-step (one
+    # extra round-trip on the rename path only) so the SET below
+    # gets a fully-formed list parameter and we don't have to ask
+    # AGE to do list-concat in Cypher (which is finicky).
+    previous_slugs: list[str] | None = None
+    if org.slug != original_slug:
+        existing_records = await db.execute(
+            'MATCH (n:Organization {{slug: {original_slug}}})'
+            ' RETURN n.previous_slugs AS previous_slugs',
+            {'original_slug': original_slug},
+            columns=['previous_slugs'],
+        )
+        if not existing_records:
+            raise fastapi.HTTPException(
+                status_code=404,
+                detail=f'Organization with slug {original_slug!r} not found',
+            )
+        prior_raw = graph.parse_agtype(existing_records[0]['previous_slugs'])
+        prior: list[str] = (
+            [str(s) for s in typing.cast(list[object], prior_raw)]
+            if isinstance(prior_raw, list)
+            else []
+        )
+        if original_slug not in prior:
+            prior.append(original_slug)
+        previous_slugs = prior
+
+    update_query: typing.LiteralString
+    if previous_slugs is not None:
+        update_query = (
+            'MATCH (n:Organization {{slug: {original_slug}}})'
+            ' SET n.name = {name},'
+            ' n.slug = {slug},'
+            ' n.description = {description},'
+            ' n.icon = {icon},'
+            ' n.updated_at = {updated_at},'
+            ' n.previous_slugs = {previous_slugs}'
+            ' RETURN n'
+        )
+    else:
+        update_query = (
+            'MATCH (n:Organization {{slug: {original_slug}}})'
+            ' SET n.name = {name},'
+            ' n.slug = {slug},'
+            ' n.description = {description},'
+            ' n.icon = {icon},'
+            ' n.updated_at = {updated_at}'
+            ' RETURN n'
+        )
     props = org.model_dump(mode='json')
     params: dict[str, typing.Any] = {
         'original_slug': original_slug,
@@ -352,6 +393,8 @@ async def _persist_organization(
         'icon': props.get('icon'),
         'updated_at': props['updated_at'],
     }
+    if previous_slugs is not None:
+        params['previous_slugs'] = previous_slugs
     try:
         records = await db.execute(update_query, params)
     except psycopg.errors.UniqueViolation as e:

--- a/tests/endpoints/test_organizations.py
+++ b/tests/endpoints/test_organizations.py
@@ -309,9 +309,12 @@ class OrganizationEndpointsTestCase(unittest.TestCase):
     def test_patch_organization_slug_conflict(self) -> None:
         """Test slug rename to conflicting slug returns 409."""
         self.mock_db.match.return_value = [self.test_org]
-        self.mock_db.execute.side_effect = psycopg.errors.UniqueViolation(
-            'Duplicate'
-        )
+        # First call fetches existing previous_slugs (L9), then the
+        # actual SET raises the unique-violation we're testing for.
+        self.mock_db.execute.side_effect = [
+            [{'previous_slugs': None}],
+            psycopg.errors.UniqueViolation('Duplicate'),
+        ]
 
         response = self.client.patch(
             '/organizations/engineering',
@@ -342,3 +345,81 @@ class OrganizationEndpointsTestCase(unittest.TestCase):
         )
 
         self.assertEqual(response.status_code, 400)
+
+    def test_patch_organization_rename_captures_previous_slug(self) -> None:
+        """L9: renaming an org appends the old slug to previous_slugs."""
+        self.mock_db.match.return_value = [self.test_org]
+        # 1st execute = fetch previous_slugs (none yet); 2nd execute
+        # = SET; 3rd execute = the count query in _persist_organization.
+        renamed_org = {
+            'id': self.test_org.id,
+            'name': self.test_org.name,
+            'slug': 'eng',
+            'description': self.test_org.description,
+            'icon': self.test_org.icon,
+            'created_at': self.test_org.created_at.isoformat(),
+            'updated_at': self.test_org.updated_at,
+            'previous_slugs': ['engineering'],
+        }
+        self.mock_db.execute.side_effect = [
+            [{'previous_slugs': None}],
+            [{'n': renamed_org}],
+            [
+                {
+                    'team_count': 0,
+                    'member_count': 0,
+                    'project_count': 0,
+                }
+            ],
+        ]
+
+        response = self.client.patch(
+            '/organizations/engineering',
+            json=[{'op': 'replace', 'path': '/slug', 'value': 'eng'}],
+        )
+
+        self.assertEqual(response.status_code, 200)
+        # The SET call (call_args_list[1]) should have received the
+        # original slug as the new previous_slugs entry.
+        set_call = self.mock_db.execute.call_args_list[1]
+        params = set_call.args[1]
+        self.assertEqual(params['previous_slugs'], ['engineering'])
+        self.assertEqual(params['slug'], 'eng')
+        self.assertEqual(params['original_slug'], 'engineering')
+
+    def test_patch_organization_no_rename_skips_previous_slugs(
+        self,
+    ) -> None:
+        """L9: a non-slug update does not touch previous_slugs."""
+        self.mock_db.match.return_value = [self.test_org]
+        renamed_org = {
+            'id': self.test_org.id,
+            'name': 'New Name',
+            'slug': self.test_org.slug,
+            'description': self.test_org.description,
+            'icon': self.test_org.icon,
+            'created_at': self.test_org.created_at.isoformat(),
+            'updated_at': self.test_org.updated_at,
+        }
+        # No previous_slugs fetch on the non-rename path: just SET then
+        # the count query.
+        self.mock_db.execute.side_effect = [
+            [{'n': renamed_org}],
+            [
+                {
+                    'team_count': 0,
+                    'member_count': 0,
+                    'project_count': 0,
+                }
+            ],
+        ]
+
+        response = self.client.patch(
+            '/organizations/engineering',
+            json=[{'op': 'replace', 'path': '/name', 'value': 'New Name'}],
+        )
+
+        self.assertEqual(response.status_code, 200)
+        set_call = self.mock_db.execute.call_args_list[0]
+        params = set_call.args[1]
+        self.assertNotIn('previous_slugs', params)


### PR DESCRIPTION
## Summary
A PATCH that changes ``Organization.slug`` previously left no breadcrumb pointing the old slug at the new one — bookmarks, audit log entries, and any external integration that hard-coded the prior slug would 404 silently with no path to recover.

## Changes
``_persist_organization``, on the rename path only, now fetches the existing ``previous_slugs`` list, appends the about-to-be-replaced slug if not already present, and persists it via the SET clause. The non-rename path is unchanged (no extra round trip).

A future PR can layer redirect resolution on top by MATCHing ``WHERE {old_slug} IN n.previous_slugs`` and returning the canonical slug — out of scope here so the storage half lands in isolation.

## Tests
- Added ``test_patch_organization_rename_captures_previous_slug``.
- Added ``test_patch_organization_no_rename_skips_previous_slugs``.
- Updated ``test_patch_organization_slug_conflict`` to mock the new previous_slugs fetch ahead of the SET that raises.

## Test plan
- [x] ``uv run python -m unittest tests.endpoints.test_organizations`` (16/16)

Refs CODE_REVIEW_PUNCHLIST.md L9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)