### PR TITLE
Align ProjectResponse.relationships schema with the runtime shape

### DIFF
--- a/src/imbi_api/endpoints/projects.py
+++ b/src/imbi_api/endpoints/projects.py
@@ -125,14 +125,11 @@ class ProjectUpdate(pydantic.BaseModel):
     identifiers: dict[str, int | str] | None = None
 
 
-class ProjectRelationships(pydantic.BaseModel):
-    """Typed relationship links and counts for a project."""
-
-    team: models.RelationshipLink
-    environments: models.RelationshipLink
-    href: str
-    outbound_count: int = 0
-    inbound_count: int = 0
+# ProjectRelationships now lives in imbi_common.models so the OpenAPI
+# schema emitted from ``make_response_model(Project)`` matches the
+# runtime shape that this endpoint actually returns. Re-export under
+# the historical name for callers in this module.
+ProjectRelationships = models.ProjectRelationships
 
 
 class ReleaseInfo(pydantic.BaseModel):

--- a/uv.lock
+++ b/uv.lock
@@ -1114,7 +1114,7 @@ docs = [
 [[package]]
 name = "imbi-common"
 version = "2.6.1"
-source = { git = "https://github.com/AWeber-Imbi/imbi-common.git?branch=main#623c2ca4242c1238480ed250b744a182772713a4" }
+source = { git = "https://github.com/AWeber-Imbi/imbi-common.git?branch=main#8acb3501798444d5c83fb7568ccd80be1d6b2fbd" }
 dependencies = [
   { name = "cryptography" },
   { name = "httpx" },


### PR DESCRIPTION
## Why

fastmcp's output validation was rejecting every project PATCH/GET response with:

> `Output validation error: '/api/organizations/.../relationships' is not of type 'object'`

…even though imbi-api returned 200. The LLM then treated the call as a hard failure and looped.

Root cause: the published OpenAPI schema for `ProjectResponse.relationships` was `dict[str, RelationshipLink] | None` (injected unconditionally by `imbi_common.blueprints.make_response_model`), but this module's hand-rolled `ProjectResponse` actually returns a richer typed `ProjectRelationships` — with `href`, `outbound_count`, `inbound_count` at the top level — so validators iterating the dict against `RelationshipLink` tripped on those scalars.

## Change

Companion to [imbi-common#136](https://github.com/AWeber-Imbi/imbi-common/pull/136), which moves `ProjectRelationships` into imbi-common and teaches `make_response_model` to skip the dict override when the base already declares `relationships`. This PR:

- Drops the local `class ProjectRelationships` in `endpoints/projects.py` and re-exports `models.ProjectRelationships` for in-module callers.
- Bumps the imbi-common lock entry to pull in `8acb3501` so the emitted schema reflects the typed shape.

Result: `make_response_model(Project)` now emits `relationships: ProjectRelationships | None`, matching what the PATCH/GET endpoints actually return.

## Test plan

- `python -m pytest tests/endpoints/test_projects.py` — 59 passed
- `ruff check`, `mypy`, `basedpyright` — clean on `src/imbi_api/endpoints/projects.py`
- Locally verified `make_response_model(models.Project).model_fields['relationships'].annotation` is `ProjectRelationships | None`

🤖 Generated with [Claude Code](https://claude.com/claude-code)