### PR TITLE
Extract shared cursor-pagination helpers (M1)

### DIFF
--- a/CODE_REVIEW_PUNCHLIST.md
+++ b/CODE_REVIEW_PUNCHLIST.md
@@ -60,7 +60,7 @@ Severity legend: **C** Critical · **H** High · **M** Medium · **L** Low
 
 (Highest LOC-reduction ROI.)
 
-- [ ] **M1.** Extract pagination helpers (`_encode_cursor`, `_decode_cursor`, `_build_link_header`, `_parse_iso`) into `_helpers.py` / new `_pagination.py`. Duplicated verbatim across `src/imbi_api/endpoints/user_activity.py:661-710`, `operations_log.py:107-135, 337-357`, `documents.py:77+`, `events.py:48+`.
+- [x] **M1.** Extract pagination helpers (`_encode_cursor`, `_decode_cursor`, `_build_link_header`, `_parse_iso`) into `_helpers.py` / new `_pagination.py`. Duplicated verbatim across `src/imbi_api/endpoints/user_activity.py:661-710`, `operations_log.py:107-135, 337-357`, `documents.py:77+`, `events.py:48+`. — Added `src/imbi_api/endpoints/_pagination.py` with `encode_cursor`/`decode_cursor`/`parse_iso`/`build_link_header`; `events.py`, `documents.py`, `operations_log.py`, and `user_activity.py` now import them (dropping their orphaned `base64`/`urllib.parse`/`json` imports). New `tests/endpoints/test_pagination.py` covers the canonical module; the existing per-endpoint cursor tests were repointed at the shared names. Also collapsed the Python-2-style `except ValueError, UnicodeDecodeError:` clauses that lived in the removed copies (cf. C1).
 - [ ] **M2.** Extract `fetch_or_404` helper. Cloned in `releases.py:238`, `third_party_services.py:1015`, `documents.py:444`, `document_templates.py:204`, `plugin_entities.py:173`.
 - [ ] **M3.** Wrap `psycopg.errors.UniqueViolation → 409` in a decorator (26+ duplicates).
 - [ ] **M4.** Extract `_serialize_json_fields` / `_deserialize_json_fields` (defined in `third_party_services.py:56-83`); re-implemented ad hoc in `projects.py:873-878, 1873-1875` and `documents.py`.

--- a/src/imbi_api/endpoints/_pagination.py
+++ b/src/imbi_api/endpoints/_pagination.py
@@ -1,0 +1,103 @@
+"""Shared cursor-pagination helpers for list endpoints.
+
+Several read endpoints (events, documents, operations log, user
+activity) page over a ``(timestamp, id)`` keyset and expose a
+``Link`` header. They each carried byte-for-byte copies of the same
+cursor encode/decode, ISO parsing, and Link-header builders; this
+module is the single home for that logic.
+"""
+
+from __future__ import annotations
+
+import base64
+import datetime
+import urllib.parse
+
+import fastapi
+
+
+def encode_cursor(timestamp: datetime.datetime, entry_id: str) -> str:
+    """Encode a ``(timestamp, id)`` keyset cursor as urlsafe base64."""
+    payload = f'{timestamp.isoformat()}|{entry_id}'.encode()
+    return base64.urlsafe_b64encode(payload).rstrip(b'=').decode('ascii')
+
+
+def decode_cursor(
+    cursor: str,
+) -> tuple[datetime.datetime, str] | None:
+    """Decode a cursor string; return None for any malformed input.
+
+    The timestamp is normalized to UTC (naive values are assumed UTC).
+    """
+    if not cursor:
+        return None
+    padding = '=' * (-len(cursor) % 4)
+    try:
+        raw = base64.urlsafe_b64decode(cursor + padding).decode('utf-8')
+    except ValueError, UnicodeDecodeError:
+        return None
+    if '|' not in raw:
+        return None
+    ts_str, _, entry_id = raw.partition('|')
+    if not entry_id:
+        return None
+    try:
+        ts = datetime.datetime.fromisoformat(ts_str)
+    except ValueError:
+        return None
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=datetime.UTC)
+    return ts.astimezone(datetime.UTC), entry_id
+
+
+def parse_iso(value: str, field_name: str) -> datetime.datetime:
+    """Parse an ISO-8601 query-param value, raising HTTP 400 on failure.
+
+    Naive timestamps are assumed UTC; the result is normalized to UTC.
+    """
+    try:
+        parsed = datetime.datetime.fromisoformat(value)
+    except ValueError as err:
+        raise fastapi.HTTPException(
+            status_code=400,
+            detail=f'Invalid ISO timestamp for {field_name!r}',
+        ) from err
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=datetime.UTC)
+    return parsed.astimezone(datetime.UTC)
+
+
+def build_link_header(
+    request: fastapi.Request,
+    next_cursor: str | None,
+) -> str:
+    """Build an RFC 8288 ``Link`` header with ``first`` and ``next``.
+
+    All existing query params are preserved except ``cursor``, which is
+    replaced on the ``next`` link.
+    """
+    url = request.url
+    base_params = {
+        k: v for k, v in request.query_params.multi_items() if k != 'cursor'
+    }
+
+    def _url_with(params: dict[str, str]) -> str:
+        scheme_host_path = f'{url.scheme}://{url.netloc}{url.path}'
+        if not params:
+            return scheme_host_path
+        return f'{scheme_host_path}?{urllib.parse.urlencode(params)}'
+
+    links = [f'<{_url_with(base_params)}>; rel="first"']
+    if next_cursor is not None:
+        next_params = dict(base_params)
+        next_params['cursor'] = next_cursor
+        links.append(f'<{_url_with(next_params)}>; rel="next"')
+    return ', '.join(links)
+
+
+__all__ = [
+    'build_link_header',
+    'decode_cursor',
+    'encode_cursor',
+    'parse_iso',
+]

