### PR TITLE
Don't cache OpenAPI schema with partial failures (L14)

### DIFF
--- a/src/imbi_api/openapi.py
+++ b/src/imbi_api/openapi.py
@@ -221,18 +221,36 @@ def create_custom_openapi(
             # populated the cache while we were waiting.
             if _schema_cache is not None:
                 return _schema_cache
-            _schema_cache = _build_schema(app)
-            return _schema_cache
+            schema, had_failure = _build_schema(app)
+            # L14: pin the result only when every per-model schema
+            # generated cleanly. A partial result is returned to the
+            # caller so ``/openapi.json`` doesn't fail outright, but the
+            # next request retries from scratch instead of seeing a
+            # broken schema for the lifetime of the worker.
+            if not had_failure:
+                _schema_cache = schema
+            else:
+                LOGGER.warning(
+                    'OpenAPI schema generated with partial failures; '
+                    'refusing to cache so the next request can retry'
+                )
+            return schema
 
     return custom_openapi
 
 
-def _build_schema(app: fastapi.FastAPI) -> dict[str, typing.Any]:
+def _build_schema(
+    app: fastapi.FastAPI,
+) -> tuple[dict[str, typing.Any], bool]:
     """Generate the OpenAPI schema with blueprint-enhanced models.
 
     Pulled out of ``custom_openapi`` so the locked build path is a
     single straight-line function — easier to reason about than a
     nested closure straddling the lock.
+
+    Returns ``(schema, had_failure)``. The flag is ``True`` when any
+    per-model ``model_json_schema`` call raised; the caller uses it
+    to decide whether the result is safe to cache.
     """
     openapi_schema = fastapi.openapi.utils.get_openapi(
         title=app.title,
@@ -258,6 +276,8 @@ def _build_schema(app: fastapi.FastAPI) -> dict[str, typing.Any]:
         openapi_schema['components']['schemas'],
     )
 
+    had_failure = False
+
     if _blueprint_models:
         for model_name in _blueprint_models:
             write_model = _blueprint_models[model_name]
@@ -274,6 +294,7 @@ def _build_schema(app: fastapi.FastAPI) -> dict[str, typing.Any]:
                     'Failed to generate write schema for %s',
                     model_name,
                 )
+                had_failure = True
 
             # Response schema (with relationships)
             resp_name = f'{model_name}Response'
@@ -286,6 +307,7 @@ def _build_schema(app: fastapi.FastAPI) -> dict[str, typing.Any]:
                     'Failed to generate response schema for %s',
                     model_name,
                 )
+                had_failure = True
 
         _hoist_defs_to_components(schemas)
         _rewrite_path_schemas(openapi_schema)
@@ -301,11 +323,12 @@ def _build_schema(app: fastapi.FastAPI) -> dict[str, typing.Any]:
                 'Failed to generate edge schema for %s',
                 edge_name,
             )
+            had_failure = True
 
     if _edge_models:
         _hoist_defs_to_components(schemas)
 
-    return openapi_schema
+    return openapi_schema, had_failure
 
 
 def _hoist_defs_to_components(

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -285,7 +285,9 @@ class CreateCustomOpenapiTestCase(unittest.TestCase):
         build_count = 0
         original_build = openapi._build_schema
 
-        def counting_build(a: fastapi.FastAPI) -> dict:
+        def counting_build(
+            a: fastapi.FastAPI,
+        ) -> tuple[dict, bool]:
             nonlocal build_count
             build_count += 1
             return original_build(a)
@@ -311,6 +313,26 @@ class CreateCustomOpenapiTestCase(unittest.TestCase):
         # All callers observe the same cached schema instance.
         for r in results[1:]:
             self.assertIs(r, results[0])
+
+    def test_partial_failure_does_not_pin_cache(self) -> None:
+        """L14: a per-model failure must not pin a broken schema."""
+        broken = unittest.mock.MagicMock(spec=pydantic.BaseModel)
+        broken.model_json_schema.side_effect = ValueError('boom-for-test')
+        # Stuff the registry with a broken write model so generation
+        # raises on the first ``model_json_schema`` call.
+        openapi._blueprint_models = {'Team': broken}
+        openapi._response_models = {'Team': broken}
+        openapi._edge_models = {}
+
+        app = fastapi.FastAPI(title='Test', version='1.0.0')
+        custom_openapi_fn = openapi.create_custom_openapi(app)
+
+        schema = custom_openapi_fn()
+        # Schema still returned (best-effort) so /openapi.json keeps
+        # working for the unaffected paths...
+        self.assertIsInstance(schema, dict)
+        # ...but the cache stays empty so the next request retries.
+        self.assertIsNone(openapi._schema_cache)
 
     def test_path_schema_rewriting(self) -> None:
         """Test list endpoints get array response schemas."""


### PR DESCRIPTION
## Summary
``custom_openapi`` was pinning the assembled schema into ``_schema_cache`` regardless of whether the per-model ``model_json_schema`` calls succeeded. The three ``except Exception`` swallows inside the build log the failure but degrade the schema silently — and once that broken result lands in the cache, every subsequent ``/openapi.json`` request keeps returning it for the lifetime of the worker.

## Changes
- Tracks a local ``had_failure`` flag across the three try / except blocks and skips the ``_schema_cache = schema`` assignment when anything went wrong.
- Schema is still returned (best-effort) so ``/openapi.json`` doesn't fail outright; the next request retries from scratch.
- Adds a ``WARNING`` log when caching is skipped so the condition is visible without grepping for ``LOGGER.exception`` lines.

## Notes
- Cache will collide with #366 (H16) when both land; the resolution is mechanical (apply the same ``had_failure`` tracking inside the extracted ``_build_schema``). I'll handle the conflict at rebase time.

## Tests
- Added ``test_partial_failure_does_not_pin_cache``.
- ``tests.test_openapi`` 14/14.

## Test plan
- [x] ``uv run python -m unittest tests.test_openapi``

Refs CODE_REVIEW_PUNCHLIST.md L14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)