### PR TITLE
Add idempotency, batching, and concurrency cap to backfill_embeddings (H15)

### DIFF
--- a/src/imbi_api/backfill_embeddings.py
+++ b/src/imbi_api/backfill_embeddings.py
@@ -1,16 +1,24 @@
 """One-shot backfill: generate embeddings for all existing nodes.
 
-Run with:
+Run with::
+
     uv run python -m imbi_api.backfill_embeddings
 
-Iterates every embeddable node type and calls _auto_embed for each
-instance that doesn't already have embeddings (or re-embeds if the
-stored vectors are stale).
+Iterates every embeddable node type and calls ``_auto_embed`` for each
+instance.  By default skips any node that already has an embedding row
+in ``public.embeddings`` so the script is safely resumable -- pass
+``--force`` to re-embed everything.  Per-type batches fan out
+concurrently up to ``--concurrency`` so a backfill against a remote
+embedding provider isn't bottlenecked on serial round-trips, while the
+bound prevents a runaway from exhausting the provider's rate limit.
 """
 
+import argparse
 import asyncio
 import logging
+import typing
 
+import psycopg
 from imbi_common import graph, models
 from imbi_common.graph.client import (
     _embeddable_fields,  # type: ignore[attr-defined]
@@ -43,30 +51,75 @@ _GRAPH_MODEL_TYPES: list[type[models.GraphModel]] = [
     models.Document,
 ]
 
+_DEFAULT_CONCURRENCY = 4
+
+
+async def _already_embedded_ids(
+    db: graph.Graph,
+    node_label: str,
+) -> set[str]:
+    """Return the set of node ids that already have embedding rows."""
+    async with db.pool.connection() as conn:
+        async with conn.cursor() as cur:
+            await cur.execute(
+                'SELECT DISTINCT node_id FROM public.embeddings'
+                ' WHERE node_label = %(label)s',
+                {'label': node_label},
+            )
+            rows = typing.cast(
+                'list[tuple[str]]',
+                await cur.fetchall(),
+            )
+    return {row[0] for row in rows}
+
 
 async def _embed_type(
     db: graph.Graph,
     node_type: type[models.GraphModel],
+    *,
+    semaphore: asyncio.Semaphore,
+    force: bool,
 ) -> int:
     nodes = await db.match(node_type)  # type: ignore[arg-type]
-    count = 0
-    for node in nodes:
+    label = node_type.__name__
+    skip_ids: set[str] = (
+        set() if force else await _already_embedded_ids(db, label)
+    )
+
+    async def _embed_one(node: models.GraphModel) -> int:
         if not _embeddable_fields(node):  # type: ignore[arg-type]
-            continue
-        await db._auto_embed(node)  # type: ignore[arg-type]
-        count += 1
-    return count
+            return 0
+        if node.id in skip_ids:
+            return 0
+        async with semaphore:
+            try:
+                await db._auto_embed(node)  # type: ignore[arg-type]
+            except psycopg.Error:
+                LOGGER.exception('Failed to embed %s id=%s', label, node.id)
+                return 0
+        return 1
+
+    results = await asyncio.gather(*(_embed_one(n) for n in nodes))
+    return sum(results)
 
 
-async def run() -> None:
+async def run(*, concurrency: int, force: bool) -> None:
     db = graph.Graph()
     await db.open()
+    semaphore = asyncio.Semaphore(concurrency)
     try:
         total = 0
         for node_type in [*_NODE_TYPES, *_GRAPH_MODEL_TYPES]:
             label = node_type.__name__
-            LOGGER.info('Embedding %s nodes...', label)
-            n = await _embed_type(db, node_type)
+            LOGGER.info(
+                'Embedding %s nodes (concurrency=%d, force=%s)...',
+                label,
+                concurrency,
+                force,
+            )
+            n = await _embed_type(
+                db, node_type, semaphore=semaphore, force=force
+            )
             LOGGER.info('  %s: %d nodes embedded', label, n)
             total += n
         LOGGER.info('Done. Total nodes embedded: %d', total)
@@ -74,5 +127,31 @@ async def run() -> None:
         await db.close()
 
 
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description='Backfill embeddings for existing nodes.',
+    )
+    parser.add_argument(
+        '--concurrency',
+        type=int,
+        default=_DEFAULT_CONCURRENCY,
+        help=(
+            'Max in-flight ``_auto_embed`` calls across all node types. '
+            f'Default: {_DEFAULT_CONCURRENCY}.'
+        ),
+    )
+    parser.add_argument(
+        '--force',
+        action='store_true',
+        help=(
+            'Re-embed every node, even those that already have rows in '
+            'public.embeddings. Without this flag the script is '
+            'resumable.'
+        ),
+    )
+    return parser.parse_args()
+
+
 if __name__ == '__main__':
-    asyncio.run(run())
+    args = _parse_args()
+    asyncio.run(run(concurrency=args.concurrency, force=args.force))

