### PR TITLE
Ingest CycloneDX 1.7 SBoMs onto Release dependency edges

### DIFF
--- a/docs/adr/0015-cyclonedx-1.7-sbom-standard.md
+++ b/docs/adr/0015-cyclonedx-1.7-sbom-standard.md
@@ -1,0 +1,170 @@
+# ADR 0015: CycloneDX 1.7 as the SBoM Standard
+
+## Status
+
+Accepted
+
+Date: 2026-05-27
+
+Source design lives in [`plans/sbom-ingest.md`](https://github.com/AWeber-Imbi/imbi-development/blob/main/plans/sbom-ingest.md).
+
+## Context
+
+Imbi attributes third-party software usage to a project's `Release`
+via the `Release -[:USES_COMPONENT_RELEASE]-> ComponentRelease` edge
+(see `ReleaseComponentEdge` in
+`imbi-common/src/imbi_common/models.py`). To populate that edge we
+ingest Software Bills of Materials (SBoMs) produced by build CI and
+push the resulting `Component` / `ComponentRelease` /
+`ComponentIdentifier` nodes through a single
+`PUT /organizations/{org}/projects/{project_id}/releases/{release_id}/sbom`
+endpoint.
+
+Two questions had to be settled before the ingest pipeline could be
+written:
+
+1. **Which SBoM spec version do we accept on the wire?** CycloneDX
+   1.5, 1.6, and 1.7 are all in the wild. Each release strictly
+   expanded the schema; 1.7 added fields Imbi reads (notably
+   per-component properties used to carry dependency-group attribution
+   in the cdxgen output). Accepting earlier versions would silently
+   drop those fields on the floor.
+2. **Which producer do we recommend in build CI?** Imbi's normalizer
+   only sees what the producer emitted. We need a single tool that
+   covers our polyglot service population (uv-based Python, npm /
+   yarn / pnpm JS / TS, Maven / Gradle Java, Go) and that emits the
+   per-component metadata required to populate `scope` and `groups`
+   on `ReleaseComponentEdge`.
+
+We evaluated `cyclonedx-py` (the `cyclonedx-bom` PyPI package) for
+the Python side and found it does not handle PEP 735
+`[dependency-groups]` at all — dev-vs-runtime attribution is simply
+lost for `uv` and `pdm` projects. We also considered an ecosystem-
+per-tool fleet (cyclonedx-py for Python, cyclonedx-npm for JS, the
+Maven plugin for Java, etc.) but rejected it because each tool
+encodes group / scope metadata in a different shape, which would
+push ecosystem-specific knowledge into the Imbi normalizer. cdxgen
+(<https://github.com/CycloneDX/cdxgen>) is the only common tool we
+found that emits CycloneDX 1.7 with consistent, useful
+per-component metadata across the languages we care about.
+
+## Decision
+
+### 1. CycloneDX 1.7 is the only spec version Imbi accepts
+
+The ingest endpoint enforces `specVersion == "1.7"` and rejects
+anything else with `415 Unsupported Media Type`. Implementation:
+
+- `imbi-api/src/imbi_api/sbom.py` declares
+  `SUPPORTED_SPEC_VERSION: typing.Final = '1.7'`.
+- A version mismatch raises `UnsupportedSpecVersionError` from
+  `parse()`, which the endpoint maps to HTTP 415.
+
+We deliberately do not coerce 1.5 / 1.6 payloads up to 1.7. The
+later schema introduced fields we depend on; silent up-conversion
+would produce CycloneDX documents that look 1.7-shaped but are
+missing data the normalizer expects.
+
+### 2. cdxgen is the recommended producer
+
+cdxgen (<https://github.com/CycloneDX/cdxgen>) is the SBoM producer
+Imbi documents in service-onboarding guidance for build CI. It
+covers the languages currently in the fleet from a single
+invocation, and — critically — exposes per-component metadata that
+Imbi reads to populate `ReleaseComponentEdge`:
+
+- **`component.scope`** (`required` / `optional` / `excluded`) is
+  defined by CycloneDX itself and is universal across ecosystems.
+  Imbi stores it verbatim as `ReleaseComponentEdge.scope`, mapping
+  `None` to "producer did not declare a scope."
+- **`component.properties[].name == "cdx:pyproject:group"`** is
+  cdxgen's encoding for both PEP 735 `[dependency-groups]` and
+  Poetry `[tool.poetry.group.X]`. Imbi flattens these into
+  `ReleaseComponentEdge.groups`, sorted and de-duplicated at ingest
+  time so equality comparisons across releases are stable.
+
+Python is currently the only ecosystem that emits named dependency
+groups; the Imbi parser maintains a curated allow-list of property
+names rather than ingesting every cdxgen property by default. As
+cdxgen adds equivalent group support for other ecosystems (e.g. npm
+`devDependencies` groups, Maven scopes-as-groups), the allow-list
+grows — the consuming graph contract does not change.
+
+### 3. `cyclonedx-python-lib` is the parser, not the producer
+
+Imbi parses incoming SBoMs with the `cyclonedx-python-lib`
+PyPI package, pinned `>=11.7,<12` in `imbi-api/pyproject.toml`.
+This is an entirely separate concern from the producer choice:
+
+- The library gives us a typed, validated CycloneDX 1.7 object
+  graph to project into `NormalizedComponent` records.
+- It runs server-side, on whatever payload the producer emitted.
+  We could swap producers tomorrow and the parser would not move.
+
+The two choices are recorded together in this ADR only because
+they are easy to conflate in conversation; conflating them in
+code (e.g., gating ingestion on `User-Agent: cdxgen/*`) would be
+a mistake.
+
+## Consequences
+
+### Positive
+
+- The producer side and consumer side share one schema version, so
+  every field cdxgen emits maps onto a field Imbi understands. No
+  silent data loss on dev-group attribution for Python.
+- The Imbi normalizer stays ecosystem-agnostic. It reads
+  `component.scope` and one curated set of property names; it does
+  not branch on `purl` type to decide which fields exist.
+- A single recommended producer simplifies onboarding docs and CI
+  templates. Service teams get one `cdxgen … -o cyclonedx.json`
+  invocation, not a per-language matrix.
+- The parser is library-pinned and free to evolve independently of
+  build CI; producer upgrades don't force coordinated API releases.
+
+### Negative
+
+- Build CI is on the hook for keeping cdxgen current. cdxgen is
+  active upstream but not run by us; an upstream regression in
+  group emission would degrade attribution quietly until someone
+  noticed `groups` arrays going empty.
+- Rejecting 1.5 / 1.6 means any team running an older cdxgen (or a
+  different tool that only emits 1.6) gets a hard `415` instead of
+  a partial ingest. This is intentional — partial ingest is the
+  failure mode this ADR exists to avoid — but it does shift the
+  fix-it work onto the producer side.
+- We are tied to one producer's property naming convention
+  (`cdx:pyproject:group`) for dependency-group attribution. If
+  cdxgen renames or restructures the property, the Imbi
+  normalizer's allow-list must move with it. That coupling is the
+  price of ecosystem-agnostic ingest.
+
+### Risks Accepted
+
+- **Multi-version compatibility**: not a goal. We will not run a
+  1.5 / 1.6 compatibility shim. Producers that cannot emit 1.7 are
+  not supported producers.
+- **Producer monoculture**: we are recommending a single tool. A
+  team is free to emit CycloneDX 1.7 from a different producer
+  (the parser does not care), but they lose dependency-group
+  attribution unless that producer happens to emit the same
+  property names. This is acceptable because the alternative —
+  matrixing the normalizer over every producer's metadata
+  convention — pushes ecosystem branching into core.
+- **bom-ref persistence**: not done. CycloneDX `bom-ref` is a
+  per-SBoM internal cross-reference, not a stable component
+  identity, and the parser excludes it from `_IDENTIFIER_KINDS` in
+  `imbi-api/src/imbi_api/sbom.py`. Anyone tempted to "just persist
+  the bom-ref" should re-read the comment there before doing so.
+
+## References
+
+- [`plans/sbom-ingest.md`](https://github.com/AWeber-Imbi/imbi-development/blob/main/plans/sbom-ingest.md) — Full ingest plan, including the cdxgen evaluation and the curated property allow-list.
+- `imbi-api/src/imbi_api/sbom.py` — `SUPPORTED_SPEC_VERSION`,
+  `UnsupportedSpecVersionError`, and the parse / upsert pipeline.
+- `imbi-common/src/imbi_common/models.py` — `Component`,
+  `ComponentRelease`, `ComponentIdentifier`, and
+  `ReleaseComponentEdge` (the graph contract this ADR populates).
+- [CycloneDX 1.7 specification](https://cyclonedx.org/docs/1.7/json/)
+- [cdxgen](https://github.com/CycloneDX/cdxgen) — recommended SBoM producer.
+- [cyclonedx-python-lib](https://github.com/CycloneDX/cyclonedx-python-lib) — server-side parser.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -235,6 +235,3 @@ exclude-newer-package = { "clickhouse-connect" = false, "imbi-common" = false, "
 [[tool.uv.index]]
 url = "https://pypi.org/simple"
 default = true
-
-[tool.uv.sources]
-imbi-common = { git = "https://github.com/AWeber-Imbi/imbi-common.git", branch = "main" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
   "aiohttp",
   "argon2-cffi>=25.1.0",
   "authlib>=1.6.11",
+  "cyclonedx-python-lib>=11.7,<12",
   "fastapi",
   "filetype",
   "httpx>=0.28.1,<1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
   "fastapi",
   "filetype",
   "httpx>=0.28.1,<1",
-  "imbi-common[databases,llm,sentry,server]>=2.6.0",
+  "imbi-common[databases,llm,sentry,server]>=2.7.0",
   "jinja2",
   "jsonpatch>=1.33",
   "nanoid>=2.0.0",

--- a/src/imbi_api/endpoints/releases.py
+++ b/src/imbi_api/endpoints/releases.py
@@ -23,6 +23,7 @@ from imbi_common import graph, models
 from imbi_common.plugins.base import CheckStatus
 
 from imbi_api import patch as json_patch
+from imbi_api import sbom
 from imbi_api.auth import permissions
 from imbi_api.endpoints.operations_log import complete_opslog_entry
 from imbi_api.plugins import call_with_timeout
@@ -1351,3 +1352,175 @@ async def get_deployment_edge(
             ),
         )
     return _edge_to_response(env, deployments)
+
+
+# -- SBoM ingest / dependency listing ---------------------------------
+
+
+class ReleaseDependencyIdentifier(pydantic.BaseModel):
+    """One ``(kind, value)`` pair on a component in the GET response."""
+
+    kind: str
+    value: str
+
+
+class ReleaseDependencyComponent(pydantic.BaseModel):
+    """One row in the dependency listing for a release.
+
+    ``scope`` and ``groups`` are per-release usage facts populated
+    from the ``USES_COMPONENT_RELEASE`` edge — a given component
+    version can be ``required`` in one release and a dev group in
+    another. See ADR 0015 for the producer-side semantics.
+    """
+
+    purl_name: str
+    name: str
+    ecosystem: str
+    description: str | None = None
+    version: str
+    license: str | None = None
+    supplier: str | None = None
+    hashes: dict[str, str] = pydantic.Field(default_factory=dict)
+    identifiers: list[ReleaseDependencyIdentifier] = pydantic.Field(
+        default_factory=list,
+    )
+    scope: typing.Literal['required', 'optional', 'excluded'] | None = None
+    groups: list[str] = pydantic.Field(default_factory=list)
+
+
+class ReleaseDependenciesResponse(pydantic.BaseModel):
+    """Response body for ``GET .../releases/{release_id}/dependencies``."""
+
+    release_id: str
+    components: list[ReleaseDependencyComponent] = pydantic.Field(
+        default_factory=list,
+    )
+
+
+def _coerce_scope(
+    raw: str | None,
+) -> typing.Literal['required', 'optional', 'excluded'] | None:
+    """Narrow the graph-side scope string to the response literal.
+
+    The graph layer types ``scope`` as ``str | None`` (it stores
+    whatever the producer sent). Anything outside the
+    CycloneDX-spec'd vocabulary collapses to ``None`` rather than
+    surfacing in the API, so older / non-conformant SBoMs don't
+    leak unexpected strings into the UI.
+    """
+    if raw == 'required':
+        return 'required'
+    if raw == 'optional':
+        return 'optional'
+    if raw == 'excluded':
+        return 'excluded'
+    return None
+
+
+@releases_router.put(
+    '/{release_id}/sbom',
+    status_code=204,
+    responses={
+        204: {'description': 'SBoM ingested successfully.'},
+        400: {'description': 'Payload is not a valid CycloneDX document.'},
+        404: {'description': 'Project or release not found.'},
+        415: {'description': 'Unsupported CycloneDX specVersion.'},
+    },
+)
+async def put_release_sbom(
+    org_slug: str,
+    project_id: str,
+    release_id: str,
+    body: dict[str, typing.Any],
+    db: graph.Pool,
+    _auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('project:write'),
+        ),
+    ],
+) -> fastapi.Response:
+    """Ingest a CycloneDX 1.7 SBoM for a release.
+
+    The payload is the verbatim CycloneDX document — no envelope.
+    The PUT is idempotent: existing dependency edges from this
+    release are dropped and rebuilt from the new SBoM, while
+    ``Component`` / ``ComponentRelease`` / ``ComponentIdentifier``
+    nodes are MERGE-ed so other projects keep their references.
+    """
+    if await _fetch_release(db, org_slug, project_id, release_id) is None:
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail=(
+                f'Release {release_id!r} for project {project_id!r} not found'
+            ),
+        )
+    try:
+        components = sbom.parse(body)
+    except sbom.UnsupportedSpecVersionError as exc:
+        raise fastapi.HTTPException(
+            status_code=415,
+            detail=str(exc),
+        ) from exc
+    except sbom.MalformedSBomError as exc:
+        raise fastapi.HTTPException(
+            status_code=400,
+            detail=str(exc),
+        ) from exc
+    await sbom.replace_release_components(db, release_id, components)
+    return fastapi.Response(status_code=204)
+
+
+@releases_router.get(
+    '/{release_id}/dependencies',
+    response_model=ReleaseDependenciesResponse,
+)
+async def list_release_dependencies(
+    org_slug: str,
+    project_id: str,
+    release_id: str,
+    db: graph.Pool,
+    _auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('project:read'),
+        ),
+    ],
+) -> ReleaseDependenciesResponse:
+    """List the components ingested for a release.
+
+    Returns an empty ``components`` list when no SBoM has been
+    ingested yet — the release existing without an SBoM is the
+    common bootstrap case, not an error. ``404`` is returned only
+    when the release itself is unknown.
+    """
+    if await _fetch_release(db, org_slug, project_id, release_id) is None:
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail=(
+                f'Release {release_id!r} for project {project_id!r} not found'
+            ),
+        )
+    rows = await sbom.list_release_components(db, release_id)
+    return ReleaseDependenciesResponse(
+        release_id=release_id,
+        components=[
+            ReleaseDependencyComponent(
+                purl_name=row.purl_name,
+                name=row.name,
+                ecosystem=row.ecosystem,
+                description=row.description,
+                version=row.version,
+                license=row.license,
+                supplier=row.supplier,
+                hashes=row.hashes,
+                identifiers=[
+                    ReleaseDependencyIdentifier(kind=i.kind, value=i.value)
+                    for i in row.identifiers
+                ],
+                scope=_coerce_scope(row.scope),
+                groups=row.groups,
+            )
+            for row in rows
+        ],
+    )

--- a/src/imbi_api/sbom.py
+++ b/src/imbi_api/sbom.py
@@ -1,0 +1,739 @@
+# pyright: reportUnknownMemberType=false
+# pyright: reportUnknownVariableType=false
+# pyright: reportUnknownArgumentType=false
+# pyright: reportAttributeAccessIssue=false
+# pyright: reportOptionalMemberAccess=false
+#
+# The cyclonedx-python-lib uses py_serializable's
+# ``@serializable.serializable_class`` decorator, which causes
+# basedpyright to see its model classes as ``_JsonSerializable |
+# _XmlSerializable`` rather than their declared interfaces. Field
+# accessors (``Component.purl``, ``Component.cpe`` etc.) and the
+# dynamic ``from_json`` classmethod are typed at runtime but
+# invisible to the static checker. The suppressions above are
+# scoped to this module so the rest of the codebase keeps strict
+# checking.
+"""CycloneDX 1.7 SBoM ingestion.
+
+This module owns the full SBoM ingestion pipeline:
+
+1. :func:`parse` — pure CycloneDX 1.7 deserialization, returns a
+   flat list of :class:`NormalizedComponent` records.
+2. :func:`replace_release_components` — idempotent graph upsert
+   that drops a release's existing component edges and rebuilds
+   them from a normalized list (``Component`` →
+   ``ComponentRelease`` → ``ComponentIdentifier``).
+3. :func:`list_release_components` — reverse lookup used by the
+   ``GET .../dependencies`` endpoint.
+
+Cypher templates live as ``typing.LiteralString`` constants below.
+The CycloneDX parse path is pure and depends only on stdlib and
+``cyclonedx-python-lib``; the graph functions accept a
+:class:`graph.Graph` and perform AGE I/O.
+"""
+
+import asyncio
+import collections.abc
+import datetime
+import json
+import logging
+import typing
+
+import cyclonedx.exception.model
+import cyclonedx.model
+import nanoid
+import pydantic
+from cyclonedx.model import bom as cdx_bom
+from cyclonedx.model import component as cdx_component
+from cyclonedx.model import license as cdx_license
+from imbi_common import graph
+from packageurl import PackageURL
+
+LOGGER = logging.getLogger(__name__)
+
+#: The single CycloneDX spec version we accept on the wire. The
+#: producer side (build CI) is expected to emit 1.7 verbatim; we
+#: deliberately do not silently coerce earlier versions because the
+#: 1.7 schema introduces a handful of fields (e.g. tagged-by) we
+#: store, and 1.5/1.6 payloads would arrive with subtle data loss.
+SUPPORTED_SPEC_VERSION: typing.Final = '1.7'
+
+#: CycloneDX identifier kinds we project into ``ComponentIdentifier``
+#: nodes. ``bom-ref`` is intentionally excluded — it is a per-SBoM
+#: internal cross-reference, not a stable global identity for a
+#: component, and conflating the two would create spurious matches
+#: across unrelated SBoMs that happen to reuse the same string.
+_IDENTIFIER_KINDS: typing.Final = ('purl', 'cpe')
+
+#: ``component.properties[].name`` values cdxgen emits to attribute a
+#: component to a named dependency group. The list is intentionally
+#: short — only ``cdx:pyproject:group`` is in use today and covers
+#: both Poetry groups and PEP 735 ``[dependency-groups]``. As cdxgen
+#: gains support for similar groupings in other ecosystems (npm
+#: workspaces, Maven profiles, etc.) we extend this tuple rather than
+#: matching ``cdx:*:group`` with a regex, so that boolean-flag
+#: properties like ``cdx:npm:package:development`` never accidentally
+#: land in the ``groups`` list.
+#:
+#: The CycloneDX 1.7 property-taxonomy reference is at
+#: https://github.com/CycloneDX/cyclonedx-property-taxonomy.
+_GROUP_PROPERTY_NAMES: typing.Final[tuple[str, ...]] = ('cdx:pyproject:group',)
+
+#: CycloneDX 1.7 ``scope`` values we round-trip on the ingest path.
+_COMPONENT_SCOPES: typing.Final = ('required', 'optional', 'excluded')
+
+#: Maximum number of components we upsert in parallel during a single
+#: SBoM PUT. A typical Python project ships 30-80 components, while a
+#: typical npm tree is 500-1500 — serial upserts at AGE round-trip
+#: latency are slow enough that the gateway times out before the API
+#: finishes. Bound the gather so we don't swamp the connection pool;
+#: each task holds one connection for the lifetime of its
+#: UPSERT_COMPONENT_AND_LINK + identifier upserts. 16 is conservative
+#: against the default psycopg pool size and leaves headroom for
+#: other in-flight requests. Tune via the settings module if pool-
+#: saturation warnings start appearing under realistic SBoM sizes.
+_UPSERT_CONCURRENCY: typing.Final = 16
+
+
+class SBomError(Exception):
+    """Base class for SBoM parsing failures.
+
+    Subclasses map to specific HTTP responses on the endpoint side
+    so the API can return precise status codes without inspecting
+    error messages.
+    """
+
+
+class UnsupportedSpecVersionError(SBomError):
+    """Raised when ``specVersion`` is not :data:`SUPPORTED_SPEC_VERSION`.
+
+    Mapped to ``415 Unsupported Media Type`` at the endpoint.
+    """
+
+    def __init__(self, received: object) -> None:
+        super().__init__(
+            f'CycloneDX specVersion {received!r} is not supported; '
+            f'expected {SUPPORTED_SPEC_VERSION!r}.'
+        )
+        self.received = received
+
+
+class MalformedSBomError(SBomError):
+    """Raised when the payload is not a valid CycloneDX document.
+
+    Mapped to ``400 Bad Request`` at the endpoint.
+    """
+
+
+class ComponentIdentity(pydantic.BaseModel):
+    """A single ``(kind, value)`` pair attached to a component."""
+
+    model_config = pydantic.ConfigDict(frozen=True)
+
+    kind: typing.Literal['purl', 'cpe']
+    value: str
+
+
+class NormalizedComponent(pydantic.BaseModel):
+    """Graph-ready projection of a single CycloneDX component.
+
+    ``purl_name`` is the version-stripped package URL and is the
+    canonical key for the upstream ``Component`` node. ``version``
+    keys the ``ComponentRelease``. ``identifiers`` carry the
+    version-stripped identifier values used to MERGE
+    ``ComponentIdentifier`` nodes — the version-bearing purl/cpe
+    direct from the SBoM is intentionally not persisted as a node.
+
+    ``scope`` and ``groups`` are *usage* facts — they describe how
+    the component is used by *this* release. They land on the
+    ``Release-[:USES_COMPONENT_RELEASE]->ComponentRelease`` edge,
+    not on the ``ComponentRelease`` node, because the same package
+    version can be required by one project and a dev-only
+    dependency in another.
+    """
+
+    model_config = pydantic.ConfigDict(frozen=True)
+
+    purl_name: str
+    name: str
+    ecosystem: str
+    version: str
+    license: str | None = None
+    supplier: str | None = None
+    hashes: dict[str, str] = pydantic.Field(default_factory=dict)
+    description: str | None = None
+    identifiers: list[ComponentIdentity] = pydantic.Field(
+        default_factory=list,
+    )
+    scope: typing.Literal['required', 'optional', 'excluded'] | None = None
+    groups: list[str] = pydantic.Field(default_factory=list)
+
+
+def parse(payload: object) -> list[NormalizedComponent]:
+    """Validate and normalize a CycloneDX 1.7 payload.
+
+    :param payload: The decoded JSON body (already a ``dict``).
+    :returns: A deduplicated list of ``NormalizedComponent`` records,
+        one per unique ``(purl_name, version)`` pair encountered in
+        ``components[]``. Components without enough information to
+        derive a ``purl_name`` are silently skipped — the SBoM
+        producer is responsible for emitting a purl for everything
+        we care about; skipping is preferable to inventing a
+        synthetic identity that may collide.
+    :raises UnsupportedSpecVersionError: if ``specVersion`` is not
+        ``"1.7"``.
+    :raises MalformedSBomError: if the payload is not a CycloneDX
+        document the library can parse.
+    """
+    if not isinstance(payload, dict):
+        raise MalformedSBomError('CycloneDX payload must be a JSON object')
+    spec_version = payload.get('specVersion')
+    if spec_version != SUPPORTED_SPEC_VERSION:
+        raise UnsupportedSpecVersionError(spec_version)
+
+    try:
+        # ``from_json`` is dynamically injected by py_serializable and
+        # is therefore invisible to mypy / basedpyright.
+        bom = cdx_bom.Bom.from_json(  # type: ignore[attr-defined]
+            typing.cast(typing.Any, payload)
+        )
+    except (
+        cyclonedx.exception.model.CycloneDxModelException,
+        AttributeError,
+        KeyError,
+        TypeError,
+        ValueError,
+    ) as exc:
+        raise MalformedSBomError(f'Invalid CycloneDX document: {exc}') from exc
+
+    seen: dict[tuple[str, str], NormalizedComponent] = {}
+    for component in bom.components:
+        normalized = _normalize(component)
+        if normalized is None:
+            continue
+        key = (normalized.purl_name, normalized.version)
+        if key in seen:
+            continue
+        seen[key] = normalized
+    return list(seen.values())
+
+
+def _normalize(
+    component: cdx_component.Component,
+) -> NormalizedComponent | None:
+    """Project a CycloneDX ``Component`` into a NormalizedComponent.
+
+    Returns ``None`` when the component has no purl — without one
+    we have no stable identity to key on. Callers skip such rows.
+    """
+    purl = component.purl
+    if purl is None:
+        LOGGER.debug('Skipping component %r — no purl in SBoM', component.name)
+        return None
+
+    purl_name = _strip_purl_version(purl)
+    version = component.version or purl.version
+    if not version:
+        LOGGER.debug(
+            'Skipping component %r — no version in SBoM',
+            component.name,
+        )
+        return None
+
+    identifiers: list[ComponentIdentity] = [
+        ComponentIdentity(kind='purl', value=purl_name),
+    ]
+    if component.cpe:
+        identifiers.append(
+            ComponentIdentity(
+                kind='cpe', value=_strip_cpe_version(component.cpe)
+            ),
+        )
+
+    return NormalizedComponent(
+        purl_name=purl_name,
+        name=component.name,
+        ecosystem=purl.type,
+        version=version,
+        license=_normalize_license(component.licenses),
+        supplier=component.supplier.name if component.supplier else None,
+        hashes={hash_.alg.value: hash_.content for hash_ in component.hashes},
+        description=component.description,
+        scope=_normalize_scope(component.scope),
+        groups=_collect_groups(component.properties),
+        identifiers=identifiers,
+    )
+
+
+def _strip_purl_version(purl: PackageURL) -> str:
+    """Return the purl string with any ``@version`` segment removed."""
+    return str(
+        PackageURL(
+            type=purl.type,
+            namespace=purl.namespace,
+            name=purl.name,
+            qualifiers=purl.qualifiers,
+            subpath=purl.subpath,
+        )
+    )
+
+
+def _strip_cpe_version(cpe: str) -> str:
+    """Return a CPE 2.3 string with the version segment masked to ``*``.
+
+    CPE 2.3 URIs are colon-delimited with version at index 5
+    (``cpe:2.3:<part>:<vendor>:<product>:<version>:<update>:…``).
+    Replacing the version with ``*`` collapses every per-version CPE
+    a producer might emit to a single component-level identifier.
+    Inputs that don't look like CPE 2.3 are returned unchanged —
+    that's an SBoM producer issue, not ours to silently rewrite.
+    """
+    parts = cpe.split(':')
+    if len(parts) >= 6 and parts[0] == 'cpe' and parts[1] == '2.3':
+        parts[5] = '*'
+        return ':'.join(parts)
+    return cpe
+
+
+def _normalize_license(
+    licenses: collections.abc.Iterable[cdx_license.License],
+) -> str | None:
+    """Reduce CycloneDX license records to a single SPDX-ish string.
+
+    Producers emit licenses in three shapes:
+    - ``LicenseExpression`` (the SPDX expression form, preferred)
+    - ``License`` with an ``id`` (SPDX identifier like ``MIT``)
+    - ``License`` with a free-form ``name``
+
+    We return the first hit in that priority order, joined with
+    ``" AND "`` when multiple records co-exist. ``None`` means the
+    component declared no license metadata.
+    """
+    expressions: list[str] = []
+    for record in licenses:
+        if isinstance(record, cdx_license.LicenseExpression):
+            expressions.append(str(record.value))
+            continue
+        if record.id:
+            expressions.append(record.id)
+            continue
+        if record.name:
+            expressions.append(record.name)
+    if not expressions:
+        return None
+    return ' AND '.join(expressions)
+
+
+def _normalize_scope(
+    scope: cdx_component.ComponentScope | None,
+) -> typing.Literal['required', 'optional', 'excluded'] | None:
+    """Coerce ``cyclonedx.model.component.ComponentScope`` to a literal.
+
+    CycloneDX 1.7 defines three scopes; we round-trip exactly those.
+    A ``None`` input — the producer did not declare ``scope`` — is
+    surfaced as ``None`` rather than defaulted to ``"required"``,
+    so the UI can distinguish "explicitly required" from "unstated".
+    """
+    if scope is None:
+        return None
+    value = scope.value
+    if value == 'required':
+        return 'required'
+    if value == 'optional':
+        return 'optional'
+    if value == 'excluded':
+        return 'excluded'
+    return None
+
+
+def _collect_groups(
+    properties: collections.abc.Iterable[cyclonedx.model.Property],
+) -> list[str]:
+    """Read dependency-group names off of the curated property allow-list.
+
+    Returns a sorted, de-duplicated list. Properties with empty
+    values are skipped — they appear in some pipelines as placeholder
+    rows when the producer cannot determine the group.
+    """
+    groups: set[str] = set()
+    for prop in properties:
+        if prop.name in _GROUP_PROPERTY_NAMES and prop.value:
+            groups.add(prop.value)
+    return sorted(groups)
+
+
+# ----- Graph upsert / lookup ----------------------------------------
+
+# Drops every USES_COMPONENT_RELEASE edge from a project release.
+# Re-running an SBoM PUT replaces the dependency set wholesale —
+# this query is the "replace" half of that contract. ``Component``
+# and ``ComponentRelease`` nodes are intentionally left alone; they
+# may still be referenced by other projects.
+_CLEAR_RELEASE_COMPONENTS: typing.LiteralString = """
+MATCH (:Release {{id: {release_id}}})-[edge:USES_COMPONENT_RELEASE]->()
+DELETE edge
+"""
+
+# Upsert one Component plus its single ComponentRelease and link
+# that ComponentRelease to the project Release. ``COALESCE`` lets
+# the same plain ``SET`` clause serve both create and update —
+# AGE has no ``ON CREATE SET`` / ``ON MATCH SET`` distinction.
+#
+# The ``USES_COMPONENT_RELEASE`` edge carries the *usage* facts
+# (``scope`` and ``groups``) — see ``ReleaseComponentEdge`` and
+# ADR 0015. ``groups`` is JSON-encoded because AGE stores list-of-
+# string properties as JSON strings the same way it stores dicts.
+_UPSERT_COMPONENT_AND_LINK: typing.LiteralString = """
+MATCH (r:Release {{id: {release_id}}})
+MERGE (c:Component {{purl_name: {purl_name}}})
+SET c.id = COALESCE(c.id, {component_id}),
+    c.name = {name},
+    c.ecosystem = {ecosystem},
+    c.description = {description},
+    c.created_at = COALESCE(c.created_at, {now}),
+    c.updated_at = {now}
+MERGE (c)-[:HAS_RELEASE]->(cr:ComponentRelease {{version: {version}}})
+SET cr.id = COALESCE(cr.id, {component_release_id}),
+    cr.license = {license},
+    cr.supplier = {supplier},
+    cr.hashes = {hashes},
+    cr.created_at = COALESCE(cr.created_at, {now}),
+    cr.updated_at = {now}
+MERGE (r)-[e:USES_COMPONENT_RELEASE]->(cr)
+SET e.scope = {scope},
+    e.groups = {groups}
+RETURN c.id AS component_id
+"""
+
+# Attach one identifier to a Component, MERGEing on the globally
+# unique ``(kind, value)`` pair so the same purl shared by two
+# components is impossible by construction.
+_UPSERT_COMPONENT_IDENTIFIER: typing.LiteralString = """
+MATCH (c:Component {{id: {component_id}}})
+MERGE (ci:ComponentIdentifier {{kind: {kind}, value: {value}}})
+SET ci.id = COALESCE(ci.id, {identifier_id}),
+    ci.created_at = COALESCE(ci.created_at, {now}),
+    ci.updated_at = {now}
+MERGE (c)-[:IDENTIFIED_BY]->(ci)
+"""
+
+# Pull every component the named release uses, with version,
+# license, supplier, identifier list, and per-release usage
+# attribution off of the ``USES_COMPONENT_RELEASE`` edge.
+# ``OPTIONAL MATCH`` on identifiers keeps a component visible even
+# when no identifier nodes have been attached yet.
+_LIST_RELEASE_COMPONENTS: typing.LiteralString = """
+MATCH (:Release {{id: {release_id}}})
+      -[e:USES_COMPONENT_RELEASE]->(cr:ComponentRelease)
+MATCH (c:Component)-[:HAS_RELEASE]->(cr)
+OPTIONAL MATCH (c)-[:IDENTIFIED_BY]->(ci:ComponentIdentifier)
+RETURN c.id AS component_id,
+       c.purl_name AS purl_name,
+       c.name AS name,
+       c.ecosystem AS ecosystem,
+       c.description AS description,
+       cr.id AS component_release_id,
+       cr.version AS version,
+       cr.license AS license,
+       cr.supplier AS supplier,
+       cr.hashes AS hashes,
+       e.scope AS scope,
+       e.groups AS groups,
+       collect(DISTINCT {{kind: ci.kind, value: ci.value}}) AS identifiers
+"""
+
+
+async def replace_release_components(
+    db: graph.Graph,
+    release_id: str,
+    components: collections.abc.Sequence[NormalizedComponent],
+) -> None:
+    """Replace a release's component edges with the given set.
+
+    The operation is idempotent: existing
+    ``USES_COMPONENT_RELEASE`` edges from ``release_id`` are
+    dropped, then re-created from ``components``. Component and
+    ComponentRelease nodes are MERGE-ed (created if absent,
+    updated if present) so unrelated projects keep their
+    references intact.
+
+    Concurrency strategy: components are bucketed by ``purl_name``;
+    each bucket runs sequentially, and buckets parallelize via
+    ``asyncio.gather`` bounded by :data:`_UPSERT_CONCURRENCY`.
+    Serializing within a bucket is load-bearing — two parallel
+    MERGEs against the same ``Component`` vertex (e.g.
+    ``react-is@17`` and ``react-is@18``, which share
+    ``pkg:npm/react-is``) trigger AGE's "Entity failed to be
+    updated: 3" vertex-version conflict. Different purl_names
+    target different vertices, so cross-bucket parallelism is
+    safe. Each task holds one pool connection at a time for the
+    duration of its current ``db.execute``.
+
+    Failures are *non-fatal*: a per-component exception is caught,
+    logged as a warning, and the other components continue
+    (within the same bucket and across buckets). Partial graph
+    state is more useful than no graph state for deps-listing
+    purposes, and the producer side typically re-PUTs on the
+    next build anyway.
+
+    The function does not own a transaction — callers using the
+    Graph pool already run each ``execute`` inside its own
+    connection. If atomic replace-set semantics become important
+    we should lift the calls into an explicit transaction.
+    """
+    now = datetime.datetime.now(datetime.UTC).isoformat()
+    await db.execute(
+        _CLEAR_RELEASE_COMPONENTS,
+        {'release_id': release_id},
+    )
+    if not components:
+        return
+    buckets: dict[str, list[NormalizedComponent]] = {}
+    for component in components:
+        buckets.setdefault(component.purl_name, []).append(component)
+    semaphore = asyncio.Semaphore(_UPSERT_CONCURRENCY)
+    bucket_items = list(buckets.values())
+    results = await asyncio.gather(
+        *(
+            _upsert_component_bucket(db, release_id, bucket, now, semaphore)
+            for bucket in bucket_items
+        ),
+        return_exceptions=True,
+    )
+    # Bucket-level exceptions (something escaped the per-component
+    # try/except — usually a connection-pool or programming error)
+    # land here. Per-component failures were already logged
+    # inside the bucket task.
+    for bucket, result in zip(bucket_items, results, strict=True):
+        if isinstance(result, BaseException):
+            LOGGER.warning(
+                'Bucket %s failed during SBoM ingest for release %s: %s: %s',
+                bucket[0].purl_name,
+                release_id,
+                type(result).__name__,
+                result,
+            )
+
+
+async def _upsert_component_bucket(
+    db: graph.Graph,
+    release_id: str,
+    bucket: collections.abc.Sequence[NormalizedComponent],
+    now: str,
+    semaphore: asyncio.Semaphore,
+) -> None:
+    """Upsert every component in a ``purl_name`` bucket sequentially.
+
+    All components in the bucket share a ``purl_name`` — and
+    therefore the same ``Component`` vertex — so they must be
+    serialized to avoid AGE's "Entity failed to be updated: 3"
+    conflict. Per-component failures are logged here, not raised,
+    so one bad version doesn't stop the bucket's remaining
+    versions from landing. The bucket itself raises only on
+    unexpected (non-component) errors.
+    """
+    async with semaphore:
+        for component in bucket:
+            try:
+                await _upsert_one_component(db, release_id, component, now)
+            except Exception as exc:  # noqa: BLE001
+                LOGGER.warning(
+                    'Failed to ingest component %s@%s for release %s: %s: %s',
+                    component.purl_name,
+                    component.version,
+                    release_id,
+                    type(exc).__name__,
+                    exc,
+                )
+
+
+async def _upsert_one_component(
+    db: graph.Graph,
+    release_id: str,
+    component: NormalizedComponent,
+    now: str,
+) -> None:
+    """Upsert one ``Component`` + ``ComponentRelease`` + identifiers.
+
+    Raises on any AGE failure so the bucket loop can log it and
+    move on. Concurrency control is the bucket's responsibility
+    (it owns the semaphore); this helper assumes serial execution
+    against a single purl_name.
+    """
+    rows = await db.execute(
+        _UPSERT_COMPONENT_AND_LINK,
+        {
+            'release_id': release_id,
+            'purl_name': component.purl_name,
+            'component_id': nanoid.generate(),
+            'name': component.name,
+            'ecosystem': component.ecosystem,
+            'description': component.description,
+            'version': component.version,
+            'component_release_id': nanoid.generate(),
+            'license': component.license,
+            'supplier': component.supplier,
+            'hashes': json.dumps(component.hashes),
+            'scope': component.scope,
+            'groups': json.dumps(component.groups),
+            'now': now,
+        },
+        ['component_id'],
+    )
+    if not rows:
+        # The release was deleted (or never existed) — the upsert
+        # MATCHed nothing. Surface this as an exception so the
+        # bucket logs it the same way it logs any other
+        # per-component failure.
+        raise RuntimeError(
+            f'release {release_id!r} not found during component upsert'
+        )
+    component_db_id = graph.parse_agtype(rows[0]['component_id'])
+    for identifier in component.identifiers:
+        await db.execute(
+            _UPSERT_COMPONENT_IDENTIFIER,
+            {
+                'component_id': component_db_id,
+                'kind': identifier.kind,
+                'value': identifier.value,
+                'identifier_id': nanoid.generate(),
+                'now': now,
+            },
+        )
+
+
+class ListedIdentifier(pydantic.BaseModel):
+    """One ``(kind, value)`` pair on a component returned by GET."""
+
+    kind: str
+    value: str
+
+
+class ListedComponent(pydantic.BaseModel):
+    """Flattened component row for the ``GET …/dependencies`` body.
+
+    ``scope`` and ``groups`` come off of the
+    ``USES_COMPONENT_RELEASE`` edge — they are per-release usage
+    facts, not properties of the component-release itself.
+    """
+
+    purl_name: str
+    name: str
+    ecosystem: str
+    description: str | None = None
+    version: str
+    license: str | None = None
+    supplier: str | None = None
+    hashes: dict[str, str] = pydantic.Field(default_factory=dict)
+    identifiers: list[ListedIdentifier] = pydantic.Field(
+        default_factory=list,
+    )
+    scope: str | None = None
+    groups: list[str] = pydantic.Field(default_factory=list)
+
+
+async def list_release_components(
+    db: graph.Graph, release_id: str
+) -> list[ListedComponent]:
+    """Return the dependency set a release was ingested with.
+
+    Components without a recorded SBoM yield an empty list — the
+    caller (the GET endpoint) is responsible for distinguishing
+    "no SBoM yet" from "unknown release" via a separate
+    ``_fetch_release`` precondition check.
+    """
+    rows = await db.execute(
+        _LIST_RELEASE_COMPONENTS,
+        {'release_id': release_id},
+        [
+            'component_id',
+            'purl_name',
+            'name',
+            'ecosystem',
+            'description',
+            'component_release_id',
+            'version',
+            'license',
+            'supplier',
+            'hashes',
+            'scope',
+            'groups',
+            'identifiers',
+        ],
+    )
+    out: list[ListedComponent] = []
+    for row in rows:
+        hashes_raw = graph.parse_agtype(row['hashes'])
+        if isinstance(hashes_raw, str):
+            hashes_decoded = typing.cast(
+                dict[str, str], json.loads(hashes_raw)
+            )
+        elif isinstance(hashes_raw, dict):
+            hashes_decoded = typing.cast(dict[str, str], hashes_raw)
+        else:
+            hashes_decoded = {}
+        identifiers_raw = graph.parse_agtype(row['identifiers'])
+        identifiers: list[ListedIdentifier] = []
+        if isinstance(identifiers_raw, list):
+            for entry in identifiers_raw:
+                if (
+                    isinstance(entry, dict)
+                    and entry.get('kind') is not None
+                    and entry.get('value') is not None
+                ):
+                    identifiers.append(
+                        ListedIdentifier(
+                            kind=str(entry['kind']),
+                            value=str(entry['value']),
+                        ),
+                    )
+        out.append(
+            ListedComponent(
+                purl_name=str(graph.parse_agtype(row['purl_name'])),
+                name=str(graph.parse_agtype(row['name'])),
+                ecosystem=str(graph.parse_agtype(row['ecosystem'])),
+                description=_optional_str(row.get('description')),
+                version=str(graph.parse_agtype(row['version'])),
+                license=_optional_str(row.get('license')),
+                supplier=_optional_str(row.get('supplier')),
+                hashes=hashes_decoded,
+                identifiers=identifiers,
+                scope=_optional_str(row.get('scope')),
+                groups=_decode_groups(row.get('groups')),
+            ),
+        )
+    return out
+
+
+def _decode_groups(raw: typing.Any) -> list[str]:
+    """Decode the JSON-encoded ``e.groups`` edge property into a list.
+
+    AGE stores list-of-string edge properties as JSON strings the
+    same way it stores dicts. ``None`` and unparseable values
+    collapse to an empty list rather than propagating ``None`` —
+    the empty-list case is by far the most common (a release with
+    no scoped group info).
+    """
+    if raw is None:
+        return []
+    value = graph.parse_agtype(raw)
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return [str(g) for g in value]
+    if isinstance(value, str):
+        try:
+            decoded = json.loads(value)
+        except (TypeError, ValueError):
+            return []
+        if isinstance(decoded, list):
+            return [str(g) for g in decoded]
+    return []
+
+
+def _optional_str(raw: typing.Any) -> str | None:
+    """Return ``str(value)`` for present scalars, else ``None``."""
+    value = graph.parse_agtype(raw) if raw is not None else None
+    if value is None:
+        return None
+    return str(value)

--- a/tests/endpoints/test_releases.py
+++ b/tests/endpoints/test_releases.py
@@ -1341,3 +1341,443 @@ class CurrentReleasesHydrationTestCase(_ReleasesTestBase):
         # Status untouched (still in_progress); ci_status null.
         self.assertEqual(body['current_status'], 'in_progress')
         self.assertIsNone(body['ci_status'])
+
+
+def _tiny_sbom() -> dict[str, typing.Any]:
+    """Return a fresh minimal CycloneDX 1.7 document."""
+    return {
+        'bomFormat': 'CycloneDX',
+        'specVersion': '1.7',
+        'version': 1,
+        'components': [
+            {
+                'type': 'library',
+                'bom-ref': 'pkg:npm/express@4.18.2',
+                'name': 'express',
+                'version': '4.18.2',
+                'purl': 'pkg:npm/express@4.18.2',
+                'licenses': [{'license': {'id': 'MIT'}}],
+            }
+        ],
+    }
+
+
+class PutReleaseSbomTestCase(_ReleasesTestBase):
+    """PUT /releases/{release_id}/sbom"""
+
+    def test_put_success_returns_204(self) -> None:
+        # _fetch_release row, then CLEAR_RELEASE_COMPONENTS (no rows),
+        # then UPSERT_COMPONENT_AND_LINK (one row), then identifier
+        # upsert (no rows expected back).
+        self.mock_db.execute.side_effect = [
+            [{'release': _release_row()}],
+            [],
+            [{'component_id': 'comp-1'}],
+            [],
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            response = self.client.put(
+                self._url(f'/{RELEASE_ID}/sbom'),
+                json=_tiny_sbom(),
+            )
+        self.assertEqual(response.status_code, 204)
+        # First execute was _fetch_release; the second was the clear
+        # query — that's the load-bearing idempotence assertion.
+        clear_call = self.mock_db.execute.call_args_list[1]
+        self.assertIn(
+            'DELETE edge',
+            clear_call.args[0],
+        )
+        # The third call (UPSERT_COMPONENT_AND_LINK) carries the
+        # edge-attribution params for ReleaseComponentEdge — the
+        # tiny SBoM emits no scope and no group properties, so
+        # both come through as None / "[]" rather than absent.
+        upsert_call = self.mock_db.execute.call_args_list[2]
+        upsert_params = upsert_call.args[1]
+        self.assertIn('scope', upsert_params)
+        self.assertIn('groups', upsert_params)
+        self.assertIsNone(upsert_params['scope'])
+        self.assertEqual(upsert_params['groups'], '[]')
+
+    def test_put_unknown_release_returns_404(self) -> None:
+        self.mock_db.execute.side_effect = [[]]
+        response = self.client.put(
+            self._url(f'/{RELEASE_ID}/sbom'),
+            json=_tiny_sbom(),
+        )
+        self.assertEqual(response.status_code, 404)
+
+    def test_put_wrong_spec_version_returns_415(self) -> None:
+        self.mock_db.execute.side_effect = [
+            [{'release': _release_row()}],
+        ]
+        bad = _tiny_sbom()
+        bad['specVersion'] = '1.5'
+        response = self.client.put(
+            self._url(f'/{RELEASE_ID}/sbom'),
+            json=bad,
+        )
+        self.assertEqual(response.status_code, 415)
+
+    def test_put_malformed_payload_returns_400(self) -> None:
+        self.mock_db.execute.side_effect = [
+            [{'release': _release_row()}],
+        ]
+        bad = _tiny_sbom()
+        bad['components'] = 'not a list'
+        response = self.client.put(
+            self._url(f'/{RELEASE_ID}/sbom'),
+            json=bad,
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_put_idempotent_clear_runs_twice_for_two_puts(self) -> None:
+        # Two PUTs in succession: each must run a CLEAR_RELEASE_COMPONENTS
+        # before re-linking — that is the durable contract.
+        for _ in range(2):
+            self.mock_db.execute.side_effect = [
+                [{'release': _release_row()}],
+                [],
+                [{'component_id': 'comp-1'}],
+                [],
+            ]
+            with mock.patch(
+                'imbi_common.graph.parse_agtype',
+                side_effect=lambda x: x,
+            ):
+                response = self.client.put(
+                    self._url(f'/{RELEASE_ID}/sbom'),
+                    json=_tiny_sbom(),
+                )
+            self.assertEqual(response.status_code, 204)
+            clear_call = self.mock_db.execute.call_args_list[1]
+            self.assertIn('DELETE edge', clear_call.args[0])
+            self.mock_db.execute.reset_mock()
+
+    def test_put_continues_past_per_component_failure(self) -> None:
+        # Two-component SBoM where one component's upsert raises.
+        # The action must log a warning for the failing component
+        # and still return 204 — partial graph state is more useful
+        # than an aborted ingest. The mock keys responses off the
+        # Cypher template + purl_name so the parallel-gather order
+        # is irrelevant.
+        two_component_sbom = {
+            'bomFormat': 'CycloneDX',
+            'specVersion': '1.7',
+            'version': 1,
+            'components': [
+                {
+                    'type': 'library',
+                    'bom-ref': 'pkg:npm/good@1.0.0',
+                    'name': 'good',
+                    'version': '1.0.0',
+                    'purl': 'pkg:npm/good@1.0.0',
+                },
+                {
+                    'type': 'library',
+                    'bom-ref': 'pkg:npm/broken@1.0.0',
+                    'name': 'broken',
+                    'version': '1.0.0',
+                    'purl': 'pkg:npm/broken@1.0.0',
+                },
+            ],
+        }
+
+        async def fake_execute(
+            query: str,
+            params: dict[str, typing.Any] | None = None,
+            columns: list[str] | None = None,
+        ) -> list[dict[str, typing.Any]]:
+            del columns
+            params = params or {}
+            if 'MATCH (p:Project' in query and 'RETURN r' in query:
+                return [{'release': _release_row()}]
+            if 'DELETE edge' in query:
+                return []
+            if 'MERGE (c:Component' in query:
+                if params['purl_name'] == 'pkg:npm/broken':
+                    raise RuntimeError('simulated AGE error')
+                return [{'component_id': f'comp-{params["purl_name"]}'}]
+            if 'MERGE (ci:ComponentIdentifier' in query:
+                return []
+            raise AssertionError(f'unexpected query in mock: {query[:60]!r}')
+
+        self.mock_db.execute.side_effect = fake_execute
+
+        with (
+            mock.patch(
+                'imbi_common.graph.parse_agtype',
+                side_effect=lambda x: x,
+            ),
+            self.assertLogs('imbi_api.sbom', level='WARNING') as cm,
+        ):
+            response = self.client.put(
+                self._url(f'/{RELEASE_ID}/sbom'),
+                json=two_component_sbom,
+            )
+
+        self.assertEqual(response.status_code, 204)
+        # The failing component must show up in the logs with its
+        # purl + version + release id so on-call can find it.
+        failure_lines = [
+            line for line in cm.output if 'pkg:npm/broken' in line
+        ]
+        self.assertEqual(
+            len(failure_lines), 1, msg=f'logs were: {cm.output!r}'
+        )
+        self.assertIn('1.0.0', failure_lines[0])
+        self.assertIn(RELEASE_ID, failure_lines[0])
+        self.assertIn('simulated AGE error', failure_lines[0])
+        # The healthy component must still have made its upsert
+        # call — that's the "some data > no data" contract.
+        upsert_purls = {
+            call.args[1]['purl_name']
+            for call in self.mock_db.execute.call_args_list
+            if 'MERGE (c:Component' in call.args[0]
+        }
+        self.assertEqual(upsert_purls, {'pkg:npm/good', 'pkg:npm/broken'})
+
+    def test_put_same_purl_versions_run_sequentially_in_same_bucket(
+        self,
+    ) -> None:
+        # Regression for the AGE "Entity failed to be updated: 3"
+        # conflict — two versions of the same package (sharing one
+        # purl_name and therefore one Component vertex) MUST be
+        # serialized in the same bucket. Across-bucket parallelism
+        # is fine; within-bucket parallelism deadlocks AGE.
+        multi_version_sbom = {
+            'bomFormat': 'CycloneDX',
+            'specVersion': '1.7',
+            'version': 1,
+            'components': [
+                {
+                    'type': 'library',
+                    'bom-ref': 'pkg:npm/react-is@17.0.2',
+                    'name': 'react-is',
+                    'version': '17.0.2',
+                    'purl': 'pkg:npm/react-is@17.0.2',
+                },
+                {
+                    'type': 'library',
+                    'bom-ref': 'pkg:npm/react-is@18.3.1',
+                    'name': 'react-is',
+                    'version': '18.3.1',
+                    'purl': 'pkg:npm/react-is@18.3.1',
+                },
+                # An unrelated package in a different bucket — it
+                # may interleave with the react-is bucket but
+                # MUST NOT serialize *between* the two react-is
+                # versions.
+                {
+                    'type': 'library',
+                    'bom-ref': 'pkg:npm/chalk@5.0.0',
+                    'name': 'chalk',
+                    'version': '5.0.0',
+                    'purl': 'pkg:npm/chalk@5.0.0',
+                },
+            ],
+        }
+
+        # Track which purl_names are mid-upsert so we can assert
+        # no two tasks ever hold the same Component vertex
+        # simultaneously. ``asyncio.sleep(0)`` inside the mock
+        # forces a scheduler yield so any latent within-bucket
+        # parallelism gets a chance to expose itself.
+        in_flight: set[str] = set()
+        overlapping_calls: list[str] = []
+
+        async def fake_execute(
+            query: str,
+            params: dict[str, typing.Any] | None = None,
+            columns: list[str] | None = None,
+        ) -> list[dict[str, typing.Any]]:
+            import asyncio as _asyncio
+
+            del columns
+            params = params or {}
+            if 'MATCH (p:Project' in query and 'RETURN r' in query:
+                return [{'release': _release_row()}]
+            if 'DELETE edge' in query:
+                return []
+            if 'MERGE (c:Component' in query:
+                purl = params['purl_name']
+                if purl in in_flight:
+                    overlapping_calls.append(purl)
+                in_flight.add(purl)
+                await _asyncio.sleep(0)
+                in_flight.discard(purl)
+                return [{'component_id': f'comp-{purl}'}]
+            if 'MERGE (ci:ComponentIdentifier' in query:
+                return []
+            raise AssertionError(f'unexpected query in mock: {query[:60]!r}')
+
+        self.mock_db.execute.side_effect = fake_execute
+
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            response = self.client.put(
+                self._url(f'/{RELEASE_ID}/sbom'),
+                json=multi_version_sbom,
+            )
+
+        self.assertEqual(response.status_code, 204)
+        # The load-bearing assertion: no two upserts on the same
+        # Component vertex ever overlapped. Anything in
+        # ``overlapping_calls`` is a regression that would
+        # reproduce the AGE "Entity failed to be updated: 3"
+        # error in production.
+        self.assertEqual(overlapping_calls, [])
+        # And both react-is versions still ended up upserted.
+        upsert_purls_with_versions = sorted(
+            (call.args[1]['purl_name'], call.args[1]['version'])
+            for call in self.mock_db.execute.call_args_list
+            if 'MERGE (c:Component' in call.args[0]
+        )
+        self.assertEqual(
+            upsert_purls_with_versions,
+            [
+                ('pkg:npm/chalk', '5.0.0'),
+                ('pkg:npm/react-is', '17.0.2'),
+                ('pkg:npm/react-is', '18.3.1'),
+            ],
+        )
+
+
+class GetReleaseDependenciesTestCase(_ReleasesTestBase):
+    """GET /releases/{release_id}/dependencies"""
+
+    def test_get_empty_release_returns_empty_components(self) -> None:
+        self.mock_db.execute.side_effect = [
+            [{'release': _release_row()}],
+            [],
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            response = self.client.get(
+                self._url(f'/{RELEASE_ID}/dependencies'),
+            )
+        self.assertEqual(response.status_code, 200)
+        body = response.json()
+        self.assertEqual(body['release_id'], RELEASE_ID)
+        self.assertEqual(body['components'], [])
+
+    def test_get_unknown_release_returns_404(self) -> None:
+        self.mock_db.execute.side_effect = [[]]
+        response = self.client.get(
+            self._url(f'/{RELEASE_ID}/dependencies'),
+        )
+        self.assertEqual(response.status_code, 404)
+
+    def test_get_populated_release_returns_components(self) -> None:
+        self.mock_db.execute.side_effect = [
+            [{'release': _release_row()}],
+            [
+                {
+                    'component_id': 'comp-1',
+                    'purl_name': 'pkg:npm/express',
+                    'name': 'express',
+                    'ecosystem': 'npm',
+                    'description': None,
+                    'component_release_id': 'cr-1',
+                    'version': '4.18.2',
+                    'license': 'MIT',
+                    'supplier': 'OpenJS Foundation',
+                    'hashes': '{}',
+                    'scope': 'optional',
+                    'groups': '["dev","test"]',
+                    'identifiers': [
+                        {'kind': 'purl', 'value': 'pkg:npm/express'},
+                    ],
+                },
+            ],
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            response = self.client.get(
+                self._url(f'/{RELEASE_ID}/dependencies'),
+            )
+        self.assertEqual(response.status_code, 200)
+        body = response.json()
+        self.assertEqual(len(body['components']), 1)
+        component = body['components'][0]
+        self.assertEqual(component['purl_name'], 'pkg:npm/express')
+        self.assertEqual(component['version'], '4.18.2')
+        self.assertEqual(component['license'], 'MIT')
+        self.assertEqual(component['supplier'], 'OpenJS Foundation')
+        self.assertEqual(
+            component['identifiers'],
+            [{'kind': 'purl', 'value': 'pkg:npm/express'}],
+        )
+        # ReleaseComponentEdge round-trip — these are per-release
+        # usage facts that the UI keys off to render scope/group
+        # chips.
+        self.assertEqual(component['scope'], 'optional')
+        self.assertEqual(component['groups'], ['dev', 'test'])
+        # AGE ``cypher()`` requires the SELECT AS column list to match
+        # the RETURN clause column count. The second execute call (the
+        # dependency listing) must pass the 13-column ``columns``
+        # parameter — without it AGE raises a DatatypeMismatch at run
+        # time even though our mock-based tests would still pass.
+        list_call = self.mock_db.execute.call_args_list[1]
+        self.assertEqual(
+            list_call.args[2],
+            [
+                'component_id',
+                'purl_name',
+                'name',
+                'ecosystem',
+                'description',
+                'component_release_id',
+                'version',
+                'license',
+                'supplier',
+                'hashes',
+                'scope',
+                'groups',
+                'identifiers',
+            ],
+        )
+
+    def test_get_release_with_missing_edge_attrs(self) -> None:
+        """Releases ingested before scope/groups were tracked must
+        still render — defaulting to null/empty rather than 500."""
+        self.mock_db.execute.side_effect = [
+            [{'release': _release_row()}],
+            [
+                {
+                    'component_id': 'comp-1',
+                    'purl_name': 'pkg:npm/express',
+                    'name': 'express',
+                    'ecosystem': 'npm',
+                    'description': None,
+                    'component_release_id': 'cr-1',
+                    'version': '4.18.2',
+                    'license': None,
+                    'supplier': None,
+                    'hashes': '{}',
+                    'scope': None,
+                    'groups': None,
+                    'identifiers': [],
+                },
+            ],
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            response = self.client.get(
+                self._url(f'/{RELEASE_ID}/dependencies'),
+            )
+        self.assertEqual(response.status_code, 200)
+        component = response.json()['components'][0]
+        self.assertIsNone(component['scope'])
+        self.assertEqual(component['groups'], [])

--- a/tests/fixtures/sbom/npm-realistic.json
+++ b/tests/fixtures/sbom/npm-realistic.json
@@ -1,0 +1,58 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.7",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2026-05-01T00:00:00Z",
+    "tools": {
+      "components": [
+        {
+          "type": "application",
+          "name": "@cyclonedx/cyclonedx-npm",
+          "version": "1.19.0"
+        }
+      ]
+    },
+    "component": {
+      "type": "application",
+      "name": "my-react-app",
+      "version": "1.4.0",
+      "purl": "pkg:npm/my-react-app@1.4.0"
+    }
+  },
+  "components": [
+    {
+      "type": "library",
+      "bom-ref": "pkg:npm/react@18.3.1",
+      "name": "react",
+      "version": "18.3.1",
+      "purl": "pkg:npm/react@18.3.1",
+      "licenses": [{"license": {"id": "MIT"}}],
+      "description": "React is a JavaScript library for building user interfaces."
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:npm/react-dom@18.3.1",
+      "name": "react-dom",
+      "version": "18.3.1",
+      "purl": "pkg:npm/react-dom@18.3.1",
+      "licenses": [{"license": {"id": "MIT"}}]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:npm/%40babel/runtime@7.24.0",
+      "name": "@babel/runtime",
+      "version": "7.24.0",
+      "purl": "pkg:npm/%40babel/runtime@7.24.0",
+      "licenses": [{"license": {"id": "MIT"}}]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:npm/lodash@4.17.21",
+      "name": "lodash",
+      "version": "4.17.21",
+      "purl": "pkg:npm/lodash@4.17.21",
+      "licenses": [{"expression": "MIT"}]
+    }
+  ]
+}

--- a/tests/fixtures/sbom/pypi-realistic.json
+++ b/tests/fixtures/sbom/pypi-realistic.json
@@ -1,0 +1,58 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.7",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2026-05-01T00:00:00Z",
+    "tools": {
+      "components": [
+        {
+          "type": "application",
+          "name": "cyclonedx-bom",
+          "version": "5.0.0"
+        }
+      ]
+    },
+    "component": {
+      "type": "application",
+      "name": "my-python-app",
+      "version": "0.5.2",
+      "purl": "pkg:pypi/my-python-app@0.5.2"
+    }
+  },
+  "components": [
+    {
+      "type": "library",
+      "bom-ref": "pkg:pypi/fastapi@0.128.0",
+      "name": "fastapi",
+      "version": "0.128.0",
+      "purl": "pkg:pypi/fastapi@0.128.0",
+      "licenses": [{"license": {"id": "MIT"}}],
+      "supplier": {"name": "Sebastián Ramírez"}
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:pypi/pydantic@2.10.0",
+      "name": "pydantic",
+      "version": "2.10.0",
+      "purl": "pkg:pypi/pydantic@2.10.0",
+      "licenses": [{"license": {"id": "MIT"}}]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:pypi/httpx@0.27.2",
+      "name": "httpx",
+      "version": "0.27.2",
+      "purl": "pkg:pypi/httpx@0.27.2",
+      "licenses": [{"license": {"id": "BSD-3-Clause"}}]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:pypi/cryptography@43.0.1",
+      "name": "cryptography",
+      "version": "43.0.1",
+      "purl": "pkg:pypi/cryptography@43.0.1",
+      "licenses": [{"expression": "Apache-2.0 OR BSD-3-Clause"}]
+    }
+  ]
+}

--- a/tests/fixtures/sbom/tiny.json
+++ b/tests/fixtures/sbom/tiny.json
@@ -1,0 +1,31 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.7",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2026-05-01T00:00:00Z",
+    "component": {
+      "type": "application",
+      "name": "tiny-app",
+      "version": "1.0.0"
+    }
+  },
+  "components": [
+    {
+      "type": "library",
+      "bom-ref": "pkg:npm/express@4.18.2",
+      "name": "express",
+      "version": "4.18.2",
+      "purl": "pkg:npm/express@4.18.2",
+      "licenses": [{"license": {"id": "MIT"}}],
+      "cpe": "cpe:2.3:a:expressjs:express:4.18.2:*:*:*:*:*:*:*",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "0000000000000000000000000000000000000000000000000000000000000000"
+        }
+      ],
+      "supplier": {"name": "OpenJS Foundation"}
+    }
+  ]
+}

