### PR TITLE
Batch lifecycle-dispatch ClickHouse inserts (H17)

### DIFF
--- a/src/imbi_api/plugins/lifecycle_dispatch.py
+++ b/src/imbi_api/plugins/lifecycle_dispatch.py
@@ -97,7 +97,12 @@ async def dispatch_lifecycle(
         )
         invocation = await _invoke_one(db, ctx, resolved, event, auth)
         results.append(invocation)
-        await _emit_event(project_id, event, invocation, auth)
+    # H17: emit all per-plugin events in a single ClickHouse insert
+    # rather than one round-trip per plugin. The dispatch loop hits N
+    # plugins serially, so a project assigned to a handful of plugins
+    # was paying N CH round trips on every lifecycle tick.
+    if results:
+        await _emit_events_batch(project_id, event, results, auth)
     return results
 
 
@@ -234,50 +239,59 @@ def _extract_http_detail(exc: fastapi.HTTPException) -> str:
     return str(detail)
 
 
-async def _emit_event(
+_EVENT_COLUMNS = [
+    'id',
+    'project_id',
+    'recorded_at',
+    'type',
+    'third_party_service',
+    'attributed_to',
+    'metadata',
+    'payload',
+]
+
+
+async def _emit_events_batch(
     project_id: str,
     event: LifecycleEvent,
-    invocation: LifecycleInvocation,
+    invocations: list[LifecycleInvocation],
     auth: permissions.AuthContext,
 ) -> None:
-    """Log a per-plugin lifecycle event to ClickHouse.
+    """Log all per-plugin lifecycle events in one ClickHouse insert.
 
     Errors here never bubble — the operator action already succeeded
-    and a ClickHouse hiccup must not poison the response.
+    and a ClickHouse hiccup must not poison the response. H17: this
+    replaces the per-invocation insert that was paying N round trips
+    for an N-plugin lifecycle dispatch.
     """
+    if not invocations:
+        return
+    now = datetime.datetime.now(datetime.UTC)
+    principal = auth.principal_name
+    rows: list[list[typing.Any]] = [
+        [
+            nanoid.generate(),
+            project_id,
+            now,
+            f'plugin.lifecycle.{event}',
+            invocation.plugin_slug,
+            principal,
+            {'plugin_id': invocation.plugin_id},
+            {
+                'status': invocation.status,
+                'message': invocation.message,
+                'artifacts': invocation.artifacts,
+            },
+        ]
+        for invocation in invocations
+    ]
     try:
         await ch_client.Clickhouse.get_instance().insert(
-            'events',
-            [
-                [
-                    nanoid.generate(),
-                    project_id,
-                    datetime.datetime.now(datetime.UTC),
-                    f'plugin.lifecycle.{event}',
-                    invocation.plugin_slug,
-                    auth.principal_name,
-                    {'plugin_id': invocation.plugin_id},
-                    {
-                        'status': invocation.status,
-                        'message': invocation.message,
-                        'artifacts': invocation.artifacts,
-                    },
-                ]
-            ],
-            [
-                'id',
-                'project_id',
-                'recorded_at',
-                'type',
-                'third_party_service',
-                'attributed_to',
-                'metadata',
-                'payload',
-            ],
+            'events', rows, _EVENT_COLUMNS
         )
     except Exception:
         LOGGER.exception(
-            'Failed to emit lifecycle event for plugin %s on project %s',
-            invocation.plugin_slug,
+            'Failed to emit %d lifecycle events for project %s',
+            len(rows),
             project_id,
         )

--- a/tests/test_lifecycle_dispatch.py
+++ b/tests/test_lifecycle_dispatch.py
@@ -140,6 +140,19 @@ class DispatchLifecycleTestCase(unittest.TestCase):
         )
         insert.assert_awaited_once()
 
+    def test_emits_one_clickhouse_call_for_multiple_plugins(self) -> None:
+        """H17: N plugins → 1 ClickHouse insert (rows batched)."""
+        entries = [
+            _resolved(_make_lifecycle_entry(f'gh-{i}')) for i in range(3)
+        ]
+        results, insert = self._run(entries)
+        self.assertEqual(len(results), 3)
+        insert.assert_awaited_once()
+        args = insert.call_args.args
+        self.assertEqual(args[0], 'events')
+        rows = args[1]
+        self.assertEqual(len(rows), 3)
+
     def test_unarchive_not_implemented_is_skipped(self) -> None:
         entry = _make_lifecycle_entry('gh')
         results, _ = self._run([_resolved(entry)], event='unarchived')


### PR DESCRIPTION
## Summary
``dispatch_lifecycle`` ran ``_emit_event`` after every plugin invocation, blocking the loop on one ClickHouse round trip per plugin. A project assigned to multiple lifecycle plugins paid N sequential CH inserts on every lifecycle tick — and since the loop awaits ``_emit_event``, those round trips don't even overlap with the next ``_invoke_one``.

## Changes
- Replaces the per-invocation insert with ``_emit_events_batch`` that runs after the loop with all N rows in one insert.
- Error-swallowing behavior preserved (operator action already succeeded; a CH hiccup must not poison the response).

## Tests
- Added ``test_emits_one_clickhouse_call_for_multiple_plugins`` to lock in the N → 1 round-trip semantic.
- ``tests.test_lifecycle_dispatch`` 10/10.

## Test plan
- [x] ``uv run python -m unittest tests.test_lifecycle_dispatch``

Refs CODE_REVIEW_PUNCHLIST.md H17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)