### PR TITLE
Add blueprint attribute filtering to project listing

### DIFF
--- a/src/imbi_api/blueprint_attributes.py
+++ b/src/imbi_api/blueprint_attributes.py
@@ -1,0 +1,77 @@
+"""Resolve filterable project attributes from blueprints.
+
+Blueprint ``node`` schemas for the ``Project`` type contribute the
+dynamic properties stored on each project vertex (e.g. ``framework``,
+``programming_language``). This module flattens those schemas into a
+catalog of filterable attributes, scoped to a project type.
+
+Both the ``include_schema`` flag on the project-type listing (which
+advertises the catalog) and the ``filter`` parameter on the project
+listing (which validates filter fields against it) share this
+resolver, so the advertised and accepted attribute sets cannot drift.
+"""
+
+import pydantic
+from imbi_common import graph, models
+
+
+class FilterableAttribute(pydantic.BaseModel):
+    """A single project attribute that can be filtered on."""
+
+    field: str
+    type: str | None = None
+    format: str | None = None
+    enum: list[str] | None = None
+
+
+def resolve(
+    blueprints: list[models.Blueprint],
+    type_slug: str | None,
+) -> dict[str, FilterableAttribute]:
+    """Return filterable attributes keyed by field name.
+
+    ``blueprints`` must be the enabled ``Project`` blueprints ordered
+    by ascending priority; later blueprints override earlier ones for
+    the same field name.
+
+    When ``type_slug`` is given, only blueprints whose ``project_type``
+    filter includes it (or that have no ``project_type`` filter) are
+    considered. When ``type_slug`` is ``None`` the union across every
+    project type is returned. The ``environment`` filter is ignored:
+    the property exists on the project vertex regardless of which
+    environments the project is deployed in.
+    """
+    out: dict[str, FilterableAttribute] = {}
+    for bp in blueprints:
+        if bp.kind != 'node':
+            continue
+        f = bp.filter
+        if (
+            type_slug is not None
+            and f is not None
+            and f.project_type
+            and type_slug not in f.project_type
+        ):
+            continue
+        properties = bp.json_schema.properties
+        if not properties:
+            continue
+        for name, prop in properties.items():
+            out[name] = FilterableAttribute(
+                field=name,
+                type=getattr(prop, 'type', None),
+                format=getattr(prop, 'format', None),
+                enum=getattr(prop, 'enum', None),
+            )
+    return out
+
+
+async def project_blueprints(
+    db: graph.Graph,
+) -> list[models.Blueprint]:
+    """Fetch enabled ``Project`` blueprints ordered by priority."""
+    return await db.match(
+        models.Blueprint,
+        {'type': 'Project', 'enabled': True},
+        order_by='priority',
+    )

--- a/src/imbi_api/endpoints/project_types.py
+++ b/src/imbi_api/endpoints/project_types.py
@@ -9,6 +9,7 @@ import psycopg.errors
 import pydantic
 from imbi_common import blueprints, graph, models
 
+from imbi_api import blueprint_attributes
 from imbi_api import patch as json_patch
 from imbi_api.auth import permissions
 from imbi_api.graph_sql import props_template, set_clause
@@ -145,11 +146,17 @@ async def list_project_types(
             permissions.require_permission('project_type:read'),
         ),
     ],
