### PR TITLE
Add MCP server connection-test and status endpoints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
   "imbi-common[databases,llm,sentry,server]>=2.6.1",
   "jinja2",
   "jsonpatch>=1.33",
+  "mcp>=1.26.0",
   "nanoid>=2.0.0",
   "orjson>=3.11.6",
   "pydantic[email]",

--- a/src/imbi_api/endpoints/mcp_servers.py
+++ b/src/imbi_api/endpoints/mcp_servers.py
@@ -18,6 +18,7 @@ import pydantic
 from imbi_common import graph, models
 from imbi_common.auth.encryption import encrypt_config_value
 
+from imbi_api import mcp_test
 from imbi_api.auth import permissions
 from imbi_api.graph_sql import props_template, set_clause
 
@@ -110,8 +111,45 @@ class MCPServerResponse(pydantic.BaseModel):
     oauth_client_id: str | None = None
     has_oauth_client_secret: bool = False
     oauth_scope: str | None = None
+    status: typing.Literal['unknown', 'healthy', 'degraded', 'unreachable'] = (
+        'unknown'
+    )
+    last_tested_at: datetime.datetime | None = None
+    last_tested_latency_ms: int | None = None
+    tools_discovered: int | None = None
+    last_error: str | None = None
     created_at: datetime.datetime | None = None
     updated_at: datetime.datetime | None = None
+
+
+class MCPServerTestConfig(MCPServerCreate):
+    """Request body for testing an unsaved configuration.
+
+    Same shape as :class:`MCPServerCreate`, but ``name`` and ``slug`` are
+    optional because the connection test only needs the URL and auth.
+    """
+
+    name: str = '__connection_test__'
+    slug: str = '__connection_test__'
+
+
+class MCPServerTestResult(pydantic.BaseModel):
+    """Outcome of an MCP server connection test."""
+
+    ok: bool
+    status: typing.Literal['healthy', 'degraded', 'unreachable']
+    latency_ms: int
+    tools: list[str]
+    tools_discovered: int
+    error: str | None = None
+    tested_at: datetime.datetime
+
+
+class MCPServerStatusReport(pydantic.BaseModel):
+    """Runtime status report, posted by the assistant on tool failure."""
+
+    status: typing.Literal['healthy', 'degraded', 'unreachable']
+    error: str | None = None
 
 
 def _to_response(node: models.MCPServer) -> MCPServerResponse:
@@ -137,6 +175,11 @@ def _to_response(node: models.MCPServer) -> MCPServerResponse:
             node.oauth_client_secret_encrypted is not None
         ),
         oauth_scope=node.oauth_scope,
+        status=node.status,
+        last_tested_at=node.last_tested_at,
+        last_tested_latency_ms=node.last_tested_latency_ms,
+        tools_discovered=node.tools_discovered,
+        last_error=node.last_error,
         created_at=node.created_at,
         updated_at=node.updated_at,
     )
@@ -384,6 +427,168 @@ async def delete_mcp_server(
             status_code=404,
             detail=f'MCP server with id {id!r} not found',
         )
+
+
+@mcp_servers_router.post('/{id}/test', response_model=MCPServerTestResult)
+async def test_mcp_server(
+    id: str,
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(permissions.require_permission('mcp_server:update')),
+    ],
+) -> MCPServerTestResult:
+    """Test connectivity to a saved MCP server and persist the result.
+
+    Opens a streamable-HTTP session using the server's stored
+    configuration and secrets, lists its tools, and records the outcome
+    (``status``, ``last_tested_at``, latency, tool count, and any error)
+    on the node.
+
+    Parameters:
+        id: The MCP server id.
+
+    Returns:
+        The test result, including discovered tool names.
+
+    Raises:
+        404: If no MCP server with the given id exists.
+
+    """
+    _ = auth
+    node = await _fetch(db, id)
+    result = await mcp_test.test_connection(node)
+    now = datetime.datetime.now(datetime.UTC)
+    node.status = result.status
+    node.last_tested_at = now
+    node.last_tested_latency_ms = result.latency_ms
+    node.tools_discovered = len(result.tools)
+    node.last_error = result.error
+    await _persist(db, node)
+    return MCPServerTestResult(
+        ok=result.ok,
+        status=result.status,
+        latency_ms=result.latency_ms,
+        tools=result.tools,
+        tools_discovered=len(result.tools),
+        error=result.error,
+        tested_at=now,
+    )
+
+
+@mcp_servers_router.post('/test', response_model=MCPServerTestResult)
+async def test_mcp_server_config(
+    data: MCPServerTestConfig,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(permissions.require_permission('mcp_server:create')),
+    ],
+) -> MCPServerTestResult:
+    """Test an unsaved MCP server configuration without persisting it.
+
+    Used by the create form's "Test connection" action, where secrets are
+    supplied as plaintext in the request and no record exists yet.
+
+    Parameters:
+        data: The candidate configuration; secrets are plaintext.
+
+    Returns:
+        The test result, including discovered tool names.
+
+    Raises:
+        400: If the configuration is invalid for its ``auth_type``.
+
+    """
+    _ = auth
+    try:
+        node = models.MCPServer(
+            name=data.name,
+            slug=data.slug,
+            url=data.url,
+            enabled=data.enabled,
+            tool_prefix=data.tool_prefix,
+            timeout=data.timeout,
+            verify_ssl=data.verify_ssl,
+            ignored_tools=data.ignored_tools,
+            auth_type=data.auth_type,
+            static_header=data.static_header,
+            static_value_encrypted=encrypt_config_value(data.static_value),
+            oauth_token_url=data.oauth_token_url,
+            oauth_client_id=data.oauth_client_id,
+            oauth_client_secret_encrypted=encrypt_config_value(
+                data.oauth_client_secret
+            ),
+            oauth_scope=data.oauth_scope,
+        )
+    except pydantic.ValidationError as e:
+        raise fastapi.HTTPException(
+            status_code=400,
+            detail=f'Validation error: {e.errors()}',
+        ) from e
+    result = await mcp_test.test_connection(node)
+    return MCPServerTestResult(
+        ok=result.ok,
+        status=result.status,
+        latency_ms=result.latency_ms,
+        tools=result.tools,
+        tools_discovered=len(result.tools),
+        error=result.error,
+        tested_at=datetime.datetime.now(datetime.UTC),
+    )
+
+
+@mcp_servers_router.post('/{id}/status', response_model=MCPServerResponse)
+async def report_mcp_server_status(
+    id: str,
+    data: MCPServerStatusReport,
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(permissions.require_permission('mcp_server:update')),
+    ],
+) -> MCPServerResponse:
+    """Record a runtime health observation for an MCP server.
+
+    Posted by the assistant when a live tool call against this server
+    succeeds or fails, so the admin list reflects real usage health
+    without a manual test. Updates ``status``, ``last_error``, and
+    ``last_tested_at``; leaves configuration untouched.
+
+    Parameters:
+        id: The MCP server id.
+        data: The observed status and optional error message.
+
+    Returns:
+        The updated MCP server, without any secret values.
+
+    Raises:
+        404: If no MCP server with the given id exists.
+
+    """
+    _ = auth
+    node = await _fetch(db, id)
+    node.status = data.status
+    node.last_error = data.error
+    node.last_tested_at = datetime.datetime.now(datetime.UTC)
+    return _to_response(await _persist(db, node))
+
+
+async def _persist(db: graph.Pool, node: models.MCPServer) -> models.MCPServer:
+    """Write a mutated node back to the graph and return the result.
+
+    ``id`` and ``created_at`` are preserved; every other property is
+    overwritten from ``node``.
+    """
+    props = node.model_dump(mode='json', exclude={'id', 'created_at'})
+    set_stmt = set_clause('n', props)
+    query = f'MATCH (n:MCPServer {{{{id: {{id}}}}}}) {set_stmt} RETURN n'
+    records = await db.execute(query, {**props, 'id': node.id}, ['n'])
+    if not records:
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail=f'MCP server with id {node.id!r} not found',
+        )
+    return _parse_node(records[0]['n'])
 
 
 def _parse_node(raw: typing.Any) -> models.MCPServer:

