### PR TITLE
Admin graph query endpoints for Cypher exploration

### DIFF
--- a/src/imbi_api/endpoints/__init__.py
+++ b/src/imbi_api/endpoints/__init__.py
@@ -13,6 +13,7 @@ from .auth_providers import auth_providers_router
 from .blueprints import blueprint_router
 from .client_credentials import client_credentials_router
 from .events import events_router
+from .graph_query import graph_query_router
 from .local_auth import local_auth_router
 from .mfa import mfa_router
 from .operations_log import operations_log_router
@@ -37,6 +38,7 @@ prefixed_routers: list[fastapi.APIRouter] = [
     blueprint_router,
     client_credentials_router,
     events_router,
+    graph_query_router,
     local_auth_router,
     me_identities_router,
     mfa_router,

--- a/src/imbi_api/endpoints/graph_query.py
+++ b/src/imbi_api/endpoints/graph_query.py
@@ -1,0 +1,564 @@
+"""Admin graph query endpoints.
+
+Exposes raw Cypher execution and schema introspection for the admin
+"Graph Query" tool (inspired by Neo4j Desktop). Restricted to users
+with ``is_admin=True``.
+"""
+
+import json
+import logging
+import re
+import time
+import typing
+
+import fastapi
+import psycopg
+import pydantic
+from imbi_common import graph
+from psycopg import sql
+
+from imbi_api.auth import permissions
+
+LOGGER = logging.getLogger(__name__)
+
+graph_query_router = fastapi.APIRouter(
+    prefix='/admin/graph', tags=['Admin: Graph Query']
+)
+
+
+async def require_admin(
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(permissions.get_current_user),
+    ],
+) -> permissions.AuthContext:
+    """Dependency: require an authenticated admin user."""
+    if not auth.is_admin:
+        LOGGER.warning(
+            'Graph query denied: principal=%s is not admin',
+            auth.principal_name,
+        )
+        raise fastapi.HTTPException(
+            status_code=403,
+            detail='Admin privileges required',
+        )
+    return auth
+
+
+# ---------------------------------------------------------------
+# Request / response models
+# ---------------------------------------------------------------
+
+
+class GraphQueryRequest(pydantic.BaseModel):
+    """Request body for ``POST /admin/graph/query``."""
+
+    query: str
+    params: dict[str, typing.Any] = pydantic.Field(default_factory=dict)
+
+
+class GraphQueryError(pydantic.BaseModel):
+    """Structured error returned on a failed query."""
+
+    message: str
+    code: str | None = None
+    line: int | None = None
+    column: int | None = None
+    hint: str | None = None
+
+
+class GraphNode(pydantic.BaseModel):
+    """A vertex extracted from query results."""
+
+    id: str
+    labels: list[str]
+    properties: dict[str, typing.Any]
+
+
+class GraphEdge(pydantic.BaseModel):
+    """An edge extracted from query results."""
+
+    id: str
+    type: str
+    start: str
+    end: str
+    properties: dict[str, typing.Any]
+
+
+class GraphQueryResponse(pydantic.BaseModel):
+    """Response body for a successful query."""
+
+    columns: list[str]
+    rows: list[dict[str, typing.Any]]
+    nodes: list[GraphNode]
+    edges: list[GraphEdge]
+    elapsed_ms: float
+
+
+class LabelCount(pydantic.BaseModel):
+    """A node label with its instance count."""
+
+    label: str
+    count: int
+
+
+class EdgeTypeCount(pydantic.BaseModel):
+    """An edge type with its instance count."""
+
+    type: str
+    count: int
+
+
+class GraphSchemaResponse(pydantic.BaseModel):
+    """Response body for ``GET /admin/graph/schema``."""
+
+    node_labels: list[LabelCount]
+    edge_types: list[EdgeTypeCount]
+    property_keys: list[str]
+
+
+# ---------------------------------------------------------------
+# AGE result parsing
+# ---------------------------------------------------------------
+
+_AGTYPE_SUFFIX_RE = re.compile(r'::(vertex|edge|path|numeric)$')
+
+
+def _parse_value(raw: typing.Any) -> typing.Any:
+    """Parse an AGE agtype value preserving vertex/edge structure.
+
+    Unlike ``graph.parse_agtype`` (which unwraps to a vertex's
+    properties dict), this returns a tagged structure for vertices
+    and edges so the frontend can render them coherently.
+    """
+    if raw is None:
+        return None
+    if not isinstance(raw, str):
+        return raw
+
+    match = _AGTYPE_SUFFIX_RE.search(raw)
+    suffix = match.group(1) if match else None
+    cleaned = _AGTYPE_SUFFIX_RE.sub('', raw)
+    try:
+        parsed = json.loads(cleaned)
+    except json.JSONDecodeError, TypeError:
+        return raw
+
+    return _shape_value(parsed, suffix)
+
+
+def _shape_value(parsed: typing.Any, suffix: str | None) -> typing.Any:
+    """Apply a vertex/edge shape based on the agtype suffix."""
+    if suffix == 'vertex' and isinstance(parsed, dict):
+        as_dict = typing.cast(dict[str, typing.Any], parsed)
+        return {
+            '_kind': 'node',
+            'id': str(as_dict.get('id')),
+            'labels': [as_dict['label']] if 'label' in as_dict else [],
+            'properties': as_dict.get('properties', {}),
+        }
+    if suffix == 'edge' and isinstance(parsed, dict):
+        as_dict = typing.cast(dict[str, typing.Any], parsed)
+        return {
+            '_kind': 'edge',
+            'id': str(as_dict.get('id')),
+            'type': as_dict.get('label', ''),
+            'start': str(as_dict.get('start_id')),
+            'end': str(as_dict.get('end_id')),
+            'properties': as_dict.get('properties', {}),
+        }
+    if suffix == 'path' and isinstance(parsed, list):
+        as_list = typing.cast(  # type: ignore[redundant-cast]
+            list[typing.Any], parsed
+        )
+        return {
+            '_kind': 'path',
+            'elements': [
+                _shape_value(
+                    elem,
+                    'edge' if i % 2 == 1 else 'vertex',
+                )
+                if isinstance(elem, dict)
+                else elem
+                for i, elem in enumerate(as_list)
+            ],
+        }
+    return parsed
+
+
+def _collect_graph_elements(
+    value: typing.Any,
+    nodes: dict[str, GraphNode],
+    edges: dict[str, GraphEdge],
+) -> None:
+    """Recursively scan ``value`` and collect deduped nodes / edges."""
+    if isinstance(value, dict):
+        as_dict = typing.cast(dict[str, typing.Any], value)
+        kind = as_dict.get('_kind')
+        if kind == 'node':
+            node_id = str(as_dict['id'])
+            if node_id not in nodes:
+                nodes[node_id] = GraphNode(
+                    id=node_id,
+                    labels=list(as_dict.get('labels') or []),
+                    properties=dict(as_dict.get('properties') or {}),
+                )
+            return
+        if kind == 'edge':
+            edge_id = str(as_dict['id'])
+            if edge_id not in edges:
+                edges[edge_id] = GraphEdge(
+                    id=edge_id,
+                    type=str(as_dict.get('type') or ''),
+                    start=str(as_dict['start']),
+                    end=str(as_dict['end']),
+                    properties=dict(as_dict.get('properties') or {}),
+                )
+            return
+        if kind == 'path':
+            elements = typing.cast(
+                list[typing.Any], as_dict.get('elements') or []
+            )
+            for elem in elements:
+                _collect_graph_elements(elem, nodes, edges)
+            return
+        for v in as_dict.values():
+            _collect_graph_elements(v, nodes, edges)
+    elif isinstance(value, list):
+        as_list = typing.cast(  # type: ignore[redundant-cast]
+            list[typing.Any], value
+        )
+        for item in as_list:
+            _collect_graph_elements(item, nodes, edges)
+
+
+# ---------------------------------------------------------------
+# Query column inference
+# ---------------------------------------------------------------
+
+_RETURN_RE = re.compile(r'\breturn\b', re.IGNORECASE)
+
+
+def _split_top_level_commas(text: str) -> list[str]:
+    """Split ``text`` on commas that are not nested in (), [], {}."""
+    parts: list[str] = []
+    depth = 0
+    buf: list[str] = []
+    in_str: str | None = None
+    for ch in text:
+        if in_str:
+            buf.append(ch)
+            if ch == in_str:
+                in_str = None
+            continue
+        if ch in ('"', "'", '`'):
+            in_str = ch
+            buf.append(ch)
+            continue
+        if ch in '([{':
+            depth += 1
+            buf.append(ch)
+            continue
+        if ch in ')]}':
+            depth -= 1
+            buf.append(ch)
+            continue
+        if ch == ',' and depth == 0:
+            parts.append(''.join(buf).strip())
+            buf = []
+            continue
+        buf.append(ch)
+    tail = ''.join(buf).strip()
+    if tail:
+        parts.append(tail)
+    return parts
+
+
+def _strip_return_modifiers(text: str) -> str:
+    """Drop trailing ORDER BY / SKIP / LIMIT clauses from a RETURN body."""
+    lowered = text.lower()
+    best = len(text)
+    for keyword in (' order by ', ' skip ', ' limit '):
+        idx = lowered.find(keyword)
+        if idx != -1 and idx < best:
+            best = idx
+    return text[:best]
+
+
+def _column_alias(expr: str, fallback_index: int) -> str:
+    """Extract an alias from ``expr`` or build a fallback name."""
+    # Look for ` AS alias` at the end (case-insensitive).
+    m = re.search(r'\s+AS\s+([A-Za-z_][A-Za-z0-9_]*)\s*$', expr, re.IGNORECASE)
+    if m:
+        return m.group(1)
+    # Bare identifier (e.g. ``RETURN n``).
+    if re.fullmatch(r'[A-Za-z_][A-Za-z0-9_]*', expr.strip()):
+        return expr.strip()
+    return f'col{fallback_index}'
+
+
+def _extract_columns(query: str) -> list[str]:
+    """Best-effort column-name extraction from a Cypher RETURN clause."""
+    matches = list(_RETURN_RE.finditer(query))
+    if not matches:
+        raise ValueError('Query is missing a RETURN clause')
+    # Take the last RETURN — Cypher allows multiple WITH/RETURN, but the
+    # query's final projection wins.
+    last = matches[-1]
+    body = query[last.end() :]
+    body = _strip_return_modifiers(body)
+    body = body.rstrip(';').strip()
+    if not body:
+        raise ValueError('RETURN clause is empty')
+    if body.upper().startswith('DISTINCT '):
+        body = body[len('DISTINCT ') :].lstrip()
+    parts = _split_top_level_commas(body)
+    if not parts:
+        raise ValueError('RETURN clause is empty')
+    return [_column_alias(expr, i) for i, expr in enumerate(parts)]
+
+
+# ---------------------------------------------------------------
+# Error translation
+# ---------------------------------------------------------------
+
+
+def _diagnostic_int(value: str | None) -> int | None:
+    """Convert a psycopg ``Diagnostic`` numeric field to ``int``."""
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except TypeError, ValueError:
+        return None
+
+
+def _build_error_response(
+    message: str,
+    code: str | None = None,
+    line: int | None = None,
+    column: int | None = None,
+    hint: str | None = None,
+) -> dict[str, dict[str, typing.Any]]:
+    return {
+        'error': GraphQueryError(
+            message=message,
+            code=code,
+            line=line,
+            column=column,
+            hint=hint,
+        ).model_dump(),
+    }
+
+
+def _error_from_psycopg(exc: psycopg.Error) -> dict[str, typing.Any]:
+    """Translate a psycopg exception into the public error envelope."""
+    diag = getattr(exc, 'diag', None)
+    message = ''
+    code: str | None = None
+    line: int | None = None
+    column: int | None = None
+    hint: str | None = None
+    if diag is not None:
+        message = (getattr(diag, 'message_primary', None) or '').strip()
+        code = getattr(diag, 'sqlstate', None)
+        line = _diagnostic_int(
+            getattr(diag, 'statement_position', None),
+        )
+        # psycopg exposes the position as a 1-based character offset
+        # into the full statement. We don't have the SQL text the
+        # server saw (it's AGE-wrapped), so surface it as ``column``
+        # for client-side hinting and leave ``line`` unset.
+        if line is not None:
+            column = line
+            line = None
+        hint = getattr(diag, 'message_hint', None)
+    if not message:
+        message = str(exc).strip() or exc.__class__.__name__
+    return _build_error_response(message, code, line, column, hint)
+
+
+# ---------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------
+
+
+@graph_query_router.post('/query', response_model=GraphQueryResponse)
+async def run_graph_query(
+    body: GraphQueryRequest,
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext, fastapi.Depends(require_admin)
+    ],
+) -> GraphQueryResponse:
+    """Execute an ad-hoc Cypher query against the graph."""
+    query = body.query.strip()
+    if not query:
+        raise fastapi.HTTPException(
+            status_code=400,
+            detail=_build_error_response('Query must not be empty'),
+        )
+
+    try:
+        columns = _extract_columns(query)
+    except ValueError as exc:
+        raise fastapi.HTTPException(
+            status_code=400,
+            detail=_build_error_response(str(exc)),
+        ) from exc
+
+    LOGGER.info(
+        'Graph query: principal=%s columns=%s',
+        auth.principal_name,
+        columns,
+    )
+
+    start = time.monotonic()
+    try:
+        raw_rows = await db.execute(query, body.params, columns=columns)
+    except psycopg.Error as exc:
+        LOGGER.info(
+            'Graph query failed: principal=%s error=%s',
+            auth.principal_name,
+            exc,
+        )
+        raise fastapi.HTTPException(
+            status_code=400,
+            detail=_error_from_psycopg(exc),
+        ) from exc
+    except (ValueError, KeyError, IndexError) as exc:
+        # sql.SQL.format may raise on bad placeholder references in
+        # the user's query (e.g. unmatched ``{param}``).
+        raise fastapi.HTTPException(
+            status_code=400,
+            detail=_build_error_response(str(exc) or exc.__class__.__name__),
+        ) from exc
+    elapsed_ms = (time.monotonic() - start) * 1000.0
+
+    nodes: dict[str, GraphNode] = {}
+    edges: dict[str, GraphEdge] = {}
+    shaped_rows: list[dict[str, typing.Any]] = []
+    for row in raw_rows:
+        shaped: dict[str, typing.Any] = {}
+        for col in columns:
+            value = _parse_value(row.get(col))
+            shaped[col] = value
+            _collect_graph_elements(value, nodes, edges)
+        shaped_rows.append(shaped)
+
+    return GraphQueryResponse(
+        columns=columns,
+        rows=shaped_rows,
+        nodes=list(nodes.values()),
+        edges=list(edges.values()),
+        elapsed_ms=round(elapsed_ms, 3),
+    )
+
+
+# ---------------------------------------------------------------
+# Schema introspection
+# ---------------------------------------------------------------
+
+
+async def _load_label_counts(
+    db: graph.Graph,
+) -> tuple[list[LabelCount], list[EdgeTypeCount]]:
+    """Enumerate vertex/edge labels via ``ag_catalog.ag_label``.
+
+    AGE creates one row per label (``kind = 'v'`` for vertices,
+    ``'e'`` for edges) plus the bookkeeping ``_ag_label_vertex`` /
+    ``_ag_label_edge`` rows which are filtered out.
+
+    Counts are pulled from ``pg_class.reltuples`` (the planner's
+    estimate) so the schema endpoint stays fast even on large
+    graphs. The estimate can drift between vacuums but is good
+    enough for an admin overview; a precise count would require a
+    full ``MATCH (n:Label) RETURN count(n)`` per label and could
+    easily time out.
+    """
+    query = sql.SQL(
+        """
+        SELECT l.name AS name,
+               l.kind AS kind,
+               COALESCE(c.reltuples, 0)::bigint AS row_count
+          FROM ag_catalog.ag_label l
+          JOIN ag_catalog.ag_graph g ON l.graph = g.graphid
+          LEFT JOIN pg_class c
+                 ON c.oid = (
+                    quote_ident(g.name) || '.'
+                    || quote_ident(l.name)
+                 )::regclass
+         WHERE g.name = {graph}
+           AND l.name NOT LIKE '\\_ag\\_label\\_%' ESCAPE '\\'
+         ORDER BY l.name
+        """,
+    ).format(graph=sql.Literal(db.settings.graph_name))
+
+    async with db.pool.connection() as conn:
+        async with conn.cursor() as cursor:
+            await cursor.execute(query)
+            records = await cursor.fetchall()
+
+    node_labels: list[LabelCount] = []
+    edge_types: list[EdgeTypeCount] = []
+    for row in records:
+        name, kind, count = row
+        if kind == 'v':
+            node_labels.append(
+                LabelCount(label=name, count=max(int(count), 0)),
+            )
+        elif kind == 'e':
+            edge_types.append(
+                EdgeTypeCount(type=name, count=max(int(count), 0)),
+            )
+    return node_labels, edge_types
+
+
+async def _sample_property_keys(
+    db: graph.Graph, sample_size: int = 200
+) -> list[str]:
+    """Return the union of property keys across a sample of vertices."""
+    query: typing.LiteralString = (
+        'MATCH (n) WITH n LIMIT {limit}'
+        ' UNWIND keys(n) AS k'
+        ' RETURN collect(DISTINCT k) AS keys'
+    )
+    try:
+        records = await db.execute(
+            query,
+            {'limit': sample_size},
+            columns=['keys'],
+        )
+    except psycopg.Error:
+        LOGGER.warning(
+            'Failed to sample property keys for schema endpoint',
+            exc_info=True,
+        )
+        return []
+    if not records:
+        return []
+    raw: typing.Any = graph.parse_agtype(records[0].get('keys'))
+    if not isinstance(raw, list):
+        return []
+    as_list = typing.cast(  # type: ignore[redundant-cast]
+        list[typing.Any], raw
+    )
+    return sorted({k for k in as_list if isinstance(k, str)})
+
+
+@graph_query_router.get('/schema', response_model=GraphSchemaResponse)
+async def get_graph_schema(
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext, fastapi.Depends(require_admin)
+    ],
+) -> GraphSchemaResponse:
+    """Return labels, edge types, and sampled property keys."""
+    LOGGER.info('Graph schema requested: principal=%s', auth.principal_name)
+    node_labels, edge_types = await _load_label_counts(db)
+    property_keys = await _sample_property_keys(db)
+    return GraphSchemaResponse(
+        node_labels=node_labels,
+        edge_types=edge_types,
+        property_keys=property_keys,
+    )

