### PR TITLE
Pipeline rescore_all Valkey calls (M20)

### DIFF
--- a/src/imbi_api/endpoints/scoring.py
+++ b/src/imbi_api/endpoints/scoring.py
@@ -574,12 +574,12 @@ async def rescore(
             db, body.project_type_slug
         )
     requested_by = auth.user.email if auth.user else auth.principal_name
-    results = await asyncio.gather(
-        *[
-            score_queue.enqueue_recompute(
-                valkey_client, pid, 'bulk_rescore', requested_by=requested_by
-            )
-            for pid in project_ids
-        ]
+    # M20: pipeline the per-id SET NX + XADD pairs into two round
+    # trips instead of 2N parallel gathers.
+    enqueued = await score_queue.enqueue_recompute_bulk(
+        valkey_client,
+        project_ids,
+        'bulk_rescore',
+        requested_by=requested_by,
     )
-    return scoring_models.RescoreResponse(enqueued=sum(results))
+    return scoring_models.RescoreResponse(enqueued=enqueued)

--- a/src/imbi_api/scoring/queue.py
+++ b/src/imbi_api/scoring/queue.py
@@ -105,13 +105,18 @@ async def enqueue_recompute_bulk(
     try:
         async with client.pipeline(transaction=False) as pipe:
             for pid in ids:
-                pipe.set(
+                pipe.set(  # pyright: ignore[reportUnknownMemberType]
                     f'{DEBOUNCE_PREFIX}:{pid}',
                     b'1',
                     ex=DEBOUNCE_SECONDS,
                     nx=True,
                 )
-            set_results = await pipe.execute()
+            # ``execute()`` is typed as ``list[Unknown]`` by valkey-py
+            # — cast to the concrete shape we actually get from ``SET
+            # NX EX``: ``True`` on acquire, ``None`` on conflict.
+            set_results = typing.cast(
+                'list[bool | None]', await pipe.execute()
+            )
         accepted = [
             pid for pid, ok in zip(ids, set_results, strict=True) if ok
         ]
@@ -119,7 +124,7 @@ async def enqueue_recompute_bulk(
             return 0
         async with client.pipeline(transaction=False) as pipe:
             for pid in accepted:
-                pipe.xadd(
+                pipe.xadd(  # pyright: ignore[reportUnknownMemberType]
                     STREAM,
                     {
                         'project_id': pid,

--- a/src/imbi_api/scoring/queue.py
+++ b/src/imbi_api/scoring/queue.py
@@ -80,6 +80,60 @@ async def enqueue_recompute(
     return True
 
 
+async def enqueue_recompute_bulk(
+    client: valkey.Valkey | None,
+    project_ids: abc.Iterable[str],
+    reason: ChangeReason,
+    requested_by: str | None = None,
+) -> int:
+    """Pipeline-batched version of :func:`enqueue_recompute`.
+
+    Sends every debounce ``SET NX EX`` in one pipeline round trip,
+    then sends every ``XADD`` for the acquired ids in a second
+    pipeline. Returns the count of newly-enqueued jobs (the ones
+    whose debounce SET succeeded).
+
+    Designed for the admin-initiated bulk rescore path where
+    ``project_ids`` may be in the thousands — the previous
+    ``asyncio.gather`` over per-id calls produced 2N round trips
+    plus N debounce-fail rejections taking a full round trip each.
+    """
+    ids = list(project_ids)
+    if client is None or not ids:
+        return 0
+    requester = requested_by or 'system'
+    try:
+        async with client.pipeline(transaction=False) as pipe:
+            for pid in ids:
+                pipe.set(
+                    f'{DEBOUNCE_PREFIX}:{pid}',
+                    b'1',
+                    ex=DEBOUNCE_SECONDS,
+                    nx=True,
+                )
+            set_results = await pipe.execute()
+        accepted = [
+            pid for pid, ok in zip(ids, set_results, strict=True) if ok
+        ]
+        if not accepted:
+            return 0
+        async with client.pipeline(transaction=False) as pipe:
+            for pid in accepted:
+                pipe.xadd(
+                    STREAM,
+                    {
+                        'project_id': pid,
+                        'reason': reason,
+                        'requested_by': requester,
+                    },
+                )
+            await pipe.execute()
+    except Exception:
+        LOGGER.exception('enqueue_recompute_bulk failed (%d ids)', len(ids))
+        return 0
+    return len(accepted)
+
+
 async def ensure_group(client: valkey.Valkey) -> None:
     try:
         await client.xgroup_create(STREAM, GROUP, id='$', mkstream=True)

--- a/tests/endpoints/test_scoring.py
+++ b/tests/endpoints/test_scoring.py
@@ -13,6 +13,44 @@ from imbi_api import app, models
 from imbi_api import scoring as scoring_di
 
 
+class _PipelineProxy:
+    """Test stand-in for a Valkey async pipeline.
+
+    M20: the rescore endpoint now talks to Valkey through
+    ``client.pipeline(transaction=False)``. We replay each queued
+    command through the underlying ``mock_valkey`` mock so existing
+    assertions (``mock_valkey.xadd.await_count``,
+    ``mock_valkey.set.side_effect = [...]``) keep working without
+    each test having to mock the pipeline protocol itself.
+    """
+
+    def __init__(self, client: mock.AsyncMock) -> None:
+        self._client = client
+        self._queued: list[tuple[str, tuple, dict]] = []
+
+    async def __aenter__(self) -> _PipelineProxy:
+        return self
+
+    async def __aexit__(self, *_: object) -> None:
+        return None
+
+    def set(self, *args: object, **kwargs: object) -> _PipelineProxy:
+        self._queued.append(('set', args, kwargs))
+        return self
+
+    def xadd(self, *args: object, **kwargs: object) -> _PipelineProxy:
+        self._queued.append(('xadd', args, kwargs))
+        return self
+
+    async def execute(self) -> list[object]:
+        results: list[object] = []
+        for method, args, kwargs in self._queued:
+            fn = getattr(self._client, method)
+            results.append(await fn(*args, **kwargs))
+        self._queued = []
+        return results
+
+
 class ScoringEndpointsTestCase(unittest.TestCase):
     def setUp(self) -> None:
         from imbi_api.auth import permissions
@@ -45,6 +83,12 @@ class ScoringEndpointsTestCase(unittest.TestCase):
         self.mock_valkey = mock.AsyncMock()
         self.mock_valkey.set = mock.AsyncMock(return_value=True)
         self.mock_valkey.xadd = mock.AsyncMock()
+        # M20: rescore now uses pipeline(); the proxy replays each
+        # queued command through ``mock_valkey.set`` / ``xadd`` so
+        # the per-call assertions in existing tests keep working.
+        self.mock_valkey.pipeline = mock.MagicMock(
+            side_effect=lambda **_kw: _PipelineProxy(self.mock_valkey)
+        )
 
         self.test_app.dependency_overrides[graph._inject_graph] = (
             lambda: self.mock_db


### PR DESCRIPTION
## Summary
The bulk-rescore endpoint was firing ``enqueue_recompute`` in an ``asyncio.gather`` over every affected project id — N debounce ``SET NX EX`` + N ``XADD`` calls, each a separate round trip, plus N debounce-fail rejections paying full RTT to learn the SET returned None. A few thousand projects = a few thousand round trips on what should be a one-button admin action.

## Changes
Adds ``score_queue.enqueue_recompute_bulk`` that runs two ``client.pipeline(transaction=False)`` batches:

1. Every debounce ``SET NX EX`` in one round trip; the result list tells us which ids weren't already in flight.
2. Every ``XADD`` for the accepted ids in a second round trip.

Returns the count of newly-enqueued jobs. The legacy single-id ``enqueue_recompute`` stays around — call sites that fire one recompute on a hot path don't need the extra plumbing.

## Tests
- ``_PipelineProxy`` test helper replays queued commands through the underlying ``mock_valkey.set`` / ``mock_valkey.xadd`` so existing per-call assertions (``await_count``, ``side_effect``) keep working without each test mocking the pipeline protocol.
- 29/29 scoring endpoint tests + 40/40 queue / trigger tests pass.

## Test plan
- [x] ``uv run python -m unittest tests.endpoints.test_scoring``
- [x] ``uv run python -m unittest tests.test_scoring_queue tests.test_scoring_triggers``

Refs CODE_REVIEW_PUNCHLIST.md M20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)