### PR TITLE
Add admin CRUD API for MCP server configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -233,3 +233,6 @@ exclude-newer-package = { "clickhouse-connect" = false, "imbi-common" = false, "
 [[tool.uv.index]]
 url = "https://pypi.org/simple"
 default = true
+
+[tool.uv.sources]
+imbi-common = { path = "../imbi-common", editable = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
   "fastapi",
   "filetype",
   "httpx>=0.28.1,<1",
-  "imbi-common[databases,llm,sentry,server]>=2.6.0",
+  "imbi-common[databases,llm,sentry,server]>=2.6.1",
   "jinja2",
   "jsonpatch>=1.33",
   "nanoid>=2.0.0",
@@ -235,4 +235,4 @@ url = "https://pypi.org/simple"
 default = true
 
 [tool.uv.sources]
-imbi-common = { path = "../imbi-common", editable = true }
+imbi-common = { git = "https://github.com/AWeber-Imbi/imbi-common.git", branch = "main" }

--- a/src/imbi_api/auth/seed.py
+++ b/src/imbi_api/auth/seed.py
@@ -88,6 +88,31 @@ STANDARD_PERMISSIONS: list[tuple[str, str, str, str]] = [
         'delete',
         'Delete link definitions',
     ),
+    # MCP server management
+    (
+        'mcp_server:create',
+        'mcp_server',
+        'create',
+        'Create MCP servers',
+    ),
+    (
+        'mcp_server:read',
+        'mcp_server',
+        'read',
+        'View MCP servers',
+    ),
+    (
+        'mcp_server:update',
+        'mcp_server',
+        'update',
+        'Update MCP servers',
+    ),
+    (
+        'mcp_server:delete',
+        'mcp_server',
+        'delete',
+        'Delete MCP servers',
+    ),
     # Environment management
     (
         'environment:create',

--- a/src/imbi_api/blueprint_attributes.py
+++ b/src/imbi_api/blueprint_attributes.py
@@ -1,0 +1,77 @@
+"""Resolve filterable project attributes from blueprints.
+
+Blueprint ``node`` schemas for the ``Project`` type contribute the
+dynamic properties stored on each project vertex (e.g. ``framework``,
+``programming_language``). This module flattens those schemas into a
+catalog of filterable attributes, scoped to a project type.
+
+Both the ``include_schema`` flag on the project-type listing (which
+advertises the catalog) and the ``filter`` parameter on the project
+listing (which validates filter fields against it) share this
+resolver, so the advertised and accepted attribute sets cannot drift.
+"""
+
+import pydantic
+from imbi_common import graph, models
+
+
+class FilterableAttribute(pydantic.BaseModel):
+    """A single project attribute that can be filtered on."""
+
+    field: str
+    type: str | None = None
+    format: str | None = None
+    enum: list[str] | None = None
+
+
+def resolve(
+    blueprints: list[models.Blueprint],
+    type_slug: str | None,
+) -> dict[str, FilterableAttribute]:
+    """Return filterable attributes keyed by field name.
+
+    ``blueprints`` must be the enabled ``Project`` blueprints ordered
+    by ascending priority; later blueprints override earlier ones for
+    the same field name.
+
+    When ``type_slug`` is given, only blueprints whose ``project_type``
+    filter includes it (or that have no ``project_type`` filter) are
+    considered. When ``type_slug`` is ``None`` the union across every
+    project type is returned. The ``environment`` filter is ignored:
+    the property exists on the project vertex regardless of which
+    environments the project is deployed in.
+    """
+    out: dict[str, FilterableAttribute] = {}
+    for bp in blueprints:
+        if bp.kind != 'node':
+            continue
+        f = bp.filter
+        if (
+            type_slug is not None
+            and f is not None
+            and f.project_type
+            and type_slug not in f.project_type
+        ):
+            continue
+        properties = bp.json_schema.properties
+        if not properties:
+            continue
+        for name, prop in properties.items():
+            out[name] = FilterableAttribute(
+                field=name,
+                type=getattr(prop, 'type', None),
+                format=getattr(prop, 'format', None),
+                enum=getattr(prop, 'enum', None),
+            )
+    return out
+
+
+async def project_blueprints(
+    db: graph.Graph,
+) -> list[models.Blueprint]:
+    """Fetch enabled ``Project`` blueprints ordered by priority."""
+    return await db.match(
+        models.Blueprint,
+        {'type': 'Project', 'enabled': True},
+        order_by='priority',
+    )

--- a/src/imbi_api/endpoints/__init__.py
+++ b/src/imbi_api/endpoints/__init__.py
@@ -15,6 +15,7 @@ from .client_credentials import client_credentials_router
 from .events import events_router
 from .graph_query import graph_query_router
 from .local_auth import local_auth_router
+from .mcp_servers import mcp_servers_router
 from .mfa import mfa_router
 from .operations_log import operations_log_router
 from .organizations import organizations_router
@@ -40,6 +41,7 @@ prefixed_routers: list[fastapi.APIRouter] = [
     events_router,
     graph_query_router,
     local_auth_router,
+    mcp_servers_router,
     me_identities_router,
     mfa_router,
     operations_log_router,

--- a/src/imbi_api/endpoints/mcp_servers.py
+++ b/src/imbi_api/endpoints/mcp_servers.py
@@ -40,7 +40,7 @@ class MCPServerCreate(pydantic.BaseModel):
 
     name: str
     slug: str
-    url: str
+    url: pydantic.HttpUrl
     description: str | None = None
     icon: pydantic.HttpUrl | str | None = None
     enabled: bool = True
@@ -51,7 +51,7 @@ class MCPServerCreate(pydantic.BaseModel):
     auth_type: AuthType = 'none'
     static_header: str | None = None
     static_value: str | None = None
-    oauth_token_url: str | None = None
+    oauth_token_url: pydantic.HttpUrl | None = None
     oauth_client_id: str | None = None
     oauth_client_secret: str | None = None
     oauth_scope: str | None = None
@@ -68,7 +68,7 @@ class MCPServerUpdate(pydantic.BaseModel):
 
     name: str | None = None
     slug: str | None = None
-    url: str | None = None
+    url: pydantic.HttpUrl | None = None
     description: str | None = None
     icon: pydantic.HttpUrl | str | None = None
     enabled: bool | None = None
@@ -79,7 +79,7 @@ class MCPServerUpdate(pydantic.BaseModel):
     auth_type: AuthType | None = None
     static_header: str | None = None
     static_value: str | None = None
-    oauth_token_url: str | None = None
+    oauth_token_url: pydantic.HttpUrl | None = None
     oauth_client_id: str | None = None
     oauth_client_secret: str | None = None
     oauth_scope: str | None = None
@@ -95,7 +95,7 @@ class MCPServerResponse(pydantic.BaseModel):
     id: str
     name: str
     slug: str
-    url: str
+    url: pydantic.HttpUrl
     description: str | None = None
     icon: pydantic.HttpUrl | str | None = None
     enabled: bool = True
@@ -106,7 +106,7 @@ class MCPServerResponse(pydantic.BaseModel):
     auth_type: AuthType = 'none'
     static_header: str | None = None
     has_static_value: bool = False
-    oauth_token_url: str | None = None
+    oauth_token_url: pydantic.HttpUrl | None = None
     oauth_client_id: str | None = None
     has_oauth_client_secret: bool = False
     oauth_scope: str | None = None

--- a/src/imbi_api/endpoints/mcp_servers.py
+++ b/src/imbi_api/endpoints/mcp_servers.py
@@ -1,0 +1,406 @@
+"""Admin CRUD endpoints for MCPServer global configuration.
+
+``MCPServer`` is global config — it has no organization edge. Secrets
+(``static_value`` and ``oauth_client_secret``) are accepted as plaintext
+request fields, encrypted via :mod:`imbi_common.auth.encryption`, and
+persisted only as ciphertext in the ``*_encrypted`` model fields.
+Responses never expose plaintext or ciphertext secrets; instead they
+surface ``has_static_value`` / ``has_oauth_client_secret`` booleans.
+"""
+
+import datetime
+import logging
+import typing
+
+import fastapi
+import psycopg.errors
+import pydantic
+from imbi_common import graph, models
+from imbi_common.auth.encryption import encrypt_config_value
+
+from imbi_api.auth import permissions
+from imbi_api.graph_sql import props_template, set_clause
+
+LOGGER = logging.getLogger(__name__)
+
+mcp_servers_router = fastapi.APIRouter(
+    prefix='/mcp-servers',
+    tags=['MCP Servers'],
+)
+
+AuthType = typing.Literal['none', 'static', 'oauth_client_credentials']
+
+
+class MCPServerCreate(pydantic.BaseModel):
+    """Request model for creating an MCP server.
+
+    Secrets (``static_value`` and ``oauth_client_secret``) are plaintext
+    here and are encrypted before persistence.
+    """
+
+    name: str
+    slug: str
+    url: str
+    description: str | None = None
+    icon: pydantic.HttpUrl | str | None = None
+    enabled: bool = True
+    tool_prefix: str | None = None
+    timeout: int = 30
+    verify_ssl: bool = True
+    ignored_tools: list[str] = pydantic.Field(default_factory=list)
+    auth_type: AuthType = 'none'
+    static_header: str | None = None
+    static_value: str | None = None
+    oauth_token_url: str | None = None
+    oauth_client_id: str | None = None
+    oauth_client_secret: str | None = None
+    oauth_scope: str | None = None
+
+
+class MCPServerUpdate(pydantic.BaseModel):
+    """Request model for partially updating an MCP server.
+
+    Every field is optional. An omitted secret field leaves the stored
+    ciphertext unchanged; an explicit ``null``/empty value clears it; a
+    new value re-encrypts it. ``exclude_unset`` on the parsed model is
+    used to distinguish "omitted" from "explicitly null".
+    """
+
+    name: str | None = None
+    slug: str | None = None
+    url: str | None = None
+    description: str | None = None
+    icon: pydantic.HttpUrl | str | None = None
+    enabled: bool | None = None
+    tool_prefix: str | None = None
+    timeout: int | None = None
+    verify_ssl: bool | None = None
+    ignored_tools: list[str] | None = None
+    auth_type: AuthType | None = None
+    static_header: str | None = None
+    static_value: str | None = None
+    oauth_token_url: str | None = None
+    oauth_client_id: str | None = None
+    oauth_client_secret: str | None = None
+    oauth_scope: str | None = None
+
+
+class MCPServerResponse(pydantic.BaseModel):
+    """Response model for an MCP server.
+
+    Secrets are never returned; their presence is surfaced via the
+    ``has_static_value`` and ``has_oauth_client_secret`` booleans.
+    """
+
+    id: str
+    name: str
+    slug: str
+    url: str
+    description: str | None = None
+    icon: pydantic.HttpUrl | str | None = None
+    enabled: bool = True
+    tool_prefix: str | None = None
+    timeout: int = 30
+    verify_ssl: bool = True
+    ignored_tools: list[str] = pydantic.Field(default_factory=list)
+    auth_type: AuthType = 'none'
+    static_header: str | None = None
+    has_static_value: bool = False
+    oauth_token_url: str | None = None
+    oauth_client_id: str | None = None
+    has_oauth_client_secret: bool = False
+    oauth_scope: str | None = None
+    created_at: datetime.datetime | None = None
+    updated_at: datetime.datetime | None = None
+
+
+def _to_response(node: models.MCPServer) -> MCPServerResponse:
+    """Build a secret-free response from a persisted MCPServer node."""
+    return MCPServerResponse(
+        id=node.id,
+        name=node.name,
+        slug=node.slug,
+        url=node.url,
+        description=node.description,
+        icon=node.icon,
+        enabled=node.enabled,
+        tool_prefix=node.tool_prefix,
+        timeout=node.timeout,
+        verify_ssl=node.verify_ssl,
+        ignored_tools=node.ignored_tools,
+        auth_type=node.auth_type,
+        static_header=node.static_header,
+        has_static_value=node.static_value_encrypted is not None,
+        oauth_token_url=node.oauth_token_url,
+        oauth_client_id=node.oauth_client_id,
+        has_oauth_client_secret=(
+            node.oauth_client_secret_encrypted is not None
+        ),
+        oauth_scope=node.oauth_scope,
+        created_at=node.created_at,
+        updated_at=node.updated_at,
+    )
+
+
+@mcp_servers_router.post(
+    '/', response_model=MCPServerResponse, status_code=201
+)
+async def create_mcp_server(
+    data: MCPServerCreate,
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(permissions.require_permission('mcp_server:create')),
+    ],
+) -> MCPServerResponse:
+    """Create a new MCP server.
+
+    Parameters:
+        data: MCP server data; ``slug`` must be unique. ``static_value``
+            and ``oauth_client_secret`` are plaintext and are encrypted
+            before persistence.
+
+    Returns:
+        The created MCP server, without any secret values.
+
+    Raises:
+        409: If an MCP server with the same slug already exists.
+
+    """
+    _ = auth
+    try:
+        node = models.MCPServer(
+            name=data.name,
+            slug=data.slug,
+            url=data.url,
+            description=data.description,
+            icon=data.icon,
+            enabled=data.enabled,
+            tool_prefix=data.tool_prefix,
+            timeout=data.timeout,
+            verify_ssl=data.verify_ssl,
+            ignored_tools=data.ignored_tools,
+            auth_type=data.auth_type,
+            static_header=data.static_header,
+            static_value_encrypted=encrypt_config_value(data.static_value),
+            oauth_token_url=data.oauth_token_url,
+            oauth_client_id=data.oauth_client_id,
+            oauth_client_secret_encrypted=encrypt_config_value(
+                data.oauth_client_secret
+            ),
+            oauth_scope=data.oauth_scope,
+        )
+    except pydantic.ValidationError as e:
+        raise fastapi.HTTPException(
+            status_code=400,
+            detail=f'Validation error: {e.errors()}',
+        ) from e
+
+    now = datetime.datetime.now(datetime.UTC)
+    node.created_at = now
+    node.updated_at = now
+    props = node.model_dump(mode='json')
+    query = f'CREATE (n:MCPServer {props_template(props)}) RETURN n'
+    try:
+        records = await db.execute(query, props, ['n'])
+    except psycopg.errors.UniqueViolation as e:
+        raise fastapi.HTTPException(
+            status_code=409,
+            detail=f'MCP server with slug {node.slug!r} already exists',
+        ) from e
+    if not records:
+        raise fastapi.HTTPException(
+            status_code=500,
+            detail='MCP server create returned no rows',
+        )
+    return _to_response(_parse_node(records[0]['n']))
+
+
+@mcp_servers_router.get('/', response_model=list[MCPServerResponse])
+async def list_mcp_servers(
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(permissions.require_permission('mcp_server:read')),
+    ],
+) -> list[MCPServerResponse]:
+    """List all MCP servers ordered by name.
+
+    Returns:
+        Every MCP server, without any secret values.
+
+    """
+    _ = auth
+    nodes = await db.match(models.MCPServer, order_by='name')
+    return [_to_response(node) for node in nodes]
+
+
+@mcp_servers_router.get('/{id}', response_model=MCPServerResponse)
+async def get_mcp_server(
+    id: str,
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(permissions.require_permission('mcp_server:read')),
+    ],
+) -> MCPServerResponse:
+    """Get an MCP server by id.
+
+    Parameters:
+        id: The MCP server id.
+
+    Returns:
+        The MCP server, without any secret values.
+
+    Raises:
+        404: If no MCP server with the given id exists.
+
+    """
+    _ = auth
+    node = await _fetch(db, id)
+    return _to_response(node)
+
+
+@mcp_servers_router.patch('/{id}', response_model=MCPServerResponse)
+async def update_mcp_server(
+    id: str,
+    data: MCPServerUpdate,
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(permissions.require_permission('mcp_server:update')),
+    ],
+) -> MCPServerResponse:
+    """Partially update an MCP server.
+
+    Omitted fields are left unchanged. For the secret fields
+    (``static_value``/``oauth_client_secret``): an omitted field leaves
+    the stored ciphertext unchanged; an explicit ``null``/empty value
+    clears it; a new value re-encrypts it.
+
+    Parameters:
+        id: The MCP server id.
+        data: Fields to update.
+
+    Returns:
+        The updated MCP server, without any secret values.
+
+    Raises:
+        404: If no MCP server with the given id exists.
+        409: If the new slug collides with another MCP server.
+
+    """
+    _ = auth
+    existing = await _fetch(db, id)
+    set_fields = data.model_dump(exclude_unset=True)
+
+    updates: dict[str, typing.Any] = {}
+    for field in (
+        'name',
+        'slug',
+        'url',
+        'description',
+        'icon',
+        'enabled',
+        'tool_prefix',
+        'timeout',
+        'verify_ssl',
+        'ignored_tools',
+        'auth_type',
+        'static_header',
+        'oauth_token_url',
+        'oauth_client_id',
+        'oauth_scope',
+    ):
+        if field in set_fields:
+            updates[field] = set_fields[field]
+
+    if 'static_value' in set_fields:
+        updates['static_value_encrypted'] = encrypt_config_value(
+            set_fields['static_value']
+        )
+    if 'oauth_client_secret' in set_fields:
+        updates['oauth_client_secret_encrypted'] = encrypt_config_value(
+            set_fields['oauth_client_secret']
+        )
+
+    if not updates:
+        return _to_response(existing)
+
+    merged = existing.model_dump()
+    merged.update(updates)
+    try:
+        node = models.MCPServer.model_validate(merged)
+    except pydantic.ValidationError as e:
+        raise fastapi.HTTPException(
+            status_code=400,
+            detail=f'Validation error: {e.errors()}',
+        ) from e
+    node.updated_at = datetime.datetime.now(datetime.UTC)
+
+    props = node.model_dump(mode='json', exclude={'id', 'created_at'})
+    set_stmt = set_clause('n', props)
+    query = f'MATCH (n:MCPServer {{{{id: {{id}}}}}}) {set_stmt} RETURN n'
+    try:
+        records = await db.execute(query, {**props, 'id': id}, ['n'])
+    except psycopg.errors.UniqueViolation as e:
+        raise fastapi.HTTPException(
+            status_code=409,
+            detail=f'MCP server with slug {node.slug!r} already exists',
+        ) from e
+    if not records:
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail=f'MCP server with id {id!r} not found',
+        )
+    return _to_response(_parse_node(records[0]['n']))
+
+
+@mcp_servers_router.delete('/{id}', status_code=204)
+async def delete_mcp_server(
+    id: str,
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(permissions.require_permission('mcp_server:delete')),
+    ],
+) -> None:
+    """Delete an MCP server by id.
+
+    Parameters:
+        id: The id of the MCP server to delete.
+
+    Raises:
+        404: If no MCP server with the given id exists.
+
+    """
+    _ = auth
+    query: typing.LiteralString = (
+        'MATCH (n:MCPServer {{id: {id}}}) DETACH DELETE n RETURN n'
+    )
+    records = await db.execute(query, {'id': id})
+    if not records:
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail=f'MCP server with id {id!r} not found',
+        )
+
+
+def _parse_node(raw: typing.Any) -> models.MCPServer:
+    """Parse a graph agtype vertex into an MCPServer model."""
+    props: typing.Any = graph.parse_agtype(raw)
+    return models.MCPServer.model_validate(props)
+
+
+async def _fetch(db: graph.Graph, id: str) -> models.MCPServer:
+    """Fetch a single MCP server by id or raise 404."""
+    results = await db.match(models.MCPServer, {'id': id})
+    if not results:
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail=f'MCP server with id {id!r} not found',
+        )
+    return results[0]
+
+
+__all__ = ['mcp_servers_router']

