### PR TITLE
Run admin Graph Query workbench queries as raw Cypher

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
   "fastapi",
   "filetype",
   "httpx>=0.28.1,<1",
-  "imbi-common[databases,llm,sentry,server]>=2.5.5",
+  "imbi-common[databases,llm,sentry,server]>=2.6.0",
   "jinja2",
   "jsonpatch>=1.33",
   "nanoid>=2.0.0",

--- a/src/imbi_api/endpoints/graph_query.py
+++ b/src/imbi_api/endpoints/graph_query.py
@@ -415,7 +415,9 @@ async def run_graph_query(
 
     start = time.monotonic()
     try:
-        raw_rows = await db.execute(query, body.params, columns=columns)
+        raw_rows = await db.execute(
+            query, body.params, columns=columns, raw=True
+        )
     except psycopg.Error as exc:
         LOGGER.info(
             'Graph query failed: principal=%s error=%s',

--- a/uv.lock
+++ b/uv.lock
@@ -1050,7 +1050,7 @@ requires-dist = [
   { name = "fastapi" },
   { name = "filetype" },
   { name = "httpx", specifier = ">=0.28.1,<1" },
-  { name = "imbi-common", extras = ["databases", "llm", "sentry", "server"], specifier = ">=2.5.5" },
+  { name = "imbi-common", extras = ["databases", "llm", "sentry", "server"], specifier = ">=2.6.0" },
   { name = "imbi-plugin-aws", marker = "extra == 'plugins'", specifier = ">=1.0.0" },
   { name = "imbi-plugin-github", marker = "extra == 'plugins'", specifier = ">=1.0.0" },
   { name = "imbi-plugin-logzio", marker = "extra == 'plugins'", specifier = ">=1.0.0" },
@@ -1102,7 +1102,7 @@ docs = [
 
 [[package]]
 name = "imbi-common"
-version = "2.5.5"
+version = "2.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
   { name = "cryptography" },
@@ -1118,9 +1118,9 @@ dependencies = [
   { name = "python-slugify" },
   { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0d/b7/6dab7155b281f9c075d3434e3f234ef217fe49db840b14e59e3e5a75faa2/imbi_common-2.5.5.tar.gz", hash = "sha256:56751efe31fdc1fcb1d1be19e6b3f073d5b3e4fda3c89c0bcdec5c7943549477", size = 277481, upload-time = "2026-05-20T02:10:09.044Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/08/d574411419c425a48596d4bb252283b526fcdd940073b3ffea734ae19a8f/imbi_common-2.6.0.tar.gz", hash = "sha256:730f7bd3b3c2365ea3a0845f81fba4a5ab8f23c98749842dadff5464bc2dc71a", size = 293163, upload-time = "2026-05-26T21:19:43.795Z" }
 wheels = [
-  { url = "https://files.pythonhosted.org/packages/48/04/69e72ec3a1968a9dd8b91df38e6a7be16e1399a054a953777a23f34c60ca/imbi_common-2.5.5-py3-none-any.whl", hash = "sha256:19ffa23d9cdb0b8065af1d3a9166f819c15414fc4b5707d089adaf64b932ebf1", size = 91154, upload-time = "2026-05-20T02:10:07.448Z" },
+  { url = "https://files.pythonhosted.org/packages/49/3b/f5db4005675fd033454696599427d72d809f9534e2afcd0a6584bb3fb29e/imbi_common-2.6.0-py3-none-any.whl", hash = "sha256:875a057b4edcc2fecb35747927dcd853c602e58fd1c1f3c05063584360a86c83", size = 94110, upload-time = "2026-05-26T21:19:42.066Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

The admin Graph Query workbench passes arbitrary user-entered Cypher to `Graph.execute`. Queries containing map literals — e.g. `MATCH (p:Project {name: "RabbitMQ"}) RETURN p` or `MATCH (p:Project)-[r:\`DEPLOYED_TO\`]-(n) RETURN p,r,n` — failed with `no format specification supported by SQL`, because their single braces were parsed as `sql.SQL.format` placeholders.

## Solution

imbi-common 2.6.0 adds an explicit `raw` flag to `Graph.execute` that treats the template as literal Cypher and skips the formatter (templated callers keep their always-format brace unescaping). This PR:

- Bumps the pin to `imbi-common>=2.6.0` (and updates `uv.lock`).
- Passes `raw=True` from the graph query endpoint.

## Testing

- `mypy` / `basedpyright` on the endpoint — clean (confirms `raw=` is accepted by the 2.6.0 API)
- `pytest tests/endpoints/test_graph_query.py` — 11 passing

## Related

Completes the workbench fix paired with imbi-common #130 (released in [v2.6.0](https://github.com/AWeber-Imbi/imbi-common/releases/tag/v2.6.0)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)