### PR TITLE
Atomic plugin assignment replace + extract writer module (H11, M10)

### DIFF
--- a/src/imbi_api/endpoints/project_plugins.py
+++ b/src/imbi_api/endpoints/project_plugins.py
@@ -1,6 +1,5 @@
 """Plugin assignment endpoints for projects."""
 
-import json
 import typing
 
 import fastapi
@@ -8,7 +7,7 @@ from imbi_common import graph
 
 from imbi_api.auth import permissions
 from imbi_api.domain import models
-from imbi_api.graph_sql import props_template
+from imbi_api.plugins.assignment_writer import replace_assignments
 from imbi_api.plugins.assignments import (
     PluginAssignmentRow,
     build_assignment_response,
@@ -159,47 +158,15 @@ async def replace_project_plugins(
 
     # Scope mutations to the org via the project's team→org chain so a
     # caller from another org can't modify edges by guessing project_id.
-    delete_query: typing.LiteralString = """
-    MATCH (proj:Project {{id: {project_id}}})
-          -[:OWNED_BY]->(:Team)-[:BELONGS_TO]->
-          (:Organization {{slug: {org_slug}}})
-    OPTIONAL MATCH (proj)-[e:USES_PLUGIN]->()
-    DELETE e
-    RETURN count(e) AS deleted
-    """
-    await db.execute(
-        delete_query,
-        {'project_id': project_id, 'org_slug': org_slug},
-        ['deleted'],
+    # ``replace_assignments`` fuses delete + creates into a single
+    # Cypher statement so a mid-replace failure rolls back atomically.
+    await replace_assignments(
+        db,
+        parent_label='Project',
+        parent_key='id',
+        parent_value=project_id,
+        org_slug=org_slug,
+        rows=rows,
     )
-
-    for row in rows:
-        edge_props: dict[str, typing.Any] = {
-            'tab': row['tab'],
-            'default': row['default'],
-            'options': json.dumps(row['options']),
-        }
-        identity_id = row.get('identity_plugin_id')
-        if identity_id:
-            edge_props['identity_plugin_id'] = identity_id
-        env_payloads = row.get('env_payloads')
-        if env_payloads:
-            edge_props['env_payloads'] = json.dumps(env_payloads)
-        create_query: str = (
-            'MATCH (proj:Project {{id: {project_id}}})'
-            ' -[:OWNED_BY]->(:Team)-[:BELONGS_TO]->'
-            ' (:Organization {{slug: {org_slug}}})'
-            ' MATCH (p:Plugin {{id: {plugin_id}}})'
-            f' CREATE (proj)-[:USES_PLUGIN {props_template(edge_props)}]->(p)'
-        )
-        await db.execute(
-            create_query,
-            {
-                'project_id': project_id,
-                'org_slug': org_slug,
-                'plugin_id': row['plugin_id'],
-                **edge_props,
-            },
-        )
 
     return await get_project_plugins(org_slug, project_id, db, auth)

--- a/src/imbi_api/endpoints/project_type_plugins.py
+++ b/src/imbi_api/endpoints/project_type_plugins.py
@@ -1,6 +1,5 @@
 """Plugin assignment endpoints for project types."""
 
-import json
 import typing
 
 import fastapi
@@ -8,7 +7,7 @@ from imbi_common import graph
 
 from imbi_api.auth import permissions
 from imbi_api.domain import models
-from imbi_api.graph_sql import props_template
+from imbi_api.plugins.assignment_writer import replace_assignments
 from imbi_api.plugins.assignments import (
     PluginAssignmentRow,
     build_assignment_response,
@@ -127,45 +126,15 @@ async def replace_project_type_plugins(
             ),
         )
 
-    delete_query: typing.LiteralString = """
-    MATCH (pt:ProjectType {{slug: {pt_slug}}})
-          -[:BELONGS_TO]->(o:Organization {{slug: {org_slug}}})
-    OPTIONAL MATCH (pt)-[e:USES_PLUGIN]->()
-    DELETE e
-    RETURN count(e) AS deleted
-    """
-    await db.execute(
-        delete_query,
-        {'pt_slug': pt_slug, 'org_slug': org_slug},
-        ['deleted'],
+    # ``replace_assignments`` fuses delete + creates into a single
+    # Cypher statement so a mid-replace failure rolls back atomically.
+    await replace_assignments(
+        db,
+        parent_label='ProjectType',
+        parent_key='slug',
+        parent_value=pt_slug,
+        org_slug=org_slug,
+        rows=rows,
     )
-
-    for row in rows:
-        edge_props: dict[str, typing.Any] = {
-            'tab': row['tab'],
-            'default': row['default'],
-            'options': json.dumps(row['options']),
-        }
-        identity_id = row.get('identity_plugin_id')
-        if identity_id:
-            edge_props['identity_plugin_id'] = identity_id
-        env_payloads = row.get('env_payloads')
-        if env_payloads:
-            edge_props['env_payloads'] = json.dumps(env_payloads)
-        merge_query: str = (
-            'MATCH (pt:ProjectType {{slug: {pt_slug}}})'
-            ' -[:BELONGS_TO]->(o:Organization {{slug: {org_slug}}})'
-            ' MATCH (p:Plugin {{id: {plugin_id}}})'
-            f' CREATE (pt)-[:USES_PLUGIN {props_template(edge_props)}]->(p)'
-        )
-        await db.execute(
-            merge_query,
-            {
-                'pt_slug': pt_slug,
-                'org_slug': org_slug,
-                'plugin_id': row['plugin_id'],
-                **edge_props,
-            },
-        )
 
     return await list_project_type_plugins(org_slug, pt_slug, db, auth)

--- a/src/imbi_api/plugins/assignment_writer.py
+++ b/src/imbi_api/plugins/assignment_writer.py
@@ -1,0 +1,135 @@
+"""Transactional ``USES_PLUGIN`` replace for projects and project types.
+
+The pre-existing ``replace_project_plugins`` /
+``replace_project_type_plugins`` performed a two-step
+"DELETE all, then CREATE one-by-one" sequence with N+1 separate
+``db.execute`` calls.  If any CREATE failed midway, the project or
+project type was left with a partially dropped assignment set (the
+DELETE landed, only some CREATEs ran) — see punchlist **H11**.
+
+This module fuses the DELETE + UNWIND CREATE into a single Cypher
+statement so AGE wraps the whole replace in one server-side
+transaction.  A failure during validation aborts before the DELETE
+runs; a failure during the fused write rolls back the DELETE too.
+"""
+
+from __future__ import annotations
+
+import json
+import typing
+
+from imbi_common import graph
+
+from imbi_api.graph_sql import escape_prop
+from imbi_api.plugins.assignments import PluginAssignmentRow
+
+_ROW_KEYS: tuple[str, ...] = (
+    'plugin_id',
+    'tab',
+    'default',
+    'options',
+    'identity_plugin_id',
+    'env_payloads',
+)
+
+
+def _assignment_rows_template(
+    rows: list[PluginAssignmentRow],
+) -> tuple[str, dict[str, typing.Any]]:
+    """Build an inline Cypher list of maps + the params dict.
+
+    Mirrors the ``_env_entries_template`` pattern in ``projects.py``:
+    each row's values become indexed placeholders so the resulting
+    query is safe to pass through ``sql.SQL.format``. Optional fields
+    (``identity_plugin_id``, ``env_payloads``) are always emitted --
+    null when absent -- so every row in the UNWIND has the same shape;
+    downstream readers already treat missing and null the same.
+    """
+    if not rows:
+        return '[]', {}
+    maps: list[str] = []
+    params: dict[str, typing.Any] = {}
+    for i, row in enumerate(rows):
+        pairs: list[str] = []
+        for key in _ROW_KEYS:
+            placeholder = f'asgn_{i}_{key}'
+            pairs.append(f'{escape_prop(key)}: {{{placeholder}}}')
+            params[placeholder] = _row_value(row, key)
+        maps.append('{{' + ', '.join(pairs) + '}}')
+    return '[' + ', '.join(maps) + ']', params
+
+
+def _row_value(row: PluginAssignmentRow, key: str) -> typing.Any:
+    """Pull a row field; JSON-encode dict-valued ones for AGE storage."""
+    if key == 'options':
+        return json.dumps(row['options'])
+    if key == 'env_payloads':
+        value = row.get('env_payloads')
+        return json.dumps(value) if value else None
+    if key == 'identity_plugin_id':
+        return row.get('identity_plugin_id') or None
+    return row[key]  # type: ignore[literal-required]
+
+
+async def replace_assignments(
+    db: graph.Graph,
+    *,
+    parent_label: typing.Literal['Project', 'ProjectType'],
+    parent_key: typing.Literal['id', 'slug'],
+    parent_value: str,
+    org_slug: str,
+    rows: list[PluginAssignmentRow],
+) -> None:
+    """Atomically replace every ``USES_PLUGIN`` edge on a parent node.
+
+    The MATCH clause scopes the write to ``org_slug`` via the parent's
+    ``BELONGS_TO`` chain so a caller from another org cannot mutate
+    edges by guessing the parent key.
+
+    Callers must validate plugin ids, identity_plugin_ids, and the
+    one-default-per-tab invariant up front; passing an empty ``rows``
+    list clears all assignments.
+    """
+    parent_head = (
+        f'MATCH (parent:{parent_label} {{{{{parent_key}: {{parent_value}}}}}})'
+    )
+    if parent_label == 'Project':
+        parent_match = (
+            parent_head + ' -[:OWNED_BY]->(:Team)-[:BELONGS_TO]->'
+            ' (:Organization {{slug: {org_slug}}})'
+        )
+    else:
+        parent_match = (
+            parent_head
+            + ' -[:BELONGS_TO]->(:Organization {{slug: {org_slug}}})'
+        )
+
+    rows_tpl, row_params = _assignment_rows_template(rows)
+    if rows:
+        query = (
+            parent_match + ' OPTIONAL MATCH (parent)-[old:USES_PLUGIN]->()'
+            ' DELETE old'
+            ' WITH parent'
+            f' UNWIND {rows_tpl} AS row'
+            ' MATCH (p:Plugin {{id: row.plugin_id}})'
+            ' CREATE (parent)-[:USES_PLUGIN {{tab: row.tab,'
+            ' default: row.default,'
+            ' options: row.options,'
+            ' identity_plugin_id: row.identity_plugin_id,'
+            ' env_payloads: row.env_payloads}}]->(p)'
+        )
+    else:
+        query = (
+            parent_match + ' OPTIONAL MATCH (parent)-[old:USES_PLUGIN]->()'
+            ' DELETE old'
+        )
+
+    await db.execute(
+        query,
+        {
+            'parent_value': parent_value,
+            'org_slug': org_slug,
+            **row_params,
+        },
+        [],
+    )

--- a/tests/endpoints/test_project_plugins.py
+++ b/tests/endpoints/test_project_plugins.py
@@ -153,11 +153,10 @@ class ProjectPluginsEndpointTestCase(unittest.TestCase):
             'options': '{}',
             'api_version': 1,
         }
-        # validate plugin_ids + delete + create + final read
+        # validate plugin_ids + fused delete+create + final read
         self.mock_db.execute.side_effect = [
             [{'found': '1'}],  # validate
-            [{'deleted': '0'}],  # delete
-            [],  # create
+            [],  # fused delete + UNWIND create
             [
                 {
                     'pt_rows': '[]',

--- a/tests/endpoints/test_project_type_plugins.py
+++ b/tests/endpoints/test_project_type_plugins.py
@@ -109,8 +109,7 @@ class ProjectTypePluginsEndpointTestCase(unittest.TestCase):
         }
         self.mock_db.execute.side_effect = [
             [{'found': '1'}],  # validate plugin_ids
-            [{'deleted': '0'}],  # delete
-            [],  # create edge
+            [],  # fused delete + UNWIND create
             [plugin_record],  # final list call
         ]
         with testclient.TestClient(self.test_app) as client:

--- a/tests/test_assignment_writer.py
+++ b/tests/test_assignment_writer.py
@@ -1,0 +1,123 @@
+"""Tests for ``imbi_api.plugins.assignment_writer``.
+
+Focuses on the Cypher-template construction: the fused delete+UNWIND
+write is a pure transformation of inputs to query+params, so direct
+template assertions are tighter and faster than a graph round-trip
+through the endpoint tests.
+"""
+
+import asyncio
+import json
+import unittest
+import unittest.mock as mock
+
+from imbi_api.plugins.assignment_writer import (
+    _assignment_rows_template,
+    replace_assignments,
+)
+from imbi_api.plugins.assignments import PluginAssignmentRow
+
+
+class AssignmentRowsTemplateTestCase(unittest.TestCase):
+    def test_empty_rows_yields_empty_literal(self) -> None:
+        tpl, params = _assignment_rows_template([])
+        self.assertEqual(tpl, '[]')
+        self.assertEqual(params, {})
+
+    def test_serializes_options_and_env_payloads_as_json(self) -> None:
+        row: PluginAssignmentRow = {
+            'plugin_id': 'p1',
+            'tab': 'configuration',
+            'default': True,
+            'options': {'k': 'v'},
+            'identity_plugin_id': None,
+            'env_payloads': {'prod': {'inputs': {'a': 1}}},
+        }
+        _, params = _assignment_rows_template([row])
+        self.assertEqual(params['asgn_0_options'], json.dumps({'k': 'v'}))
+        self.assertEqual(
+            params['asgn_0_env_payloads'],
+            json.dumps({'prod': {'inputs': {'a': 1}}}),
+        )
+        self.assertIsNone(params['asgn_0_identity_plugin_id'])
+
+    def test_empty_env_payloads_collapse_to_null(self) -> None:
+        row: PluginAssignmentRow = {
+            'plugin_id': 'p1',
+            'tab': 'configuration',
+            'default': True,
+            'options': {},
+            'identity_plugin_id': None,
+            'env_payloads': {},
+        }
+        _, params = _assignment_rows_template([row])
+        self.assertIsNone(params['asgn_0_env_payloads'])
+
+
+class ReplaceAssignmentsQueryTestCase(unittest.TestCase):
+    """Snapshot tests for the fused delete+create query."""
+
+    def _captured_call(
+        self, rows: list[PluginAssignmentRow], **kwargs: str
+    ) -> tuple[str, dict[str, object]]:
+        db = mock.MagicMock()
+        db.execute = mock.AsyncMock(return_value=[])
+        asyncio.run(replace_assignments(db, rows=rows, **kwargs))  # type: ignore[arg-type]
+        args, _ = db.execute.call_args
+        return args[0], args[1]
+
+    def test_project_with_rows_emits_single_fused_query(self) -> None:
+        rows: list[PluginAssignmentRow] = [
+            {
+                'plugin_id': 'p1',
+                'tab': 'configuration',
+                'default': True,
+                'options': {},
+                'identity_plugin_id': None,
+                'env_payloads': None,  # type: ignore[typeddict-item]
+            }
+        ]
+        query, params = self._captured_call(
+            rows,
+            parent_label='Project',
+            parent_key='id',
+            parent_value='proj-1',
+            org_slug='myorg',
+        )
+        self.assertIn('OPTIONAL MATCH (parent)-[old:USES_PLUGIN]', query)
+        self.assertIn('DELETE old', query)
+        self.assertIn('UNWIND', query)
+        self.assertIn('CREATE (parent)-[:USES_PLUGIN', query)
+        self.assertIn(':Team', query)
+        self.assertEqual(params['parent_value'], 'proj-1')
+        self.assertEqual(params['org_slug'], 'myorg')
+        self.assertEqual(params['asgn_0_plugin_id'], 'p1')
+
+    def test_project_type_uses_belongs_to_chain(self) -> None:
+        rows: list[PluginAssignmentRow] = []
+        query, _ = self._captured_call(
+            rows,
+            parent_label='ProjectType',
+            parent_key='slug',
+            parent_value='web',
+            org_slug='myorg',
+        )
+        self.assertIn('-[:BELONGS_TO]->', query)
+        self.assertNotIn(':Team', query)
+        self.assertNotIn('UNWIND', query)
+
+    def test_empty_rows_emits_delete_only(self) -> None:
+        query, _ = self._captured_call(
+            [],
+            parent_label='Project',
+            parent_key='id',
+            parent_value='proj-1',
+            org_slug='myorg',
+        )
+        self.assertIn('DELETE old', query)
+        self.assertNotIn('CREATE', query)
+        self.assertNotIn('UNWIND', query)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

`replace_project_plugins` and `replace_project_type_plugins` ran `DELETE` then N separate `CREATE` statements as independent `db.execute` round-trips. If any `CREATE` failed mid-loop, the project landed with a partial assignment set: DELETE persisted, only some CREATEs ran. Plugin routing silently broke.

Extracted `imbi_api.plugins.assignment_writer.replace_assignments` — a single fused Cypher that:
- MATCHes the parent (`Project` or `ProjectType`) under its org chain,
- DELETEs every existing `USES_PLUGIN` edge,
- UNWINDs an inline list of row maps,
- MATCHes each plugin and CREATEs the edge.

AGE wraps the whole Cypher in one server-side transaction, so a mid-write failure now rolls back the DELETE too.

The inline-list pattern mirrors `_env_entries_template` in `projects.py`; optional `identity_plugin_id` / `env_payloads` are always emitted (null when absent) so every row has the same shape — downstream readers already treated missing and null the same.

Punchlist: **H11** (transactional replace) + **M10** (extract `plugins/assignment_writer.py`).

## Test plan

- [x] Updated `tests/endpoints/test_project_plugins.py` and `test_project_type_plugins.py` to feed 3 mock responses (validate + fused + final read) instead of 4.
- [x] Added `tests/test_assignment_writer.py` (6 tests) covering empty rows, JSON encoding, and the two parent-label MATCH variants.
- [x] `pytest tests/test_assignment_writer.py tests/endpoints/test_project_plugins.py tests/endpoints/test_project_type_plugins.py tests/test_plugins.py` — 68 passed.
- [x] `basedpyright` / `mypy` clean.
- [x] `ruff format` / `ruff check` clean.