+    include_schema: bool = False,
 ) -> list[dict[str, typing.Any]]:
     """List all project types in an organization.
 
     Parameters:
         org_slug: Organization slug from URL path.
+        include_schema: When true, each project type gains a
+            ``schema`` key listing the blueprint-defined attributes
+            (``field``, ``type``, ``format``, ``enum``) that projects
+            of that type can be filtered on via the project listing's
+            ``filter`` parameter.
 
     Returns:
         Project types ordered by name, each including their
@@ -170,6 +177,11 @@ async def list_project_types(
         {'org_slug': org_slug},
         columns=['pt', 'o', 'project_count'],
     )
+    bps = (
+        await blueprint_attributes.project_blueprints(db)
+        if include_schema
+        else []
+    )
     for record in records:
         pt = graph.parse_agtype(record['pt'])
         org = graph.parse_agtype(record['o'])
@@ -178,6 +190,13 @@ async def list_project_types(
         pt['relationships'] = _project_type_relationships(
             request, org_slug, pt['slug'], pc or 0
         )
+        if include_schema:
+            pt['schema'] = [
+                attr.model_dump()
+                for attr in blueprint_attributes.resolve(
+                    bps, pt['slug']
+                ).values()
+            ]
         project_types.append(pt)
     return project_types
 

--- a/src/imbi_api/endpoints/projects.py
+++ b/src/imbi_api/endpoints/projects.py
@@ -8,6 +8,7 @@ import asyncio
 import datetime
 import json
 import logging
+import re
 import typing
 
 import fastapi
@@ -18,6 +19,7 @@ from imbi_common import blueprints, graph, models
 from imbi_common.clickhouse import client as ch_client
 from imbi_common.scoring import compute_score
 
+from imbi_api import blueprint_attributes
 from imbi_api import patch as json_patch
 from imbi_api.auth import permissions
 from imbi_api.domain import scoring as scoring_models
@@ -1075,6 +1077,82 @@ async def _resolve_release_display_names(
             env_map[slug] = info.model_copy(update={'performed_by': name})
 
 
+_FILTER_FIELD_RE = re.compile(r'^[A-Za-z_][A-Za-z0-9_]*$')
+_FILTER_OPS = frozenset({'eq', 'ne', 'in', 'not_in', 'exists', 'not_exists'})
+
+
+def _build_attribute_filter(
+    filters: list[str],
+    whitelist: dict[str, blueprint_attributes.FilterableAttribute],
+) -> tuple[str, dict[str, typing.Any]]:
+    """Translate ``field:op[:value]`` predicates into a Cypher WHERE.
+
+    Returns ``(fragment, params)`` where ``fragment`` is empty or a
+    ``WHERE`` clause (predicates joined by AND) referencing the ``p``
+    project node, and ``params`` holds the bound values. ``ne`` and
+    ``not_in`` use plain inequality, so projects without the attribute
+    set are excluded.
+
+    Field names are validated against ``whitelist`` (and an identifier
+    pattern) before being interpolated; values are always bound as
+    query parameters. Raises ``HTTPException`` (400) on malformed
+    predicates, unknown operators, or non-filterable fields.
+    """
+    clauses: list[str] = []
+    params: dict[str, typing.Any] = {}
+    for index, raw in enumerate(filters):
+        field, _, rest = raw.partition(':')
+        op, _, value = rest.partition(':')
+        if not field or not op:
+            raise fastapi.HTTPException(
+                status_code=400,
+                detail=f'Invalid filter {raw!r}; expected field:op[:value]',
+            )
+        if op not in _FILTER_OPS:
+            raise fastapi.HTTPException(
+                status_code=400,
+                detail=(
+                    f'Unknown filter operator {op!r}; valid operators are '
+                    f'{", ".join(sorted(_FILTER_OPS))}'
+                ),
+            )
+        if field not in whitelist or not _FILTER_FIELD_RE.match(field):
+            raise fastapi.HTTPException(
+                status_code=400,
+                detail=(
+                    f'Attribute {field!r} is not filterable for this '
+                    'project type'
+                ),
+            )
+        if op in ('exists', 'not_exists'):
+            null_op = 'IS NOT NULL' if op == 'exists' else 'IS NULL'
+            clauses.append(f'p.{field} {null_op}')
+            continue
+        values = (
+            [v for v in value.split(',') if v]
+            if op in ('in', 'not_in')
+            else [value]
+        )
+        if not values:
+            raise fastapi.HTTPException(
+                status_code=400,
+                detail=f'Filter {raw!r} requires a value',
+            )
+        comparator = '=' if op in ('eq', 'in') else '<>'
+        joiner = ' OR ' if op in ('eq', 'in') else ' AND '
+        terms: list[str] = []
+        for value_index, item in enumerate(values):
+            key = f'f{index}_{value_index}'
+            params[key] = item
+            terms.append(f'p.{field} {comparator} {{{key}}}')
+        clauses.append(
+            terms[0] if len(terms) == 1 else '(' + joiner.join(terms) + ')'
+        )
+    if not clauses:
+        return '', params
+    return 'WHERE ' + ' AND '.join(clauses), params
+
+
 @projects_router.get('/', name='list_projects')
 async def list_projects(
     org_slug: str,
@@ -1089,11 +1167,31 @@ async def list_projects(
     project_type: str | None = None,
     include_archived: bool = False,
     slim: bool = False,
+    filters: typing.Annotated[
+        list[str] | None,
+        fastapi.Query(
+            alias='filter',
+            description=(
+                'Filter projects by blueprint attribute, as '
+                '``field:op[:value]`` (repeatable; combined with AND). '
+                'Operators: eq, ne, in, not_in (comma-separated values), '
+                'exists, not_exists. ne/not_in exclude projects where the '
+                'attribute is unset. Valid fields and enum values per '
+                'project type come from the project-type listing with '
+                '``include_schema=true``. Example: '
+                'framework:ne:http-service-lib'
+            ),
+        ),
+    ] = None,
 ) -> list[ProjectListItem] | list[ProjectResponse]:
     """List projects in the organization.
 
     By default archived projects are excluded.  Pass
     ``include_archived=true`` to include them.
