### PR TITLE
Cache successful API-key auth in a bounded LRU (M15)

### DIFF
--- a/src/imbi_api/auth/permissions.py
+++ b/src/imbi_api/auth/permissions.py
@@ -1,9 +1,12 @@
 """Permission checking and authorization dependencies."""
 
 import asyncio
+import collections
 import collections.abc
 import datetime
+import hashlib
 import logging
+import time
 import typing
 
 import fastapi
@@ -72,6 +75,60 @@ class AuthContext(pydantic.BaseModel):
                 403, 'This endpoint requires user authentication'
             )
         return self.user
+
+
+# M15: bounded per-process cache for successful API-key auth so a
+# hot path (CI bot hammering the API with the same key) doesn't pay
+# the full Argon2 verify + graph round-trip on every request. The
+# cache value is a fully-formed AuthContext; the key is the SHA-256
+# of the raw API key string so we don't keep the plaintext key in
+# memory. TTL is short so revocations / scope changes propagate
+# within a minute.
+_API_KEY_CACHE_TTL_SECONDS = 60
+_API_KEY_CACHE_MAX_ENTRIES = 1024
+_api_key_cache: collections.OrderedDict[str, tuple[float, AuthContext]] = (
+    collections.OrderedDict()
+)
+
+
+def _api_key_cache_key(key: str) -> str:
+    return hashlib.sha256(key.encode('utf-8')).hexdigest()
+
+
+def _api_key_cache_lookup(key: str) -> AuthContext | None:
+    """Return a cached AuthContext if present and unexpired."""
+    h = _api_key_cache_key(key)
+    entry = _api_key_cache.get(h)
+    if entry is None:
+        return None
+    expires, ctx = entry
+    if time.monotonic() > expires:
+        _api_key_cache.pop(h, None)
+        return None
+    # Refresh LRU recency on hit.
+    _api_key_cache.move_to_end(h)
+    return ctx
+
+
+def _api_key_cache_store(key: str, ctx: AuthContext) -> None:
+    """Store an AuthContext in the bounded LRU cache."""
+    h = _api_key_cache_key(key)
+    while len(_api_key_cache) >= _API_KEY_CACHE_MAX_ENTRIES:
+        _api_key_cache.popitem(last=False)
+    _api_key_cache[h] = (
+        time.monotonic() + _API_KEY_CACHE_TTL_SECONDS,
+        ctx,
+    )
+
+
+def clear_api_key_cache() -> None:
+    """Drop every cached API-key AuthContext.
+
+    Tests use this to keep cases independent; callers that rotate /
+    revoke a key in-process can also use it for instant invalidation
+    instead of waiting on the TTL.
+    """
+    _api_key_cache.clear()
 
 
 PrincipalLabel = typing.Literal['User', 'ServiceAccount']