--- a/tests/test_sbom.py
+++ b/tests/test_sbom.py
@@ -1,0 +1,303 @@
+import json
+import pathlib
+import typing
+import unittest
+
+from imbi_api import sbom
+
+_FIXTURE_DIR = pathlib.Path(__file__).parent / 'fixtures' / 'sbom'
+
+
+def _load(name: str) -> dict[str, typing.Any]:
+    return typing.cast(
+        dict[str, typing.Any],
+        json.loads((_FIXTURE_DIR / name).read_text()),
+    )
+
+
+def _tiny() -> dict[str, typing.Any]:
+    return _load('tiny.json')
+
+
+class SpecVersionTests(unittest.TestCase):
+    def test_accepts_1_7(self) -> None:
+        components = sbom.parse(_tiny())
+        self.assertEqual(len(components), 1)
+        self.assertEqual(components[0].name, 'express')
+
+    def test_rejects_1_5(self) -> None:
+        payload = _tiny()
+        payload['specVersion'] = '1.5'
+        with self.assertRaises(sbom.UnsupportedSpecVersionError) as ctx:
+            sbom.parse(payload)
+        self.assertEqual(ctx.exception.received, '1.5')
+
+    def test_rejects_1_6(self) -> None:
+        payload = _tiny()
+        payload['specVersion'] = '1.6'
+        with self.assertRaises(sbom.UnsupportedSpecVersionError):
+            sbom.parse(payload)
+
+    def test_rejects_missing_spec_version(self) -> None:
+        payload = _tiny()
+        del payload['specVersion']
+        with self.assertRaises(sbom.UnsupportedSpecVersionError) as ctx:
+            sbom.parse(payload)
+        self.assertIsNone(ctx.exception.received)
+
+
+class MalformedPayloadTests(unittest.TestCase):
+    def test_rejects_non_object(self) -> None:
+        with self.assertRaises(sbom.MalformedSBomError):
+            sbom.parse('not a dict')
+
+    def test_rejects_garbage(self) -> None:
+        with self.assertRaises(sbom.MalformedSBomError):
+            sbom.parse(
+                {
+                    'specVersion': '1.7',
+                    'bomFormat': 'CycloneDX',
+                    'components': 'oops',
+                },
+            )
+
+
+class ComponentExtractionTests(unittest.TestCase):
+    def test_tiny_component(self) -> None:
+        [component] = sbom.parse(_tiny())
+        self.assertEqual(component.purl_name, 'pkg:npm/express')
+        self.assertEqual(component.name, 'express')
+        self.assertEqual(component.ecosystem, 'npm')
+        self.assertEqual(component.version, '4.18.2')
+        self.assertEqual(component.license, 'MIT')
+        self.assertEqual(component.supplier, 'OpenJS Foundation')
+        self.assertEqual(component.hashes, {'SHA-256': '0' * 64})
+
+    def test_strips_purl_version(self) -> None:
+        [component] = sbom.parse(_tiny())
+        self.assertNotIn('@', component.purl_name)
+        self.assertEqual(component.purl_name, 'pkg:npm/express')
+
+    def test_strips_cpe_version(self) -> None:
+        [component] = sbom.parse(_tiny())
+        identifiers = {(i.kind, i.value) for i in component.identifiers}
+        self.assertIn(
+            ('cpe', 'cpe:2.3:a:expressjs:express:*:*:*:*:*:*:*:*'),
+            identifiers,
+        )
+
+    def test_emits_purl_identifier(self) -> None:
+        [component] = sbom.parse(_tiny())
+        identifiers = {(i.kind, i.value) for i in component.identifiers}
+        self.assertIn(('purl', 'pkg:npm/express'), identifiers)
+
+    def test_skips_component_without_purl(self) -> None:
+        payload = _tiny()
+        payload['components'].append(
+            {
+                'type': 'library',
+                'bom-ref': 'no-purl',
+                'name': 'no-purl-library',
+                'version': '1.0.0',
+            },
+        )
+        components = sbom.parse(payload)
+        self.assertEqual(len(components), 1)
+        self.assertEqual(components[0].name, 'express')
+
+
+class DeduplicationTests(unittest.TestCase):
+    def test_dedupes_duplicate_components(self) -> None:
+        payload = _tiny()
+        # Two entries for the same (purl_name, version) — e.g. a
+        # transitive dependency reached via two paths.
+        payload['components'].append(dict(payload['components'][0]))
+        components = sbom.parse(payload)
+        self.assertEqual(len(components), 1)
+
+    def test_does_not_dedupe_distinct_versions(self) -> None:
+        payload = _tiny()
+        second = dict(payload['components'][0])
+        second['version'] = '4.19.0'
+        second['purl'] = 'pkg:npm/express@4.19.0'
+        second['bom-ref'] = 'pkg:npm/express@4.19.0'
+        payload['components'].append(second)
+        components = sbom.parse(payload)
+        versions = sorted(c.version for c in components)
+        self.assertEqual(versions, ['4.18.2', '4.19.0'])
+
+
+class LicenseTests(unittest.TestCase):
+    def _component_with(
+        self, licenses: list[dict[str, typing.Any]]
+    ) -> sbom.NormalizedComponent:
+        payload = _tiny()
+        payload['components'][0]['licenses'] = licenses
+        [component] = sbom.parse(payload)
+        return component
+
+    def test_license_id(self) -> None:
+        component = self._component_with([{'license': {'id': 'MIT'}}])
+        self.assertEqual(component.license, 'MIT')
+
+    def test_license_expression(self) -> None:
+        component = self._component_with([{'expression': 'MIT OR Apache-2.0'}])
+        self.assertEqual(component.license, 'MIT OR Apache-2.0')
+
+    def test_license_freeform_name(self) -> None:
+        component = self._component_with(
+            [{'license': {'name': 'Some Custom EULA'}}],
+        )
+        self.assertEqual(component.license, 'Some Custom EULA')
+
+    def test_license_absent(self) -> None:
+        payload = _tiny()
+        del payload['components'][0]['licenses']
+        [component] = sbom.parse(payload)
+        self.assertIsNone(component.license)
+
+    def test_license_multiple_records_joined(self) -> None:
+        # The cyclonedx LicenseRepository is a SortedSet, so input
+        # order is not preserved — assert on membership and the
+        # joiner, not on order.
+        component = self._component_with(
+            [
+                {'license': {'id': 'MIT'}},
+                {'license': {'id': 'Apache-2.0'}},
+            ],
+        )
+        self.assertIsNotNone(component.license)
+        assert component.license is not None
+        parts = component.license.split(' AND ')
+        self.assertEqual(set(parts), {'MIT', 'Apache-2.0'})
+
+
+class RealisticFixtureTests(unittest.TestCase):
+    def test_npm_fixture(self) -> None:
+        components = sbom.parse(_load('npm-realistic.json'))
+        by_name = {c.name: c for c in components}
+        self.assertEqual(
+            set(by_name), {'react', 'react-dom', '@babel/runtime', 'lodash'}
+        )
+        self.assertEqual(by_name['react'].ecosystem, 'npm')
+        self.assertEqual(by_name['react'].version, '18.3.1')
+        self.assertEqual(
+            by_name['@babel/runtime'].purl_name,
+            'pkg:npm/%40babel/runtime',
+        )
+
+    def test_pypi_fixture(self) -> None:
+        components = sbom.parse(_load('pypi-realistic.json'))
+        by_name = {c.name: c for c in components}
+        self.assertEqual(
+            set(by_name),
+            {'fastapi', 'pydantic', 'httpx', 'cryptography'},
+        )
+        self.assertEqual(by_name['fastapi'].ecosystem, 'pypi')
+        self.assertEqual(by_name['fastapi'].supplier, 'Sebastián Ramírez')
+        self.assertEqual(
+            by_name['cryptography'].license, 'Apache-2.0 OR BSD-3-Clause'
+        )
+
+    def test_pypi_fixture_emits_purl_identifier(self) -> None:
+        components = sbom.parse(_load('pypi-realistic.json'))
+        by_name = {c.name: c for c in components}
+        identifiers = {i.value for i in by_name['fastapi'].identifiers}
+        self.assertIn('pkg:pypi/fastapi', identifiers)
+
+
+class ScopeAndGroupsTests(unittest.TestCase):
+    """``component.scope`` + ``cdx:pyproject:group`` extraction.
+
+    These two fields are the cdxgen-specific signals Imbi keys on
+    to populate the ``Release-[:USES_COMPONENT_RELEASE]->`` edge
+    with ``ReleaseComponentEdge.scope`` and ``.groups`` (see
+    ADR 0015 and plans/sbom-ingest.md).
+    """
+
+    def _with(
+        self, **component_overrides: typing.Any
+    ) -> sbom.NormalizedComponent:
+        payload = _tiny()
+        payload['components'][0].update(component_overrides)
+        [component] = sbom.parse(payload)
+        return component
+
+    def test_scope_default_is_none(self) -> None:
+        # cyclonedx-py emits no scope; cdxgen for runtime deps also
+        # omits it. ``None`` (rather than defaulted "required") lets
+        # the UI render an "unstated" cell distinct from explicit
+        # required.
+        component = self._with()
+        self.assertIsNone(component.scope)
+
+    def test_scope_required_round_trips(self) -> None:
+        component = self._with(scope='required')
+        self.assertEqual(component.scope, 'required')
+
+    def test_scope_optional_round_trips(self) -> None:
+        # cdxgen for uv/Poetry dev groups + npm devDependencies.
+        component = self._with(scope='optional')
+        self.assertEqual(component.scope, 'optional')
+
+    def test_scope_excluded_round_trips(self) -> None:
+        component = self._with(scope='excluded')
+        self.assertEqual(component.scope, 'excluded')
+
+    def test_groups_default_empty(self) -> None:
+        component = self._with()
+        self.assertEqual(component.groups, [])
+
+    def test_groups_captured_from_cdx_pyproject_group(self) -> None:
+        # The cdxgen Python branch emits one property per group the
+        # package was attributed to (PEP 735 + Poetry). Imbi must
+        # capture every entry.
+        component = self._with(
+            scope='optional',
+            properties=[
+                {'name': 'cdx:pyproject:group', 'value': 'dev'},
+                {'name': 'cdx:pyproject:group', 'value': 'test'},
+            ],
+        )
+        self.assertEqual(component.scope, 'optional')
+        self.assertEqual(component.groups, ['dev', 'test'])
+
+    def test_groups_sorted_and_deduplicated(self) -> None:
+        # Producer-side duplication or random order shouldn't be
+        # observable in the graph — equality comparisons across
+        # releases must stay stable.
+        component = self._with(
+            properties=[
+                {'name': 'cdx:pyproject:group', 'value': 'test'},
+                {'name': 'cdx:pyproject:group', 'value': 'dev'},
+                {'name': 'cdx:pyproject:group', 'value': 'dev'},
+            ],
+        )
+        self.assertEqual(component.groups, ['dev', 'test'])
+
+    def test_groups_ignore_non_allowlisted_properties(self) -> None:
+        # cdxgen also emits properties like
+        # ``cdx:npm:package:development`` (a boolean flag, not a
+        # group name) and ``cdx:python:package:required-extra``.
+        # Neither belongs in ``groups`` — only allow-listed
+        # property names contribute.
+        component = self._with(
+            properties=[
+                {'name': 'cdx:npm:package:development', 'value': 'true'},
+                {
+                    'name': 'cdx:python:package:required-extra',
+                    'value': 'dev',
+                },
+                {'name': 'cdx:pyproject:group', 'value': 'real-group'},
+            ],
+        )
+        self.assertEqual(component.groups, ['real-group'])
+
+    def test_empty_group_value_skipped(self) -> None:
+        component = self._with(
+            properties=[
+                {'name': 'cdx:pyproject:group', 'value': ''},
+                {'name': 'cdx:pyproject:group', 'value': 'dev'},
+            ],
+        )
+        self.assertEqual(component.groups, ['dev'])