--- a/tests/endpoints/test_graph_query.py
+++ b/tests/endpoints/test_graph_query.py
@@ -1,0 +1,368 @@
+"""Tests for the admin graph query endpoints."""
+
+import datetime
+import json
+import unittest
+from unittest import mock
+
+import psycopg
+from fastapi import testclient
+from imbi_common import graph
+
+from imbi_api import app, models
+from imbi_api.auth import password, permissions
+
+
+def _build_user(*, is_admin: bool) -> models.User:
+    return models.User(
+        email=('admin' if is_admin else 'user') + '@example.com',
+        display_name='Admin' if is_admin else 'User',
+        is_active=True,
+        is_admin=is_admin,
+        password_hash=password.hash_password('testpassword123'),
+        created_at=datetime.datetime.now(datetime.UTC),
+    )
+
+
+class GraphQueryEndpointTestCase(unittest.TestCase):
+    """Tests for ``POST /admin/graph/query``."""
+
+    def setUp(self) -> None:
+        self.test_app = app.create_app()
+        self.auth_context = permissions.AuthContext(
+            user=_build_user(is_admin=True),
+            session_id='test-session',
+            auth_method='jwt',
+            permissions=set(),
+        )
+
+        async def mock_get_current_user() -> permissions.AuthContext:
+            return self.auth_context
+
+        self.test_app.dependency_overrides[permissions.get_current_user] = (
+            mock_get_current_user
+        )
+
+        self.mock_db = mock.AsyncMock(spec=graph.Graph)
+        # Schema endpoint accesses ``db.settings.graph_name`` and
+        # ``db.pool``; tests touching the schema endpoint configure
+        # these via mocks of their own.
+        self.test_app.dependency_overrides[graph._inject_graph] = lambda: (
+            self.mock_db
+        )
+        self.client = testclient.TestClient(self.test_app)
+
+    def _set_non_admin(self) -> None:
+        self.auth_context = permissions.AuthContext(
+            user=_build_user(is_admin=False),
+            session_id='test-session',
+            auth_method='jwt',
+            permissions=set(),
+        )
+
+    def test_admin_query_success_with_vertex(self) -> None:
+        """Admin POST returns 200 with shaped rows, nodes, and edges."""
+        vertex = (
+            json.dumps(
+                {
+                    'id': 844424930131969,
+                    'label': 'User',
+                    'properties': {'email': 'admin@example.com'},
+                }
+            )
+            + '::vertex'
+        )
+        self.mock_db.execute.return_value = [{'u': vertex}]
+
+        response = self.client.post(
+            '/admin/graph/query',
+            json={'query': 'MATCH (u:User) RETURN u LIMIT 1'},
+        )
+
+        self.assertEqual(response.status_code, 200, response.text)
+        data = response.json()
+        self.assertEqual(data['columns'], ['u'])
+        self.assertEqual(len(data['rows']), 1)
+        self.assertEqual(data['rows'][0]['u']['_kind'], 'node')
+        self.assertEqual(data['rows'][0]['u']['labels'], ['User'])
+        self.assertEqual(
+            data['rows'][0]['u']['properties']['email'],
+            'admin@example.com',
+        )
+        self.assertEqual(len(data['nodes']), 1)
+        self.assertEqual(data['nodes'][0]['labels'], ['User'])
+        self.assertEqual(data['edges'], [])
+        self.assertIn('elapsed_ms', data)
+        self.assertIsInstance(data['elapsed_ms'], (int, float))
+
+    def test_admin_query_dedupes_nodes_and_edges(self) -> None:
+        """Same vertex/edge appearing twice across rows is deduped."""
+        vertex_a = (
+            json.dumps(
+                {
+                    'id': 1,
+                    'label': 'User',
+                    'properties': {'email': 'a@example.com'},
+                }
+            )
+            + '::vertex'
+        )
+        vertex_b = (
+            json.dumps(
+                {
+                    'id': 2,
+                    'label': 'User',
+                    'properties': {'email': 'b@example.com'},
+                }
+            )
+            + '::vertex'
+        )
+        edge = (
+            json.dumps(
+                {
+                    'id': 10,
+                    'label': 'KNOWS',
+                    'start_id': 1,
+                    'end_id': 2,
+                    'properties': {},
+                }
+            )
+            + '::edge'
+        )
+        self.mock_db.execute.return_value = [
+            {'a': vertex_a, 'r': edge, 'b': vertex_b},
+            {'a': vertex_a, 'r': edge, 'b': vertex_b},
+        ]
+
+        response = self.client.post(
+            '/admin/graph/query',
+            json={
+                'query': ('MATCH (a:User)-[r:KNOWS]->(b:User) RETURN a, r, b')
+            },
+        )
+
+        self.assertEqual(response.status_code, 200, response.text)
+        data = response.json()
+        self.assertEqual(data['columns'], ['a', 'r', 'b'])
+        self.assertEqual(len(data['rows']), 2)
+        self.assertEqual(len(data['nodes']), 2)
+        self.assertEqual(len(data['edges']), 1)
+        self.assertEqual(data['edges'][0]['type'], 'KNOWS')
+        self.assertEqual(data['edges'][0]['start'], '1')
+        self.assertEqual(data['edges'][0]['end'], '2')
+
+    def test_admin_query_scalar_columns(self) -> None:
+        """Non-vertex scalar columns are returned as-is."""
+        self.mock_db.execute.return_value = [{'cnt': 5}]
+
+        response = self.client.post(
+            '/admin/graph/query',
+            json={'query': 'MATCH (n) RETURN count(n) AS cnt'},
+        )
+
+        self.assertEqual(response.status_code, 200, response.text)
+        data = response.json()
+        self.assertEqual(data['columns'], ['cnt'])
+        self.assertEqual(data['rows'], [{'cnt': 5}])
+        self.assertEqual(data['nodes'], [])
+        self.assertEqual(data['edges'], [])
+
+    def test_non_admin_query_forbidden(self) -> None:
+        """Non-admin POST returns 403 without invoking the graph."""
+        self._set_non_admin()
+
+        response = self.client.post(
+            '/admin/graph/query',
+            json={'query': 'MATCH (n) RETURN n'},
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertIn('Admin', response.json()['detail'])
+        self.mock_db.execute.assert_not_awaited()
+
+    def test_empty_query_rejected(self) -> None:
+        """Whitespace-only query returns 400 with the empty-query error."""
+        response = self.client.post(
+            '/admin/graph/query',
+            json={'query': '   '},
+        )
+
+        self.assertEqual(response.status_code, 400)
+        body = response.json()
+        self.assertIn('error', body['detail'])
+        self.assertIn('empty', body['detail']['error']['message'].lower())
+        self.mock_db.execute.assert_not_awaited()
+
+    def test_query_without_return_rejected(self) -> None:
+        """A query missing a RETURN clause is rejected with 400."""
+        response = self.client.post(
+            '/admin/graph/query',
+            json={'query': 'MATCH (n)'},
+        )
+
+        self.assertEqual(response.status_code, 400)
+        body = response.json()
+        self.assertIn('RETURN', body['detail']['error']['message'])
+        self.mock_db.execute.assert_not_awaited()
+
+    def test_malformed_query_translates_psycopg_error(self) -> None:
+        """A psycopg syntax error becomes a 400 with structured detail."""
+
+        class FakeDiag:
+            message_primary = 'syntax error at or near "RETUR"'
+            sqlstate = '42601'
+            statement_position = '14'
+            message_hint = None
+
+        # ``psycopg.Error`` defines ``diag`` as a libpq-backed property
+        # with no setter. A plain attribute on a stand-in subclass
+        # would be shadowed by the descriptor, so we override the
+        # class attribute for the lifetime of this test.
+        class FakeSyntaxError(psycopg.Error):
+            diag = FakeDiag()  # type: ignore[assignment]
+
+        self.mock_db.execute.side_effect = FakeSyntaxError(
+            'syntax error at or near "RETUR"',
+        )
+
+        response = self.client.post(
+            '/admin/graph/query',
+            # Passes our RETURN-clause check; the simulated server-side
+            # syntax error is what we exercise here.
+            json={'query': 'MATCH (n) WHEER true RETURN n'},
+        )
+
+        self.assertEqual(response.status_code, 400, response.text)
+        body = response.json()
+        err = body['detail']['error']
+        self.assertEqual(err['code'], '42601', response.text)
+        self.assertIn('syntax error', err['message'])
+        # statement_position is exposed as ``column``.
+        self.assertEqual(err['column'], 14)
+
+    def test_query_with_params_passes_through(self) -> None:
+        """The request's ``params`` are forwarded to ``db.execute``."""
+        self.mock_db.execute.return_value = []
+
+        response = self.client.post(
+            '/admin/graph/query',
+            json={
+                'query': 'MATCH (u:User {email: {email}}) RETURN u',
+                'params': {'email': 'admin@example.com'},
+            },
+        )
+
+        self.assertEqual(response.status_code, 200, response.text)
+        self.mock_db.execute.assert_awaited_once()
+        call = self.mock_db.execute.await_args
+        assert call is not None
+        self.assertEqual(call.args[1], {'email': 'admin@example.com'})
+
+
+class GraphSchemaEndpointTestCase(unittest.TestCase):
+    """Tests for ``GET /admin/graph/schema``."""
+
+    def setUp(self) -> None:
+        self.test_app = app.create_app()
+        self.auth_context = permissions.AuthContext(
+            user=_build_user(is_admin=True),
+            session_id='test-session',
+            auth_method='jwt',
+            permissions=set(),
+        )
+
+        async def mock_get_current_user() -> permissions.AuthContext:
+            return self.auth_context
+
+        self.test_app.dependency_overrides[permissions.get_current_user] = (
+            mock_get_current_user
+        )
+
+        self.mock_db = mock.MagicMock(spec=graph.Graph)
+        self.mock_db.settings = mock.MagicMock()
+        self.mock_db.settings.graph_name = 'imbi'
+        self.mock_db.execute = mock.AsyncMock()
+
+        # Build an async-context-manager chain for db.pool.connection()
+        # → conn.cursor() → cursor.fetchall()
+        self.mock_cursor = mock.AsyncMock()
+        self.mock_cursor.fetchall.return_value = [
+            ('User', 'v', 42),
+            ('Project', 'v', 17),
+            ('KNOWS', 'e', 100),
+        ]
+
+        cursor_ctx = mock.MagicMock()
+        cursor_ctx.__aenter__ = mock.AsyncMock(return_value=self.mock_cursor)
+        cursor_ctx.__aexit__ = mock.AsyncMock(return_value=None)
+
+        mock_conn = mock.MagicMock()
+        mock_conn.cursor = mock.MagicMock(return_value=cursor_ctx)
+
+        conn_ctx = mock.MagicMock()
+        conn_ctx.__aenter__ = mock.AsyncMock(return_value=mock_conn)
+        conn_ctx.__aexit__ = mock.AsyncMock(return_value=None)
+
+        self.mock_db.pool = mock.MagicMock()
+        self.mock_db.pool.connection = mock.MagicMock(return_value=conn_ctx)
+
+        self.test_app.dependency_overrides[graph._inject_graph] = lambda: (
+            self.mock_db
+        )
+        self.client = testclient.TestClient(self.test_app)
+
+    def _set_non_admin(self) -> None:
+        self.auth_context = permissions.AuthContext(
+            user=_build_user(is_admin=False),
+            session_id='test-session',
+            auth_method='jwt',
+            permissions=set(),
+        )
+
+    def test_schema_admin_returns_labels(self) -> None:
+        """Schema endpoint groups results into nodes/edges/keys."""
+        self.mock_db.execute.return_value = [
+            {'keys': '["id", "email", "displayName"]'},
+        ]
+
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda x: json.loads(x) if isinstance(x, str) else x,
+        ):
+            response = self.client.get('/admin/graph/schema')
+
+        self.assertEqual(response.status_code, 200, response.text)
+        data = response.json()
+        labels = {lc['label']: lc['count'] for lc in data['node_labels']}
+        self.assertEqual(labels, {'User': 42, 'Project': 17})
+        types = {et['type']: et['count'] for et in data['edge_types']}
+        self.assertEqual(types, {'KNOWS': 100})
+        self.assertEqual(
+            data['property_keys'],
+            ['displayName', 'email', 'id'],
+        )
+
+    def test_schema_property_key_failure_is_soft(self) -> None:
+        """A failure sampling property keys yields an empty list."""
+
+        class FakeOpError(psycopg.Error):
+            pass
+
+        self.mock_db.execute.side_effect = FakeOpError('boom')
+
+        response = self.client.get('/admin/graph/schema')
+
+        self.assertEqual(response.status_code, 200, response.text)
+        data = response.json()
+        self.assertEqual(data['property_keys'], [])
+        self.assertTrue(data['node_labels'])
+
+    def test_schema_non_admin_forbidden(self) -> None:
+        """Non-admin GET returns 403 without touching the graph."""
+        self._set_non_admin()
+
+        response = self.client.get('/admin/graph/schema')
+
+        self.assertEqual(response.status_code, 403)
+        self.mock_db.pool.connection.assert_not_called()
+        self.mock_db.execute.assert_not_awaited()


