### PR TITLE
Defer audit/event ClickHouse writes to BackgroundTasks (H13)

### DIFF
--- a/src/imbi_api/endpoints/project_deployments.py
+++ b/src/imbi_api/endpoints/project_deployments.py
@@ -875,6 +875,7 @@ async def trigger_deployment(
     org_slug: str,
     project_id: str,
     body: DeploymentRequestBody,
+    background: fastapi.BackgroundTasks,
     db: graph.Pool,
     auth: typing.Annotated[
         permissions.AuthContext,
@@ -898,10 +899,22 @@ async def trigger_deployment(
     """
     if body.action == 'promote':
         return await _handle_promote(
-            db, org_slug, project_id, auth, body, source=source
+            db,
+            org_slug,
+            project_id,
+            auth,
+            body,
+            background=background,
+            source=source,
         )
     return await _handle_deploy(
-        db, org_slug, project_id, auth, body, source=source
+        db,
+        org_slug,
+        project_id,
+        auth,
+        body,
+        background=background,
+        source=source,
     )
 
 
@@ -984,6 +997,7 @@ async def _handle_deploy(
     auth: permissions.AuthContext,
     body: DeployActionRequest,
     *,
+    background: fastapi.BackgroundTasks,
     source: str | None,
 ) -> DeploymentTriggerResponse:
     env_flags = await _load_env_flags(
@@ -1105,7 +1119,12 @@ async def _handle_deploy(
             candidate_tag,
         )
     else:
-        await _record_deployment_audit(
+        # H13: defer the operations_log ClickHouse insert until after
+        # the response goes out. The graph write that establishes the
+        # DeploymentEvent already succeeded; the audit row only feeds
+        # the activity history and can lag by milliseconds.
+        background.add_task(
+            _record_deployment_audit,
             project_id=project_id,
             project_slug=ctx.project_slug,
             environment_slug=body.environment,
@@ -1234,6 +1253,7 @@ async def _handle_promote(
     auth: permissions.AuthContext,
     body: PromoteActionRequest,
     *,
+    background: fastapi.BackgroundTasks,
     source: str | None,
 ) -> DeploymentTriggerResponse:
     env_flags = await _load_env_flags(
@@ -1397,7 +1417,10 @@ async def _handle_promote(
         ctx.actor_user_id,
         run.run_id,
     )
-    await _record_deployment_audit(
+    # H13: defer the operations_log ClickHouse insert until after the
+    # response goes out (same rationale as the deploy path above).
+    background.add_task(
+        _record_deployment_audit,
         project_id=project_id,
         project_slug=ctx.project_slug,
         environment_slug=body.to_environment,

--- a/src/imbi_api/endpoints/projects.py
+++ b/src/imbi_api/endpoints/projects.py
@@ -1968,6 +1968,7 @@ async def patch_project(
     project_id: str,
     operations: list[json_patch.PatchOperation],
     request: fastapi.Request,
+    background: fastapi.BackgroundTasks,
     db: graph.Pool,
     valkey_client: OptionalValkeyClient,
     auth: typing.Annotated[
@@ -2096,7 +2097,12 @@ async def patch_project(
     await score_queue.enqueue_recompute(
         valkey_client, project_id, 'attribute_change'
     )
-    await _emit_change_events(
+    # H13: ClickHouse insert is non-critical for the response, so move
+    # it off the hot path. The graph write already succeeded; the
+    # events row exists to feed the activity log and can lag by
+    # milliseconds without anyone noticing.
+    background.add_task(
+        _emit_change_events,
         project_id,
         auth.principal_name,
         before_snapshot,


### PR DESCRIPTION
## Summary
Two hot endpoint paths were paying for a ClickHouse insert inline:

- ``patch_project`` called ``_emit_change_events`` after the graph write, blocking the response on N row inserts (one per changed field).
- ``trigger_deployment`` ran ``_record_deployment_audit`` after every ``deploy`` / ``redeploy`` / ``promote`` to record an ``operations_log`` row, also blocking the response.

The graph writes that actually establish project / deploy state succeed before either of these fired, so the rows exist only to feed the activity log — losing or delaying them by a few milliseconds doesn't affect correctness. Moved both into ``fastapi.BackgroundTasks`` so the response goes out as soon as the graph work commits.

## Changes
- ``patch_project`` takes ``background: BackgroundTasks`` and schedules ``_emit_change_events`` instead of awaiting it.
- ``trigger_deployment`` threads ``background`` through ``_handle_deploy`` and ``_handle_promote`` so each audit site schedules itself.

## Tests
- 134/134 across ``test_projects`` + ``test_project_deployments`` keep passing.
- ``TestClient`` runs background tasks synchronously, so mock-based assertions on ``Clickhouse.insert`` still observe the call.

## Test plan
- [x] ``uv run python -m unittest tests.endpoints.test_project_deployments tests.endpoints.test_projects``

Refs CODE_REVIEW_PUNCHLIST.md H13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)