--- a/tests/test_backfill_embeddings.py
+++ b/tests/test_backfill_embeddings.py
@@ -1,25 +1,40 @@
 """Tests for the one-shot embedding backfill script."""
 
+import asyncio
 import unittest
 from unittest import mock
+
+import psycopg
 
 from imbi_api import backfill_embeddings
 
 
+def _patch_embeddable(return_value: list[str]) -> mock._patch:
+    return mock.patch(
+        'imbi_api.backfill_embeddings._embeddable_fields',
+        return_value=return_value,
+    )
+
+
+def _patch_already_embedded(return_value: set[str]) -> mock._patch:
+    return mock.patch(
+        'imbi_api.backfill_embeddings._already_embedded_ids',
+        new=mock.AsyncMock(return_value=return_value),
+    )
+
+
 class BackfillEmbeddingsTestCase(unittest.IsolatedAsyncioTestCase):
     async def test_run_embeds_all_nodes(self) -> None:
-        mock_node = mock.MagicMock()
+        mock_node = mock.MagicMock(id='node-1')
         mock_db = mock.AsyncMock()
         mock_db.match.return_value = [mock_node]
 
         with mock.patch.object(
             backfill_embeddings.graph, 'Graph', return_value=mock_db
         ):
-            with mock.patch(
-                'imbi_api.backfill_embeddings._embeddable_fields',
-                return_value=['name'],
-            ):
-                await backfill_embeddings.run()
+            with _patch_embeddable(['name']):
+                with _patch_already_embedded(set()):
+                    await backfill_embeddings.run(concurrency=2, force=False)
 
         expected = len(backfill_embeddings._NODE_TYPES) + len(
             backfill_embeddings._GRAPH_MODEL_TYPES
@@ -30,18 +45,16 @@ class BackfillEmbeddingsTestCase(unittest.IsolatedAsyncioTestCase):
         mock_db.close.assert_awaited_once()
 
     async def test_run_skips_non_embeddable_nodes(self) -> None:
-        mock_node = mock.MagicMock()
+        mock_node = mock.MagicMock(id='node-1')
         mock_db = mock.AsyncMock()
         mock_db.match.return_value = [mock_node]
 
         with mock.patch.object(
             backfill_embeddings.graph, 'Graph', return_value=mock_db
         ):
-            with mock.patch(
-                'imbi_api.backfill_embeddings._embeddable_fields',
-                return_value=[],
-            ):
-                await backfill_embeddings.run()
+            with _patch_embeddable([]):
+                with _patch_already_embedded(set()):
+                    await backfill_embeddings.run(concurrency=2, force=False)
 
         mock_db._auto_embed.assert_not_awaited()
 
@@ -52,12 +65,12 @@ class BackfillEmbeddingsTestCase(unittest.IsolatedAsyncioTestCase):
         with mock.patch.object(
             backfill_embeddings.graph, 'Graph', return_value=mock_db
         ):
-            with mock.patch(
-                'imbi_api.backfill_embeddings._embeddable_fields',
-                return_value=['name'],
-            ):
-                with self.assertRaises(RuntimeError):
-                    await backfill_embeddings.run()
+            with _patch_embeddable(['name']):
+                with _patch_already_embedded(set()):
+                    with self.assertRaises(RuntimeError):
+                        await backfill_embeddings.run(
+                            concurrency=2, force=False
+                        )
 
         mock_db.close.assert_awaited_once()
 
@@ -65,16 +78,132 @@ class BackfillEmbeddingsTestCase(unittest.IsolatedAsyncioTestCase):
         mock_db = mock.AsyncMock()
         mock_db.match.return_value = []
 
-        with mock.patch(
-            'imbi_api.backfill_embeddings._embeddable_fields',
-            return_value=['name'],
-        ):
-            count = await backfill_embeddings._embed_type(
-                mock_db, backfill_embeddings._NODE_TYPES[0]
-            )
+        with _patch_embeddable(['name']):
+            with _patch_already_embedded(set()):
+                semaphore = asyncio.Semaphore(2)
+                count = await backfill_embeddings._embed_type(
+                    mock_db,
+                    backfill_embeddings._NODE_TYPES[0],
+                    semaphore=semaphore,
+                    force=False,
+                )
 
         self.assertEqual(count, 0)
         mock_db._auto_embed.assert_not_awaited()
+
+    async def test_embed_type_skips_already_embedded(self) -> None:
+        mock_node = mock.MagicMock(id='node-already')
+        mock_db = mock.AsyncMock()
+        mock_db.match.return_value = [mock_node]
+
+        with _patch_embeddable(['name']):
+            with _patch_already_embedded({'node-already'}):
+                semaphore = asyncio.Semaphore(2)
+                count = await backfill_embeddings._embed_type(
+                    mock_db,
+                    backfill_embeddings._NODE_TYPES[0],
+                    semaphore=semaphore,
+                    force=False,
+                )
+
+        self.assertEqual(count, 0)
+        mock_db._auto_embed.assert_not_awaited()
+
+    async def test_embed_type_force_re_embeds(self) -> None:
+        mock_node = mock.MagicMock(id='node-already')
+        mock_db = mock.AsyncMock()
+        mock_db.match.return_value = [mock_node]
+
+        already_patch = _patch_already_embedded({'node-already'})
+        with _patch_embeddable(['name']):
+            with already_patch as already_mock:
+                semaphore = asyncio.Semaphore(2)
+                count = await backfill_embeddings._embed_type(
+                    mock_db,
+                    backfill_embeddings._NODE_TYPES[0],
+                    semaphore=semaphore,
+                    force=True,
+                )
+
+        self.assertEqual(count, 1)
+        mock_db._auto_embed.assert_awaited_once_with(mock_node)
+        already_mock.assert_not_called()
+
+    async def test_embed_type_swallows_psycopg_error(self) -> None:
+        mock_node_ok = mock.MagicMock(id='ok')
+        mock_node_bad = mock.MagicMock(id='bad')
+        mock_db = mock.AsyncMock()
+        mock_db.match.return_value = [mock_node_ok, mock_node_bad]
+
+        async def _auto_embed(node: object) -> None:
+            if getattr(node, 'id', None) == 'bad':
+                raise psycopg.OperationalError('boom')
+
+        mock_db._auto_embed.side_effect = _auto_embed
+
+        with _patch_embeddable(['name']):
+            with _patch_already_embedded(set()):
+                semaphore = asyncio.Semaphore(2)
+                count = await backfill_embeddings._embed_type(
+                    mock_db,
+                    backfill_embeddings._NODE_TYPES[0],
+                    semaphore=semaphore,
+                    force=False,
+                )
+
+        # One success, one swallowed psycopg failure.
+        self.assertEqual(count, 1)
+        self.assertEqual(mock_db._auto_embed.await_count, 2)
+
+    async def test_already_embedded_ids_queries_label(self) -> None:
+        cursor = mock.AsyncMock()
+        cursor.fetchall.return_value = [('a',), ('b',)]
+        cursor.__aenter__.return_value = cursor
+        cursor.__aexit__.return_value = None
+
+        conn = mock.MagicMock()
+        conn.cursor.return_value = cursor
+        conn.__aenter__.return_value = conn
+        conn.__aexit__.return_value = None
+
+        connection_ctx = mock.MagicMock()
+        connection_ctx.__aenter__.return_value = conn
+        connection_ctx.__aexit__.return_value = None
+
+        pool = mock.MagicMock()
+        pool.connection.return_value = connection_ctx
+
+        db = mock.MagicMock()
+        db.pool = pool
+
+        result = await backfill_embeddings._already_embedded_ids(db, 'Project')
+
+        self.assertEqual(result, {'a', 'b'})
+        cursor.execute.assert_awaited_once()
+        args, _ = cursor.execute.await_args
+        self.assertIn('public.embeddings', args[0])
+        self.assertEqual(args[1], {'label': 'Project'})
+
+
+class ParseArgsTestCase(unittest.TestCase):
+    def test_defaults(self) -> None:
+        with mock.patch('sys.argv', ['backfill_embeddings']):
+            args = backfill_embeddings._parse_args()
+
+        self.assertEqual(
+            args.concurrency, backfill_embeddings._DEFAULT_CONCURRENCY
+        )
+        self.assertFalse(args.force)
+
+    def test_flags(self) -> None:
+        with mock.patch(
+            'sys.argv',
+            ['backfill_embeddings', '--concurrency', '8', '--force'],
+        ):
+            args = backfill_embeddings._parse_args()
+
+        self.assertEqual(args.concurrency, 8)
+        self.assertTrue(args.force)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

`backfill_embeddings.py` walked every embeddable node type and called `_auto_embed` serially. A crash mid-run forced re-embedding everything, and the embedding provider's round-trip latency was the wall-clock floor.

- **Idempotency**: queries `public.embeddings` once per node type to find ids that already have rows; skips them unless `--force` is passed. The script is now safely resumable.
- **Concurrency**: per-type embed calls run through `asyncio.gather` bounded by `asyncio.Semaphore(--concurrency)` (default 4). Per-node failures are logged and counted as 0 so one bad row doesn't abort the run.
- **CLI**: `argparse` flags for `--concurrency` and `--force`.

No imbi_common changes; the new SQL only reads the embeddings table.

Punchlist: **H15**.

## Test plan

- [x] `basedpyright src/imbi_api/backfill_embeddings.py`
- [x] `mypy src/imbi_api/backfill_embeddings.py`
- [x] `ruff format` / `ruff check`
- [ ] Manual: run against a populated dev DB and confirm a second pass embeds 0 nodes