@@ -385,6 +442,16 @@ async def authenticate_api_key(
     key_id = f'ik_{parts[1]}'
     key_secret = parts[2]
 
+    # M15: fast path — a hot key (e.g. a CI bot looping requests)
+    # would otherwise re-run Argon2 + 2 graph round-trips per call.
+    # The cache short-circuits the whole thing for up to
+    # ``_API_KEY_CACHE_TTL_SECONDS``; revocations propagate at the
+    # next miss. ``_stamp_api_key_last_used`` is still invoked on a
+    # miss, so ``last_used`` updates at most once per TTL window.
+    cached = _api_key_cache_lookup(key)
+    if cached is not None:
+        return cached
+
     # Fetch API key and owner (User or ServiceAccount)
     query = (
         'MATCH (k:APIKey {{key_id: {key_id}}}) '
@@ -457,12 +524,14 @@ async def authenticate_api_key(
         # Update last_used only after all validation passes
         await _stamp_api_key_last_used(db, key_id, auth_settings)
 
-        return AuthContext(
+        ctx = AuthContext(
             service_account=sa,
             session_id=key_id,
             auth_method='api_key',
             permissions=filtered,
         )
+        _api_key_cache_store(key, ctx)
+        return ctx
 
     user = models.User(**user_data)
     if not user.is_active:
@@ -479,13 +548,15 @@ async def authenticate_api_key(
     # Update last_used only after all validation passes
     await _stamp_api_key_last_used(db, key_id, auth_settings)
 
-    return AuthContext(
+    ctx = AuthContext(
         user=user,
         session_id=key_id,
         auth_method='api_key',
         permissions=filtered,
         identities=identities,
     )
+    _api_key_cache_store(key, ctx)
+    return ctx
 
 
 async def get_current_user(

--- a/tests/auth/test_api_key_auth.py
+++ b/tests/auth/test_api_key_auth.py
@@ -17,6 +17,9 @@ class AuthenticateAPIKeyTestCase(unittest.IsolatedAsyncioTestCase):
 
     def setUp(self) -> None:
         """Set up test fixtures."""
+        # M15: the LRU cache lives at module scope; clear it per test
+        # so cached AuthContexts from one case don't pollute another.
+        permissions.clear_api_key_cache()
         self.auth_settings = settings.Auth(
             jwt_secret='test-secret-key-min-32-chars-long',
         )
@@ -346,12 +349,92 @@ class AuthenticateAPIKeyTestCase(unittest.IsolatedAsyncioTestCase):
         self.assertIn('read:projects', auth_context.permissions)
         self.assertNotIn('write:projects', auth_context.permissions)
 
+    async def test_second_call_with_same_key_skips_db(self) -> None:
+        """M15: cached auth short-circuits the DB + Argon2 path."""
+        mock_db = mock.AsyncMock()
+        user_dict = self.test_user.model_dump(mode='json')
+
+        def execute_side_effect(query, params=None, columns=None):
+            if 'APIKey' in query and 'OWNED_BY' in query:
+                return [
+                    {
+                        'k': self.api_key_data,
+                        'u': user_dict,
+                        's': None,
+                    }
+                ]
+            elif 'last_used' in query:
+                return []
+            elif (
+                'Permission' in query
+                or 'GRANTS' in query
+                or 'MEMBER_OF' in query
+            ):
+                return [{'permissions': ['read:projects']}]
+            return []
+
+        mock_db.execute = mock.AsyncMock(side_effect=execute_side_effect)
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            first = await permissions.authenticate_api_key(
+                mock_db, self.full_key, self.auth_settings
+            )
+            calls_after_first = mock_db.execute.await_count
+            second = await permissions.authenticate_api_key(
+                mock_db, self.full_key, self.auth_settings
+            )
+        self.assertEqual(mock_db.execute.await_count, calls_after_first)
+        # Cache returns the same AuthContext instance.
+        self.assertIs(second, first)
+
+    async def test_clear_api_key_cache_forces_refetch(self) -> None:
+        """M15: clear_api_key_cache makes the next call hit the DB."""
+        mock_db = mock.AsyncMock()
+        user_dict = self.test_user.model_dump(mode='json')
+
+        def execute_side_effect(query, params=None, columns=None):
+            if 'APIKey' in query and 'OWNED_BY' in query:
+                return [
+                    {
+                        'k': self.api_key_data,
+                        'u': user_dict,
+                        's': None,
+                    }
+                ]
+            elif 'last_used' in query:
+                return []
+            elif (
+                'Permission' in query
+                or 'GRANTS' in query
+                or 'MEMBER_OF' in query
+            ):
+                return [{'permissions': []}]
+            return []
+
+        mock_db.execute = mock.AsyncMock(side_effect=execute_side_effect)
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            await permissions.authenticate_api_key(
+                mock_db, self.full_key, self.auth_settings
+            )
+            calls_after_first = mock_db.execute.await_count
+            permissions.clear_api_key_cache()
+            await permissions.authenticate_api_key(
+                mock_db, self.full_key, self.auth_settings
+            )
+        self.assertGreater(mock_db.execute.await_count, calls_after_first)
+
 
 class GetCurrentUserTestCase(unittest.IsolatedAsyncioTestCase):
     """Test get_current_user function with API key."""
 
     def setUp(self) -> None:
         """Set up test fixtures."""
+        permissions.clear_api_key_cache()
         self.auth_settings = settings.Auth(
             jwt_secret='test-secret-key-min-32-chars-long',
         )


### PR DESCRIPTION
## Summary
``authenticate_api_key`` was running the full validation pipeline on every request — APIKey + owner round trip, Argon2 verify, role graph traversal — even when the same key had passed verification moments earlier. The existing ``_stamp_api_key_last_used`` throttle short-circuits a single write but doesn't help the read path that a hot caller (CI bot, dashboard widget polling) walks end-to-end on every call.

## Changes
- Per-process ``OrderedDict`` cache keyed on SHA-256 of the raw key, capped at ``_API_KEY_CACHE_MAX_ENTRIES`` (1024) with ``_API_KEY_CACHE_TTL_SECONDS`` (60 s) expiry.
- ``_api_key_cache_lookup`` / ``_api_key_cache_store`` integrated at the top of ``authenticate_api_key`` (lookup) and at both success branches (store, after all validation).
- Public ``clear_api_key_cache()`` for test isolation and instant in-process invalidation by callers that rotate / revoke keys.

## Notes
- Revocations and scope changes propagate at the next miss (≤60 s window). The TTL deliberately matches the existing ``last_used`` throttle so they stay aligned.
- Plaintext keys are never stored in the cache; only their SHA-256 hashes.

## Tests
- ``test_second_call_with_same_key_skips_db`` — second call sees ``await_count`` unchanged and returns the same ``AuthContext`` instance.
- ``test_clear_api_key_cache_forces_refetch``.
- ``setUp`` clears the cache so individual cases stay independent.
- ``tests.auth.test_api_key_auth`` 15/15.

## Test plan
- [x] ``uv run python -m unittest tests.auth.test_api_key_auth``

Refs CODE_REVIEW_PUNCHLIST.md M15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)