--- a/src/imbi_api/endpoints/mcp_servers.py
+++ b/src/imbi_api/endpoints/mcp_servers.py
@@ -577,8 +577,10 @@ async def _persist(db: graph.Pool, node: models.MCPServer) -> models.MCPServer:
     """Write a mutated node back to the graph and return the result.
 
     ``id`` and ``created_at`` are preserved; every other property is
-    overwritten from ``node``.
+    overwritten from ``node``. ``updated_at`` is refreshed to the current
+    UTC time so callers always observe fresh metadata.
     """
+    node.updated_at = datetime.datetime.now(datetime.UTC)
     props = node.model_dump(mode='json', exclude={'id', 'created_at'})
     set_stmt = set_clause('n', props)
     query = f'MATCH (n:MCPServer {{{{id: {{id}}}}}}) {set_stmt} RETURN n'

--- a/src/imbi_api/mcp_test.py
+++ b/src/imbi_api/mcp_test.py
@@ -63,11 +63,16 @@ class OAuthClientCredentialsAuth(httpx.Auth):
         client_id: str,
         client_secret: str,
         scope: str | None = None,
+        *,
+        verify_ssl: bool = True,
+        timeout_s: float = _OAUTH_TOKEN_TIMEOUT,
     ) -> None:
         self._token_url = token_url
         self._client_id = client_id
         self._client_secret = client_secret
         self._scope = scope