--- a/src/imbi_api/endpoints/project_types.py
+++ b/src/imbi_api/endpoints/project_types.py
@@ -9,6 +9,7 @@ import psycopg.errors
 import pydantic
 from imbi_common import blueprints, graph, models
 
+from imbi_api import blueprint_attributes
 from imbi_api import patch as json_patch
 from imbi_api.auth import permissions
 from imbi_api.graph_sql import props_template, set_clause
@@ -145,11 +146,17 @@ async def list_project_types(
             permissions.require_permission('project_type:read'),
         ),
     ],
+    include_schema: bool = False,
 ) -> list[dict[str, typing.Any]]:
     """List all project types in an organization.
 
     Parameters:
         org_slug: Organization slug from URL path.
+        include_schema: When true, each project type gains a
+            ``schema`` key listing the blueprint-defined attributes
+            (``field``, ``type``, ``format``, ``enum``) that projects
+            of that type can be filtered on via the project listing's
+            ``filter`` parameter.
 
     Returns:
         Project types ordered by name, each including their
@@ -170,6 +177,11 @@ async def list_project_types(
         {'org_slug': org_slug},
         columns=['pt', 'o', 'project_count'],
     )
+    bps = (
+        await blueprint_attributes.project_blueprints(db)
+        if include_schema
+        else []
+    )
     for record in records:
         pt = graph.parse_agtype(record['pt'])
         org = graph.parse_agtype(record['o'])
@@ -178,6 +190,13 @@ async def list_project_types(
         pt['relationships'] = _project_type_relationships(
             request, org_slug, pt['slug'], pc or 0
         )
+        if include_schema:
+            pt['schema'] = [
+                attr.model_dump()
+                for attr in blueprint_attributes.resolve(
+                    bps, pt['slug']
+                ).values()
+            ]
         project_types.append(pt)
     return project_types
 

--- a/src/imbi_api/endpoints/projects.py
+++ b/src/imbi_api/endpoints/projects.py
@@ -8,6 +8,7 @@ import asyncio
 import datetime
 import json
 import logging
+import re
 import typing
 
 import fastapi
@@ -18,6 +19,7 @@ from imbi_common import blueprints, graph, models
 from imbi_common.clickhouse import client as ch_client
 from imbi_common.scoring import compute_score
 
+from imbi_api import blueprint_attributes
 from imbi_api import patch as json_patch
 from imbi_api.auth import permissions
 from imbi_api.domain import scoring as scoring_models
@@ -1075,6 +1077,82 @@ async def _resolve_release_display_names(
             env_map[slug] = info.model_copy(update={'performed_by': name})
 
 
+_FILTER_FIELD_RE = re.compile(r'^[A-Za-z_][A-Za-z0-9_]*$')
+_FILTER_OPS = frozenset({'eq', 'ne', 'in', 'not_in', 'exists', 'not_exists'})
+
+
+def _build_attribute_filter(
+    filters: list[str],
+    whitelist: dict[str, blueprint_attributes.FilterableAttribute],
+) -> tuple[str, dict[str, typing.Any]]:
+    """Translate ``field:op[:value]`` predicates into a Cypher WHERE.
+
+    Returns ``(fragment, params)`` where ``fragment`` is empty or a
+    ``WHERE`` clause (predicates joined by AND) referencing the ``p``
+    project node, and ``params`` holds the bound values. ``ne`` and
+    ``not_in`` use plain inequality, so projects without the attribute
+    set are excluded.
+
+    Field names are validated against ``whitelist`` (and an identifier
+    pattern) before being interpolated; values are always bound as
+    query parameters. Raises ``HTTPException`` (400) on malformed
+    predicates, unknown operators, or non-filterable fields.
+    """
+    clauses: list[str] = []
+    params: dict[str, typing.Any] = {}
+    for index, raw in enumerate(filters):
+        field, _, rest = raw.partition(':')
+        op, _, value = rest.partition(':')
+        if not field or not op:
+            raise fastapi.HTTPException(
+                status_code=400,
+                detail=f'Invalid filter {raw!r}; expected field:op[:value]',
+            )
+        if op not in _FILTER_OPS:
+            raise fastapi.HTTPException(
+                status_code=400,
+                detail=(
+                    f'Unknown filter operator {op!r}; valid operators are '
+                    f'{", ".join(sorted(_FILTER_OPS))}'
+                ),
+            )
+        if field not in whitelist or not _FILTER_FIELD_RE.match(field):
+            raise fastapi.HTTPException(
+                status_code=400,
+                detail=(
+                    f'Attribute {field!r} is not filterable for this '
+                    'project type'
+                ),
+            )
+        if op in ('exists', 'not_exists'):
+            null_op = 'IS NOT NULL' if op == 'exists' else 'IS NULL'
+            clauses.append(f'p.{field} {null_op}')
+            continue
+        values = (
+            [v for v in value.split(',') if v]
+            if op in ('in', 'not_in')
+            else [value]
+        )
+        if not values:
+            raise fastapi.HTTPException(
+                status_code=400,
+                detail=f'Filter {raw!r} requires a value',
+            )
+        comparator = '=' if op in ('eq', 'in') else '<>'
+        joiner = ' OR ' if op in ('eq', 'in') else ' AND '
+        terms: list[str] = []
+        for value_index, item in enumerate(values):
+            key = f'f{index}_{value_index}'
+            params[key] = item
+            terms.append(f'p.{field} {comparator} {{{key}}}')
+        clauses.append(
+            terms[0] if len(terms) == 1 else '(' + joiner.join(terms) + ')'
+        )
+    if not clauses:
+        return '', params
+    return 'WHERE ' + ' AND '.join(clauses), params
+
+
 @projects_router.get('/', name='list_projects')
 async def list_projects(
     org_slug: str,
@@ -1089,11 +1167,31 @@ async def list_projects(
     project_type: str | None = None,
     include_archived: bool = False,
     slim: bool = False,
+    filters: typing.Annotated[
+        list[str] | None,
+        fastapi.Query(
+            alias='filter',
+            description=(
+                'Filter projects by blueprint attribute, as '
+                '``field:op[:value]`` (repeatable; combined with AND). '
+                'Operators: eq, ne, in, not_in (comma-separated values), '
+                'exists, not_exists. ne/not_in exclude projects where the '
+                'attribute is unset. Valid fields and enum values per '
+                'project type come from the project-type listing with '
+                '``include_schema=true``. Example: '
+                'framework:ne:http-service-lib'
+            ),
+        ),
+    ] = None,
 ) -> list[ProjectListItem] | list[ProjectResponse]:
     """List projects in the organization.
 
     By default archived projects are excluded.  Pass
     ``include_archived=true`` to include them.
