### PR TITLE
Document cross-org behavior of list_service_applications (L23)

### DIFF
--- a/src/imbi_api/endpoints/third_party_services.py
+++ b/src/imbi_api/endpoints/third_party_services.py
@@ -706,9 +706,22 @@ async def list_service_applications(
     Defaults to the "integration" view: apps registered in this org's
     instance of the service AND any app with ``usage IN
     ('login','both')`` from any org (rendered ``is_global=True``).
+
+    ``usage='login'`` is deliberately cross-org: login providers are
+    inherently global (any user reaching ``/api/auth/login/<slug>``
+    can already discover which providers exist), so the response only
+    exposes names and slugs that are reachable through public auth
+    endpoints. ``ServiceApplication.client_secret`` is *not* surfaced
+    here -- see ``ServiceApplicationResponse``. ``org_slug`` still
+    gates the *route* (callers without ``third_party_service:read``
+    on the org cannot reach this handler at all), and the
+    ``owner_slug`` on each row preserves attribution. If a future
+    product surface needs to restrict cross-org visibility, add a
+    dedicated ``auth_provider:list_global`` permission and branch on
+    it here.
     """
     if usage == 'login':
-        # Login view ignores org boundaries entirely.
+        # Login view ignores org boundaries entirely -- see docstring.
         query: typing.LiteralString = """
         MATCH (a:ServiceApplication)-[:REGISTERED_IN]->
               (s:ThirdPartyService {{slug: {slug}}})


### PR DESCRIPTION
## Summary

`list_service_applications?usage=login` deliberately ignores `org_slug` because login providers are inherently global -- any user reaching `/api/auth/login/<slug>` can discover them regardless. The handler's existing one-line comment didn't make that clear, so reviewers (rightly) flagged it as a potential cross-org leak.

This PR upgrades the docstring to spell out the rationale and identify the escape hatch (an `auth_provider:list_global` permission) for any future surface that needs tighter scoping.

No behavior change.

Punchlist: **L23**.

## Test plan

- [x] `ruff format` / `ruff check`
- [x] Docstring renders correctly in OpenAPI -- visual check