--- a/uv.lock
+++ b/uv.lock
@@ -7,7 +7,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-05-19T16:28:14.76436Z"
+exclude-newer = "2026-05-21T13:08:27.976467Z"
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
@@ -1085,7 +1085,7 @@ requires-dist = [
   { name = "fastapi" },
   { name = "filetype" },
   { name = "httpx", specifier = ">=0.28.1,<1" },
-  { name = "imbi-common", extras = ["databases", "llm", "sentry", "server"], specifier = ">=2.6.0" },
+  { name = "imbi-common", extras = ["databases", "llm", "sentry", "server"], specifier = ">=2.7.0" },
   { name = "imbi-plugin-aws", marker = "extra == 'plugins'", specifier = ">=1.0.0" },
   { name = "imbi-plugin-github", marker = "extra == 'plugins'", specifier = ">=1.0.0" },
   { name = "imbi-plugin-logzio", marker = "extra == 'plugins'", specifier = ">=1.0.0" },
@@ -1137,7 +1137,7 @@ docs = [
 
 [[package]]
 name = "imbi-common"
-version = "2.6.0"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
   { name = "cryptography" },
@@ -1153,9 +1153,9 @@ dependencies = [
   { name = "python-slugify" },
   { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/cc/08/d574411419c425a48596d4bb252283b526fcdd940073b3ffea734ae19a8f/imbi_common-2.6.0.tar.gz", hash = "sha256:730f7bd3b3c2365ea3a0845f81fba4a5ab8f23c98749842dadff5464bc2dc71a", size = 293163, upload-time = "2026-05-26T21:19:43.795Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4b/b0/5f28ac0670d239c885822e5a7c9a94b2bb9c1ea205dccba82ac2ae36f329/imbi_common-2.7.0.tar.gz", hash = "sha256:723d2a7ecffef3f0cf86828173586a9721931b95068718c7b0c7cff768c7f764", size = 303583, upload-time = "2026-05-28T12:56:17.525Z" }
 wheels = [
-  { url = "https://files.pythonhosted.org/packages/49/3b/f5db4005675fd033454696599427d72d809f9534e2afcd0a6584bb3fb29e/imbi_common-2.6.0-py3-none-any.whl", hash = "sha256:875a057b4edcc2fecb35747927dcd853c602e58fd1c1f3c05063584360a86c83", size = 94110, upload-time = "2026-05-26T21:19:42.066Z" },
+  { url = "https://files.pythonhosted.org/packages/ce/33/e801c0e9d7ecfef434ca1f178291584f4dce1e55f34590c9425c2086c4f6/imbi_common-2.7.0-py3-none-any.whl", hash = "sha256:c475153119376753d5f09b18de686eb872464625fdaf073aa893fec38b3956ab", size = 98903, upload-time = "2026-05-28T12:56:16.147Z" },
 ]
 
 [package.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -7,7 +7,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "0001-01-01T00:00:00Z"  # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer = "2026-05-19T16:28:14.76436Z"
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
@@ -343,6 +343,15 @@ wheels = [
 ]
 
 [[package]]
+name = "boolean-py"
+version = "5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c4/cf/85379f13b76f3a69bca86b60237978af17d6aa0bc5998978c3b8cf05abb2/boolean_py-5.0.tar.gz", hash = "sha256:60cbc4bad079753721d32649545505362c754e121570ada4658b852a3a318d95", size = 37047, upload-time = "2025-04-03T10:39:49.734Z" }
+wheels = [
+  { url = "https://files.pythonhosted.org/packages/e5/ca/78d423b324b8d77900030fa59c4aa9054261ef0925631cd2501dd015b7b7/boolean_py-5.0-py3-none-any.whl", hash = "sha256:ef28a70bd43115208441b53a045d1549e2f0ec6e3d08a9d142cbc41c1938e8d9", size = 26577, upload-time = "2025-04-03T10:39:48.449Z" },
+]
+
+[[package]]
 name = "boto3"
 version = "1.40.61"
 source = { registry = "https://pypi.org/simple" }
@@ -623,6 +632,30 @@ wheels = [
   { url = "https://files.pythonhosted.org/packages/1e/75/a2e55f99c16fcac7b5d6c1eb19ad8e00799854d6be5ca845f9259eae1681/cryptography-48.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a5da777e32ffed6f85a7b2b3f7c5cbc88c146bfcd0a1d7baf5fcc6c52ee35dd4", size = 4960575, upload-time = "2026-05-04T22:59:09.851Z" },
   { url = "https://files.pythonhosted.org/packages/b8/23/6e6f32143ab5d8b36ca848a502c4bcd477ae75b9e1677e3530d669062578/cryptography-48.0.0-cp39-abi3-win32.whl", hash = "sha256:77a2ccbbe917f6710e05ba9adaa25fb5075620bf3ea6fb751997875aff4ae4bd", size = 3279117, upload-time = "2026-05-04T22:59:12.019Z" },
   { url = "https://files.pythonhosted.org/packages/9d/9a/0fea98a70cf1749d41d738836f6349d97945f7c89433a259a6c2642eefeb/cryptography-48.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:16cd65b9330583e4619939b3a3843eec1e6e789744bb01e7c7e2e62e33c239c8", size = 3792100, upload-time = "2026-05-04T22:59:14.884Z" },
+]
+
+[[package]]
+name = "cyclonedx-python-lib"
+version = "11.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+  { name = "license-expression" },
+  { name = "packageurl-python" },
+  { name = "py-serializable" },
+  { name = "sortedcontainers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/0d/64f02d3fd9c116d6f50a540d04d1e4f2e3c487f5062d2db53733ddb25917/cyclonedx_python_lib-11.7.0.tar.gz", hash = "sha256:fb1bc3dedfa31208444dbd743007f478ab6984010a184e5bd466bffd969e936e", size = 1411174, upload-time = "2026-03-17T15:19:16.606Z" }
+wheels = [
+  { url = "https://files.pythonhosted.org/packages/30/09/fe0e3bc32bd33707c519b102fc064ad2a2ce5a1b53e2be38b86936b476b1/cyclonedx_python_lib-11.7.0-py3-none-any.whl", hash = "sha256:02fa4f15ddbba21ac9093039f8137c0d1813af7fe88b760c5dcd3311a8da2178", size = 513041, upload-time = "2026-03-17T15:19:14.369Z" },
+]
+
+[[package]]
+name = "defusedxml"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
+wheels = [
+  { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
 ]
 
 [[package]]
@@ -981,6 +1014,7 @@ dependencies = [
   { name = "aiohttp" },
   { name = "argon2-cffi" },
   { name = "authlib" },
+  { name = "cyclonedx-python-lib" },
   { name = "fastapi" },
   { name = "filetype" },
   { name = "httpx" },
@@ -1047,6 +1081,7 @@ requires-dist = [
   { name = "aiohttp" },
   { name = "argon2-cffi", specifier = ">=25.1.0" },
   { name = "authlib", specifier = ">=1.6.11" },
+  { name = "cyclonedx-python-lib", specifier = ">=11.7,<12" },
   { name = "fastapi" },
   { name = "filetype" },
   { name = "httpx", specifier = ">=0.28.1,<1" },
@@ -1366,6 +1401,18 @@ wheels = [
   { url = "https://files.pythonhosted.org/packages/15/1f/dc6771a52592a4451be6effa200cbfc9cec61e4393d3033d81a9d307961d/librt-0.11.0-cp314-cp314t-win32.whl", hash = "sha256:2b481d846ac894c4e8403c5fd0e87c5d11d6499e404b474602508a224ff531c8", size = 103562, upload-time = "2026-05-10T18:17:03.99Z" },
   { url = "https://files.pythonhosted.org/packages/62/4a/7d1415567027286a75ba1093ec4aca11f073e0f559c530cf3e0a757ad55c/librt-0.11.0-cp314-cp314t-win_amd64.whl", hash = "sha256:28edb433edde181112a908c78907af28f964eabc15f4dd16c9d66c834302677c", size = 124327, upload-time = "2026-05-10T18:17:05.465Z" },
   { url = "https://files.pythonhosted.org/packages/ce/62/b40b382fa0c66fee1478073eb8db352a4a6beda4a1adccf1df911d8c289c/librt-0.11.0-cp314-cp314t-win_arm64.whl", hash = "sha256:dee008f20b542e3cd162ba338a7f9ec0f6d23d395f66fe8aeeec3c9d067ea253", size = 102572, upload-time = "2026-05-10T18:17:06.809Z" },
+]
+
+[[package]]
+name = "license-expression"
+version = "30.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+  { name = "boolean-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/40/71/d89bb0e71b1415453980fd32315f2a037aad9f7f70f695c7cec7035feb13/license_expression-30.4.4.tar.gz", hash = "sha256:73448f0aacd8d0808895bdc4b2c8e01a8d67646e4188f887375398c761f340fd", size = 186402, upload-time = "2025-07-22T11:13:32.17Z" }
+wheels = [
+  { url = "https://files.pythonhosted.org/packages/af/40/791891d4c0c4dab4c5e187c17261cedc26285fd41541577f900470a45a4d/license_expression-30.4.4-py3-none-any.whl", hash = "sha256:421788fdcadb41f049d2dc934ce666626265aeccefddd25e162a26f23bcbf8a4", size = 120615, upload-time = "2025-07-22T11:13:31.217Z" },
 ]
 
 [[package]]
@@ -2003,6 +2050,15 @@ wheels = [
 ]
 
 [[package]]
+name = "packageurl-python"
+version = "0.17.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f5/d6/3b5a4e3cfaef7a53869a26ceb034d1ff5e5c27c814ce77260a96d50ab7bb/packageurl_python-0.17.6.tar.gz", hash = "sha256:1252ce3a102372ca6f86eb968e16f9014c4ba511c5c37d95a7f023e2ca6e5c25", size = 50618, upload-time = "2025-11-24T15:20:17.998Z" }
+wheels = [
+  { url = "https://files.pythonhosted.org/packages/b1/2f/c7277b7615a93f51b5fbc1eacfc1b75e8103370e786fd8ce2abf6e5c04ab/packageurl_python-0.17.6-py3-none-any.whl", hash = "sha256:31a85c2717bc41dd818f3c62908685ff9eebcb68588213745b14a6ee9e7df7c9", size = 36776, upload-time = "2025-11-24T15:20:16.962Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2221,6 +2277,18 @@ name = "py-rust-stemmers"
 version = "0.1.5"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8e/63/4fbc14810c32d2a884e2e94e406a7d5bf8eee53e1103f558433817230342/py_rust_stemmers-0.1.5.tar.gz", hash = "sha256:e9c310cfb5c2470d7c7c8a0484725965e7cab8b1237e106a0863d5741da3e1f7", size = 9388, upload-time = "2025-02-19T13:56:28.708Z" }
+
+[[package]]
+name = "py-serializable"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+  { name = "defusedxml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/73/21/d250cfca8ff30c2e5a7447bc13861541126ce9bd4426cd5d0c9f08b5547d/py_serializable-2.1.0.tar.gz", hash = "sha256:9d5db56154a867a9b897c0163b33a793c804c80cee984116d02d49e4578fc103", size = 52368, upload-time = "2025-07-21T09:56:48.07Z" }
+wheels = [
+  { url = "https://files.pythonhosted.org/packages/9b/bf/7595e817906a29453ba4d99394e781b6fabe55d21f3c15d240f85dd06bb1/py_serializable-2.1.0-py3-none-any.whl", hash = "sha256:b56d5d686b5a03ba4f4db5e769dc32336e142fc3bd4d68a8c25579ebb0a67304", size = 23045, upload-time = "2025-07-21T09:56:46.848Z" },
+]
 
 [[package]]
 name = "pycparser"
@@ -2606,6 +2674,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
   { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
+wheels = [
+  { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -7,7 +7,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-05-21T13:24:47.280521Z"
+exclude-newer = "2026-05-21T13:28:51.887969Z"
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
@@ -1095,7 +1095,7 @@ requires-dist = [
   { name = "fastapi" },
   { name = "filetype" },
   { name = "httpx", specifier = ">=0.28.1,<1" },
-  { name = "imbi-common", extras = ["databases", "llm", "sentry", "server"], git = "https://github.com/AWeber-Imbi/imbi-common.git?branch=main" },
+  { name = "imbi-common", extras = ["databases", "llm", "sentry", "server"], specifier = ">=2.7.0" },
   { name = "imbi-plugin-aws", marker = "extra == 'plugins'", specifier = ">=1.0.0" },
   { name = "imbi-plugin-github", marker = "extra == 'plugins'", specifier = ">=1.0.0" },
   { name = "imbi-plugin-logzio", marker = "extra == 'plugins'", specifier = ">=1.0.0" },
@@ -1149,7 +1149,7 @@ docs = [
 [[package]]
 name = "imbi-common"
 version = "2.7.0"
-source = { git = "https://github.com/AWeber-Imbi/imbi-common.git?branch=main#052a64ef91b7d94a5c0818c5604e84fac95bb26b" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
   { name = "cryptography" },
   { name = "httpx" },
@@ -1163,6 +1163,10 @@ dependencies = [
   { name = "pyjwt" },
   { name = "python-slugify" },
   { name = "typer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4b/b0/5f28ac0670d239c885822e5a7c9a94b2bb9c1ea205dccba82ac2ae36f329/imbi_common-2.7.0.tar.gz", hash = "sha256:723d2a7ecffef3f0cf86828173586a9721931b95068718c7b0c7cff768c7f764", size = 303583, upload-time = "2026-05-28T12:56:17.525Z" }
+wheels = [
+  { url = "https://files.pythonhosted.org/packages/ce/33/e801c0e9d7ecfef434ca1f178291584f4dce1e55f34590c9425c2086c4f6/imbi_common-2.7.0-py3-none-any.whl", hash = "sha256:c475153119376753d5f09b18de686eb872464625fdaf073aa893fec38b3956ab", size = 98903, upload-time = "2026-05-28T12:56:16.147Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

Add the SBoM ingest pipeline on the API side. `PUT /organizations/{org}/projects/{project_id}/releases/{release_id}/sbom` accepts a CycloneDX 1.7 document, normalizes the components, and re-creates the release's `USES_COMPONENT_RELEASE` edges. `GET .../dependencies` powers the new Dependencies tab in imbi-ui.

The new graph types this PR depends on (`Component`, `ComponentRelease`, `ComponentIdentifier`, `ReleaseComponentEdge`) ship in **AWeber-Imbi/imbi-common#132** — this PR is in **DRAFT until imbi-common#132 is merged** and an imbi-common release containing those models is consumable.

## Problem

Builds for Imbi-managed projects already emit CycloneDX SBoMs as a CI side-effect (`features/sbom-ingest.md`). Today those artifacts are thrown away. We want to:

1. *What components and versions are deployed in a given environment?*
2. *Which projects use a given component?*
3. *Which projects use a given version of a given component?*

The API side owns CycloneDX parsing, normalization, and the graph mutation. Producer-side (cdxgen + gateway webhook) and consumer-side (UI tab) changes land in the companion PRs.

## Solution

**Parsing (`src/imbi_api/sbom.py`):**

- `sbom.parse` validates `specVersion == "1.7"` (HTTP 415 on mismatch), runs the payload through `cyclonedx-python-lib` (`>=11.7,<12`, pinned via `uv add`), and projects each component into a `NormalizedComponent` (purl + identifiers + version + license + scope + groups + hashes + supplier).
- Identifiers are normalized to version-agnostic form (purl `@version` stripped; CPE version segment masked to `*`) so a `Component` MERGE on `purl_name` resolves the same vertex for all versions of a package.
- `cdx:pyproject:group` properties are collected via a curated allow-list (covers Poetry + PEP 735 today). A regex-match would catch flag properties like `cdx:npm:package:development` and pollute the groups list.

**Graph mutation (idempotent, parallel, fault-tolerant):**

- `replace_release_components` CLEARs the release's existing `USES_COMPONENT_RELEASE` edges, then re-creates them. `Component` / `ComponentRelease` / `ComponentIdentifier` nodes are MERGE-ed and never destroyed.
- Per-component upserts run in parallel via `asyncio.gather` under an `asyncio.Semaphore(16)` cap — serial round-trips were too slow on npm SBoMs (500-1500 components) and the gateway timed out before the API finished.
- Components are **bucketed by `purl_name`**; buckets parallelize, but within a bucket the upserts serialize. Within-bucket serialization is load-bearing: parallel MERGEs against the same `Component` vertex trigger AGE's "Entity failed to be updated: 3" vertex-version conflict (we reproduced this with `react-is@17` + `@18`, four `commander` versions, two `chalk`, etc. — all on shared purl_names).
- Per-component failures log a WARNING with purl + version + release id and the rest of the batch continues. Partial graph state is more useful than aborting.

**Endpoints (`src/imbi_api/endpoints/releases.py`):**

- `PUT /releases/{release_id}/sbom` — requires `project:write`. Validates spec version, normalizes, calls `replace_release_components`. 204 on success; 400 on malformed payload; 404 on unknown release; 415 on non-1.7 spec.
- `GET /releases/{release_id}/dependencies` — requires `project:read`. Reads scope/groups off the `USES_COMPONENT_RELEASE` edge and returns a flat component list.

**ADR 0015** codifies the CycloneDX-1.7-only acceptance window and the choice of cdxgen as the recommended producer.

## Companion PRs

- **Requires:** [imbi-common#132](https://github.com/AWeber-Imbi/imbi-common/pull/132) — graph models
- **Required by:** imbi-gateway PR (action handler) and imbi-ui PR (Dependencies tab) — links to be added once those drafts open

## Test plan

- [x] CI green (`just lint && just test`)
- [x] Coverage stays ≥ 85%
- [x] After imbi-common#132 lands and is released, smoke-test against a real cdxgen SBoM for a node-js project: 200+ components ingest without "Entity failed to be updated" errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)