+        self._verify_ssl = verify_ssl
+        self._timeout_s = timeout_s
 
     async def _fetch_token(self) -> str:
         data: dict[str, str] = {
@@ -78,7 +83,8 @@ class OAuthClientCredentialsAuth(httpx.Auth):
         if self._scope:
             data['scope'] = self._scope
         async with httpx.AsyncClient(
-            timeout=httpx.Timeout(_OAUTH_TOKEN_TIMEOUT)
+            timeout=httpx.Timeout(self._timeout_s),
+            verify=self._verify_ssl,
         ) as client:
             response = await client.post(self._token_url, data=data)
             response.raise_for_status()
@@ -118,6 +124,8 @@ def _build_auth(
                 client_id=server.oauth_client_id,
                 client_secret=secret,
                 scope=server.oauth_scope,
+                verify_ssl=server.verify_ssl,
+                timeout_s=float(server.timeout),
             )
         raise ValueError('OAuth auth is missing configuration')
     return None, None

--- a/src/imbi_api/mcp_test.py
+++ b/src/imbi_api/mcp_test.py
@@ -1,0 +1,204 @@
+"""One-shot connection testing for :class:`~imbi_common.models.MCPServer`.
+
+The admin UI needs to verify that a configured MCP server is reachable,
+authenticates correctly, and lists its tools. This module opens a single
+streamable-HTTP MCP session, measures round-trip latency, and discovers
+the server's tools, then tears the session down.
+
+It deliberately mirrors the connect/auth logic in
+``imbi_assistant.external_mcp`` (which maintains long-lived connections for
+the running assistant) rather than importing it: the assistant is a
+separate service and is not a dependency of the API.
+"""
+
+import asyncio
+import collections.abc
+import contextlib
+import dataclasses
+import logging
+import time
+import typing
+
+import httpx
+import mcp
+from imbi_common import models
+from imbi_common.auth.encryption import decrypt_config_value
+from mcp.client import streamable_http
+from mcp.shared._httpx_utils import create_mcp_http_client
+
+LOGGER = logging.getLogger(__name__)
+
+# A successful connection slower than this is reported as ``degraded``
+# rather than ``healthy``.
+DEGRADED_LATENCY_MS = 1000
+
+_OAUTH_EXPIRY_BUFFER = 60.0
+
+_OAUTH_TOKEN_TIMEOUT = 10.0
+
+Status = typing.Literal['healthy', 'degraded', 'unreachable']
+
+
+@dataclasses.dataclass(slots=True)
+class ConnectionTestResult:
+    """Outcome of a single MCP server connection test."""
+
+    ok: bool
+    status: Status
+    latency_ms: int
+    tools: list[str]
+    error: str | None = None
+
+
+class OAuthClientCredentialsAuth(httpx.Auth):
+    """httpx Auth that fetches an OAuth client-credentials token.
+
+    Unlike the assistant's long-lived variant, this is used for a single
+    test and does not need refresh-ahead caching.
+    """
+
+    def __init__(
+        self,
+        token_url: str,
+        client_id: str,
+        client_secret: str,
+        scope: str | None = None,
+    ) -> None:
+        self._token_url = token_url
+        self._client_id = client_id
+        self._client_secret = client_secret
+        self._scope = scope
+
+    async def _fetch_token(self) -> str:
+        data: dict[str, str] = {
+            'grant_type': 'client_credentials',
+            'client_id': self._client_id,
+            'client_secret': self._client_secret,
+        }
+        if self._scope:
+            data['scope'] = self._scope
+        async with httpx.AsyncClient(
+            timeout=httpx.Timeout(_OAUTH_TOKEN_TIMEOUT)
+        ) as client:
+            response = await client.post(self._token_url, data=data)
+            response.raise_for_status()
+            return str(response.json()['access_token'])
+
+    async def async_auth_flow(
+        self,
+        request: httpx.Request,
+    ) -> collections.abc.AsyncGenerator[httpx.Request, httpx.Response]:
+        token = await self._fetch_token()
+        request.headers['Authorization'] = f'Bearer {token}'
+        yield request
+
+
+def _build_auth(
+    server: models.MCPServer,
+) -> tuple[dict[str, str] | None, httpx.Auth | None]:
+    """Resolve request headers and httpx auth, decrypting any secrets.
+
+    Returns:
+        Tuple of (static headers or None, httpx.Auth or None).
+
+    Raises:
+        ValueError: If the server's auth configuration is incomplete.
+
+    """
+    if server.auth_type == 'static':
+        value = decrypt_config_value(server.static_value_encrypted)
+        if server.static_header and value is not None:
+            return {server.static_header: value}, None
+        raise ValueError('Static auth is missing a header or value')
+    if server.auth_type == 'oauth_client_credentials':
+        secret = decrypt_config_value(server.oauth_client_secret_encrypted)
+        if server.oauth_token_url and server.oauth_client_id and secret:
+            return None, OAuthClientCredentialsAuth(
+                token_url=str(server.oauth_token_url),
+                client_id=server.oauth_client_id,
+                client_secret=secret,
+                scope=server.oauth_scope,
+            )
+        raise ValueError('OAuth auth is missing configuration')
+    return None, None
+
+
+async def test_connection(server: models.MCPServer) -> ConnectionTestResult:
+    """Open a streamable-HTTP session, list tools, and time the round trip.
+
+    Never raises: a connection or auth failure is returned as an
+    ``unreachable`` result with the error message.
+
+    Parameters:
+        server: The MCP server to test. Secrets are read from the
+            ``*_encrypted`` fields and decrypted at connect time.
+
+    Returns:
+        The test outcome, including discovered tool names and latency.
+
+    """
+    timeout_s = float(server.timeout)
+    started = time.monotonic()
+    try:
+        headers, http_auth = _build_auth(server)
+        if server.verify_ssl:
+            http_client = create_mcp_http_client(
+                headers, httpx.Timeout(timeout_s), http_auth
+            )
+        else:
+            http_client = httpx.AsyncClient(
+                headers=headers,
+                timeout=httpx.Timeout(timeout_s),
+                auth=http_auth,
+                follow_redirects=True,
+                verify=False,  # noqa: S501 - opt-in for in-cluster endpoints
+            )
+        async with contextlib.AsyncExitStack() as stack:
+            streams = await stack.enter_async_context(
+                streamable_http.streamable_http_client(
+                    str(server.url), http_client=http_client
+                )
+            )
+            session = await stack.enter_async_context(
+                mcp.ClientSession(streams[0], streams[1])
+            )
+            await asyncio.wait_for(session.initialize(), timeout=timeout_s)
+            result = await asyncio.wait_for(
+                session.list_tools(), timeout=timeout_s
+            )
+            tools = [tool.name for tool in result.tools]
+    except asyncio.CancelledError:
+        raise
+    except TimeoutError:
+        latency_ms = int((time.monotonic() - started) * 1000)
+        return ConnectionTestResult(
+            ok=False,
+            status='unreachable',
+            latency_ms=latency_ms,
+            tools=[],
+            error=f'Timed out after {server.timeout}s',
+        )
+    except Exception as err:  # noqa: BLE001 - any failure is a failed test
+        latency_ms = int((time.monotonic() - started) * 1000)
+        LOGGER.info('MCP connection test for %r failed: %s', server.slug, err)
+        return ConnectionTestResult(
+            ok=False,
+            status='unreachable',
+            latency_ms=latency_ms,
+            tools=[],
+            error=str(err) or err.__class__.__name__,
+        )
+    latency_ms = int((time.monotonic() - started) * 1000)
+    status: Status = (
+        'degraded' if latency_ms >= DEGRADED_LATENCY_MS else 'healthy'
+    )
+    return ConnectionTestResult(
+        ok=True,
+        status=status,
+        latency_ms=latency_ms,
+        tools=tools,
+        error=None,
+    )
+
+
+__all__ = ['ConnectionTestResult', 'test_connection']

--- a/tests/endpoints/test_mcp_servers.py
+++ b/tests/endpoints/test_mcp_servers.py
@@ -11,6 +11,7 @@ from imbi_common import graph
 
 from imbi_api import app, models
 from imbi_api.auth import permissions
+from imbi_api.mcp_test import ConnectionTestResult
 
 
 class MCPServerEndpointsTestCase(unittest.TestCase):
@@ -386,6 +387,159 @@ class MCPServerEndpointsTestCase(unittest.TestCase):
         response = self.client.delete('/mcp-servers/missing')
         self.assertEqual(response.status_code, 404)
 
+    # -- Connection test -----------------------------------------------
+
+    def test_test_saved_server_persists_result(self) -> None:
+        """Testing a saved server records status/latency/tool count."""
+        self.mock_db.match.return_value = [self._model()]
+        self.mock_db.execute.return_value = [
+            {'n': self._server_props(status='healthy')}
+        ]
+        result = ConnectionTestResult(
+            ok=True,
+            status='healthy',
+            latency_ms=80,
+            tools=['list_repos', 'get_repo'],
+            error=None,
+        )
+        with (
+            mock.patch(
+                'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+            ),
+            mock.patch(
+                'imbi_api.endpoints.mcp_servers.mcp_test.test_connection',
+                new_callable=mock.AsyncMock,
+                return_value=result,
+            ) as tested,
+        ):
+            response = self.client.post('/mcp-servers/srv-1/test')
+        self.assertEqual(response.status_code, 200)
+        tested.assert_awaited_once()
+        data = response.json()
+        self.assertTrue(data['ok'])
+        self.assertEqual(data['status'], 'healthy')
+        self.assertEqual(data['latency_ms'], 80)
+        self.assertEqual(data['tools'], ['list_repos', 'get_repo'])
+        self.assertEqual(data['tools_discovered'], 2)
+        # The outcome was persisted onto the node.
+        persisted = self.mock_db.execute.call_args.args[1]
+        self.assertEqual(persisted['status'], 'healthy')
+        self.assertEqual(persisted['tools_discovered'], 2)
+        self.assertIsNotNone(persisted['last_tested_at'])
+
+    def test_test_saved_server_failure_marks_unreachable(self) -> None:
+        """A failed test persists an unreachable status and the error."""
+        self.mock_db.match.return_value = [self._model()]
+        self.mock_db.execute.return_value = [
+            {'n': self._server_props(status='unreachable')}
+        ]
+        result = ConnectionTestResult(
+            ok=False,
+            status='unreachable',
+            latency_ms=4001,
+            tools=[],
+            error='Timed out after 4s',
+        )
+        with (
+            mock.patch(
+                'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+            ),
+            mock.patch(
+                'imbi_api.endpoints.mcp_servers.mcp_test.test_connection',
+                new_callable=mock.AsyncMock,
+                return_value=result,
+            ),
+        ):
+            response = self.client.post('/mcp-servers/srv-1/test')
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertFalse(data['ok'])
+        self.assertEqual(data['error'], 'Timed out after 4s')
+        persisted = self.mock_db.execute.call_args.args[1]
+        self.assertEqual(persisted['status'], 'unreachable')
+        self.assertEqual(persisted['last_error'], 'Timed out after 4s')
+
+    def test_test_saved_server_not_found(self) -> None:
+        """Testing a missing id returns 404."""
+        self.mock_db.match.return_value = []
+        response = self.client.post('/mcp-servers/missing/test')
+        self.assertEqual(response.status_code, 404)
+
+    def test_test_config_does_not_persist(self) -> None:
+        """Testing an unsaved config returns a result without writing."""
+        result = ConnectionTestResult(
+            ok=True,
+            status='healthy',
+            latency_ms=42,
+            tools=['search'],
+            error=None,
+        )
+        with (
+            mock.patch(
+                'imbi_api.endpoints.mcp_servers.encrypt_config_value',
+                side_effect=lambda v: None if v is None else f'enc:{v}',
+            ),
+            mock.patch(
+                'imbi_api.endpoints.mcp_servers.mcp_test.test_connection',
+                new_callable=mock.AsyncMock,
+                return_value=result,
+            ),
+        ):
+            response = self.client.post(
+                '/mcp-servers/test',
+                json={'url': 'https://mcp.example.com', 'auth_type': 'none'},
+            )
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertTrue(data['ok'])
+        self.assertEqual(data['tools'], ['search'])
+        self.mock_db.execute.assert_not_called()
+
+    def test_test_config_invalid_returns_400(self) -> None:
+        """An incomplete config (static, no secret) is rejected."""
+        with mock.patch(
+            'imbi_api.endpoints.mcp_servers.encrypt_config_value',
+            side_effect=lambda v: None if v is None else f'enc:{v}',
+        ):
+            response = self.client.post(
+                '/mcp-servers/test',
+                json={
+                    'url': 'https://mcp.example.com',
+                    'auth_type': 'static',
+                },
+            )
+        self.assertEqual(response.status_code, 400)
+
+    # -- Status report -------------------------------------------------
+
+    def test_report_status_persists(self) -> None:
+        """A runtime status report updates status and last_error."""
+        self.mock_db.match.return_value = [self._model()]
+        self.mock_db.execute.return_value = [
+            {'n': self._server_props(status='degraded')}
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.post(
+                '/mcp-servers/srv-1/status',
+                json={'status': 'degraded', 'error': 'tool call failed'},
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()['status'], 'degraded')
+        persisted = self.mock_db.execute.call_args.args[1]
+        self.assertEqual(persisted['status'], 'degraded')
+        self.assertEqual(persisted['last_error'], 'tool call failed')
+        self.assertIsNotNone(persisted['last_tested_at'])
+
+    def test_report_status_not_found(self) -> None:
+        """Reporting status for a missing id returns 404."""
+        self.mock_db.match.return_value = []
+        response = self.client.post(
+            '/mcp-servers/missing/status', json={'status': 'healthy'}
+        )
+        self.assertEqual(response.status_code, 404)
+
 
 class MCPServerPermissionTestCase(unittest.TestCase):
     """Non-admin permission enforcement for MCP server endpoints."""
@@ -450,3 +604,15 @@ class MCPServerPermissionTestCase(unittest.TestCase):
         self.mock_db.match.return_value = []
         response = self.client.get('/mcp-servers/')
         self.assertEqual(response.status_code, 200)
+
+    def test_test_denied(self) -> None:
+        """Testing without mcp_server:update is forbidden."""
+        response = self.client.post('/mcp-servers/srv-1/test')
+        self.assertEqual(response.status_code, 403)
+
+    def test_status_report_denied(self) -> None:
+        """Reporting status without mcp_server:update is forbidden."""
+        response = self.client.post(
+            '/mcp-servers/srv-1/status', json={'status': 'healthy'}
+        )
+        self.assertEqual(response.status_code, 403)

--- a/tests/endpoints/test_mcp_servers.py
+++ b/tests/endpoints/test_mcp_servers.py
@@ -605,6 +605,14 @@ class MCPServerPermissionTestCase(unittest.TestCase):
         response = self.client.get('/mcp-servers/')
         self.assertEqual(response.status_code, 200)
 
+    def test_test_config_denied(self) -> None:
+        """Testing an unsaved config without mcp_server:create is forbidden."""
+        response = self.client.post(
+            '/mcp-servers/test',
+            json={'url': 'https://mcp.example.com', 'auth_type': 'none'},
+        )
+        self.assertEqual(response.status_code, 403)
+
     def test_test_denied(self) -> None:
         """Testing without mcp_server:update is forbidden."""
         response = self.client.post('/mcp-servers/srv-1/test')

--- a/uv.lock
+++ b/uv.lock
@@ -935,6 +935,15 @@ wheels = [
 ]
 
 [[package]]
+name = "httpx-sse"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+wheels = [
+  { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
 name = "huggingface-hub"
 version = "1.14.0"
 source = { registry = "https://pypi.org/simple" }
@@ -987,6 +996,7 @@ dependencies = [
   { name = "imbi-common", extra = ["databases", "llm", "sentry", "server"] },
   { name = "jinja2" },
   { name = "jsonpatch" },
+  { name = "mcp" },
   { name = "nanoid" },
   { name = "orjson" },
   { name = "pillow" },
@@ -1058,6 +1068,7 @@ requires-dist = [
   { name = "imbi-plugin-sonarqube", marker = "extra == 'plugins'", specifier = ">=0.0.0" },
   { name = "jinja2" },
   { name = "jsonpatch", specifier = ">=1.33" },
+  { name = "mcp", specifier = ">=1.26.0" },
   { name = "nanoid", specifier = ">=2.0.0" },
   { name = "opentelemetry-distro", marker = "extra == 'otel'" },
   { name = "opentelemetry-instrumentation-asyncio", marker = "extra == 'otel'" },
@@ -1319,6 +1330,21 @@ wheels = [
 ]
 
 [[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+  { name = "attrs" },
+  { name = "jsonschema-specifications" },
+  { name = "referencing" },
+  { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
+wheels = [
+  { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[[package]]
 name = "jsonschema-models"
 version = "1.2.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1328,6 +1354,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/82/dc/a8655970edd14c1594416ac21f6ef2a3cd878712b90176c4c607c86c9771/jsonschema_models-1.2.3.tar.gz", hash = "sha256:e961cacafdef11a925057c25e2f6557f50ffc4d255ac2736a533d666377fb92b", size = 11075, upload-time = "2025-04-08T22:34:46.164Z" }
 wheels = [
   { url = "https://files.pythonhosted.org/packages/67/28/182b13a309c0345684d299624d379164e455c20eab87ec6e9939950db6e4/jsonschema_models-1.2.3-py3-none-any.whl", hash = "sha256:96b4b5b7354001e5dbedd43fc039d4a870e0f3946c3a583ed5d0ad9d9ba4e856", size = 7098, upload-time = "2025-04-08T22:34:45.332Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+  { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+  { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
 ]
 
 [[package]]
@@ -1456,6 +1494,31 @@ wheels = [
   { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
   { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
   { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
+name = "mcp"
+version = "1.27.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+  { name = "anyio" },
+  { name = "httpx" },
+  { name = "httpx-sse" },
+  { name = "jsonschema" },
+  { name = "pydantic" },
+  { name = "pydantic-settings" },
+  { name = "pyjwt", extra = ["crypto"] },
+  { name = "python-multipart" },
+  { name = "pywin32", marker = "sys_platform == 'win32'" },
+  { name = "sse-starlette" },
+  { name = "starlette" },
+  { name = "typing-extensions" },
+  { name = "typing-inspection" },
+  { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/38/83/d1efe7c2980d8a3afa476f4e3d42d53dd54c0ab94c27bee5d755b45c8b73/mcp-1.27.1.tar.gz", hash = "sha256:0f47e1820f8f8f941466b39749eb1d1839a04caddca2bc60e9d46e8a99914924", size = 608458, upload-time = "2026-05-08T16:50:12.601Z" }
+wheels = [
+  { url = "https://files.pythonhosted.org/packages/fd/73/42d9596facebdb533b7f0b86c1b0364ef350d1f8ba78b1052e8a58b48b65/mcp-1.27.1-py3-none-any.whl", hash = "sha256:1af3c4203b329430fde7a87b4fcb6392a041f5cb851fd68fc674016ab4e7c06f", size = 216260, upload-time = "2026-05-08T16:50:10.547Z" },
 ]
 
 [[package]]
@@ -2320,6 +2383,11 @@ wheels = [
   { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
 ]
 
+[package.optional-dependencies]
+crypto = [
+  { name = "cryptography" },
+]
+
 [[package]]
 name = "pymdown-extensions"
 version = "10.21.3"
@@ -2437,6 +2505,16 @@ wheels = [
 ]
 
 [[package]]
+name = "pywin32"
+version = "311"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+  { url = "https://files.pythonhosted.org/packages/c9/31/097f2e132c4f16d99a22bfb777e0fd88bd8e1c634304e102f313af69ace5/pywin32-311-cp314-cp314-win32.whl", hash = "sha256:b7a2c10b93f8986666d0c803ee19b5990885872a7de910fc460f9b0c2fbf92ee", size = 8840714, upload-time = "2025-07-14T20:13:32.449Z" },
+  { url = "https://files.pythonhosted.org/packages/90/4b/07c77d8ba0e01349358082713400435347df8426208171ce297da32c313d/pywin32-311-cp314-cp314-win_amd64.whl", hash = "sha256:3aca44c046bd2ed8c90de9cb8427f581c479e594e99b5c0bb19b29c10fd6cb87", size = 9656800, upload-time = "2025-07-14T20:13:34.312Z" },
+  { url = "https://files.pythonhosted.org/packages/c0/d2/21af5c535501a7233e734b8af901574572da66fcc254cb35d0609c9080dd/pywin32-311-cp314-cp314-win_arm64.whl", hash = "sha256:a508e2d9025764a8270f93111a970e1d0fbfc33f4153b388bb649b7eec4f9b42", size = 8932540, upload-time = "2025-07-14T20:13:36.379Z" },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -2487,6 +2565,19 @@ wheels = [
 ]
 
 [[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+  { name = "attrs" },
+  { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+wheels = [
+  { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
 name = "requests"
 version = "2.34.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2512,6 +2603,43 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
 wheels = [
   { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
+name = "rpds-py"
+version = "0.30.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/af/3f2f423103f1113b36230496629986e0ef7e199d2aa8392452b484b38ced/rpds_py-0.30.0.tar.gz", hash = "sha256:dd8ff7cf90014af0c0f787eea34794ebf6415242ee1d6fa91eaba725cc441e84", size = 69469, upload-time = "2025-11-30T20:24:38.837Z" }
+wheels = [
+  { url = "https://files.pythonhosted.org/packages/86/81/dad16382ebbd3d0e0328776d8fd7ca94220e4fa0798d1dc5e7da48cb3201/rpds_py-0.30.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:68f19c879420aa08f61203801423f6cd5ac5f0ac4ac82a2368a9fcd6a9a075e0", size = 362099, upload-time = "2025-11-30T20:23:27.316Z" },
+  { url = "https://files.pythonhosted.org/packages/2b/60/19f7884db5d5603edf3c6bce35408f45ad3e97e10007df0e17dd57af18f8/rpds_py-0.30.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ec7c4490c672c1a0389d319b3a9cfcd098dcdc4783991553c332a15acf7249be", size = 353192, upload-time = "2025-11-30T20:23:29.151Z" },
+  { url = "https://files.pythonhosted.org/packages/bf/c4/76eb0e1e72d1a9c4703c69607cec123c29028bff28ce41588792417098ac/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f251c812357a3fed308d684a5079ddfb9d933860fc6de89f2b7ab00da481e65f", size = 384080, upload-time = "2025-11-30T20:23:30.785Z" },
+  { url = "https://files.pythonhosted.org/packages/72/87/87ea665e92f3298d1b26d78814721dc39ed8d2c74b86e83348d6b48a6f31/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ac98b175585ecf4c0348fd7b29c3864bda53b805c773cbf7bfdaffc8070c976f", size = 394841, upload-time = "2025-11-30T20:23:32.209Z" },
+  { url = "https://files.pythonhosted.org/packages/77/ad/7783a89ca0587c15dcbf139b4a8364a872a25f861bdb88ed99f9b0dec985/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3e62880792319dbeb7eb866547f2e35973289e7d5696c6e295476448f5b63c87", size = 516670, upload-time = "2025-11-30T20:23:33.742Z" },
+  { url = "https://files.pythonhosted.org/packages/5b/3c/2882bdac942bd2172f3da574eab16f309ae10a3925644e969536553cb4ee/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4e7fc54e0900ab35d041b0601431b0a0eb495f0851a0639b6ef90f7741b39a18", size = 408005, upload-time = "2025-11-30T20:23:35.253Z" },
+  { url = "https://files.pythonhosted.org/packages/ce/81/9a91c0111ce1758c92516a3e44776920b579d9a7c09b2b06b642d4de3f0f/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47e77dc9822d3ad616c3d5759ea5631a75e5809d5a28707744ef79d7a1bcfcad", size = 382112, upload-time = "2025-11-30T20:23:36.842Z" },
+  { url = "https://files.pythonhosted.org/packages/cf/8e/1da49d4a107027e5fbc64daeab96a0706361a2918da10cb41769244b805d/rpds_py-0.30.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:b4dc1a6ff022ff85ecafef7979a2c6eb423430e05f1165d6688234e62ba99a07", size = 399049, upload-time = "2025-11-30T20:23:38.343Z" },
+  { url = "https://files.pythonhosted.org/packages/df/5a/7ee239b1aa48a127570ec03becbb29c9d5a9eb092febbd1699d567cae859/rpds_py-0.30.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4559c972db3a360808309e06a74628b95eaccbf961c335c8fe0d590cf587456f", size = 415661, upload-time = "2025-11-30T20:23:40.263Z" },
+  { url = "https://files.pythonhosted.org/packages/70/ea/caa143cf6b772f823bc7929a45da1fa83569ee49b11d18d0ada7f5ee6fd6/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:0ed177ed9bded28f8deb6ab40c183cd1192aa0de40c12f38be4d59cd33cb5c65", size = 565606, upload-time = "2025-11-30T20:23:42.186Z" },
+  { url = "https://files.pythonhosted.org/packages/64/91/ac20ba2d69303f961ad8cf55bf7dbdb4763f627291ba3d0d7d67333cced9/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ad1fa8db769b76ea911cb4e10f049d80bf518c104f15b3edb2371cc65375c46f", size = 591126, upload-time = "2025-11-30T20:23:44.086Z" },
+  { url = "https://files.pythonhosted.org/packages/21/20/7ff5f3c8b00c8a95f75985128c26ba44503fb35b8e0259d812766ea966c7/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:46e83c697b1f1c72b50e5ee5adb4353eef7406fb3f2043d64c33f20ad1c2fc53", size = 553371, upload-time = "2025-11-30T20:23:46.004Z" },
+  { url = "https://files.pythonhosted.org/packages/72/c7/81dadd7b27c8ee391c132a6b192111ca58d866577ce2d9b0ca157552cce0/rpds_py-0.30.0-cp314-cp314-win32.whl", hash = "sha256:ee454b2a007d57363c2dfd5b6ca4a5d7e2c518938f8ed3b706e37e5d470801ed", size = 215298, upload-time = "2025-11-30T20:23:47.696Z" },
+  { url = "https://files.pythonhosted.org/packages/3e/d2/1aaac33287e8cfb07aab2e6b8ac1deca62f6f65411344f1433c55e6f3eb8/rpds_py-0.30.0-cp314-cp314-win_amd64.whl", hash = "sha256:95f0802447ac2d10bcc69f6dc28fe95fdf17940367b21d34e34c737870758950", size = 228604, upload-time = "2025-11-30T20:23:49.501Z" },
+  { url = "https://files.pythonhosted.org/packages/e8/95/ab005315818cc519ad074cb7784dae60d939163108bd2b394e60dc7b5461/rpds_py-0.30.0-cp314-cp314-win_arm64.whl", hash = "sha256:613aa4771c99f03346e54c3f038e4cc574ac09a3ddfb0e8878487335e96dead6", size = 222391, upload-time = "2025-11-30T20:23:50.96Z" },
+  { url = "https://files.pythonhosted.org/packages/9e/68/154fe0194d83b973cdedcdcc88947a2752411165930182ae41d983dcefa6/rpds_py-0.30.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:7e6ecfcb62edfd632e56983964e6884851786443739dbfe3582947e87274f7cb", size = 364868, upload-time = "2025-11-30T20:23:52.494Z" },
+  { url = "https://files.pythonhosted.org/packages/83/69/8bbc8b07ec854d92a8b75668c24d2abcb1719ebf890f5604c61c9369a16f/rpds_py-0.30.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a1d0bc22a7cdc173fedebb73ef81e07faef93692b8c1ad3733b67e31e1b6e1b8", size = 353747, upload-time = "2025-11-30T20:23:54.036Z" },
+  { url = "https://files.pythonhosted.org/packages/ab/00/ba2e50183dbd9abcce9497fa5149c62b4ff3e22d338a30d690f9af970561/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0d08f00679177226c4cb8c5265012eea897c8ca3b93f429e546600c971bcbae7", size = 383795, upload-time = "2025-11-30T20:23:55.556Z" },
+  { url = "https://files.pythonhosted.org/packages/05/6f/86f0272b84926bcb0e4c972262f54223e8ecc556b3224d281e6598fc9268/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5965af57d5848192c13534f90f9dd16464f3c37aaf166cc1da1cae1fd5a34898", size = 393330, upload-time = "2025-11-30T20:23:57.033Z" },
+  { url = "https://files.pythonhosted.org/packages/cb/e9/0e02bb2e6dc63d212641da45df2b0bf29699d01715913e0d0f017ee29438/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9a4e86e34e9ab6b667c27f3211ca48f73dba7cd3d90f8d5b11be56e5dbc3fb4e", size = 518194, upload-time = "2025-11-30T20:23:58.637Z" },
+  { url = "https://files.pythonhosted.org/packages/ee/ca/be7bca14cf21513bdf9c0606aba17d1f389ea2b6987035eb4f62bd923f25/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e5d3e6b26f2c785d65cc25ef1e5267ccbe1b069c5c21b8cc724efee290554419", size = 408340, upload-time = "2025-11-30T20:24:00.2Z" },
+  { url = "https://files.pythonhosted.org/packages/c2/c7/736e00ebf39ed81d75544c0da6ef7b0998f8201b369acf842f9a90dc8fce/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:626a7433c34566535b6e56a1b39a7b17ba961e97ce3b80ec62e6f1312c025551", size = 383765, upload-time = "2025-11-30T20:24:01.759Z" },
+  { url = "https://files.pythonhosted.org/packages/4a/3f/da50dfde9956aaf365c4adc9533b100008ed31aea635f2b8d7b627e25b49/rpds_py-0.30.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:acd7eb3f4471577b9b5a41baf02a978e8bdeb08b4b355273994f8b87032000a8", size = 396834, upload-time = "2025-11-30T20:24:03.687Z" },
+  { url = "https://files.pythonhosted.org/packages/4e/00/34bcc2565b6020eab2623349efbdec810676ad571995911f1abdae62a3a0/rpds_py-0.30.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fe5fa731a1fa8a0a56b0977413f8cacac1768dad38d16b3a296712709476fbd5", size = 415470, upload-time = "2025-11-30T20:24:05.232Z" },
+  { url = "https://files.pythonhosted.org/packages/8c/28/882e72b5b3e6f718d5453bd4d0d9cf8df36fddeb4ddbbab17869d5868616/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:74a3243a411126362712ee1524dfc90c650a503502f135d54d1b352bd01f2404", size = 565630, upload-time = "2025-11-30T20:24:06.878Z" },
+  { url = "https://files.pythonhosted.org/packages/3b/97/04a65539c17692de5b85c6e293520fd01317fd878ea1995f0367d4532fb1/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:3e8eeb0544f2eb0d2581774be4c3410356eba189529a6b3e36bbbf9696175856", size = 591148, upload-time = "2025-11-30T20:24:08.445Z" },
+  { url = "https://files.pythonhosted.org/packages/85/70/92482ccffb96f5441aab93e26c4d66489eb599efdcf96fad90c14bbfb976/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:dbd936cde57abfee19ab3213cf9c26be06d60750e60a8e4dd85d1ab12c8b1f40", size = 556030, upload-time = "2025-11-30T20:24:10.956Z" },
+  { url = "https://files.pythonhosted.org/packages/20/53/7c7e784abfa500a2b6b583b147ee4bb5a2b3747a9166bab52fec4b5b5e7d/rpds_py-0.30.0-cp314-cp314t-win32.whl", hash = "sha256:dc824125c72246d924f7f796b4f63c1e9dc810c7d9e2355864b3c3a73d59ade0", size = 211570, upload-time = "2025-11-30T20:24:12.735Z" },
+  { url = "https://files.pythonhosted.org/packages/d0/02/fa464cdfbe6b26e0600b62c528b72d8608f5cc49f96b8d6e38c95d60c676/rpds_py-0.30.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27f4b0e92de5bfbc6f86e43959e6edd1425c33b5e69aab0984a72047f2bcf1e3", size = 226532, upload-time = "2025-11-30T20:24:14.634Z" },
 ]
 
 [[package]]
@@ -2602,6 +2730,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
   { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "sse-starlette"
+version = "3.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+  { name = "anyio" },
+  { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f7/2b/58abc2d1fd397e7dde08e947e05c884d8ef2f78d5e2588c17a12d42d6994/sse_starlette-3.4.4.tar.gz", hash = "sha256:07e0fa0460138baf25cdd5fb28683472c3995dc1642225191b3832d62526bcb0", size = 31819, upload-time = "2026-05-12T17:37:17.019Z" }
+wheels = [
+  { url = "https://files.pythonhosted.org/packages/dc/67/805710444ea8cc75fbf70b920ed431a560c4bf9c57f7d5a3117213189399/sse_starlette-3.4.4-py3-none-any.whl", hash = "sha256:3f4dd50d8aed2771a091f3a83000323fc3844541c16b4fe585ae2420cc6df973", size = 16514, upload-time = "2026-05-12T17:37:15.601Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1114,7 +1114,7 @@ docs = [
 [[package]]
 name = "imbi-common"
 version = "2.6.1"
-source = { git = "https://github.com/AWeber-Imbi/imbi-common.git?branch=main#0a09872a453c6b3bcfa79e30b6e3dbd5e8385592" }
+source = { git = "https://github.com/AWeber-Imbi/imbi-common.git?branch=main#623c2ca4242c1238480ed250b744a182772713a4" }
 dependencies = [
   { name = "cryptography" },
   { name = "httpx" },


### PR DESCRIPTION
## Summary
Adds three endpoints to the existing `/mcp-servers` router so the Imbi Assistant admin UI can verify a server's connectivity and the assistant can report runtime health.

## Endpoints
- **POST /mcp-servers/{id}/test** — connect to a saved server, list its tools, measure latency, and **persist** `status` / `last_tested_at` / `last_tested_latency_ms` / `tools_discovered` / `last_error`.
- **POST /mcp-servers/test** — test an **unsaved** config (the create form); plaintext secrets in the body, nothing persisted.
- **POST /mcp-servers/{id}/status** — record a runtime health observation (`status` + `error`), intended for the assistant to call when a live tool call fails. *(Wiring the assistant to actually call this is follow-up work in imbi-assistant.)*

## Implementation
- New `imbi_api/mcp_test.py` opens a one-shot streamable-HTTP MCP session and lists tools, reusing the connect/auth pattern from `imbi-assistant/external_mcp.py` (decrypting secrets via imbi-common). It never raises — failures become an `unreachable` result. Latency ≥ 1000 ms → `degraded`.
- Adds the `mcp` dependency.
- `MCPServerResponse` gains the new health fields; `test`/`status` reuse the existing SET-based persistence.
- Adds endpoint + permission tests (test reuses `mcp_server:update`; config-test reuses `mcp_server:create`).

## Dependency / merge order
Requires the `MCPServer` health fields from **AWeber-Imbi/imbi-common#135**. The lockfile currently pins pre-merge imbi-common, so this branch's CI (`UV_FROZEN`) will be red until #135 merges and imbi-common is bumped here (`just update-imbi-common` / `uv lock --upgrade-package imbi-common`).

**Merge order: imbi-common#135 → this → imbi-ui#376.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)