### PR TITLE
Self-heal stored repo link on plugin-reported rename

### DIFF
--- a/src/imbi_api/endpoints/_helpers.py
+++ b/src/imbi_api/endpoints/_helpers.py
@@ -171,6 +171,37 @@ async def lookup_project_links(
     return {str(k): str(v) for k, v in items.items() if v}
 
 
+async def update_project_link(
+    db: graph.Graph,
+    project_id: str,
+    key: str,
+    url: str,
+) -> bool:
+    """Set a single entry in the project's external link map.
+
+    Reads the current links (via :func:`lookup_project_links`), sets
+    ``links[key] = url``, and writes the map back as the JSON-encoded
+    string ``p.links`` is stored as on the AGE node. Returns ``True`` when
+    a write happened and ``False`` when the link already had ``url`` (a
+    no-op). Used to self-heal a stale ``github-repository`` link after a
+    deployment plugin reports the remote repository was renamed.
+    """
+    links = await lookup_project_links(db, project_id)
+    if links.get(key) == url:
+        return False
+    links[key] = url
+    query: typing.LiteralString = (
+        'MATCH (p:Project {{id: {project_id}}}) '
+        'SET p.links = {links} RETURN p.id AS id'
+    )
+    await db.execute(
+        query,
+        {'project_id': project_id, 'links': json.dumps(links)},
+        ['id'],
+    )
+    return True
+
+
 async def lookup_project_type_slugs(
     db: graph.Graph,
     project_id: str,

--- a/src/imbi_api/endpoints/_helpers.py
+++ b/src/imbi_api/endpoints/_helpers.py
@@ -6,6 +6,7 @@ import typing
 
 import fastapi
 from imbi_common import graph
+from imbi_common.plugins.base import PluginContext
 
 from imbi_api import patch as json_patch
 
@@ -200,6 +201,40 @@ async def update_project_link(
         ['id'],
     )
     return True
+
+
+async def heal_relocated_link(db: graph.Graph, ctx: PluginContext) -> None:
+    """Persist a repository rename a plugin reported on ``ctx``.
+
+    A deployment / lifecycle plugin sets ``ctx.repository_relocation``
+    when the remote reports the repository has permanently moved (e.g. a
+    GitHub ``301`` after a rename). Rewrite the project's stored link so
+    later calls skip the redirect and the UI shows the current name.
+    Best-effort: a write failure is logged and swallowed so self-healing
+    never fails the user-facing request whose result we already have.
+    """
+    reloc = ctx.repository_relocation
+    if reloc is None:
+        return
+    try:
+        changed = await update_project_link(
+            db, ctx.project_id, reloc.link_key, reloc.new_url
+        )
+    except Exception:  # noqa: BLE001
+        LOGGER.warning(
+            'Failed to self-heal relocated repository link for project %s',
+            ctx.project_id,
+            exc_info=True,
+        )
+        return
+    if changed:
+        LOGGER.info(
+            'Self-healed %s link for project %s after repo rename %s -> %s',
+            reloc.link_key,
+            ctx.project_id,
+            reloc.old_owner_repo,
+            reloc.new_owner_repo,
+        )
 
 
 async def lookup_project_type_slugs(

--- a/src/imbi_api/endpoints/project_deployments.py
+++ b/src/imbi_api/endpoints/project_deployments.py
@@ -42,6 +42,7 @@ from imbi_api.endpoints._helpers import (
     lookup_project_links,
     lookup_project_slugs,
     lookup_project_type_slugs,
+    update_project_link,
 )
 from imbi_api.endpoints.releases import (
     AppendOutcome,
@@ -293,6 +294,40 @@ async def _resolve_and_context(
                 ),
             )
     return resolved, ctx, credentials
+
+
+async def heal_relocated_link(db: graph.Graph, ctx: PluginContext) -> None:
+    """Persist a repository rename a deployment plugin reported on ``ctx``.
+
+    A deployment plugin sets ``ctx.repository_relocation`` when the remote
+    reports the repository has permanently moved (e.g. a GitHub ``301``
+    after a rename). Rewrite the project's stored link so later calls skip
+    the redirect and the UI shows the current name. Best-effort: a write
+    failure is logged and swallowed so self-healing never fails the
+    user-facing request whose result we already have.
+    """
+    reloc = ctx.repository_relocation
+    if reloc is None:
+        return
+    try:
+        changed = await update_project_link(
+            db, ctx.project_id, reloc.link_key, reloc.new_url
+        )
+    except Exception:  # noqa: BLE001
+        LOGGER.warning(
+            'Failed to self-heal relocated repository link for project %s',
+            ctx.project_id,
+            exc_info=True,
+        )
+        return
+    if changed:
+        LOGGER.info(
+            'Self-healed %s link for project %s after repo rename %s -> %s',
+            reloc.link_key,
+            ctx.project_id,
+            reloc.old_owner_repo,
+            reloc.new_owner_repo,
+        )
 
 
 class _EnvFlags(typing.NamedTuple):
@@ -654,6 +689,7 @@ async def resync_for_project(
                 'list_recent_deployments.'
             ),
         ) from exc
+    await heal_relocated_link(db, ctx)
     summary.observed = len(observations)
     # Track identities we've already touched so ``releases_created`` /
     # ``releases_updated`` are counted once per distinct
@@ -823,9 +859,11 @@ async def list_refs(
         db, org_slug, project_id, auth, source=source
     )
     handler = _handler(resolved)
-    return await call_with_timeout(
+    refs = await call_with_timeout(
         handler.list_refs(ctx, credentials, kind=kind, query=q)
     )
+    await heal_relocated_link(db, ctx)
+    return refs
 
 
 @project_deployments_router.get('/refs/{ref:path}/commits')
@@ -848,9 +886,11 @@ async def list_commits(
         db, org_slug, project_id, auth, source=source
     )
     handler = _handler(resolved)
-    return await call_with_timeout(
+    commits = await call_with_timeout(
         handler.list_commits(ctx, credentials, ref=ref, limit=limit)
     )
+    await heal_relocated_link(db, ctx)
+    return commits
 
 
 @project_deployments_router.get('/commits/{committish}')
@@ -872,9 +912,11 @@ async def resolve_commit(
         db, org_slug, project_id, auth, source=source
     )
     handler = _handler(resolved)
-    return await call_with_timeout(
+    commit = await call_with_timeout(
         handler.resolve_committish(ctx, credentials, committish)
     )
+    await heal_relocated_link(db, ctx)
+    return commit
 
 
 @project_deployments_router.get('/compare')
@@ -897,9 +939,11 @@ async def compare_refs(
         db, org_slug, project_id, auth, source=source
     )
     handler = _handler(resolved)
-    return await call_with_timeout(
+    result = await call_with_timeout(
         handler.compare(ctx, credentials, base=base, head=head)
     )
+    await heal_relocated_link(db, ctx)
+    return result
 
 
 @project_deployments_router.post('', status_code=202)
@@ -1095,6 +1139,7 @@ async def _handle_deploy(
     run = await call_with_identity_retry(
         db, ctx, resolved, auth, fn=_trigger, attached=True
     )
+    await heal_relocated_link(db, ctx)
     LOGGER.info(
         'Deployment triggered: project=%s env=%s ref=%s plugin=%s '
         'action=%s actor=%s run_id=%s',
@@ -1409,6 +1454,8 @@ async def _handle_promote(
             tag=body.tag,
             warning='; '.join(warnings) if warnings else None,
         )
+
+    await heal_relocated_link(db, ctx)
 
     # 4. Upsert the Release node so future deploys of the same tag
     #    can attach a DeploymentEvent.

--- a/src/imbi_api/endpoints/project_deployments.py
+++ b/src/imbi_api/endpoints/project_deployments.py
@@ -39,10 +39,10 @@ from imbi_common.plugins.errors import PluginCredentialsMissing
 
 from imbi_api.auth import permissions
 from imbi_api.endpoints._helpers import (
+    heal_relocated_link,
     lookup_project_links,
     lookup_project_slugs,
     lookup_project_type_slugs,
-    update_project_link,
 )
 from imbi_api.endpoints.releases import (
     AppendOutcome,
@@ -294,40 +294,6 @@ async def _resolve_and_context(
                 ),
             )
     return resolved, ctx, credentials
-
-
-async def heal_relocated_link(db: graph.Graph, ctx: PluginContext) -> None:
-    """Persist a repository rename a deployment plugin reported on ``ctx``.
-
-    A deployment plugin sets ``ctx.repository_relocation`` when the remote
-    reports the repository has permanently moved (e.g. a GitHub ``301``
-    after a rename). Rewrite the project's stored link so later calls skip
-    the redirect and the UI shows the current name. Best-effort: a write
-    failure is logged and swallowed so self-healing never fails the
-    user-facing request whose result we already have.
-    """
-    reloc = ctx.repository_relocation
-    if reloc is None:
-        return
-    try:
-        changed = await update_project_link(
-            db, ctx.project_id, reloc.link_key, reloc.new_url
-        )
-    except Exception:  # noqa: BLE001
-        LOGGER.warning(
-            'Failed to self-heal relocated repository link for project %s',
-            ctx.project_id,
-            exc_info=True,
-        )
-        return
-    if changed:
-        LOGGER.info(
-            'Self-healed %s link for project %s after repo rename %s -> %s',
-            reloc.link_key,
-            ctx.project_id,
-            reloc.old_owner_repo,
-            reloc.new_owner_repo,
-        )
 
 
 class _EnvFlags(typing.NamedTuple):

--- a/src/imbi_api/plugins/lifecycle_dispatch.py
+++ b/src/imbi_api/plugins/lifecycle_dispatch.py
@@ -25,6 +25,7 @@ from imbi_common.plugins.base import (
     LifecyclePlugin,
     LifecycleResult,
     PluginContext,
+    RepositoryRelocation,
 )
 from imbi_common.plugins.errors import PluginCredentialsMissing
 
@@ -127,10 +128,20 @@ async def _invoke_one(
         else 'on_project_unarchived'
     )
 
+    # call_with_identity_retry re-attaches identity onto a fresh context
+    # before invoking ``_call`` (attached defaults to False here), so the
+    # plugin mutates that inner context, not ``ctx``. Capture any
+    # relocation it reports through the closure so we can self-heal the
+    # link after the call regardless of which context instance was used.
+    captured_relocation: list[RepositoryRelocation] = []
+
     async def _call(c: PluginContext) -> LifecycleResult:
         credentials = await _resolve_credentials(db, c, resolved)
         method = getattr(handler, method_name)
-        return await call_with_timeout(method(c, credentials))
+        res: LifecycleResult = await call_with_timeout(method(c, credentials))
+        if c.repository_relocation is not None:
+            captured_relocation.append(c.repository_relocation)
+        return res
 
     try:
         result = await call_with_identity_retry(
@@ -181,6 +192,14 @@ async def _invoke_one(
             status='failed',
             message=f'{type(exc).__name__}: {exc}',
         )
+
+    if captured_relocation:
+        # Lazy import to avoid the endpoints/_helpers <-> this-module
+        # cycle described above.
+        from imbi_api.endpoints._helpers import heal_relocated_link
+
+        ctx.repository_relocation = captured_relocation[-1]
+        await heal_relocated_link(db, ctx)
 
     return LifecycleInvocation(
         plugin_id=resolved.plugin_id,

--- a/tests/endpoints/test_project_deployments.py
+++ b/tests/endpoints/test_project_deployments.py
@@ -164,6 +164,7 @@ def _entry() -> RegistryEntry:
 
 
 _MODULE = 'imbi_api.endpoints.project_deployments'
+_UPDATE_LINK = 'imbi_api.endpoints._helpers.update_project_link'
 
 
 class ProjectDeploymentsTestCase(unittest.TestCase):
@@ -1528,7 +1529,7 @@ class RepositoryRelocationHealingTestCase(ProjectDeploymentsTestCase):
         self.mocks['resolve_plugin'].return_value = _relocating_resolved()
         # update_project_link is async; patch auto-uses AsyncMock.
         self.update_link = self._start(
-            mock.patch(f'{_MODULE}.update_project_link', return_value=True)
+            mock.patch(_UPDATE_LINK, return_value=True)
         )
 
     def test_list_commits_heals_relocated_link(self) -> None:
@@ -1574,7 +1575,7 @@ class HealRelocatedLinkTestCase(unittest.IsolatedAsyncioTestCase):
 
     async def test_noop_when_no_relocation(self) -> None:
         db = mock.AsyncMock()
-        with mock.patch(f'{_MODULE}.update_project_link') as update_link:
+        with mock.patch(_UPDATE_LINK) as update_link:
             await heal_relocated_link(db, self._ctx(None))
         update_link.assert_not_called()
 
@@ -1586,9 +1587,7 @@ class HealRelocatedLinkTestCase(unittest.IsolatedAsyncioTestCase):
             old_owner_repo='octo/demo',
             new_owner_repo='octo/renamed',
         )
-        with mock.patch(
-            f'{_MODULE}.update_project_link', return_value=True
-        ) as update_link:
+        with mock.patch(_UPDATE_LINK, return_value=True) as update_link:
             await heal_relocated_link(db, self._ctx(reloc))
         update_link.assert_awaited_once_with(
             db, 'proj1', 'github-repository', 'https://github.com/octo/renamed'
@@ -1601,7 +1600,7 @@ class HealRelocatedLinkTestCase(unittest.IsolatedAsyncioTestCase):
             new_url='https://github.com/octo/renamed',
         )
         with mock.patch(
-            f'{_MODULE}.update_project_link',
+            _UPDATE_LINK,
             side_effect=RuntimeError('graph down'),
         ):
             # Must not raise — self-heal is best-effort.

--- a/tests/endpoints/test_project_deployments.py
+++ b/tests/endpoints/test_project_deployments.py
@@ -1,6 +1,7 @@
 """Tests for the project deployment plugin endpoints."""
 
 import datetime
+import json
 import typing
 import unittest
 from unittest import mock
@@ -18,14 +19,17 @@ from imbi_common.plugins.base import (
     RefInfo,
     ReleaseInfo,
     RemoteDeployment,
+    RepositoryRelocation,
 )
 from imbi_common.plugins.registry import RegistryEntry
 
 from imbi_api import app, models
 from imbi_api.auth import password, permissions
+from imbi_api.endpoints import _helpers
 from imbi_api.endpoints.project_deployments import (
     DraftReleaseNotes,
     _EnvFlags,
+    heal_relocated_link,
 )
 from imbi_api.llm.dependencies import _get_anthropic_client
 from imbi_api.plugins.resolution import ResolvedPlugin
@@ -117,6 +121,37 @@ class _FakeNoSyncDeploymentPlugin(_FakeDeploymentPlugin):
         plugin_type='deployment',
         supports_deployment_sync=False,
     )
+
+
+class _RelocatingDeploymentPlugin(_FakeDeploymentPlugin):
+    """Deployment plugin that reports a repo rename on every call.
+
+    Mirrors how the real GitHub plugin stashes a
+    ``RepositoryRelocation`` on ``ctx`` after following a 301.
+    """
+
+    @staticmethod
+    def _report(ctx: typing.Any) -> None:
+        ctx.repository_relocation = RepositoryRelocation(
+            link_key='github-repository',
+            new_url='https://github.com/octo/renamed',
+            old_owner_repo='octo/demo',
+            new_owner_repo='octo/renamed',
+        )
+
+    async def list_commits(  # type: ignore[override]
+        self, ctx, credentials, ref, limit=25
+    ):
+        self._report(ctx)
+        return await super().list_commits(ctx, credentials, ref, limit)
+
+    async def trigger_deployment(  # type: ignore[override]
+        self, ctx, credentials, ref_or_sha, inputs=None
+    ):
+        self._report(ctx)
+        return await super().trigger_deployment(
+            ctx, credentials, ref_or_sha, inputs
+        )
 
 
 def _entry() -> RegistryEntry:
@@ -1467,3 +1502,148 @@ class SafeAuditUrlTestCase(unittest.TestCase):
         from imbi_api.endpoints.project_deployments import _safe_audit_url
 
         self.assertIsNone(_safe_audit_url('file:///etc/passwd'))
+
+
+def _relocating_resolved() -> ResolvedPlugin:
+    return ResolvedPlugin(
+        plugin_id='p-1',
+        plugin_slug='github-deployment',
+        entry=RegistryEntry(
+            handler_cls=_RelocatingDeploymentPlugin,
+            manifest=_RelocatingDeploymentPlugin.manifest,
+            package_name='imbi-plugin-github',
+            package_version='0.1.0',
+        ),
+        options={'owner': 'octo', 'repo': 'demo'},
+    )
+
+
+class RepositoryRelocationHealingTestCase(ProjectDeploymentsTestCase):
+    """The endpoint self-heals the stored link when a plugin reports a
+    repository rename on ``ctx.repository_relocation``.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.mocks['resolve_plugin'].return_value = _relocating_resolved()
+        # update_project_link is async; patch auto-uses AsyncMock.
+        self.update_link = self._start(
+            mock.patch(f'{_MODULE}.update_project_link', return_value=True)
+        )
+
+    def test_list_commits_heals_relocated_link(self) -> None:
+        with testclient.TestClient(self.test_app) as client:
+            response = client.get(
+                '/organizations/myorg/projects/proj1/deployments/'
+                'refs/main/commits'
+            )
+        self.assertEqual(response.status_code, 200)
+        self.update_link.assert_awaited_once()
+        args = self.update_link.await_args.args
+        # (db, project_id, link_key, new_url)
+        self.assertEqual(args[2], 'github-repository')
+        self.assertEqual(args[3], 'https://github.com/octo/renamed')
+
+    def test_trigger_deploy_heals_relocated_link(self) -> None:
+        with testclient.TestClient(self.test_app) as client:
+            response = client.post(
+                '/organizations/myorg/projects/proj1/deployments',
+                json={
+                    'action': 'deploy',
+                    'environment': 'testing',
+                    'committish': 'main',
+                    'ref_label': 'main',
+                },
+            )
+        self.assertEqual(response.status_code, 202)
+        self.update_link.assert_awaited_once()
+        self.assertEqual(
+            self.update_link.await_args.args[3],
+            'https://github.com/octo/renamed',
+        )
+
+
+class HealRelocatedLinkTestCase(unittest.IsolatedAsyncioTestCase):
+    """Unit coverage for ``heal_relocated_link``."""
+
+    def _ctx(self, reloc: RepositoryRelocation | None) -> mock.MagicMock:
+        ctx = mock.MagicMock()
+        ctx.project_id = 'proj1'
+        ctx.repository_relocation = reloc
+        return ctx
+
+    async def test_noop_when_no_relocation(self) -> None:
+        db = mock.AsyncMock()
+        with mock.patch(f'{_MODULE}.update_project_link') as update_link:
+            await heal_relocated_link(db, self._ctx(None))
+        update_link.assert_not_called()
+
+    async def test_writes_when_relocation_present(self) -> None:
+        db = mock.AsyncMock()
+        reloc = RepositoryRelocation(
+            link_key='github-repository',
+            new_url='https://github.com/octo/renamed',
+            old_owner_repo='octo/demo',
+            new_owner_repo='octo/renamed',
+        )
+        with mock.patch(
+            f'{_MODULE}.update_project_link', return_value=True
+        ) as update_link:
+            await heal_relocated_link(db, self._ctx(reloc))
+        update_link.assert_awaited_once_with(
+            db, 'proj1', 'github-repository', 'https://github.com/octo/renamed'
+        )
+
+    async def test_swallows_write_failure(self) -> None:
+        db = mock.AsyncMock()
+        reloc = RepositoryRelocation(
+            link_key='github-repository',
+            new_url='https://github.com/octo/renamed',
+        )
+        with mock.patch(
+            f'{_MODULE}.update_project_link',
+            side_effect=RuntimeError('graph down'),
+        ):
+            # Must not raise — self-heal is best-effort.
+            await heal_relocated_link(db, self._ctx(reloc))
+
+
+class UpdateProjectLinkTestCase(unittest.IsolatedAsyncioTestCase):
+    """Unit coverage for ``_helpers.update_project_link``."""
+
+    async def test_writes_new_value(self) -> None:
+        db = mock.AsyncMock()
+        with mock.patch.object(
+            _helpers,
+            'lookup_project_links',
+            mock.AsyncMock(return_value={'other': 'https://x'}),
+        ):
+            changed = await _helpers.update_project_link(
+                db, 'proj1', 'github-repository', 'https://github.com/o/new'
+            )
+        self.assertTrue(changed)
+        db.execute.assert_awaited_once()
+        params = db.execute.await_args.args[1]
+        self.assertEqual(params['project_id'], 'proj1')
+        self.assertEqual(
+            json.loads(params['links']),
+            {
+                'other': 'https://x',
+                'github-repository': 'https://github.com/o/new',
+            },
+        )
+
+    async def test_noop_when_unchanged(self) -> None:
+        db = mock.AsyncMock()
+        with mock.patch.object(
+            _helpers,
+            'lookup_project_links',
+            mock.AsyncMock(
+                return_value={'github-repository': 'https://github.com/o/new'}
+            ),
+        ):
+            changed = await _helpers.update_project_link(
+                db, 'proj1', 'github-repository', 'https://github.com/o/new'
+            )
+        self.assertFalse(changed)
+        db.execute.assert_not_called()

--- a/tests/test_lifecycle_dispatch.py
+++ b/tests/test_lifecycle_dispatch.py
@@ -15,6 +15,7 @@ from imbi_common.plugins.base import (
     LifecyclePlugin,
     LifecycleResult,
     PluginManifest,
+    RepositoryRelocation,
 )
 from imbi_common.plugins.registry import RegistryEntry
 
@@ -139,6 +140,44 @@ class DispatchLifecycleTestCase(unittest.TestCase):
             results[0].artifacts, {'repo_url': 'https://github.com/o/r'}
         )
         insert.assert_awaited_once()
+
+    def test_archive_heals_relocated_link(self) -> None:
+        # A lifecycle plugin that reports a repo rename on ctx triggers a
+        # self-heal of the stored link via update_project_link.
+        class _Reloc(LifecyclePlugin):
+            manifest = PluginManifest(
+                slug='gh', name='gh', plugin_type='lifecycle'
+            )
+
+            async def on_project_archived(self, ctx, credentials):  # type: ignore[override]
+                ctx.repository_relocation = RepositoryRelocation(
+                    link_key='github-repository',
+                    new_url='https://github.com/octo/renamed',
+                    old_owner_repo='octo/demo',
+                    new_owner_repo='octo/renamed',
+                )
+                return LifecycleResult(status='ok', message='done')
+
+            async def on_project_unarchived(self, ctx, credentials):  # type: ignore[override]
+                raise NotImplementedError
+
+        entry = RegistryEntry(
+            handler_cls=_Reloc,
+            manifest=_Reloc.manifest,
+            package_name='imbi-plugin-gh',
+            package_version='1.0.0',
+        )
+        with mock.patch(
+            'imbi_api.endpoints._helpers.update_project_link',
+            new=mock.AsyncMock(return_value=True),
+        ) as update_link:
+            results, _ = self._run([_resolved(entry)])
+        self.assertEqual(results[0].status, 'ok')
+        update_link.assert_awaited_once()
+        # heal_relocated_link(db, project_id, link_key, new_url)
+        args = update_link.await_args.args
+        self.assertEqual(args[2], 'github-repository')
+        self.assertEqual(args[3], 'https://github.com/octo/renamed')
 
     def test_emits_one_clickhouse_call_for_multiple_plugins(self) -> None:
         """H17: N plugins → 1 ClickHouse insert (rows batched)."""

--- a/uv.lock
+++ b/uv.lock
@@ -1103,7 +1103,7 @@ docs = [
 [[package]]
 name = "imbi-common"
 version = "2.6.1"
-source = { git = "https://github.com/AWeber-Imbi/imbi-common.git?branch=main#92025cb9812f3e850ec8cfb285969d5757c2539f" }
+source = { git = "https://github.com/AWeber-Imbi/imbi-common.git?branch=main#0a09872a453c6b3bcfa79e30b6e3dbd5e8385592" }
 dependencies = [
   { name = "cryptography" },
   { name = "httpx" },


### PR DESCRIPTION
## Summary

Persists a repository rename that a deployment plugin reports via `ctx.repository_relocation`, so a project's stale `github-repository` link is corrected automatically — later calls skip the redirect and the UI shows the new name.

## Problem

When a GitHub repo is renamed outside Imbi, the plugin now follows the `301` and reports the new location (AWeber-Imbi/imbi-plugin-github#21), but nothing updated the project's stored link, so every request kept paying the redirect and the UI kept showing the old name.

## Solution

- `update_project_link` helper (`endpoints/_helpers.py`) rewrites a single project link; no-op when unchanged.
- `heal_relocated_link` reads `ctx.repository_relocation` and persists it; invoked after every deployment plugin call (list refs/commits, resolve, compare, deploy, promote, resync).
- **Best-effort**: a write failure is logged and swallowed so self-heal never fails the user-facing request whose result we already have.
- Tests for the endpoint heal path (`list_commits`, `trigger`), the helper, and the no-op / no-relocation cases.

## Dependency / merge order

Consumes `RepositoryRelocation` from `imbi-common` (AWeber-Imbi/imbi-common#134). **Merge + release that first**, then bump this PR's `imbi-common` pin to the release. Validated locally against the unreleased `imbi-common` (130 tests passing, basedpyright + mypy clean).

Refs AWeber-Imbi/imbi-plugin-github#20

🤖 Generated with [Claude Code](https://claude.com/claude-code)