### PR TITLE
Close OAuth token-leak: redirect_uri allow-list + HttpOnly refresh cookie (C2)

### DIFF
--- a/src/imbi_api/endpoints/auth.py
+++ b/src/imbi_api/endpoints/auth.py
@@ -83,6 +83,38 @@ def _is_safe_redirect_uri(
     return False
 
 
+_REFRESH_COOKIE = 'imbi_refresh_token'
+
+
+def _set_refresh_cookie(
+    response: fastapi.Response, refresh_token: str
+) -> None:
+    """Store the refresh token in an HttpOnly cookie (C2).
+
+    Keeps the long-lived refresh token out of JS-readable storage and out
+    of the OAuth callback URL fragment (where it would otherwise leak via
+    browser history, the Referer header, and logs). Scoped to ``/auth`` so
+    it is only sent to the token-refresh and logout endpoints. ``Secure``
+    is set outside development; ``SameSite=Strict`` is safe because the UI
+    and API are served from one origin behind the ingress.
+    """
+    auth_settings = settings.get_auth_settings()
+    response.set_cookie(
+        _REFRESH_COOKIE,
+        refresh_token,
+        max_age=auth_settings.refresh_token_expire_seconds,
+        path='/auth',
+        httponly=True,
+        secure=settings.get_server_config().environment != 'development',
+        samesite='strict',
+    )
+
+
+def _clear_refresh_cookie(response: fastapi.Response) -> None:
+    """Remove the refresh-token cookie (logout)."""
+    response.delete_cookie(_REFRESH_COOKIE, path='/auth')
+
+
 auth_router = fastapi.APIRouter(prefix='/auth', tags=['Authentication'])
 
 
@@ -298,6 +330,7 @@ async def token(
 @rate_limit.limiter.limit('5/minute')  # type: ignore[untyped-decorator]
 async def login(
     request: fastapi.Request,
+    response: fastapi.Response,
     db: graph.Pool,
     email: typing.Annotated[pydantic.EmailStr, fastapi.Body()],
     password: typing.Annotated[str, fastapi.Body()],
@@ -454,6 +487,7 @@ async def login(
 
     LOGGER.info('User %s logged in successfully', _redact_email(user.email))
 
+    _set_refresh_cookie(response, refresh_token)
     return auth_models.TokenResponse(
         access_token=access_token,
         refresh_token=refresh_token,
@@ -533,8 +567,9 @@ async def _handle_refresh_reuse(
 @rate_limit.limiter.limit('10/minute')  # type: ignore[untyped-decorator]
 async def refresh_token(
     request: fastapi.Request,
+    response: fastapi.Response,
     db: graph.Pool,
-    refresh_request: auth_models.TokenRefreshRequest,
+    refresh_request: auth_models.TokenRefreshRequest | None = None,
 ) -> auth_models.TokenResponse:
     """Refresh access token and rotate refresh token (Phase 5).
 
@@ -555,11 +590,20 @@ async def refresh_token(
     """
     auth_settings = settings.get_auth_settings()
 
+    # The browser flow sends the refresh token as an HttpOnly cookie (C2);
+    # programmatic clients (e.g. the /auth/token grant) may still send it
+    # in the request body. Prefer the cookie, fall back to the body.
+    token_str = request.cookies.get(_REFRESH_COOKIE) or (
+        refresh_request.refresh_token if refresh_request else None
+    )
+    if not token_str:
+        raise fastapi.HTTPException(
+            status_code=401, detail='Missing refresh token'
+        )
+
     # Decode and validate refresh token
     try:
-        payload = core.verify_token(
-            refresh_request.refresh_token, auth_settings
-        )
+        payload = core.verify_token(token_str, auth_settings)
     except jwt.ExpiredSignatureError as err:
         LOGGER.warning('Token refresh failed: token expired')
         raise fastapi.HTTPException(
@@ -672,6 +716,7 @@ async def refresh_token(
         principal_id,
     )
 
+    _set_refresh_cookie(response, new_refresh_token)
     return auth_models.TokenResponse(
         access_token=access_token,
         refresh_token=new_refresh_token,  # Phase 5: Return NEW
@@ -683,6 +728,7 @@ async def refresh_token(
 @rate_limit.limiter.limit('30/minute')  # type: ignore[untyped-decorator]
 async def logout(
     request: fastapi.Request,
+    response: fastapi.Response,
     db: graph.Pool,
     auth: typing.Annotated[
         permissions.AuthContext,
@@ -700,6 +746,9 @@ async def logout(
 
     """
     now_str = datetime.datetime.now(datetime.UTC).isoformat()
+
+    # Clear the browser refresh cookie (C2) regardless of revoke scope.
+    _clear_refresh_cookie(response)
 
     # Revoke current access token
     query: typing.LiteralString = """
@@ -1092,16 +1141,19 @@ async def oauth_callback(
             provider,
         )
 
-        # Redirect to frontend with tokens in URL fragment
+        # Hand the access token to the SPA via the URL fragment but keep
+        # the refresh token out of it — it goes in an HttpOnly cookie (C2)
+        # so it never lands in browser history, the Referer header, or logs.
         redirect_url = (
             f'{state_data.redirect_uri}#'
             f'access_token={at}&'
-            f'refresh_token={rt}&'
             f'token_type=bearer&'
             f'expires_in='
             f'{auth_settings.access_token_expire_seconds}'
         )
-        return fastapi.responses.RedirectResponse(url=redirect_url)
+        redirect = fastapi.responses.RedirectResponse(url=redirect_url)
+        _set_refresh_cookie(redirect, rt)
+        return redirect
 
     except (
         ValueError,
@@ -1221,19 +1273,19 @@ async def _identity_plugin_login_callback(
     user.last_login = meta['issued_at']
     await db.merge(user, match_on=['email'])
 
-    # Redirect to frontend with tokens in URL fragment so they are not
-    # forwarded to the server in subsequent requests, matching the
-    # legacy OAuth callback's behaviour.
+    # Access token via the URL fragment; refresh token via an HttpOnly
+    # cookie (C2) so it is never exposed in the fragment.
     target = return_to or '/dashboard'
     redirect_url = (
         f'{target}#'
         f'access_token={at}&'
-        f'refresh_token={rt}&'
         f'token_type=bearer&'
         f'expires_in='
         f'{auth_settings.access_token_expire_seconds}'
     )
-    return fastapi.responses.RedirectResponse(url=redirect_url)
+    redirect = fastapi.responses.RedirectResponse(url=redirect_url)
+    _set_refresh_cookie(redirect, rt)
+    return redirect
 
 
 async def find_or_create_oauth_identity(

--- a/src/imbi_api/endpoints/auth.py
+++ b/src/imbi_api/endpoints/auth.py
@@ -86,6 +86,18 @@ def _is_safe_redirect_uri(
 _REFRESH_COOKIE = 'imbi_refresh_token'
 
 
+def _refresh_cookie_path() -> str:
+    """Browser-visible path the refresh cookie is scoped to.
+
+    The auth router is mounted at ``/auth`` within the app, but the app is
+    served behind the public ``IMBI_API_URL`` prefix (``/api`` in
+    deployment, empty in dev-loopback). The cookie ``Path`` is matched by
+    the browser against the public URL, so it must include that prefix or
+    the cookie is never sent to ``{prefix}/auth/token/refresh``.
+    """
+    return f'{settings.get_server_config().api_prefix}/auth'
+
+
 def _set_refresh_cookie(
     response: fastapi.Response, refresh_token: str
 ) -> None:
@@ -93,8 +105,8 @@ def _set_refresh_cookie(
 
     Keeps the long-lived refresh token out of JS-readable storage and out
     of the OAuth callback URL fragment (where it would otherwise leak via
-    browser history, the Referer header, and logs). Scoped to ``/auth`` so
-    it is only sent to the token-refresh and logout endpoints. ``Secure``
+    browser history, the Referer header, and logs). Scoped to the auth
+    endpoints so it is only sent to token-refresh and logout. ``Secure``
     is set outside development; ``SameSite=Strict`` is safe because the UI
     and API are served from one origin behind the ingress.
     """
@@ -103,7 +115,7 @@ def _set_refresh_cookie(
         _REFRESH_COOKIE,
         refresh_token,
         max_age=auth_settings.refresh_token_expire_seconds,
-        path='/auth',
+        path=_refresh_cookie_path(),
         httponly=True,
         secure=settings.get_server_config().environment != 'development',
         samesite='strict',
@@ -112,7 +124,7 @@ def _set_refresh_cookie(
 
 def _clear_refresh_cookie(response: fastapi.Response) -> None:
     """Remove the refresh-token cookie (logout)."""
-    response.delete_cookie(_REFRESH_COOKIE, path='/auth')
+    response.delete_cookie(_REFRESH_COOKIE, path=_refresh_cookie_path())
 
 
 auth_router = fastapi.APIRouter(prefix='/auth', tags=['Authentication'])

--- a/src/imbi_api/endpoints/auth.py
+++ b/src/imbi_api/endpoints/auth.py
@@ -830,11 +830,16 @@ async def oauth_login(
 
     # Enforce the redirect-URI allow-list before it is signed into the
     # OAuth state: the callback delivers tokens to this destination, so an
-    # off-origin value would exfiltrate them (C2).
+    # off-origin value would exfiltrate them (C2). The SPA sends an
+    # absolute same-origin callback (``window.location.origin/auth/callback``)
+    # and UI+API share a host behind the ingress, so the API's own public
+    # origin must be trusted alongside any configured CORS origins.
     server_config = settings.get_server_config()
-    if not _is_safe_redirect_uri(
-        redirect_uri, server_config.cors_allowed_origins
-    ):
+    allowed_origins = list(server_config.cors_allowed_origins)
+    own = urlparse.urlparse(server_config.public_base_url)
+    if own.scheme and own.netloc:
+        allowed_origins.append(f'{own.scheme}://{own.netloc}')
+    if not _is_safe_redirect_uri(redirect_uri, allowed_origins):
         raise fastapi.HTTPException(
             status_code=400,
             detail='Invalid redirect_uri',

--- a/src/imbi_api/endpoints/auth.py
+++ b/src/imbi_api/endpoints/auth.py
@@ -56,6 +56,33 @@ def _redact_email(email: str) -> str:
     return f'{prefix}***@{domain}'
 
 
+def _is_safe_redirect_uri(
+    redirect_uri: str, allowed_origins: list[str]
+) -> bool:
+    """Return whether *redirect_uri* is a safe post-login destination.
+
+    The OAuth callback hands freshly-minted tokens to this URI, so a
+    caller-controlled value is an account-takeover vector (tokens
+    exfiltrated to an attacker host). Only two shapes are allowed:
+
+    * a same-origin relative path — a single leading ``/`` that is not a
+      scheme-relative ``//host`` or a ``/\\`` backslash trick; and
+    * an absolute ``http(s)`` URL whose ``scheme://host[:port]`` origin is
+      in the configured CORS allow-list (the trusted front-ends).
+
+    Everything else (arbitrary absolute URLs, ``javascript:``/``data:``
+    schemes, embedded whitespace browsers may strip) is rejected.
+    """
+    if not redirect_uri or any(c.isspace() for c in redirect_uri):
+        return False
+    if redirect_uri.startswith('/'):
+        return not redirect_uri.startswith(('//', '/\\'))
+    parsed = urlparse.urlparse(redirect_uri)
+    if parsed.scheme in ('http', 'https') and parsed.netloc:
+        return f'{parsed.scheme}://{parsed.netloc}' in allowed_origins
+    return False
+
+
 auth_router = fastapi.APIRouter(prefix='/auth', tags=['Authentication'])
 
 
@@ -799,6 +826,18 @@ async def oauth_login(
         raise fastapi.HTTPException(
             status_code=404,
             detail=f'Invalid provider: {provider}',
+        )
+
+    # Enforce the redirect-URI allow-list before it is signed into the
+    # OAuth state: the callback delivers tokens to this destination, so an
+    # off-origin value would exfiltrate them (C2).
+    server_config = settings.get_server_config()
+    if not _is_safe_redirect_uri(
+        redirect_uri, server_config.cors_allowed_origins
+    ):
+        raise fastapi.HTTPException(
+            status_code=400,
+            detail='Invalid redirect_uri',
         )
 
     # Identity-plugin login providers route through the registry's

--- a/tests/endpoints/test_auth.py
+++ b/tests/endpoints/test_auth.py
@@ -271,6 +271,7 @@ class OAuthFlowTestCase(unittest.TestCase):
     def setUp(self) -> None:
         """Set up test client."""
         settings._auth_settings = None
+        rate_limit.limiter.reset()
         self.test_app = app.create_app()
 
         self.mock_db = mock.AsyncMock(spec=graph.Graph)
@@ -283,6 +284,7 @@ class OAuthFlowTestCase(unittest.TestCase):
     def tearDown(self) -> None:
         """Reset settings singleton after tests."""
         settings._auth_settings = None
+        rate_limit.limiter.reset()
 
     def test_oauth_login_invalid_provider(self) -> None:
         """Test OAuth login with unknown provider slug."""
@@ -341,6 +343,26 @@ class OAuthFlowTestCase(unittest.TestCase):
             )
         self.assertEqual(response.status_code, 400)
         self.assertIn('Invalid redirect_uri', response.json()['detail'])
+
+    def test_oauth_login_allows_same_origin_absolute_callback(self) -> None:
+        """The SPA's absolute same-origin callback URL is accepted.
+
+        imbi-ui sends ``redirect_uri=<api-origin>/auth/callback`` (an
+        absolute URL), and UI+API share a host, so the API's own public
+        origin must satisfy the allow-list even with no CORS origins set.
+        """
+        from urllib import parse as _urlparse
+
+        cfg = settings.get_server_config()
+        origin = _urlparse.urlparse(cfg.public_base_url)
+        callback = f'{origin.scheme}://{origin.netloc}/auth/callback'
+        with _patch_providers([_stub_provider('google', client_id='id')]):
+            response = self.client.get(
+                f'/auth/oauth/google?redirect_uri={callback}',
+                follow_redirects=False,
+            )
+        self.assertEqual(response.status_code, 307)
+        self.assertIn('accounts.google.com', response.headers['location'])
 
     def test_oauth_callback_error_handling(self) -> None:
         """Test OAuth callback handles provider errors."""

--- a/tests/endpoints/test_auth.py
+++ b/tests/endpoints/test_auth.py
@@ -131,6 +131,35 @@ class IsSafeRedirectURITestCase(unittest.TestCase):
         self._bad(' /leading-space')
 
 
+class RefreshCookiePathTestCase(unittest.TestCase):
+    """The refresh cookie must be scoped under the public API prefix (C2).
+
+    The auth router lives at ``/auth`` inside the app, but the browser
+    sees it behind ``IMBI_API_URL``'s prefix (``/api`` in deployment). A
+    cookie scoped to a bare ``/auth`` is never sent to
+    ``/api/auth/token/refresh``, silently breaking token refresh.
+    """
+
+    def _path_for(self, api_url: str) -> str:
+        with mock.patch.dict('os.environ', {'IMBI_API_URL': api_url}):
+            cfg = settings.ServerConfig(_env_file=None)
+        with mock.patch.object(
+            auth_endpoints.settings, 'get_server_config', return_value=cfg
+        ):
+            return auth_endpoints._refresh_cookie_path()
+
+    def test_path_includes_deployment_prefix(self) -> None:
+        self.assertEqual(
+            self._path_for('https://imbi.example.com/api'), '/api/auth'
+        )
+
+    def test_path_is_bare_auth_without_prefix(self) -> None:
+        self.assertEqual(self._path_for('https://imbi.example.com'), '/auth')
+
+    def test_path_is_bare_auth_in_dev_loopback(self) -> None:
+        self.assertEqual(self._path_for(''), '/auth')
+
+
 class RedactEmailTestCase(unittest.TestCase):
     """Test cases for the _redact_email log helper."""
 

--- a/tests/endpoints/test_auth.py
+++ b/tests/endpoints/test_auth.py
@@ -1089,10 +1089,11 @@ class OAuthCallbackSuccessTestCase(unittest.TestCase):
             self.assertIn('access_token=', location)
             # Refresh token is an HttpOnly cookie now, not in the fragment (C2)
             self.assertNotIn('refresh_token=', location)
-            self.assertIn(
-                'imbi_refresh_token',
-                response.headers.get('set-cookie', ''),
-            )
+            set_cookie = response.headers.get('set-cookie', '')
+            self.assertIn('imbi_refresh_token=', set_cookie)
+            self.assertIn('HttpOnly', set_cookie)
+            self.assertIn('SameSite=strict', set_cookie)
+            self.assertIn('Path=/auth', set_cookie)
             self.assertIn('token_type=bearer', location)
             self.assertIn('expires_in=', location)
 
@@ -1192,10 +1193,11 @@ class OAuthCallbackSuccessTestCase(unittest.TestCase):
             self.assertIn('access_token=', location)
             # Refresh token moved to an HttpOnly cookie (C2)
             self.assertNotIn('refresh_token=', location)
-            self.assertIn(
-                'imbi_refresh_token',
-                response.headers.get('set-cookie', ''),
-            )
+            set_cookie = response.headers.get('set-cookie', '')
+            self.assertIn('imbi_refresh_token=', set_cookie)
+            self.assertIn('HttpOnly', set_cookie)
+            self.assertIn('SameSite=strict', set_cookie)
+            self.assertIn('Path=/auth', set_cookie)
 
             # Verify merge was called for user + identity
             self.assertTrue(self.mock_db.merge.called)
@@ -1684,9 +1686,11 @@ class TokenRefreshTestCase(unittest.TestCase):
             )
         self.assertEqual(response.status_code, 200)
         # The rotated token is written back to the cookie.
-        self.assertIn(
-            'imbi_refresh_token', response.headers.get('set-cookie', '')
-        )
+        set_cookie = response.headers.get('set-cookie', '')
+        self.assertIn('imbi_refresh_token=', set_cookie)
+        self.assertIn('HttpOnly', set_cookie)
+        self.assertIn('SameSite=strict', set_cookie)
+        self.assertIn('Path=/auth', set_cookie)
 
     def test_refresh_token_missing_returns_401(self) -> None:
         """No cookie and no body yields 401 rather than a 422."""
@@ -2616,9 +2620,11 @@ class IdentityPluginLoginFlowTestCase(unittest.TestCase):
         self.assertIn('/projects#', location)
         self.assertIn('access_token=', location)
         self.assertNotIn('refresh_token=', location)
-        self.assertIn(
-            'imbi_refresh_token', response.headers.get('set-cookie', '')
-        )
+        set_cookie = response.headers.get('set-cookie', '')
+        self.assertIn('imbi_refresh_token=', set_cookie)
+        self.assertIn('HttpOnly', set_cookie)
+        self.assertIn('SameSite=strict', set_cookie)
+        self.assertIn('Path=/auth', set_cookie)
         upsert_mock.assert_awaited_once()
         # Verify the new user was upserted into the graph.
         merged = [c.args[0] for c in self.mock_db.merge.call_args_list]

--- a/tests/endpoints/test_auth.py
+++ b/tests/endpoints/test_auth.py
@@ -12,6 +12,7 @@ from imbi_api import app, settings
 from imbi_api.auth import local_auth, login_providers
 from imbi_api.auth import models as auth_models
 from imbi_api.domain import models as domain_models
+from imbi_api.endpoints import auth as auth_endpoints
 from imbi_api.middleware import rate_limit
 
 
@@ -84,6 +85,50 @@ def _patch_providers(
         list_login_apps=fake_list,
         get_login_app=fake_get,
     )
+
+
+class IsSafeRedirectURITestCase(unittest.TestCase):
+    """Unit tests for the OAuth redirect_uri allow-list (C2)."""
+
+    _ALLOWED: typing.ClassVar[list[str]] = [
+        'https://imbi.example.com',
+        'http://localhost:5173',
+    ]
+
+    def _ok(self, uri: str) -> None:
+        self.assertTrue(
+            auth_endpoints._is_safe_redirect_uri(uri, self._ALLOWED), uri
+        )
+
+    def _bad(self, uri: str) -> None:
+        self.assertFalse(
+            auth_endpoints._is_safe_redirect_uri(uri, self._ALLOWED), uri
+        )
+
+    def test_relative_paths_allowed(self) -> None:
+        self._ok('/dashboard')
+        self._ok('/projects/42?tab=overview')
+
+    def test_absolute_url_in_allowlist_allowed(self) -> None:
+        self._ok('https://imbi.example.com/dashboard')
+        self._ok('http://localhost:5173/')
+
+    def test_absolute_url_not_in_allowlist_rejected(self) -> None:
+        self._bad('https://evil.example/steal')
+        self._bad('https://imbi.example.com.evil.example/')
+
+    def test_scheme_relative_and_backslash_rejected(self) -> None:
+        self._bad('//evil.example/path')
+        self._bad('/\\evil.example')
+
+    def test_non_http_schemes_rejected(self) -> None:
+        self._bad('javascript:alert(1)')
+        self._bad('data:text/html,<script>')
+
+    def test_empty_and_whitespace_rejected(self) -> None:
+        self._bad('')
+        self._bad('/path\nwith-newline')
+        self._bad(' /leading-space')
 
 
 class RedactEmailTestCase(unittest.TestCase):
@@ -286,6 +331,16 @@ class OAuthFlowTestCase(unittest.TestCase):
         location = response.headers['location']
         self.assertIn('github.com/login/oauth/authorize', location)
         self.assertIn('client_id=github-id', location)
+
+    def test_oauth_login_rejects_offsite_redirect_uri(self) -> None:
+        """An off-origin redirect_uri is refused before the provider hop."""
+        with _patch_providers([_stub_provider('google', client_id='id')]):
+            response = self.client.get(
+                '/auth/oauth/google?redirect_uri=https://evil.example/x',
+                follow_redirects=False,
+            )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('Invalid redirect_uri', response.json()['detail'])
 
     def test_oauth_callback_error_handling(self) -> None:
         """Test OAuth callback handles provider errors."""

--- a/tests/endpoints/test_auth.py
+++ b/tests/endpoints/test_auth.py
@@ -1058,7 +1058,12 @@ class OAuthCallbackSuccessTestCase(unittest.TestCase):
             location = response.headers['location']
             self.assertIn('/dashboard#', location)
             self.assertIn('access_token=', location)
-            self.assertIn('refresh_token=', location)
+            # Refresh token is an HttpOnly cookie now, not in the fragment (C2)
+            self.assertNotIn('refresh_token=', location)
+            self.assertIn(
+                'imbi_refresh_token',
+                response.headers.get('set-cookie', ''),
+            )
             self.assertIn('token_type=bearer', location)
             self.assertIn('expires_in=', location)
 
@@ -1156,7 +1161,12 @@ class OAuthCallbackSuccessTestCase(unittest.TestCase):
             location = response.headers['location']
             self.assertIn('/dashboard#', location)
             self.assertIn('access_token=', location)
-            self.assertIn('refresh_token=', location)
+            # Refresh token moved to an HttpOnly cookie (C2)
+            self.assertNotIn('refresh_token=', location)
+            self.assertIn(
+                'imbi_refresh_token',
+                response.headers.get('set-cookie', ''),
+            )
 
             # Verify merge was called for user + identity
             self.assertTrue(self.mock_db.merge.called)
@@ -1610,6 +1620,56 @@ class TokenRefreshTestCase(unittest.TestCase):
             # reuse would miss every descendant minted from this call.
             second_call_params = self.mock_db.execute.call_args_list[1][0][1]
             self.assertEqual(second_call_params['family_id'], 'fam-test')
+
+    def test_refresh_token_via_cookie(self) -> None:
+        """Refresh succeeds from the HttpOnly cookie with no request body."""
+        from imbi_common.auth import core
+
+        from imbi_api import models
+
+        auth_settings = settings.Auth(
+            jwt_secret='test-secret-key-min-32-chars-long',
+        )
+        test_user = models.User(
+            email='test@example.com',
+            display_name='Test User',
+            is_active=True,
+            password_hash=None,
+            created_at=datetime.datetime.now(datetime.UTC),
+        )
+        refresh = core.create_refresh_token(
+            test_user.email, auth_settings=auth_settings
+        )
+        self.mock_db.match.return_value = [test_user]
+        self.mock_db.execute.side_effect = [
+            [{'family_id': 'fam-test'}],
+            [{'principal_count': 1}],
+        ]
+        with mock.patch(
+            'imbi_api.settings.get_auth_settings',
+            return_value=auth_settings,
+        ):
+            response = self.client.post(
+                '/auth/token/refresh',
+                cookies={'imbi_refresh_token': refresh},
+            )
+        self.assertEqual(response.status_code, 200)
+        # The rotated token is written back to the cookie.
+        self.assertIn(
+            'imbi_refresh_token', response.headers.get('set-cookie', '')
+        )
+
+    def test_refresh_token_missing_returns_401(self) -> None:
+        """No cookie and no body yields 401 rather than a 422."""
+        auth_settings = settings.Auth(
+            jwt_secret='test-secret-key-min-32-chars-long',
+        )
+        with mock.patch(
+            'imbi_api.settings.get_auth_settings',
+            return_value=auth_settings,
+        ):
+            response = self.client.post('/auth/token/refresh')
+        self.assertEqual(response.status_code, 401)
 
     def test_refresh_token_expired(self) -> None:
         """Test token refresh with expired token."""
@@ -2523,10 +2583,13 @@ class IdentityPluginLoginFlowTestCase(unittest.TestCase):
 
         self.assertEqual(response.status_code, 307)
         location = response.headers['location']
-        # Tokens land in the URL fragment, not the query string.
+        # Access token in the fragment; refresh token in an HttpOnly cookie.
         self.assertIn('/projects#', location)
         self.assertIn('access_token=', location)
-        self.assertIn('refresh_token=', location)
+        self.assertNotIn('refresh_token=', location)
+        self.assertIn(
+            'imbi_refresh_token', response.headers.get('set-cookie', '')
+        )
         upsert_mock.assert_awaited_once()
         # Verify the new user was upserted into the graph.
         merged = [c.args[0] for c in self.mock_db.merge.call_args_list]


### PR DESCRIPTION
## Summary

Closes critical punchlist item **C2** (imbi-api side). Two layers:

### 1. redirect_uri allow-list (closes the exploit)
`oauth_login` accepted an arbitrary caller-supplied `redirect_uri` and the callback later delivered tokens to it, so `?redirect_uri=https://evil.example` exfiltrated tokens. It now rejects (400) anything that isn't a same-origin relative path or an absolute http(s) URL whose origin is in `cors_allowed_origins` **or the API's own public origin** (the SPA sends an absolute same-origin callback, so the own-origin trust is required or real logins break). Scheme-relative `//host`, `/\` tricks, non-http schemes, and embedded whitespace are refused.

### 2. Refresh token → HttpOnly cookie (defense in depth)
The refresh token was placed in the OAuth callback **URL fragment** (leaks via history/Referer/logs). It now rides in an `HttpOnly; Secure; SameSite=Strict` cookie scoped to `/auth`:
- both OAuth callbacks set the cookie and drop `refresh_token` from the fragment (access token still in the fragment);
- `/auth/login` sets the cookie;
- `/auth/token/refresh` reads the cookie, **falls back to the request body** so the programmatic `/auth/token` grant clients still work, and rotates the cookie;
- `/auth/logout` clears the cookie.
- `/auth/token` (OAuth2 password grant for programmatic clients) is unchanged.

## ⚠️ Requires the imbi-ui companion before merge/deploy
The backend no longer returns `refresh_token` in the OAuth fragment, so the **current imbi-ui would break on deploy**. The matching imbi-ui PR (stop persisting the refresh token, send `credentials` on the refresh call, parse only `access_token` from the fragment) must land in lockstep. **Do not merge this until that PR is ready.**

## Test plan
- [x] 73 `test_auth.py` cases pass, incl. new: allow-list unit tests, same-origin-absolute callback accepted, off-site rejected, refresh-via-cookie, refresh-missing→401, callbacks set the cookie + no `refresh_token` in fragment.
- [x] basedpyright + mypy + ruff clean.
- [ ] **Live OAuth round-trip + cookie/refresh/logout** — needs a real provider; to be verified with the imbi-ui change before release.