### PR TITLE
Stop plugin schema audit from flagging AGE internals and domain models

### DIFF
--- a/src/imbi_api/plugins/schemas.py
+++ b/src/imbi_api/plugins/schemas.py
@@ -36,9 +36,10 @@ async def audit_plugin_schemas() -> list[dict[str, typing.Any]]:
             declared.add(vlabel.name)
 
     core_labels = _core_vlabel_names()
+    model_labels = _model_vlabel_names()
     age_labels = await _ag_label_names()
 
-    orphaned = sorted(age_labels - core_labels - declared)
+    orphaned = sorted(age_labels - core_labels - model_labels - declared)
     if orphaned:
         LOGGER.error(
             'Unavailable plugin-declared schemas (in AGE but not '
@@ -70,7 +71,10 @@ async def _ag_label_names() -> set[str]:
             exc_info=True,
         )
         return set()
-    return {row[0] for row in rows}
+    # ``_ag_label_vertex`` / ``_ag_label_edge`` are AGE's built-in
+    # inheritance-parent labels, present in every graph by construction;
+    # they are never plugin- or model-declared, so exclude them.
+    return {row[0] for row in rows if not row[0].startswith('_ag_label_')}
 
 
 def _core_vlabel_names() -> set[str]:
@@ -78,3 +82,30 @@ def _core_vlabel_names() -> set[str]:
     pkg_dir = pathlib.Path(imbi_common.graph.__file__).resolve().parent
     schemata = tomllib.loads((pkg_dir / 'schemata.toml').read_text())
     return set(schemata.get('vlabels', {}).get('name', []))
+
+
+def _model_vlabel_names() -> set[str]:
+    """Return vlabels backed by a registered ``GraphModel`` subclass.
+
+    AGE vertex labels are the model class name (the graph client always
+    derives the label as ``type(node).__name__``), so any ``GraphModel``
+    subclass defined in the shared or API-local model modules is a
+    legitimate, non-plugin vlabel that may be created lazily on first
+    write (e.g. ``Document``, ``Tag``, ``LocalAuthConfig``) and must not
+    be reported as orphaned.
+    """
+    from imbi_common import models as common_models
+
+    from imbi_api.domain import models as domain_models
+
+    base = common_models.GraphModel
+    names: set[str] = set()
+    for module in (common_models, domain_models):
+        for obj in vars(module).values():
+            if (
+                isinstance(obj, type)
+                and issubclass(obj, base)
+                and obj is not base
+            ):
+                names.add(obj.__name__)
+    return names