### PR DESCRIPTION
## Summary

Backend for the new admin "Graph Query" tool (Neo4j Desktop style).

- `POST /admin/graph/query` — run a Cypher query with optional `params`. Returns the inferred column names, raw row stream (with vertices/edges shaped as `{_kind, id, labels|type, properties, ...}`), a deduplicated `nodes` array, a deduplicated `edges` array, and `elapsed_ms` measured against `time.monotonic()`.
- `GET /admin/graph/schema` — returns `node_labels[]`, `edge_types[]` (with counts), and a sampled list of `property_keys`.

## Admin gating

Both endpoints depend on a small local `require_admin` helper that calls `permissions.get_current_user` and returns 403 if `auth.is_admin` is false. No new permission string was introduced; admin-only behavior matches how the frontend gates `/admin`.

## Error shape

`psycopg.Error` is caught and translated into:

```
HTTP 400
{ "detail": { "error": { "message", "code", "line", "column", "hint" } } }
```

`code` is the psycopg `Diagnostic.sqlstate`. `column` is the 1-based `Diagnostic.statement_position` from psycopg; `line` is left unset because the position is relative to the AGE-wrapped SQL, not the user's Cypher. Empty/whitespace queries and queries with no `RETURN` clause return 400 with the same envelope before any DB call.