+
+    ``filter`` predicates match against blueprint-defined attributes
+    stored on the project (e.g. ``framework``, ``programming_language``)
+    using the field/operator grammar described on the parameter.
 
     ``slim=true`` returns a stripped payload tailored to the
     projects-list UI: only the fields the list view reads (id, name,
@@ -1116,7 +1214,16 @@ async def list_projects(
     return_fragment: typing.LiteralString = (
         _SLIM_RETURN_FRAGMENT if slim else _RETURN_FRAGMENT
     )
-    query: typing.LiteralString = (
+    attr_filter = ''
+    attr_params: dict[str, typing.Any] = {}
+    if filters:
+        whitelist = blueprint_attributes.resolve(
+            await blueprint_attributes.project_blueprints(db),
+            project_type,
+        )
+        fragment, attr_params = _build_attribute_filter(filters, whitelist)
+        attr_filter = '\n    ' + fragment + '\n' if fragment else ''
+    query: str = (
         """
     MATCH (p:Project)-[:OWNED_BY]->(:Team)
           -[:BELONGS_TO]->(o:Organization {{slug: {org_slug}}})
@@ -1126,6 +1233,7 @@ async def list_projects(
     WITH DISTINCT p, o
     """
         + type_filter
+        + attr_filter
         + return_fragment
         + """
     ORDER BY p.name
@@ -1139,6 +1247,7 @@ async def list_projects(
         {
             'org_slug': org_slug,
             'project_type': project_type,
+            **attr_params,
         },
         columns,
     )

--- a/src/imbi_api/endpoints/projects.py
+++ b/src/imbi_api/endpoints/projects.py
@@ -1125,9 +1125,22 @@ def _build_attribute_filter(
                 ),
             )
         if op in ('exists', 'not_exists'):
+            if value:
+                raise fastapi.HTTPException(
+                    status_code=400,
+                    detail=(
+                        f'Filter {raw!r} does not accept a value for '
+                        f'operator {op!r}'
+                    ),
+                )
             null_op = 'IS NOT NULL' if op == 'exists' else 'IS NULL'
             clauses.append(f'p.{field} {null_op}')
             continue
+        if op in ('eq', 'ne') and value == '':
+            raise fastapi.HTTPException(
+                status_code=400,
+                detail=f'Filter {raw!r} requires a value',
+            )
         values = (
             [v for v in value.split(',') if v]
             if op in ('in', 'not_in')

--- a/tests/endpoints/test_project_types.py
+++ b/tests/endpoints/test_project_types.py
@@ -50,8 +50,8 @@ class ProjectTypeEndpointsTestCase(unittest.TestCase):
         )
 
         self.mock_db = mock.AsyncMock(spec=graph.Graph)
-        self.test_app.dependency_overrides[graph._inject_graph] = (
-            lambda: self.mock_db
+        self.test_app.dependency_overrides[graph._inject_graph] = lambda: (
+            self.mock_db
         )
 
         self.client = testclient.TestClient(self.test_app)
@@ -225,6 +225,87 @@ class ProjectTypeEndpointsTestCase(unittest.TestCase):
             data[1]['relationships']['projects']['count'],
             8,
         )
+
+    def test_list_project_types_include_schema(self) -> None:
+        """``include_schema=true`` attaches filterable attributes."""
+        self.mock_db.execute.return_value = [
+            {
+                'pt': {'name': 'API Service', 'slug': 'apis'},
+                'o': {'name': 'Engineering', 'slug': 'engineering'},
+                'project_count': 1,
+            },
+            {
+                'pt': {'name': 'Consumer', 'slug': 'consumers'},
+                'o': {'name': 'Engineering', 'slug': 'engineering'},
+                'project_count': 0,
+            },
+        ]
+        self.mock_db.match.return_value = [
+            models.Blueprint(
+                name='API Facts',
+                slug='apis-facts',
+                type='Project',
+                filter={'project_type': ['apis']},  # type: ignore[arg-type]
+                json_schema=models.Schema.model_validate(
+                    {
+                        'type': 'object',
+                        'properties': {
+                            'framework': {
+                                'type': 'string',
+                                'enum': ['FastAPI', 'http-service-lib'],
+                            }
+                        },
+                    }
+                ),
+            )
+        ]
+
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            response = self.client.get(
+                '/organizations/engineering/project-types/'
+                '?include_schema=true',
+            )
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(
+            data[0]['schema'],
+            [
+                {
+                    'field': 'framework',
+                    'type': 'string',
+                    'format': None,
+                    'enum': ['FastAPI', 'http-service-lib'],
+                }
+            ],
+        )
+        # The blueprint is filtered to ``apis``; ``consumers`` gets nothing.
+        self.assertEqual(data[1]['schema'], [])
+
+    def test_list_project_types_omits_schema_by_default(self) -> None:
+        """Without the flag, no ``schema`` key and no blueprint fetch."""
+        self.mock_db.execute.return_value = [
+            {
+                'pt': {'name': 'API Service', 'slug': 'apis'},
+                'o': {'name': 'Engineering', 'slug': 'engineering'},
+                'project_count': 1,
+            }
+        ]
+
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            response = self.client.get(
+                '/organizations/engineering/project-types/',
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn('schema', response.json()[0])
+        self.mock_db.match.assert_not_called()
 
     def test_get_project_type(self) -> None:
         """Test retrieving a single project type."""

--- a/tests/endpoints/test_projects.py
+++ b/tests/endpoints/test_projects.py
@@ -1223,6 +1223,85 @@ class ProjectEndpointsTestCase(unittest.TestCase):
         query = self.mock_db.execute.call_args.args[0]
         self.assertNotIn('coalesce(p.archived, false)', query)
 
+    # -- Attribute filtering -------------------------------------------
+
+    def _framework_blueprint(self) -> models.Blueprint:
+        return models.Blueprint(
+            name='API Facts',
+            slug='apis-facts',
+            type='Project',
+            json_schema=models.Schema.model_validate(
+                {
+                    'type': 'object',
+                    'properties': {
+                        'framework': {
+                            'type': 'string',
+                            'enum': ['FastAPI', 'http-service-lib'],
+                        },
+                    },
+                }
+            ),
+        )
+
+    def _list_with_filter(self, query_string: str) -> typing.Any:
+        self.mock_db.match.return_value = [self._framework_blueprint()]
+        self.mock_db.execute.return_value = []
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            return self.client.get(
+                f'/organizations/engineering/projects/?{query_string}',
+            )
+
+    def test_filter_ne_excludes_unset(self) -> None:
+        """``ne`` builds a plain inequality (unset rows excluded)."""
+        response = self._list_with_filter(
+            'filter=framework:ne:http-service-lib'
+        )
+        self.assertEqual(response.status_code, 200)
+        query = self.mock_db.execute.call_args.args[0]
+        params = self.mock_db.execute.call_args.args[1]
+        self.assertIn('p.framework <> {f0_0}', query)
+        self.assertNotIn('IS NULL', query)
+        self.assertEqual(params['f0_0'], 'http-service-lib')
+
+    def test_filter_eq_builds_equality(self) -> None:
+        response = self._list_with_filter('filter=framework:eq:FastAPI')
+        self.assertEqual(response.status_code, 200)
+        query = self.mock_db.execute.call_args.args[0]
+        self.assertIn('p.framework = {f0_0}', query)
+
+    def test_filter_exists(self) -> None:
+        response = self._list_with_filter('filter=framework:exists')
+        self.assertEqual(response.status_code, 200)
+        query = self.mock_db.execute.call_args.args[0]
+        self.assertIn('p.framework IS NOT NULL', query)
+
+    def test_filter_not_in_uses_and_of_inequalities(self) -> None:
+        response = self._list_with_filter(
+            'filter=framework:not_in:FastAPI,http-service-lib'
+        )
+        self.assertEqual(response.status_code, 200)
+        query = self.mock_db.execute.call_args.args[0]
+        self.assertIn(
+            '(p.framework <> {f0_0} AND p.framework <> {f0_1})', query
+        )
+
+    def test_filter_unknown_field_rejected(self) -> None:
+        response = self._list_with_filter('filter=bogus:eq:x')
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('not filterable', response.json()['detail'])
+
+    def test_filter_unknown_operator_rejected(self) -> None:
+        response = self._list_with_filter('filter=framework:like:x')
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('Unknown filter operator', response.json()['detail'])
+
+    def test_filter_malformed_rejected(self) -> None:
+        response = self._list_with_filter('filter=framework')
+        self.assertEqual(response.status_code, 400)
+
 
 class _RelationshipsTestBase(unittest.TestCase):
     """Shared setup for relationship endpoint tests."""

--- a/tests/endpoints/test_projects.py
+++ b/tests/endpoints/test_projects.py
@@ -1302,6 +1302,21 @@ class ProjectEndpointsTestCase(unittest.TestCase):
         response = self._list_with_filter('filter=framework')
         self.assertEqual(response.status_code, 400)
 
+    def test_filter_exists_with_value_rejected(self) -> None:
+        response = self._list_with_filter('filter=framework:exists:x')
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('does not accept a value', response.json()['detail'])
+
+    def test_filter_eq_without_value_rejected(self) -> None:
+        response = self._list_with_filter('filter=framework:eq')
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('requires a value', response.json()['detail'])
+
+    def test_filter_ne_without_value_rejected(self) -> None:
+        response = self._list_with_filter('filter=framework:ne')
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('requires a value', response.json()['detail'])
+
 
 class _RelationshipsTestBase(unittest.TestCase):
     """Shared setup for relationship endpoint tests."""

--- a/tests/test_blueprint_attributes.py
+++ b/tests/test_blueprint_attributes.py
@@ -1,0 +1,115 @@
+"""Tests for blueprint-attribute resolution."""
+
+import unittest
+
+from imbi_common import models
+
+from imbi_api import blueprint_attributes
+
+
+def _blueprint(
+    name: str,
+    properties: dict,
+    *,
+    kind: str = 'node',
+    project_type: list[str] | None = None,
+    environment: list[str] | None = None,
+) -> models.Blueprint:
+    bp_filter = None
+    if project_type is not None or environment is not None:
+        bp_filter = models.BlueprintFilter(
+            project_type=project_type or [],
+            environment=environment or [],
+        )
+    return models.Blueprint(
+        name=name,
+        slug=name,
+        kind=kind,  # type: ignore[arg-type]
+        type=None if kind == 'relationship' else 'Project',
+        filter=bp_filter,
+        json_schema=models.Schema.model_validate(
+            {'type': 'object', 'properties': properties}
+        ),
+    )
+
+
+class ResolveTestCase(unittest.TestCase):
+    """Tests for ``blueprint_attributes.resolve``."""
+
+    def test_type_scoping_includes_matching_and_unfiltered(self) -> None:
+        common = _blueprint(
+            'common',
+            {'programming_language': {'type': 'string', 'enum': ['Python']}},
+        )
+        apis = _blueprint(
+            'apis',
+            {'framework': {'type': 'string', 'enum': ['FastAPI']}},
+            project_type=['apis'],
+        )
+        consumers = _blueprint(
+            'consumers',
+            {'queue': {'type': 'string'}},
+            project_type=['consumers'],
+        )
+
+        result = blueprint_attributes.resolve(
+            [common, apis, consumers], 'apis'
+        )
+
+        self.assertEqual(set(result), {'programming_language', 'framework'})
+        self.assertEqual(result['framework'].enum, ['FastAPI'])
+        self.assertEqual(result['framework'].type, 'string')
+
+    def test_union_when_type_slug_is_none(self) -> None:
+        apis = _blueprint(
+            'apis', {'framework': {'type': 'string'}}, project_type=['apis']
+        )
+        consumers = _blueprint(
+            'consumers',
+            {'queue': {'type': 'string'}},
+            project_type=['consumers'],
+        )
+
+        result = blueprint_attributes.resolve([apis, consumers], None)
+
+        self.assertEqual(set(result), {'framework', 'queue'})
+
+    def test_later_blueprint_overrides_same_field(self) -> None:
+        first = _blueprint('first', {'framework': {'type': 'string'}})
+        second = _blueprint(
+            'second',
+            {'framework': {'type': 'string', 'enum': ['FastAPI', 'Tornado']}},
+        )
+
+        # ``resolve`` expects ascending priority order; the later entry wins.
+        result = blueprint_attributes.resolve([first, second], 'apis')
+
+        self.assertEqual(result['framework'].enum, ['FastAPI', 'Tornado'])
+
+    def test_relationship_blueprints_are_ignored(self) -> None:
+        rel = models.Blueprint.model_construct(
+            name='edge',
+            slug='edge',
+            kind='relationship',
+            type=None,
+            filter=None,
+            json_schema=models.Schema.model_validate(
+                {'type': 'object', 'properties': {'role': {'type': 'string'}}}
+            ),
+        )
+
+        result = blueprint_attributes.resolve([rel], None)
+
+        self.assertEqual(result, {})
+
+    def test_environment_filter_does_not_exclude(self) -> None:
+        env_scoped = _blueprint(
+            'env',
+            {'deployed_version': {'type': 'string'}},
+            project_type=['apis'],
+            environment=['production'],
+        )
+
+        result = blueprint_attributes.resolve([env_scoped], 'apis')
+
+        self.assertIn('deployed_version', result)


### PR DESCRIPTION
## Summary

Enables attribute-based project search (e.g. "APIs not using `http-service-lib`", "Python projects not on 3.14") so `imbi-assistant` can push filters down to the graph instead of fetching every project and reasoning over it.

The data already lives as plain vertex properties on the `Project` node (set by blueprints); this exposes it for structured filtering and discovery.

## Changes

- **`blueprint_attributes.resolve()`** (new) flattens enabled `Project` *node* blueprints into a filterable-attribute catalog (`field`/`type`/`format`/`enum`), scoped to a project type or unioned across all types. Shared by both endpoints so the advertised and accepted field sets cannot drift.
- **`list_project_types`** gains `include_schema=true`, attaching each type's catalog as a `schema` array. Blueprints are fetched once; no fetch when the flag is off.
- **`list_projects`** gains a repeatable `filter=field:op[:value]` parameter (`eq`, `ne`, `in`, `not_in`, `exists`, `not_exists`). Field names are whitelist-validated against the catalog then interpolated; values are bound as query parameters. `ne`/`not_in` use plain inequality, so projects with the attribute **unset are excluded**. Unknown field/operator → 400.

## Testing

- New `tests/test_blueprint_attributes.py` (resolver: type scoping, union, priority override, relationship/env-filter handling).
- `test_projects.py` (+7): filter operator → Cypher assertions and the 400 paths.
- `test_project_types.py` (+2): `include_schema` attaches the catalog; omitted by default.
- `ruff`, `mypy`, `basedpyright` clean. Mocked-graph tests assert the generated Cypher; **not yet exercised against a live AGE graph**.

## Notes

The new query params auto-surface as `imbi-assistant` MCP tools via the OpenAPI spec. Paired with AWeber-Imbi/imbi-assistant system-prompt PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)