+
+    ``filter`` predicates match against blueprint-defined attributes
+    stored on the project (e.g. ``framework``, ``programming_language``)
+    using the field/operator grammar described on the parameter.
 
     ``slim=true`` returns a stripped payload tailored to the
     projects-list UI: only the fields the list view reads (id, name,
@@ -1116,7 +1214,16 @@ async def list_projects(
     return_fragment: typing.LiteralString = (
         _SLIM_RETURN_FRAGMENT if slim else _RETURN_FRAGMENT
     )
-    query: typing.LiteralString = (
+    attr_filter = ''
+    attr_params: dict[str, typing.Any] = {}
+    if filters:
+        whitelist = blueprint_attributes.resolve(
+            await blueprint_attributes.project_blueprints(db),
+            project_type,
+        )
+        fragment, attr_params = _build_attribute_filter(filters, whitelist)
+        attr_filter = '\n    ' + fragment + '\n' if fragment else ''
+    query: str = (
         """
     MATCH (p:Project)-[:OWNED_BY]->(:Team)
           -[:BELONGS_TO]->(o:Organization {{slug: {org_slug}}})
@@ -1126,6 +1233,7 @@ async def list_projects(
     WITH DISTINCT p, o
     """
         + type_filter
+        + attr_filter
         + return_fragment
         + """
     ORDER BY p.name
@@ -1139,6 +1247,7 @@ async def list_projects(
         {
             'org_slug': org_slug,
             'project_type': project_type,
+            **attr_params,
         },
         columns,
     )

--- a/src/imbi_api/endpoints/projects.py
+++ b/src/imbi_api/endpoints/projects.py
@@ -1125,9 +1125,22 @@ def _build_attribute_filter(
                 ),
             )
         if op in ('exists', 'not_exists'):
+            if value:
+                raise fastapi.HTTPException(
+                    status_code=400,
+                    detail=(
+                        f'Filter {raw!r} does not accept a value for '
+                        f'operator {op!r}'
+                    ),
+                )
             null_op = 'IS NOT NULL' if op == 'exists' else 'IS NULL'
             clauses.append(f'p.{field} {null_op}')
             continue
+        if op in ('eq', 'ne') and value == '':
+            raise fastapi.HTTPException(
+                status_code=400,
+                detail=f'Filter {raw!r} requires a value',
+            )
         values = (
             [v for v in value.split(',') if v]
             if op in ('in', 'not_in')

--- a/src/imbi_api/models.py
+++ b/src/imbi_api/models.py
@@ -27,6 +27,7 @@ BlueprintEdge = _common.BlueprintEdge
 DeploymentEvent = _common.DeploymentEvent
 Environment = _common.Environment
 LinkDefinition = _common.LinkDefinition
+MCPServer = _common.MCPServer
 Node = _common.Node
 Organization = _common.Organization
 Project = _common.Project

--- a/tests/endpoints/test_mcp_servers.py
+++ b/tests/endpoints/test_mcp_servers.py
@@ -1,0 +1,398 @@
+"""Tests for MCP server admin CRUD endpoints."""
+
+import datetime
+import typing
+import unittest
+from unittest import mock
+
+import psycopg.errors
+from fastapi.testclient import TestClient
+from imbi_common import graph
+
+from imbi_api import app, models
+from imbi_api.auth import permissions
+
+
+class MCPServerEndpointsTestCase(unittest.TestCase):
+    """Test cases for MCP server CRUD endpoints."""
+
+    def setUp(self) -> None:
+        """Set up test app with admin authentication."""
+        self.test_app = app.create_app()
+
+        self.admin_user = models.User(
+            email='admin@example.com',
+            display_name='Admin User',
+            password_hash='$argon2id$hashed',
+            is_active=True,
+            is_admin=True,
+            is_service_account=False,
+            created_at=datetime.datetime.now(datetime.UTC),
+        )
+        self.auth_context = permissions.AuthContext(
+            user=self.admin_user,
+            session_id='test-session',
+            auth_method='jwt',
+            permissions=set(),
+        )
+
+        async def mock_get_current_user() -> permissions.AuthContext:
+            return self.auth_context
+
+        self.test_app.dependency_overrides[permissions.get_current_user] = (
+            mock_get_current_user
+        )
+
+        self.mock_db = mock.AsyncMock(spec=graph.Graph)
+        self.test_app.dependency_overrides[graph._inject_graph] = lambda: (
+            self.mock_db
+        )
+
+        self.client = TestClient(self.test_app)
+
+    def _server_props(self, **overrides: typing.Any) -> dict[str, typing.Any]:
+        """Return a default MCP server vertex property dict."""
+        data: dict[str, typing.Any] = {
+            'id': 'srv-1',
+            'name': 'Example',
+            'slug': 'example',
+            'url': 'https://mcp.example.com',
+            'description': None,
+            'icon': None,
+            'enabled': True,
+            'tool_prefix': None,
+            'timeout': 30,
+            'verify_ssl': True,
+            'ignored_tools': [],
+            'auth_type': 'none',
+            'static_header': None,
+            'static_value_encrypted': None,
+            'oauth_token_url': None,
+            'oauth_client_id': None,
+            'oauth_client_secret_encrypted': None,
+            'oauth_scope': None,
+            'created_at': '2026-05-27T12:00:00Z',
+            'updated_at': '2026-05-27T12:00:00Z',
+        }
+        data.update(overrides)
+        return data
+
+    def _model(self, **overrides: typing.Any) -> models.MCPServer:
+        """Return a default MCPServer model instance."""
+        return models.MCPServer.model_validate(self._server_props(**overrides))
+
+    # -- Create --------------------------------------------------------
+
+    def test_create_success(self) -> None:
+        """A server is created and secrets are encrypted, not echoed."""
+        self.mock_db.execute.return_value = [{'n': self._server_props()}]
+        with (
+            mock.patch(
+                'imbi_common.graph.parse_agtype',
+                side_effect=lambda x: x,
+            ),
+            mock.patch(
+                'imbi_api.endpoints.mcp_servers.encrypt_config_value',
+                side_effect=lambda v: None if v is None else f'enc:{v}',
+            ) as enc,
+        ):
+            response = self.client.post(
+                '/mcp-servers/',
+                json={
+                    'name': 'Example',
+                    'slug': 'example',
+                    'url': 'https://mcp.example.com',
+                    'auth_type': 'static',
+                    'static_header': 'Authorization',
+                    'static_value': 'super-secret',
+                },
+            )
+        self.assertEqual(response.status_code, 201)
+        data = response.json()
+        self.assertEqual(data['slug'], 'example')
+        self.assertEqual(data['id'], 'srv-1')
+        # Plaintext secret was encrypted before persistence.
+        enc.assert_any_call('super-secret')
+        # The persisted props carried ciphertext, never plaintext.
+        persisted = self.mock_db.execute.call_args.args[1]
+        self.assertEqual(
+            persisted['static_value_encrypted'], 'enc:super-secret'
+        )
+        self.assertNotIn('static_value', persisted)
+        # Response never leaks plaintext or ciphertext.
+        self.assertNotIn('static_value', data)
+        self.assertNotIn('static_value_encrypted', data)
+        self.assertNotIn('oauth_client_secret', data)
+        self.assertNotIn('oauth_client_secret_encrypted', data)
+
+    def test_create_validation_error(self) -> None:
+        """Missing required fields return 422."""
+        response = self.client.post('/mcp-servers/', json={})
+        self.assertEqual(response.status_code, 422)
+
+    def test_create_slug_conflict(self) -> None:
+        """A duplicate slug returns 409."""
+        self.mock_db.execute.side_effect = psycopg.errors.UniqueViolation()
+        with (
+            mock.patch(
+                'imbi_common.graph.parse_agtype',
+                side_effect=lambda x: x,
+            ),
+            mock.patch(
+                'imbi_api.endpoints.mcp_servers.encrypt_config_value',
+                side_effect=lambda v: v,
+            ),
+        ):
+            response = self.client.post(
+                '/mcp-servers/',
+                json={
+                    'name': 'Example',
+                    'slug': 'example',
+                    'url': 'https://mcp.example.com',
+                },
+            )
+        self.assertEqual(response.status_code, 409)
+        self.assertIn('already exists', response.json()['detail'])
+
+    # -- List / Get ----------------------------------------------------
+
+    def test_list_success(self) -> None:
+        """Listing returns secret-presence booleans, never secrets."""
+        self.mock_db.match.return_value = [
+            self._model(),
+            self._model(
+                id='srv-2',
+                slug='secure',
+                name='Secure',
+                static_value_encrypted='enc:abc',
+                oauth_client_secret_encrypted='enc:def',
+            ),
+        ]
+        response = self.client.get('/mcp-servers/')
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(len(data), 2)
+        self.assertFalse(data[0]['has_static_value'])
+        self.assertFalse(data[0]['has_oauth_client_secret'])
+        self.assertTrue(data[1]['has_static_value'])
+        self.assertTrue(data[1]['has_oauth_client_secret'])
+        for item in data:
+            self.assertNotIn('static_value_encrypted', item)
+            self.assertNotIn('oauth_client_secret_encrypted', item)
+
+    def test_get_success(self) -> None:
+        """Fetching by id returns the server."""
+        self.mock_db.match.return_value = [
+            self._model(static_value_encrypted='enc:abc')
+        ]
+        response = self.client.get('/mcp-servers/srv-1')
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data['id'], 'srv-1')
+        self.assertTrue(data['has_static_value'])
+        self.assertNotIn('static_value_encrypted', data)
+
+    def test_get_not_found(self) -> None:
+        """Fetching a missing id returns 404."""
+        self.mock_db.match.return_value = []
+        response = self.client.get('/mcp-servers/missing')
+        self.assertEqual(response.status_code, 404)
+
+    # -- Update --------------------------------------------------------
+
+    def test_patch_updates_non_secret_field(self) -> None:
+        """A non-secret patch updates the field and persists."""
+        self.mock_db.match.return_value = [self._model()]
+        self.mock_db.execute.return_value = [
+            {'n': self._server_props(name='Renamed')}
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.patch(
+                '/mcp-servers/srv-1', json={'name': 'Renamed'}
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()['name'], 'Renamed')
+
+    def test_patch_secret_omitted_keeps_ciphertext(self) -> None:
+        """Omitting a secret leaves the stored ciphertext untouched."""
+        self.mock_db.match.return_value = [
+            self._model(static_value_encrypted='enc:original')
+        ]
+        self.mock_db.execute.return_value = [
+            {'n': self._server_props(static_value_encrypted='enc:original')}
+        ]
+        with (
+            mock.patch(
+                'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+            ),
+            mock.patch(
+                'imbi_api.endpoints.mcp_servers.encrypt_config_value',
+                side_effect=lambda v: f'enc:{v}',
+            ) as enc,
+        ):
+            response = self.client.patch(
+                '/mcp-servers/srv-1', json={'name': 'Renamed'}
+            )
+        self.assertEqual(response.status_code, 200)
+        # Secret was not re-encrypted since it was omitted.
+        enc.assert_not_called()
+        persisted = self.mock_db.execute.call_args.args[1]
+        self.assertEqual(persisted['static_value_encrypted'], 'enc:original')
+        self.assertTrue(response.json()['has_static_value'])
+
+    def test_patch_secret_cleared_with_null(self) -> None:
+        """An explicit null secret clears the stored ciphertext."""
+        self.mock_db.match.return_value = [
+            self._model(static_value_encrypted='enc:original')
+        ]
+        self.mock_db.execute.return_value = [
+            {'n': self._server_props(static_value_encrypted=None)}
+        ]
+        with (
+            mock.patch(
+                'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+            ),
+            mock.patch(
+                'imbi_api.endpoints.mcp_servers.encrypt_config_value',
+                side_effect=lambda v: None if v is None else f'enc:{v}',
+            ) as enc,
+        ):
+            response = self.client.patch(
+                '/mcp-servers/srv-1', json={'static_value': None}
+            )
+        self.assertEqual(response.status_code, 200)
+        enc.assert_called_once_with(None)
+        persisted = self.mock_db.execute.call_args.args[1]
+        self.assertIsNone(persisted['static_value_encrypted'])
+        self.assertFalse(response.json()['has_static_value'])
+
+    def test_patch_secret_replaced(self) -> None:
+        """A new secret value is re-encrypted and persisted."""
+        self.mock_db.match.return_value = [
+            self._model(static_value_encrypted='enc:original')
+        ]
+        self.mock_db.execute.return_value = [
+            {'n': self._server_props(static_value_encrypted='enc:new')}
+        ]
+        with (
+            mock.patch(
+                'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+            ),
+            mock.patch(
+                'imbi_api.endpoints.mcp_servers.encrypt_config_value',
+                side_effect=lambda v: None if v is None else f'enc:{v}',
+            ) as enc,
+        ):
+            response = self.client.patch(
+                '/mcp-servers/srv-1', json={'static_value': 'new'}
+            )
+        self.assertEqual(response.status_code, 200)
+        enc.assert_called_once_with('new')
+        persisted = self.mock_db.execute.call_args.args[1]
+        self.assertEqual(persisted['static_value_encrypted'], 'enc:new')
+        self.assertNotIn('static_value', persisted)
+        data = response.json()
+        self.assertTrue(data['has_static_value'])
+        self.assertNotIn('static_value_encrypted', data)
+
+    def test_patch_not_found(self) -> None:
+        """Patching a missing id returns 404."""
+        self.mock_db.match.return_value = []
+        response = self.client.patch(
+            '/mcp-servers/missing', json={'name': 'X'}
+        )
+        self.assertEqual(response.status_code, 404)
+
+    def test_patch_slug_conflict(self) -> None:
+        """A slug collision on update returns 409."""
+        self.mock_db.match.return_value = [self._model()]
+        self.mock_db.execute.side_effect = psycopg.errors.UniqueViolation()
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.patch(
+                '/mcp-servers/srv-1', json={'slug': 'taken'}
+            )
+        self.assertEqual(response.status_code, 409)
+        self.assertIn('already exists', response.json()['detail'])
+
+    # -- Delete --------------------------------------------------------
+
+    def test_delete_success(self) -> None:
+        """Deleting an existing server returns 204."""
+        self.mock_db.execute.return_value = [{'n': self._server_props()}]
+        response = self.client.delete('/mcp-servers/srv-1')
+        self.assertEqual(response.status_code, 204)
+
+    def test_delete_not_found(self) -> None:
+        """Deleting a missing server returns 404."""
+        self.mock_db.execute.return_value = []
+        response = self.client.delete('/mcp-servers/missing')
+        self.assertEqual(response.status_code, 404)
+
+
+class MCPServerPermissionTestCase(unittest.TestCase):
+    """Non-admin permission enforcement for MCP server endpoints."""
+
+    def setUp(self) -> None:
+        """Set up the app with a non-admin, unprivileged principal."""
+        self.test_app = app.create_app()
+
+        self.user = models.User(
+            email='user@example.com',
+            display_name='Plain User',
+            password_hash='$argon2id$hashed',
+            is_active=True,
+            is_admin=False,
+            is_service_account=False,
+            created_at=datetime.datetime.now(datetime.UTC),
+        )
+        self.auth_context = permissions.AuthContext(
+            user=self.user,
+            session_id='test-session',
+            auth_method='jwt',
+            permissions=set(),
+        )
+
+        async def mock_get_current_user() -> permissions.AuthContext:
+            return self.auth_context
+
+        self.test_app.dependency_overrides[permissions.get_current_user] = (
+            mock_get_current_user
+        )
+        self.mock_db = mock.AsyncMock(spec=graph.Graph)
+        self.test_app.dependency_overrides[graph._inject_graph] = lambda: (
+            self.mock_db
+        )
+        self.client = TestClient(self.test_app)
+
+    def test_list_denied(self) -> None:
+        """Reading without mcp_server:read is forbidden."""
+        response = self.client.get('/mcp-servers/')
+        self.assertEqual(response.status_code, 403)
+
+    def test_create_denied(self) -> None:
+        """Creating without mcp_server:create is forbidden."""
+        response = self.client.post(
+            '/mcp-servers/',
+            json={
+                'name': 'Example',
+                'slug': 'example',
+                'url': 'https://mcp.example.com',
+            },
+        )
+        self.assertEqual(response.status_code, 403)
+
+    def test_delete_denied(self) -> None:
+        """Deleting without mcp_server:delete is forbidden."""
+        response = self.client.delete('/mcp-servers/srv-1')
+        self.assertEqual(response.status_code, 403)
+
+    def test_read_allowed_with_permission(self) -> None:
+        """Granting mcp_server:read permits listing."""
+        self.auth_context.permissions = {'mcp_server:read'}
+        self.mock_db.match.return_value = []
+        response = self.client.get('/mcp-servers/')
+        self.assertEqual(response.status_code, 200)

--- a/tests/endpoints/test_mcp_servers.py
+++ b/tests/endpoints/test_mcp_servers.py
@@ -154,6 +154,45 @@ class MCPServerEndpointsTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 409)
         self.assertIn('already exists', response.json()['detail'])
 
+    def test_create_static_missing_fields_returns_400(self) -> None:
+        """auth_type 'static' without header/value is rejected."""
+        with mock.patch(
+            'imbi_api.endpoints.mcp_servers.encrypt_config_value',
+            side_effect=lambda v: None if v is None else f'enc:{v}',
+        ):
+            response = self.client.post(
+                '/mcp-servers/',
+                json={
+                    'name': 'Example',
+                    'slug': 'example',
+                    'url': 'https://mcp.example.com',
+                    'auth_type': 'static',
+                },
+            )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('static', response.json()['detail'])
+        self.mock_db.execute.assert_not_called()
+
+    def test_create_oauth_missing_fields_returns_400(self) -> None:
+        """auth_type 'oauth_client_credentials' missing fields is rejected."""
+        with mock.patch(
+            'imbi_api.endpoints.mcp_servers.encrypt_config_value',
+            side_effect=lambda v: None if v is None else f'enc:{v}',
+        ):
+            response = self.client.post(
+                '/mcp-servers/',
+                json={
+                    'name': 'Example',
+                    'slug': 'example',
+                    'url': 'https://mcp.example.com',
+                    'auth_type': 'oauth_client_credentials',
+                    'oauth_token_url': 'https://auth.example.com/token',
+                },
+            )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('oauth_client_credentials', response.json()['detail'])
+        self.mock_db.execute.assert_not_called()
+
     # -- List / Get ----------------------------------------------------
 
     def test_list_success(self) -> None:
@@ -296,6 +335,21 @@ class MCPServerEndpointsTestCase(unittest.TestCase):
         data = response.json()
         self.assertTrue(data['has_static_value'])
         self.assertNotIn('static_value_encrypted', data)
+
+    def test_patch_auth_switch_missing_fields_returns_400(self) -> None:
+        """Switching auth_type without its required fields is rejected."""
+        self.mock_db.match.return_value = [self._model()]
+        with mock.patch(
+            'imbi_api.endpoints.mcp_servers.encrypt_config_value',
+            side_effect=lambda v: None if v is None else f'enc:{v}',
+        ):
+            response = self.client.patch(
+                '/mcp-servers/srv-1',
+                json={'auth_type': 'oauth_client_credentials'},
+            )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('oauth_client_credentials', response.json()['detail'])
+        self.mock_db.execute.assert_not_called()
 
     def test_patch_not_found(self) -> None:
         """Patching a missing id returns 404."""

--- a/tests/endpoints/test_project_types.py
+++ b/tests/endpoints/test_project_types.py
@@ -50,8 +50,8 @@ class ProjectTypeEndpointsTestCase(unittest.TestCase):
         )
 
         self.mock_db = mock.AsyncMock(spec=graph.Graph)
-        self.test_app.dependency_overrides[graph._inject_graph] = (
-            lambda: self.mock_db
+        self.test_app.dependency_overrides[graph._inject_graph] = lambda: (
+            self.mock_db
         )
 
         self.client = testclient.TestClient(self.test_app)
@@ -225,6 +225,87 @@ class ProjectTypeEndpointsTestCase(unittest.TestCase):
             data[1]['relationships']['projects']['count'],
             8,
         )
+
+    def test_list_project_types_include_schema(self) -> None:
+        """``include_schema=true`` attaches filterable attributes."""
+        self.mock_db.execute.return_value = [
+            {
+                'pt': {'name': 'API Service', 'slug': 'apis'},
+                'o': {'name': 'Engineering', 'slug': 'engineering'},
+                'project_count': 1,
+            },
+            {
+                'pt': {'name': 'Consumer', 'slug': 'consumers'},
+                'o': {'name': 'Engineering', 'slug': 'engineering'},
+                'project_count': 0,
+            },
+        ]
+        self.mock_db.match.return_value = [
+            models.Blueprint(
+                name='API Facts',
+                slug='apis-facts',
+                type='Project',
+                filter={'project_type': ['apis']},  # type: ignore[arg-type]
+                json_schema=models.Schema.model_validate(
+                    {
+                        'type': 'object',
+                        'properties': {
+                            'framework': {
+                                'type': 'string',
+                                'enum': ['FastAPI', 'http-service-lib'],
+                            }
+                        },
+                    }
+                ),
+            )
+        ]
+
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            response = self.client.get(
+                '/organizations/engineering/project-types/'
+                '?include_schema=true',
+            )
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(
+            data[0]['schema'],
+            [
+                {
+                    'field': 'framework',
+                    'type': 'string',
+                    'format': None,
+                    'enum': ['FastAPI', 'http-service-lib'],
+                }
+            ],
+        )
+        # The blueprint is filtered to ``apis``; ``consumers`` gets nothing.
+        self.assertEqual(data[1]['schema'], [])
+
+    def test_list_project_types_omits_schema_by_default(self) -> None:
+        """Without the flag, no ``schema`` key and no blueprint fetch."""
+        self.mock_db.execute.return_value = [
+            {
+                'pt': {'name': 'API Service', 'slug': 'apis'},
+                'o': {'name': 'Engineering', 'slug': 'engineering'},
+                'project_count': 1,
+            }
+        ]
+
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            response = self.client.get(
+                '/organizations/engineering/project-types/',
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn('schema', response.json()[0])
+        self.mock_db.match.assert_not_called()
 
     def test_get_project_type(self) -> None:
         """Test retrieving a single project type."""

--- a/tests/endpoints/test_projects.py
+++ b/tests/endpoints/test_projects.py
@@ -1223,6 +1223,85 @@ class ProjectEndpointsTestCase(unittest.TestCase):
         query = self.mock_db.execute.call_args.args[0]
         self.assertNotIn('coalesce(p.archived, false)', query)
 
+    # -- Attribute filtering -------------------------------------------
+
+    def _framework_blueprint(self) -> models.Blueprint:
+        return models.Blueprint(
+            name='API Facts',
+            slug='apis-facts',
+            type='Project',
+            json_schema=models.Schema.model_validate(
+                {
+                    'type': 'object',
+                    'properties': {
+                        'framework': {
+                            'type': 'string',
+                            'enum': ['FastAPI', 'http-service-lib'],
+                        },
+                    },
+                }
+            ),
+        )
+
+    def _list_with_filter(self, query_string: str) -> typing.Any:
+        self.mock_db.match.return_value = [self._framework_blueprint()]
+        self.mock_db.execute.return_value = []
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            return self.client.get(
+                f'/organizations/engineering/projects/?{query_string}',
+            )
+
+    def test_filter_ne_excludes_unset(self) -> None:
+        """``ne`` builds a plain inequality (unset rows excluded)."""
+        response = self._list_with_filter(
+            'filter=framework:ne:http-service-lib'
+        )
+        self.assertEqual(response.status_code, 200)
+        query = self.mock_db.execute.call_args.args[0]
+        params = self.mock_db.execute.call_args.args[1]
+        self.assertIn('p.framework <> {f0_0}', query)
+        self.assertNotIn('IS NULL', query)
+        self.assertEqual(params['f0_0'], 'http-service-lib')
+
+    def test_filter_eq_builds_equality(self) -> None:
+        response = self._list_with_filter('filter=framework:eq:FastAPI')
+        self.assertEqual(response.status_code, 200)
+        query = self.mock_db.execute.call_args.args[0]
+        self.assertIn('p.framework = {f0_0}', query)
+
+    def test_filter_exists(self) -> None:
+        response = self._list_with_filter('filter=framework:exists')
+        self.assertEqual(response.status_code, 200)
+        query = self.mock_db.execute.call_args.args[0]
+        self.assertIn('p.framework IS NOT NULL', query)
+
+    def test_filter_not_in_uses_and_of_inequalities(self) -> None:
+        response = self._list_with_filter(
+            'filter=framework:not_in:FastAPI,http-service-lib'
+        )
+        self.assertEqual(response.status_code, 200)
+        query = self.mock_db.execute.call_args.args[0]
+        self.assertIn(
+            '(p.framework <> {f0_0} AND p.framework <> {f0_1})', query
+        )
+
+    def test_filter_unknown_field_rejected(self) -> None:
+        response = self._list_with_filter('filter=bogus:eq:x')
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('not filterable', response.json()['detail'])
+
+    def test_filter_unknown_operator_rejected(self) -> None:
+        response = self._list_with_filter('filter=framework:like:x')
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('Unknown filter operator', response.json()['detail'])
+
+    def test_filter_malformed_rejected(self) -> None:
+        response = self._list_with_filter('filter=framework')
+        self.assertEqual(response.status_code, 400)
+
 
 class _RelationshipsTestBase(unittest.TestCase):
     """Shared setup for relationship endpoint tests."""

--- a/tests/endpoints/test_projects.py
+++ b/tests/endpoints/test_projects.py
@@ -1302,6 +1302,21 @@ class ProjectEndpointsTestCase(unittest.TestCase):
         response = self._list_with_filter('filter=framework')
         self.assertEqual(response.status_code, 400)
 
+    def test_filter_exists_with_value_rejected(self) -> None:
+        response = self._list_with_filter('filter=framework:exists:x')
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('does not accept a value', response.json()['detail'])
+
+    def test_filter_eq_without_value_rejected(self) -> None:
+        response = self._list_with_filter('filter=framework:eq')
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('requires a value', response.json()['detail'])
+
+    def test_filter_ne_without_value_rejected(self) -> None:
+        response = self._list_with_filter('filter=framework:ne')
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('requires a value', response.json()['detail'])
+
 
 class _RelationshipsTestBase(unittest.TestCase):
     """Shared setup for relationship endpoint tests."""

--- a/tests/test_blueprint_attributes.py
+++ b/tests/test_blueprint_attributes.py
@@ -1,0 +1,115 @@
+"""Tests for blueprint-attribute resolution."""
+
+import unittest
+
+from imbi_common import models
+
+from imbi_api import blueprint_attributes
+
+
+def _blueprint(
+    name: str,
+    properties: dict,
+    *,
+    kind: str = 'node',
+    project_type: list[str] | None = None,
+    environment: list[str] | None = None,
+) -> models.Blueprint:
+    bp_filter = None
+    if project_type is not None or environment is not None:
+        bp_filter = models.BlueprintFilter(
+            project_type=project_type or [],
+            environment=environment or [],
+        )
+    return models.Blueprint(
+        name=name,
+        slug=name,
+        kind=kind,  # type: ignore[arg-type]
+        type=None if kind == 'relationship' else 'Project',
+        filter=bp_filter,
+        json_schema=models.Schema.model_validate(
+            {'type': 'object', 'properties': properties}
+        ),
+    )
+
+
+class ResolveTestCase(unittest.TestCase):
+    """Tests for ``blueprint_attributes.resolve``."""
+
+    def test_type_scoping_includes_matching_and_unfiltered(self) -> None:
+        common = _blueprint(
+            'common',
+            {'programming_language': {'type': 'string', 'enum': ['Python']}},
+        )
+        apis = _blueprint(
+            'apis',
+            {'framework': {'type': 'string', 'enum': ['FastAPI']}},
+            project_type=['apis'],
+        )
+        consumers = _blueprint(
+            'consumers',
+            {'queue': {'type': 'string'}},
+            project_type=['consumers'],
+        )
+
+        result = blueprint_attributes.resolve(
+            [common, apis, consumers], 'apis'
+        )
+
+        self.assertEqual(set(result), {'programming_language', 'framework'})
+        self.assertEqual(result['framework'].enum, ['FastAPI'])
+        self.assertEqual(result['framework'].type, 'string')
+
+    def test_union_when_type_slug_is_none(self) -> None:
+        apis = _blueprint(
+            'apis', {'framework': {'type': 'string'}}, project_type=['apis']
+        )
+        consumers = _blueprint(
+            'consumers',
+            {'queue': {'type': 'string'}},
+            project_type=['consumers'],
+        )
+
+        result = blueprint_attributes.resolve([apis, consumers], None)
+
+        self.assertEqual(set(result), {'framework', 'queue'})
+
+    def test_later_blueprint_overrides_same_field(self) -> None:
+        first = _blueprint('first', {'framework': {'type': 'string'}})
+        second = _blueprint(
+            'second',
+            {'framework': {'type': 'string', 'enum': ['FastAPI', 'Tornado']}},
+        )
+
+        # ``resolve`` expects ascending priority order; the later entry wins.
+        result = blueprint_attributes.resolve([first, second], 'apis')
+
+        self.assertEqual(result['framework'].enum, ['FastAPI', 'Tornado'])
+
+    def test_relationship_blueprints_are_ignored(self) -> None:
+        rel = models.Blueprint.model_construct(
+            name='edge',
+            slug='edge',
+            kind='relationship',
+            type=None,
+            filter=None,
+            json_schema=models.Schema.model_validate(
+                {'type': 'object', 'properties': {'role': {'type': 'string'}}}
+            ),
+        )
+
+        result = blueprint_attributes.resolve([rel], None)
+
+        self.assertEqual(result, {})
+
+    def test_environment_filter_does_not_exclude(self) -> None:
+        env_scoped = _blueprint(
+            'env',
+            {'deployed_version': {'type': 'string'}},
+            project_type=['apis'],
+            environment=['production'],
+        )
+
+        result = blueprint_attributes.resolve([env_scoped], 'apis')
+
+        self.assertIn('deployed_version', result)

--- a/uv.lock
+++ b/uv.lock
@@ -1050,7 +1050,7 @@ requires-dist = [
   { name = "fastapi" },
   { name = "filetype" },
   { name = "httpx", specifier = ">=0.28.1,<1" },
-  { name = "imbi-common", extras = ["databases", "llm", "sentry", "server"], specifier = ">=2.6.0" },
+  { name = "imbi-common", extras = ["databases", "llm", "sentry", "server"], editable = "../imbi-common" },
   { name = "imbi-plugin-aws", marker = "extra == 'plugins'", specifier = ">=1.0.0" },
   { name = "imbi-plugin-github", marker = "extra == 'plugins'", specifier = ">=1.0.0" },
   { name = "imbi-plugin-logzio", marker = "extra == 'plugins'", specifier = ">=1.0.0" },
@@ -1102,8 +1102,8 @@ docs = [
 
 [[package]]
 name = "imbi-common"
-version = "2.6.0"
-source = { registry = "https://pypi.org/simple" }
+version = "2.6.1"
+source = { editable = "../imbi-common" }
 dependencies = [
   { name = "cryptography" },
   { name = "httpx" },
@@ -1117,10 +1117,6 @@ dependencies = [
   { name = "pyjwt" },
   { name = "python-slugify" },
   { name = "typer" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/cc/08/d574411419c425a48596d4bb252283b526fcdd940073b3ffea734ae19a8f/imbi_common-2.6.0.tar.gz", hash = "sha256:730f7bd3b3c2365ea3a0845f81fba4a5ab8f23c98749842dadff5464bc2dc71a", size = 293163, upload-time = "2026-05-26T21:19:43.795Z" }
-wheels = [
-  { url = "https://files.pythonhosted.org/packages/49/3b/f5db4005675fd033454696599427d72d809f9534e2afcd0a6584bb3fb29e/imbi_common-2.6.0-py3-none-any.whl", hash = "sha256:875a057b4edcc2fecb35747927dcd853c602e58fd1c1f3c05063584360a86c83", size = 94110, upload-time = "2026-05-26T21:19:42.066Z" },
 ]
 
 [package.optional-dependencies]
@@ -1140,6 +1136,71 @@ sentry = [
 server = [
   { name = "fastapi" },
   { name = "uvicorn", extra = ["standard"] },
+]
+
+[package.metadata]
+requires-dist = [
+  { name = "anthropic", marker = "extra == 'llm'", specifier = ">=0.40" },
+  { name = "clickhouse-connect", extras = ["async"], marker = "extra == 'databases'", specifier = "==1.0.0" },
+  { name = "cryptography", specifier = ">=42.0.4" },
+  { name = "fastapi", marker = "extra == 'server'", specifier = ">=0.115.0" },
+  { name = "fastembed", marker = "extra == 'databases'", specifier = ">=0.6" },
+  { name = "httpx", specifier = ">=0.28.1,<1" },
+  { name = "jsonpointer", specifier = ">=3.1.1" },
+  { name = "jsonschema-models" },
+  { name = "markdown-it-py", specifier = ">=3.0" },
+  { name = "nanoid", specifier = ">=2.0.0" },
+  { name = "opentelemetry-api", marker = "extra == 'otel'", specifier = "==1.41.1" },
+  { name = "opentelemetry-distro", marker = "extra == 'otel'", specifier = "==0.62b1" },
+  { name = "opentelemetry-exporter-otlp-proto-http", marker = "extra == 'otel'", specifier = "==1.41.1" },
+  { name = "opentelemetry-instrumentation-aiohttp-client", marker = "extra == 'otel'", specifier = "==0.62b1" },
+  { name = "opentelemetry-instrumentation-asyncio", marker = "extra == 'otel'", specifier = "==0.62b1" },
+  { name = "opentelemetry-instrumentation-fastapi", marker = "extra == 'otel'", specifier = "==0.62b1" },
+  { name = "opentelemetry-instrumentation-httpx", marker = "extra == 'otel'", specifier = "==0.62b1" },
+  { name = "opentelemetry-instrumentation-mcp", marker = "extra == 'otel'", specifier = "==0.60.0" },
+  { name = "opentelemetry-instrumentation-psycopg", marker = "extra == 'otel'", specifier = "==0.62b1" },
+  { name = "opentelemetry-instrumentation-redis", marker = "extra == 'otel'", specifier = "==0.62b1" },
+  { name = "opentelemetry-sdk", marker = "extra == 'otel'", specifier = "==1.41.1" },
+  { name = "orjson" },
+  { name = "pgvector", marker = "extra == 'databases'", specifier = ">=0.3" },
+  { name = "psycopg", extras = ["binary", "pool"], marker = "extra == 'databases'", specifier = ">=3.3" },
+  { name = "pydantic", extras = ["email"], specifier = ">=2.0" },
+  { name = "pydantic-settings" },
+  { name = "pyjwt", specifier = ">=2.10.1" },
+  { name = "python-slugify" },
+  { name = "sentry-sdk", marker = "extra == 'sentry'", specifier = ">=2.48.0" },
+  { name = "typer", specifier = ">=0.21.1" },
+  { name = "uvicorn", extras = ["standard"], marker = "extra == 'server'", specifier = ">=0.40.0" },
+  { name = "valkey", marker = "extra == 'databases'", specifier = ">=6" },
+]
+provides-extras = ["databases", "llm", "otel", "sentry", "server"]
+
+[package.metadata.requires-dev]
+dev = [
+  { name = "basedpyright" },
+  { name = "build" },
+  { name = "click", specifier = "~=8.2.1" },
+  { name = "coverage", extras = ["toml"] },
+  { name = "httpx", specifier = ">=0.28.1,<1" },
+  { name = "mypy", specifier = "~=1.19.1" },
+  { name = "pre-commit" },
+  { name = "pytest" },
+  { name = "ruff", specifier = "~=0.14.6" },
+  { name = "sentry-sdk", specifier = ">=2.48.0" },
+  { name = "tomli-w", specifier = "~=1.2" },
+  { name = "uvicorn", extras = ["standard"], specifier = ">=0.40.0" },
+]
+dist = [
+  { name = "build" },
+  { name = "twine" },
+  { name = "wheel" },
+]
+docs = [
+  { name = "griffe-pydantic" },
+  { name = "mkdocs", specifier = ">=1.5,<2" },
+  { name = "mkdocs-material", specifier = ">9.5,<10" },
+  { name = "mkdocstrings", extras = ["python"] },
+  { name = "mkdocstrings-python-xref", specifier = ">=1.6,<2" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1050,7 +1050,7 @@ requires-dist = [
   { name = "fastapi" },
   { name = "filetype" },
   { name = "httpx", specifier = ">=0.28.1,<1" },
-  { name = "imbi-common", extras = ["databases", "llm", "sentry", "server"], editable = "../imbi-common" },
+  { name = "imbi-common", extras = ["databases", "llm", "sentry", "server"], git = "https://github.com/AWeber-Imbi/imbi-common.git?branch=main" },
   { name = "imbi-plugin-aws", marker = "extra == 'plugins'", specifier = ">=1.0.0" },
   { name = "imbi-plugin-github", marker = "extra == 'plugins'", specifier = ">=1.0.0" },
   { name = "imbi-plugin-logzio", marker = "extra == 'plugins'", specifier = ">=1.0.0" },
@@ -1103,7 +1103,7 @@ docs = [
 [[package]]
 name = "imbi-common"
 version = "2.6.1"
-source = { editable = "../imbi-common" }
+source = { git = "https://github.com/AWeber-Imbi/imbi-common.git?branch=main#92025cb9812f3e850ec8cfb285969d5757c2539f" }
 dependencies = [
   { name = "cryptography" },
   { name = "httpx" },
@@ -1136,71 +1136,6 @@ sentry = [
 server = [
   { name = "fastapi" },
   { name = "uvicorn", extra = ["standard"] },
-]
-
-[package.metadata]
-requires-dist = [
-  { name = "anthropic", marker = "extra == 'llm'", specifier = ">=0.40" },
-  { name = "clickhouse-connect", extras = ["async"], marker = "extra == 'databases'", specifier = "==1.0.0" },
-  { name = "cryptography", specifier = ">=42.0.4" },
-  { name = "fastapi", marker = "extra == 'server'", specifier = ">=0.115.0" },
-  { name = "fastembed", marker = "extra == 'databases'", specifier = ">=0.6" },
-  { name = "httpx", specifier = ">=0.28.1,<1" },
-  { name = "jsonpointer", specifier = ">=3.1.1" },
-  { name = "jsonschema-models" },
-  { name = "markdown-it-py", specifier = ">=3.0" },
-  { name = "nanoid", specifier = ">=2.0.0" },
-  { name = "opentelemetry-api", marker = "extra == 'otel'", specifier = "==1.41.1" },
-  { name = "opentelemetry-distro", marker = "extra == 'otel'", specifier = "==0.62b1" },
-  { name = "opentelemetry-exporter-otlp-proto-http", marker = "extra == 'otel'", specifier = "==1.41.1" },
-  { name = "opentelemetry-instrumentation-aiohttp-client", marker = "extra == 'otel'", specifier = "==0.62b1" },
-  { name = "opentelemetry-instrumentation-asyncio", marker = "extra == 'otel'", specifier = "==0.62b1" },
-  { name = "opentelemetry-instrumentation-fastapi", marker = "extra == 'otel'", specifier = "==0.62b1" },
-  { name = "opentelemetry-instrumentation-httpx", marker = "extra == 'otel'", specifier = "==0.62b1" },
-  { name = "opentelemetry-instrumentation-mcp", marker = "extra == 'otel'", specifier = "==0.60.0" },
-  { name = "opentelemetry-instrumentation-psycopg", marker = "extra == 'otel'", specifier = "==0.62b1" },
-  { name = "opentelemetry-instrumentation-redis", marker = "extra == 'otel'", specifier = "==0.62b1" },
-  { name = "opentelemetry-sdk", marker = "extra == 'otel'", specifier = "==1.41.1" },
-  { name = "orjson" },
-  { name = "pgvector", marker = "extra == 'databases'", specifier = ">=0.3" },
-  { name = "psycopg", extras = ["binary", "pool"], marker = "extra == 'databases'", specifier = ">=3.3" },
-  { name = "pydantic", extras = ["email"], specifier = ">=2.0" },
-  { name = "pydantic-settings" },
-  { name = "pyjwt", specifier = ">=2.10.1" },
-  { name = "python-slugify" },
-  { name = "sentry-sdk", marker = "extra == 'sentry'", specifier = ">=2.48.0" },
-  { name = "typer", specifier = ">=0.21.1" },
-  { name = "uvicorn", extras = ["standard"], marker = "extra == 'server'", specifier = ">=0.40.0" },
-  { name = "valkey", marker = "extra == 'databases'", specifier = ">=6" },
-]
-provides-extras = ["databases", "llm", "otel", "sentry", "server"]
-
-[package.metadata.requires-dev]
-dev = [
-  { name = "basedpyright" },
-  { name = "build" },
-  { name = "click", specifier = "~=8.2.1" },
-  { name = "coverage", extras = ["toml"] },
-  { name = "httpx", specifier = ">=0.28.1,<1" },
-  { name = "mypy", specifier = "~=1.19.1" },
-  { name = "pre-commit" },
-  { name = "pytest" },
-  { name = "ruff", specifier = "~=0.14.6" },
-  { name = "sentry-sdk", specifier = ">=2.48.0" },
-  { name = "tomli-w", specifier = "~=1.2" },
-  { name = "uvicorn", extras = ["standard"], specifier = ">=0.40.0" },
-]
-dist = [
-  { name = "build" },
-  { name = "twine" },
-  { name = "wheel" },
-]
-docs = [
-  { name = "griffe-pydantic" },
-  { name = "mkdocs", specifier = ">=1.5,<2" },
-  { name = "mkdocs-material", specifier = ">9.5,<10" },
-  { name = "mkdocstrings", extras = ["python"] },
-  { name = "mkdocstrings-python-xref", specifier = ">=1.6,<2" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Adds admin-only CRUD endpoints for managing external MCP server configurations, the management surface the Admin UI will drive.

## Problem
External MCP server configs (introduced in imbi-common) need a secure management API: operators must be able to create/list/update/delete servers and set auth secrets, without those secrets ever being readable back.

## Solution
- New `/mcp-servers` router: `POST`, `GET` (list), `GET /{id}`, `PATCH /{id}`, `DELETE /{id}`. Global (no org scoping), mirroring the existing `plugin_entities` pattern.
- Each endpoint is guarded by a new `mcp_server:{create,read,update,delete}` permission (auto-granted to admins via the existing all-permissions seed).
- Secrets (`static_value`, `oauth_client_secret`) are accepted as plaintext, encrypted via `encrypt_config_value`, and stored only as ciphertext. Responses never include plaintext or ciphertext — presence is surfaced via `has_static_value` / `has_oauth_client_secret` booleans.
- PATCH secret semantics: omit = unchanged, explicit null = cleared, new value = re-encrypted.
- Server-side auth-shape validation (enforced by the imbi-common model validator) rejects invalid `static` / `oauth_client_credentials` configs with 400 on both create and auth_type switches; covered by tests.

## Dependency
Requires imbi-common 2.6.1 (AWeber-Imbi/imbi-common#133) for the `MCPServer` model and config encryption helpers. Resolved locally via the editable `../imbi-common` source; merge #133 and release before this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)