--- a/tests/test_plugin_schemas.py
+++ b/tests/test_plugin_schemas.py
@@ -1,0 +1,113 @@
+"""Tests for the plugin-declared schema audit (imbi_api.plugins.schemas)."""
+
+import types
+import unittest
+from unittest import mock
+
+from imbi_api.plugins import schemas
+
+
+class AgLabelNamesTests(unittest.IsolatedAsyncioTestCase):
+    """_ag_label_names must drop AGE's built-in inheritance labels."""
+
+    async def test_excludes_ag_internal_labels(self) -> None:
+        rows = [
+            ('Document',),
+            ('_ag_label_vertex',),
+            ('_ag_label_edge',),
+            ('Project',),
+        ]
+        cursor = mock.MagicMock()
+        cursor.execute = mock.AsyncMock()
+        cursor.fetchall = mock.AsyncMock(return_value=rows)
+        cursor_cm = mock.MagicMock()
+        cursor_cm.__aenter__ = mock.AsyncMock(return_value=cursor)
+        cursor_cm.__aexit__ = mock.AsyncMock(return_value=False)
+        conn = mock.MagicMock()
+        conn.cursor = mock.MagicMock(return_value=cursor_cm)
+        conn_cm = mock.MagicMock()
+        conn_cm.__aenter__ = mock.AsyncMock(return_value=conn)
+        conn_cm.__aexit__ = mock.AsyncMock(return_value=False)
+
+        with mock.patch(
+            'psycopg.AsyncConnection.connect',
+            new=mock.AsyncMock(return_value=conn_cm),
+        ):
+            result = await schemas._ag_label_names()
+
+        self.assertEqual(result, {'Document', 'Project'})
+        self.assertNotIn('_ag_label_vertex', result)
+        self.assertNotIn('_ag_label_edge', result)
+
+
+class AuditPluginSchemasTests(unittest.IsolatedAsyncioTestCase):
+    """audit_plugin_schemas distinguishes real orphans from false positives."""
+
+    def _plugin(self, *vlabels: str) -> types.SimpleNamespace:
+        return types.SimpleNamespace(
+            manifest=types.SimpleNamespace(
+                vertex_labels=[
+                    types.SimpleNamespace(name=name) for name in vlabels
+                ]
+            )
+        )
+
+    async def test_only_true_orphans_reported(self) -> None:
+        # Document/Tag/LocalAuthConfig are in-use non-plugin GraphModels;
+        # AwsAccount is plugin-declared; Organization is a core vlabel;
+        # only NoSuchLabel maps to nothing and is a genuine orphan.
+        age_labels = {
+            'Organization',
+            'Document',
+            'Tag',
+            'LocalAuthConfig',
+            'AwsAccount',
+            'NoSuchLabel',
+        }
+        with (
+            mock.patch.object(
+                schemas,
+                '_ag_label_names',
+                new=mock.AsyncMock(return_value=age_labels),
+            ),
+            mock.patch.object(
+                schemas,
+                'list_plugins',
+                return_value=[self._plugin('AwsAccount')],
+            ),
+        ):
+            result = await schemas.audit_plugin_schemas()
+
+        self.assertEqual(result, [{'vlabel': 'NoSuchLabel'}])
+
+    async def test_in_use_model_not_flagged(self) -> None:
+        with (
+            mock.patch.object(
+                schemas,
+                '_ag_label_names',
+                new=mock.AsyncMock(return_value={'Document'}),
+            ),
+            mock.patch.object(schemas, 'list_plugins', return_value=[]),
+        ):
+            result = await schemas.audit_plugin_schemas()
+
+        self.assertEqual(result, [])
+
+    async def test_no_labels_returns_empty(self) -> None:
+        # _ag_label_names already filters AGE internals, so a graph with
+        # only the built-in parent labels surfaces as an empty set here.
+        with (
+            mock.patch.object(
+                schemas,
+                '_ag_label_names',
+                new=mock.AsyncMock(return_value=set()),
+            ),
+            mock.patch.object(schemas, 'list_plugins', return_value=[]),
+        ):
+            result = await schemas.audit_plugin_schemas()
+
+        self.assertEqual(result, [])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

The startup plugin-schema audit (`plugins/schemas.py`) logged this at **ERROR every boot**:

> Unavailable plugin-declared schemas (in AGE but not declared by any loaded plugin): ['Document', 'LocalAuthConfig', 'Tag', '_ag_label_vertex']

All four are false positives:

- **`_ag_label_vertex`** is AGE's built-in inheritance-parent vertex label, present in every graph by construction. `_ag_label_names()` now drops any label matching `_ag_label_*` (also covers `_ag_label_edge`).
- **`Document`, `Tag`, `LocalAuthConfig`** are `GraphModel` subclasses (in `imbi_common.models` / `imbi_api.domain.models`) whose vlabels are created lazily on first write — absent from `schemata.toml`, declared by no plugin. New `_model_vlabel_names()` derives expected labels from the registered `GraphModel` subclasses (AGE labels are always `type(node).__name__`, verified in the graph client) and folds them into the expected set.

A vlabel that maps to no core model, no registered domain model, and no loaded plugin is **still reported** — the audit's genuine purpose is preserved (the mechanism that already excused plugin-declared `AwsAccount`).

## Test plan
- [x] New `tests/test_plugin_schemas.py` (4 cases): `_ag_label_*` excluded; in-use model (`Document`) not flagged; a genuine orphan still flagged; no-labels → empty.
- [x] `pytest tests/test_plugin_schemas.py` — 4 passed; `plugins/schemas.py` 95% (only the pre-existing DB-failure handler uncovered).
- [x] basedpyright + mypy clean; ruff clean (pinned 0.14.6).
- [x] Live-verified against the running AGE dev graph: `_ag_label_vertex` excluded; Document/Tag/LocalAuthConfig all model-covered.

> Note: CodeRabbit is rate-limited (vacuous green check); this is a surgical, low-risk change.