## Schema introspection

Labels and edge types come from `ag_catalog.ag_label` joined to `ag_catalog.ag_graph` — the internal bookkeeping labels (`_ag_label_vertex`, `_ag_label_edge`) are filtered out. Counts are pulled from `pg_class.reltuples` (planner estimate) so the endpoint stays fast on large graphs; a precise count would require a full `MATCH (n:Label) RETURN count(n)` per label and could time out on a busy environment. Property keys are sampled with `MATCH (n) WITH n LIMIT 200 UNWIND keys(n) AS k RETURN collect(DISTINCT k)`; a failure here returns an empty list instead of failing the whole schema response.

## Column inference

AGE's `cypher()` wrapper requires the caller to declare result columns in the `AS (...)` clause, so the endpoint extracts column names from the user's `RETURN` clause (handling `DISTINCT`, `ORDER BY`, `LIMIT`, `SKIP`, paren/bracket-nested commas, and `AS <alias>` aliases). Bare identifiers become their own column name; complex expressions without an alias get `col0`, `col1`, etc. Best-effort — recommend aliases in the frontend UI.

## Tests

11 new unit tests in `tests/endpoints/test_graph_query.py` cover:

- Admin POST with a vertex returns 200 with the documented shape
- Multi-row results dedupe nodes and edges by id
- Scalar columns pass through unchanged
- Non-admin POST and GET return 403 without touching the graph
- Empty query and `RETURN`-less query are rejected with 400
- `psycopg.Error` is translated to a 400 with code/column/hint
- Request `params` are forwarded to `db.execute`
- Schema endpoint returns label/edge/property buckets
- Schema endpoint soft-fails property-key sampling on DB errors

All tests use the existing `app.dependency_overrides` pattern (overriding `permissions.get_current_user` and `graph._inject_graph`) — no docker needed for this file.

## Test plan

- [x] `pytest tests/endpoints/test_graph_query.py --no-cov -v` — 11 passing
- [x] `pytest tests/endpoints/test_service_accounts.py tests/endpoints/test_admin.py tests/endpoints/test_init.py --no-cov` — 25 passing (no regressions)
- [x] `ruff check`, `ruff format --check`, `basedpyright`, `mypy -p imbi_api` — all clean
- [ ] Manual smoke test against a live Okteto graph (frontend will exercise this once the UI lands)