--- a/src/imbi_api/endpoints/documents.py
+++ b/src/imbi_api/endpoints/documents.py
@@ -7,11 +7,9 @@ by tag; ``documents_project_router`` handles CRUD scoped to a single
 project.
 """
 
-import base64
 import datetime
 import logging
 import typing
-import urllib.parse
 
 import fastapi
 import fastapi.responses
@@ -21,6 +19,11 @@ from imbi_common import graph
 
 from imbi_api import patch as json_patch
 from imbi_api.auth import permissions
+from imbi_api.endpoints._pagination import (
+    build_link_header,
+    decode_cursor,
+    encode_cursor,
+)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -71,57 +74,6 @@ class DocumentCreate(pydantic.BaseModel):
 
 class DocumentListResponse(pydantic.BaseModel):
     data: list[DocumentResponse]
-
-
-def _encode_cursor(created_at: datetime.datetime, document_id: str) -> str:
-    payload = f'{created_at.isoformat()}|{document_id}'.encode()
-    return base64.urlsafe_b64encode(payload).rstrip(b'=').decode('ascii')
-
-
-def _decode_cursor(
-    cursor: str,
-) -> tuple[datetime.datetime, str] | None:
-    if not cursor:
-        return None
-    padding = '=' * (-len(cursor) % 4)
-    try:
-        raw = base64.urlsafe_b64decode(cursor + padding).decode('utf-8')
-    except (ValueError, UnicodeDecodeError):
-        return None
-    if '|' not in raw:
-        return None
-    ts_str, _, document_id = raw.partition('|')
-    if not document_id:
-        return None
-    try:
-        ts = datetime.datetime.fromisoformat(ts_str)
-    except ValueError:
-        return None
-    if ts.tzinfo is None:
-        ts = ts.replace(tzinfo=datetime.UTC)
-    return ts.astimezone(datetime.UTC), document_id
-
-
-def _build_link_header(
-    request: fastapi.Request, next_cursor: str | None
-) -> str:
-    url = request.url
-    base_params = {
-        k: v for k, v in request.query_params.multi_items() if k != 'cursor'
-    }
-
-    def _url_with(params: dict[str, str]) -> str:
-        base = f'{url.scheme}://{url.netloc}{url.path}'
-        if not params:
-            return base
-        return f'{base}?{urllib.parse.urlencode(params)}'
-
-    links = [f'<{_url_with(base_params)}>; rel="first"']
-    if next_cursor is not None:
-        next_params = dict(base_params)
-        next_params['cursor'] = next_cursor
-        links.append(f'<{_url_with(next_params)}>; rel="next"')
-    return ', '.join(links)
 
 
 def _parse_document_row(
@@ -335,7 +287,7 @@ async def _list_documents_impl(
 
     cursor_clause = ''
     if cursor is not None:
-        decoded = _decode_cursor(cursor)
+        decoded = decode_cursor(cursor)
         if decoded is None:
             raise fastapi.HTTPException(
                 status_code=400, detail='Invalid cursor'
@@ -374,7 +326,7 @@ async def _list_documents_impl(
         last_ts = last['created_at']
         if isinstance(last_ts, str):
             last_ts = datetime.datetime.fromisoformat(last_ts)
-        next_cursor = _encode_cursor(last_ts, last['id'])
+        next_cursor = encode_cursor(last_ts, last['id'])
 
     adapter = pydantic.TypeAdapter(list[DocumentResponse])
     response = fastapi.responses.JSONResponse(
@@ -385,7 +337,7 @@ async def _list_documents_impl(
             )
         }
     )
-    response.headers['Link'] = _build_link_header(request, next_cursor)
+    response.headers['Link'] = build_link_header(request, next_cursor)
     return response
 
 

--- a/src/imbi_api/endpoints/events.py
+++ b/src/imbi_api/endpoints/events.py
@@ -9,10 +9,8 @@ The global router lives at /events; the project-scoped router is mounted at
 
 from __future__ import annotations
 
-import base64
 import datetime
 import typing
-import urllib.parse
 
 import fastapi
 import fastapi.encoders
@@ -21,6 +19,12 @@ import pydantic
 from imbi_common import clickhouse
 
 from imbi_api.auth import permissions
+from imbi_api.endpoints._pagination import (
+    build_link_header,
+    decode_cursor,
+    encode_cursor,
+    parse_iso,
+)
 
 events_router = fastapi.APIRouter(prefix='/events', tags=['Events'])
 events_project_router = fastapi.APIRouter(tags=['Events'])
@@ -42,69 +46,6 @@ class EventRecord(pydantic.BaseModel):
 
 class EventsPage(pydantic.BaseModel):
     data: list[EventRecord]
-
-
-def _encode_cursor(recorded_at: datetime.datetime, entry_id: str) -> str:
-    raw = f'{recorded_at.isoformat()}|{entry_id}'.encode()
-    return base64.urlsafe_b64encode(raw).rstrip(b'=').decode('ascii')
-
-
-def _decode_cursor(cursor: str) -> tuple[datetime.datetime, str] | None:
-    if not cursor:
-        return None
-    padding = '=' * (-len(cursor) % 4)
-    try:
-        raw = base64.urlsafe_b64decode(cursor + padding).decode('utf-8')
-    except (ValueError, UnicodeDecodeError):
-        return None
-    if '|' not in raw:
-        return None
-    ts_str, _, entry_id = raw.partition('|')
-    if not entry_id:
-        return None
-    try:
-        ts = datetime.datetime.fromisoformat(ts_str)
-    except ValueError:
-        return None
-    if ts.tzinfo is None:
-        ts = ts.replace(tzinfo=datetime.UTC)
-    return ts.astimezone(datetime.UTC), entry_id
-
-
-def _parse_iso(value: str, field_name: str) -> datetime.datetime:
-    try:
-        parsed = datetime.datetime.fromisoformat(value)
-    except ValueError as err:
-        raise fastapi.HTTPException(
-            status_code=400,
-            detail=f'Invalid ISO timestamp for {field_name!r}',
-        ) from err
-    if parsed.tzinfo is None:
-        parsed = parsed.replace(tzinfo=datetime.UTC)
-    return parsed.astimezone(datetime.UTC)
-
-
-def _build_link_header(
-    request: fastapi.Request,
-    next_cursor: str | None,
-) -> str:
-    url = request.url
-    base_params = {
-        k: v for k, v in request.query_params.multi_items() if k != 'cursor'
-    }
-
-    def _url_with(params: dict[str, str]) -> str:
-        scheme_host_path = f'{url.scheme}://{url.netloc}{url.path}'
-        if not params:
-            return scheme_host_path
-        return f'{scheme_host_path}?{urllib.parse.urlencode(params)}'
-
-    links = [f'<{_url_with(base_params)}>; rel="first"']
-    if next_cursor is not None:
-        next_params = dict(base_params)
-        next_params['cursor'] = next_cursor
-        links.append(f'<{_url_with(next_params)}>; rel="next"')
-    return ', '.join(links)
 
 
 def _row_to_response(row: dict[str, typing.Any]) -> dict[str, typing.Any]:
@@ -155,14 +96,14 @@ async def _list_impl(
             params[field] = value
 
     if since is not None:
-        params['since'] = _parse_iso(since, 'since')
+        params['since'] = parse_iso(since, 'since')
         clauses.append('recorded_at >= {since:DateTime64(3)}')
     if until is not None:
-        params['until'] = _parse_iso(until, 'until')
+        params['until'] = parse_iso(until, 'until')
         clauses.append('recorded_at < {until:DateTime64(3)}')
 
     if cursor is not None:
-        decoded = _decode_cursor(cursor)
+        decoded = decode_cursor(cursor)
         if decoded is None:
             raise fastapi.HTTPException(
                 status_code=400, detail='Invalid cursor'
@@ -188,13 +129,13 @@ async def _list_impl(
     if len(rows) > limit:
         rows.pop()
         last = rows[-1]
-        next_cursor = _encode_cursor(last['recorded_at'], last['id'])
+        next_cursor = encode_cursor(last['recorded_at'], last['id'])
 
     body = {'data': [_row_to_response(r) for r in rows]}
     response = fastapi.responses.JSONResponse(
         fastapi.encoders.jsonable_encoder(body)
     )
-    response.headers['Link'] = _build_link_header(request, next_cursor)
+    response.headers['Link'] = build_link_header(request, next_cursor)
     return response
 
 

--- a/src/imbi_api/endpoints/operations_log.py
+++ b/src/imbi_api/endpoints/operations_log.py
@@ -12,11 +12,9 @@ are hidden.
 
 from __future__ import annotations
 
-import base64
 import datetime
 import logging
 import typing
-import urllib.parse
 
 import fastapi
 import fastapi.encoders
@@ -29,6 +27,12 @@ from imbi_common.plugins.registry import list_plugins
 
 from imbi_api import patch as json_patch
 from imbi_api.auth import permissions
+from imbi_api.endpoints._pagination import (
+    build_link_header,
+    decode_cursor,
+    encode_cursor,
+    parse_iso,
+)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -102,37 +106,6 @@ class OperationLogResponse(pydantic.BaseModel):
     ticket_slug: str | None = None
     version: str | None = None
     plugin_slug: str = ''
-
-
-def _encode_cursor(occurred_at: datetime.datetime, entry_id: str) -> str:
-    """Encode a (timestamp, id) cursor as urlsafe base64."""
-    payload = f'{occurred_at.isoformat()}|{entry_id}'.encode()
-    return base64.urlsafe_b64encode(payload).rstrip(b'=').decode('ascii')
-
-
-def _decode_cursor(
-    cursor: str,
-) -> tuple[datetime.datetime, str] | None:
-    """Decode a cursor string. Return None for any malformed input."""
-    if not cursor:
-        return None
-    padding = '=' * (-len(cursor) % 4)
-    try:
-        raw = base64.urlsafe_b64decode(cursor + padding).decode('utf-8')
-    except ValueError, UnicodeDecodeError:
-        return None
-    if '|' not in raw:
-        return None
-    ts_str, _, entry_id = raw.partition('|')
-    if not entry_id:
-        return None
-    try:
-        ts = datetime.datetime.fromisoformat(ts_str)
-    except ValueError:
-        return None
-    if ts.tzinfo is None:
-        ts = ts.replace(tzinfo=datetime.UTC)
-    return ts.astimezone(datetime.UTC), entry_id
 
 
 _TIMESTAMP_FIELDS: frozenset[str] = frozenset(
@@ -321,42 +294,6 @@ _FILTER_FIELDS: tuple[str, ...] = (
 )
 
 
-def _parse_iso(value: str, field_name: str) -> datetime.datetime:
-    try:
-        parsed = datetime.datetime.fromisoformat(value)
-    except ValueError as err:
-        raise fastapi.HTTPException(
-            status_code=400,
-            detail=f'Invalid ISO timestamp for {field_name!r}',
-        ) from err
-    if parsed.tzinfo is None:
-        parsed = parsed.replace(tzinfo=datetime.UTC)
-    return parsed.astimezone(datetime.UTC)
-
-
-def _build_link_header(
-    request: fastapi.Request,
-    next_cursor: str | None,
-) -> str:
-    url = request.url
-    base_params = {
-        k: v for k, v in request.query_params.multi_items() if k != 'cursor'
-    }
-
-    def _url_with(params: dict[str, str]) -> str:
-        scheme_host_path = f'{url.scheme}://{url.netloc}{url.path}'
-        if not params:
-            return scheme_host_path
-        return f'{scheme_host_path}?{urllib.parse.urlencode(params)}'
-
-    links = [f'<{_url_with(base_params)}>; rel="first"']
-    if next_cursor is not None:
-        next_params = dict(base_params)
-        next_params['cursor'] = next_cursor
-        links.append(f'<{_url_with(next_params)}>; rel="next"')
-    return ', '.join(links)
-
-
 async def _compute_metrics(
     filter_sql: str, filter_params: dict[str, typing.Any]
 ) -> OperationLogMetrics:
@@ -436,10 +373,10 @@ async def _list_impl(
             params[field] = value
 
     if since is not None:
-        params['since'] = _parse_iso(since, 'since')
+        params['since'] = parse_iso(since, 'since')
         clauses.append('occurred_at >= {since:DateTime64(3)}')
     if until is not None:
-        params['until'] = _parse_iso(until, 'until')
+        params['until'] = parse_iso(until, 'until')
         clauses.append('occurred_at < {until:DateTime64(3)}')
 
     # Pre-cursor clause set is also what feeds the /metrics aggregate so
@@ -448,7 +385,7 @@ async def _list_impl(
     metrics_params = dict(params)
 
     if cursor is not None:
-        decoded = _decode_cursor(cursor)
+        decoded = decode_cursor(cursor)
         if decoded is None:
             raise fastapi.HTTPException(
                 status_code=400, detail='Invalid cursor'
@@ -474,7 +411,7 @@ async def _list_impl(
     if len(rows) > limit:
         rows.pop()
         last = rows[-1]
-        next_cursor = _encode_cursor(last['occurred_at'], last['id'])
+        next_cursor = encode_cursor(last['occurred_at'], last['id'])
 
     # Only compute metrics on the first page (no cursor) — the client
     # stores them once and paginates through ``data`` afterward.
@@ -493,7 +430,7 @@ async def _list_impl(
     response = fastapi.responses.JSONResponse(
         fastapi.encoders.jsonable_encoder(body)
     )
-    response.headers['Link'] = _build_link_header(request, next_cursor)
+    response.headers['Link'] = build_link_header(request, next_cursor)
     return response
 
 

--- a/src/imbi_api/endpoints/user_activity.py
+++ b/src/imbi_api/endpoints/user_activity.py
@@ -12,11 +12,9 @@ share the ``/users`` prefix and the OpenAPI tag.
 from __future__ import annotations
 
 import asyncio
-import base64
 import datetime
 import logging
 import typing
-import urllib.parse
 import zoneinfo
 
 import fastapi
@@ -26,6 +24,12 @@ import pydantic
 from imbi_common import clickhouse, graph
 
 from imbi_api.auth import permissions
+from imbi_api.endpoints._pagination import (
+    build_link_header,
+    decode_cursor,
+    encode_cursor,
+    parse_iso,
+)
 from imbi_api.endpoints.users import users_router
 
 LOGGER = logging.getLogger(__name__)
@@ -104,19 +108,6 @@ class ActivityResponse(pydantic.BaseModel):
     data: list[ActivityRecord]
 
 
-def _parse_iso(value: str, field_name: str) -> datetime.datetime:
-    try:
-        parsed = datetime.datetime.fromisoformat(value)
-    except ValueError as err:
-        raise fastapi.HTTPException(
-            status_code=400,
-            detail=f'Invalid ISO timestamp for {field_name!r}',
-        ) from err
-    if parsed.tzinfo is None:
-        parsed = parsed.replace(tzinfo=datetime.UTC)
-    return parsed.astimezone(datetime.UTC)
-
-
 def _resolve_tz(tz: str) -> zoneinfo.ZoneInfo:
     """Validate ``tz`` as an IANA timezone, returning a ZoneInfo.
 
@@ -137,12 +128,12 @@ def _resolve_window(
     until: str | None,
 ) -> tuple[datetime.datetime, datetime.datetime]:
     end = (
-        _parse_iso(until, 'until')
+        parse_iso(until, 'until')
         if until is not None
         else datetime.datetime.now(datetime.UTC)
     )
     start = (
-        _parse_iso(since, 'since')
+        parse_iso(since, 'since')
         if since is not None
         else end - datetime.timedelta(days=DEFAULT_WINDOW_DAYS)
     )
@@ -652,58 +643,6 @@ async def get_user_identities(
 # ---------------------------------------------------------------------------
 
 
-def _encode_cursor(occurred_at: datetime.datetime, entry_id: str) -> str:
-    payload = f'{occurred_at.isoformat()}|{entry_id}'.encode()
-    return base64.urlsafe_b64encode(payload).rstrip(b'=').decode('ascii')
-
-
-def _decode_cursor(
-    cursor: str,
-) -> tuple[datetime.datetime, str] | None:
-    if not cursor:
-        return None
-    padding = '=' * (-len(cursor) % 4)
-    try:
-        raw = base64.urlsafe_b64decode(cursor + padding).decode('utf-8')
-    except ValueError, UnicodeDecodeError:
-        return None
-    if '|' not in raw:
-        return None
-    ts_str, _, entry_id = raw.partition('|')
-    if not entry_id:
-        return None
-    try:
-        ts = datetime.datetime.fromisoformat(ts_str)
-    except ValueError:
-        return None
-    if ts.tzinfo is None:
-        ts = ts.replace(tzinfo=datetime.UTC)
-    return ts.astimezone(datetime.UTC), entry_id
-
-
-def _build_link_header(
-    request: fastapi.Request,
-    next_cursor: str | None,
-) -> str:
-    url = request.url
-    base_params = {
-        k: v for k, v in request.query_params.multi_items() if k != 'cursor'
-    }
-
-    def _url_with(params: dict[str, str]) -> str:
-        scheme_host_path = f'{url.scheme}://{url.netloc}{url.path}'
-        if not params:
-            return scheme_host_path
-        return f'{scheme_host_path}?{urllib.parse.urlencode(params)}'
-
-    links = [f'<{_url_with(base_params)}>; rel="first"']
-    if next_cursor is not None:
-        next_params = dict(base_params)
-        next_params['cursor'] = next_cursor
-        links.append(f'<{_url_with(next_params)}>; rel="next"')
-    return ', '.join(links)
-
-
 async def _opslog_activity(
     *,
     email: str,
@@ -1007,7 +946,7 @@ async def get_user_activity(
     before = datetime.datetime.now(datetime.UTC) + datetime.timedelta(days=1)
     cursor_id: str | None = None
     if cursor is not None:
-        decoded = _decode_cursor(cursor)
+        decoded = decode_cursor(cursor)
         if decoded is None:
             raise fastapi.HTTPException(
                 status_code=400, detail='Invalid cursor'
@@ -1063,11 +1002,11 @@ async def get_user_activity(
         merged = merged[:limit]
     if has_more and merged:
         last = merged[-1]
-        next_cursor = _encode_cursor(last.occurred_at, last.id)
+        next_cursor = encode_cursor(last.occurred_at, last.id)
 
     body = ActivityResponse(data=merged)
     response = fastapi.responses.JSONResponse(
         fastapi.encoders.jsonable_encoder(body.model_dump(mode='json'))
     )
-    response.headers['Link'] = _build_link_header(request, next_cursor)
+    response.headers['Link'] = build_link_header(request, next_cursor)
     return response

--- a/tests/endpoints/test_events.py
+++ b/tests/endpoints/test_events.py
@@ -79,8 +79,8 @@ class _EventsTestBase(unittest.TestCase):
 class CursorCodecTests(unittest.TestCase):
     def test_round_trip(self) -> None:
         ts = datetime.datetime(2026, 4, 1, 12, 0, tzinfo=datetime.UTC)
-        encoded = events._encode_cursor(ts, 'evt-1')
-        decoded = events._decode_cursor(encoded)
+        encoded = events.encode_cursor(ts, 'evt-1')
+        decoded = events.decode_cursor(encoded)
         self.assertIsNotNone(decoded)
         assert decoded is not None
         decoded_ts, decoded_id = decoded
@@ -88,14 +88,14 @@ class CursorCodecTests(unittest.TestCase):
         self.assertEqual(decoded_id, 'evt-1')
 
     def test_decode_empty_returns_none(self) -> None:
-        self.assertIsNone(events._decode_cursor(''))
+        self.assertIsNone(events.decode_cursor(''))
 
     def test_decode_invalid_base64_returns_none(self) -> None:
         # Non-utf8 bytes via raw b64
         import base64
 
         bad = base64.urlsafe_b64encode(b'\xff\xfe\xfd').rstrip(b'=').decode()
-        self.assertIsNone(events._decode_cursor(bad))
+        self.assertIsNone(events.decode_cursor(bad))
 
     def test_decode_missing_separator_returns_none(self) -> None:
         import base64
@@ -103,7 +103,7 @@ class CursorCodecTests(unittest.TestCase):
         payload = (
             base64.urlsafe_b64encode(b'no-separator').rstrip(b'=').decode()
         )
-        self.assertIsNone(events._decode_cursor(payload))
+        self.assertIsNone(events.decode_cursor(payload))
 
     def test_decode_empty_id_returns_none(self) -> None:
         import base64
@@ -113,7 +113,7 @@ class CursorCodecTests(unittest.TestCase):
             .rstrip(b'=')
             .decode()
         )
-        self.assertIsNone(events._decode_cursor(payload))
+        self.assertIsNone(events.decode_cursor(payload))
 
     def test_decode_invalid_timestamp_returns_none(self) -> None:
         import base64
@@ -123,7 +123,7 @@ class CursorCodecTests(unittest.TestCase):
             .rstrip(b'=')
             .decode()
         )
-        self.assertIsNone(events._decode_cursor(payload))
+        self.assertIsNone(events.decode_cursor(payload))
 
     def test_naive_timestamp_gets_utc(self) -> None:
         import base64
@@ -133,7 +133,7 @@ class CursorCodecTests(unittest.TestCase):
             .rstrip(b'=')
             .decode()
         )
-        decoded = events._decode_cursor(payload)
+        decoded = events.decode_cursor(payload)
         assert decoded is not None
         ts, _ = decoded
         self.assertEqual(ts.tzinfo, datetime.UTC)
@@ -144,11 +144,11 @@ class ParseIsoTests(unittest.TestCase):
         import fastapi
 
         with self.assertRaises(fastapi.HTTPException) as ctx:
-            events._parse_iso('garbage', 'since')
+            events.parse_iso('garbage', 'since')
         self.assertEqual(ctx.exception.status_code, 400)
 
     def test_naive_treated_as_utc(self) -> None:
-        result = events._parse_iso('2026-04-01T12:00:00', 'since')
+        result = events.parse_iso('2026-04-01T12:00:00', 'since')
         self.assertEqual(result.tzinfo, datetime.UTC)
 
 
@@ -266,7 +266,7 @@ class GlobalListTests(_EventsTestBase):
 
     def test_list_with_valid_cursor_filters_query(self) -> None:
         self.mock_query.return_value = []
-        cursor = events._encode_cursor(
+        cursor = events.encode_cursor(
             datetime.datetime(2026, 4, 1, tzinfo=datetime.UTC), 'evt-x'
         )
         response = self.client.get('/events/', params={'cursor': cursor})

--- a/tests/endpoints/test_operations_log.py
+++ b/tests/endpoints/test_operations_log.py
@@ -159,9 +159,9 @@ class CursorCodecTests(unittest.TestCase):
             2026, 4, 17, 14, 22, 31, 412000, tzinfo=datetime.UTC
         )
         entry_id = 'V1StGXR8_Z5jdHi6B-myT'
-        encoded = operations_log._encode_cursor(ts, entry_id)
+        encoded = operations_log.encode_cursor(ts, entry_id)
         self.assertIsInstance(encoded, str)
-        decoded = operations_log._decode_cursor(encoded)
+        decoded = operations_log.decode_cursor(encoded)
         self.assertIsNotNone(decoded)
         assert decoded is not None
         decoded_ts, decoded_id = decoded
@@ -169,16 +169,16 @@ class CursorCodecTests(unittest.TestCase):
         self.assertEqual(decoded_id, entry_id)
 
     def test_decode_malformed_returns_none(self) -> None:
-        self.assertIsNone(operations_log._decode_cursor('!!!not-base64!!!'))
+        self.assertIsNone(operations_log.decode_cursor('!!!not-base64!!!'))
 
     def test_decode_wrong_format_returns_none(self) -> None:
         import base64
 
         payload = base64.urlsafe_b64encode(b'missing-separator').decode()
-        self.assertIsNone(operations_log._decode_cursor(payload))
+        self.assertIsNone(operations_log.decode_cursor(payload))
 
     def test_decode_empty_string_returns_none(self) -> None:
-        self.assertIsNone(operations_log._decode_cursor(''))
+        self.assertIsNone(operations_log.decode_cursor(''))
 
 
 class PostOperationLogTests(_OpsLogTestBase):
@@ -304,7 +304,7 @@ class ListEntriesTests(_OpsLogTestBase):
         match = re.search(r'<[^>]*cursor=([^&>]+)[^>]*>;\s*rel="next"', link)
         assert match is not None, link
         cursor = match.group(1)
-        decoded = operations_log._decode_cursor(cursor)
+        decoded = operations_log.decode_cursor(cursor)
         self.assertIsNotNone(decoded)
         assert decoded is not None
         ts, entry_id = decoded

--- a/tests/endpoints/test_pagination.py
+++ b/tests/endpoints/test_pagination.py
@@ -1,0 +1,93 @@
+"""Tests for the shared cursor-pagination helpers."""
+
+import datetime
+import unittest
+from unittest import mock
+
+import fastapi
+
+from imbi_api.endpoints import _pagination
+
+
+class CursorTests(unittest.TestCase):
+    def test_round_trip(self) -> None:
+        ts = datetime.datetime(2026, 5, 26, 12, 0, tzinfo=datetime.UTC)
+        cursor = _pagination.encode_cursor(ts, 'abc123')
+        decoded = _pagination.decode_cursor(cursor)
+        self.assertIsNotNone(decoded)
+        assert decoded is not None
+        self.assertEqual(decoded, (ts, 'abc123'))
+
+    def test_decode_naive_timestamp_assumed_utc(self) -> None:
+        naive = datetime.datetime(2026, 5, 26, 12, 0)  # noqa: DTZ001
+        cursor = _pagination.encode_cursor(naive, 'x')
+        decoded = _pagination.decode_cursor(cursor)
+        assert decoded is not None
+        self.assertEqual(decoded[0].tzinfo, datetime.UTC)
+
+    def test_decode_empty_returns_none(self) -> None:
+        self.assertIsNone(_pagination.decode_cursor(''))
+
+    def test_decode_invalid_base64_returns_none(self) -> None:
+        self.assertIsNone(_pagination.decode_cursor('!!!not-base64!!!'))
+
+    def test_decode_missing_separator_returns_none(self) -> None:
+        import base64
+
+        payload = base64.urlsafe_b64encode(b'noseparator').rstrip(b'=')
+        self.assertIsNone(_pagination.decode_cursor(payload.decode('ascii')))
+
+    def test_decode_empty_id_returns_none(self) -> None:
+        import base64
+
+        payload = base64.urlsafe_b64encode(
+            b'2026-05-26T12:00:00+00:00|'
+        ).rstrip(b'=')
+        self.assertIsNone(_pagination.decode_cursor(payload.decode('ascii')))
+
+
+class ParseIsoTests(unittest.TestCase):
+    def test_naive_treated_as_utc(self) -> None:
+        parsed = _pagination.parse_iso('2026-05-26T12:00:00', 'since')
+        self.assertEqual(parsed.tzinfo, datetime.UTC)
+
+    def test_invalid_raises_400(self) -> None:
+        with self.assertRaises(fastapi.HTTPException) as ctx:
+            _pagination.parse_iso('not-a-date', 'since')
+        self.assertEqual(ctx.exception.status_code, 400)
+
+
+class BuildLinkHeaderTests(unittest.TestCase):
+    @staticmethod
+    def _request(query: str) -> fastapi.Request:
+        request = mock.MagicMock(spec=fastapi.Request)
+        url = mock.MagicMock()
+        url.scheme = 'https'
+        url.netloc = 'imbi.example'
+        url.path = '/events/'
+        request.url = url
+        request.query_params.multi_items.return_value = [
+            (k, v)
+            for k, _, v in (
+                part.partition('=') for part in query.split('&') if part
+            )
+        ]
+        return request
+
+    def test_first_only_when_no_next(self) -> None:
+        header = _pagination.build_link_header(self._request('limit=50'), None)
+        self.assertIn('rel="first"', header)
+        self.assertNotIn('rel="next"', header)
+        self.assertIn('limit=50', header)
+
+    def test_next_replaces_cursor(self) -> None:
+        header = _pagination.build_link_header(
+            self._request('limit=50&cursor=old'), 'newcursor'
+        )
+        self.assertIn('rel="next"', header)
+        self.assertIn('cursor=newcursor', header)
+        self.assertNotIn('cursor=old', header)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/endpoints/test_user_activity.py
+++ b/tests/endpoints/test_user_activity.py
@@ -113,16 +113,16 @@ class WindowAndCursorTests(unittest.TestCase):
 
     def test_cursor_round_trip(self) -> None:
         ts = datetime.datetime(2026, 4, 1, 12, 0, tzinfo=datetime.UTC)
-        encoded = user_activity._encode_cursor(ts, 'evt-1')
-        decoded = user_activity._decode_cursor(encoded)
+        encoded = user_activity.encode_cursor(ts, 'evt-1')
+        decoded = user_activity.decode_cursor(encoded)
         self.assertIsNotNone(decoded)
         assert decoded is not None
         self.assertEqual(decoded[0], ts)
         self.assertEqual(decoded[1], 'evt-1')
 
     def test_cursor_decode_invalid(self) -> None:
-        self.assertIsNone(user_activity._decode_cursor(''))
-        self.assertIsNone(user_activity._decode_cursor('not-base64-!@#$'))
+        self.assertIsNone(user_activity.decode_cursor(''))
+        self.assertIsNone(user_activity.decode_cursor('not-base64-!@#$'))
 
     def test_resolve_tz_valid(self) -> None:
         zone = user_activity._resolve_tz('UTC')


### PR DESCRIPTION
## Summary

Punchlist **M1**. Four list endpoints (`events`, `documents`, `operations_log`, `user_activity`) each carried byte-for-byte copies of the same keyset-cursor `encode`/`decode`, ISO-timestamp parsing, and `Link`-header builder.

- New `src/imbi_api/endpoints/_pagination.py` with `encode_cursor`, `decode_cursor`, `parse_iso`, `build_link_header`; the four endpoints import from it.
- Dropped the now-orphaned `base64` / `urllib.parse` / `json` imports in those files, and in doing so collapsed the Python-2-style `except ValueError, UnicodeDecodeError:` clauses that lived in the removed copies (cf. C1).
- New `tests/endpoints/test_pagination.py` for the canonical module; existing per-endpoint cursor tests repointed at the shared names.

No behaviour change. Net **-35 lines**.

## Test plan

- [x] `pytest tests/endpoints/test_events.py tests/endpoints/test_documents.py tests/endpoints/test_operations_log.py tests/endpoints/test_user_activity.py tests/endpoints/test_pagination.py` — 120 passed
- [x] ruff check/format, basedpyright, `mypy -p imbi_api` (111 files) clean