### PR TITLE
Rename RepositoryRelocation -> LinkWriteback (imbi-common 2.8.0 contract)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
   "fastapi",
   "filetype",
   "httpx>=0.28.1,<1",
-  "imbi-common[databases,llm,sentry,server]>=2.7.0",
+  "imbi-common[databases,llm,sentry,server]>=2.8.0",
   "jinja2",
   "jsonpatch>=1.33",
   "mcp>=1.26.0",
@@ -235,3 +235,9 @@ exclude-newer-package = { "clickhouse-connect" = false, "imbi-common" = false, "
 [[tool.uv.index]]
 url = "https://pypi.org/simple"
 default = true
+
+# Pinned to the imbi-common feature branch while the new lifecycle
+# plugin contract (PR AWeber-Imbi/imbi-common#138) is unreleased.
+# Revert this block when imbi-common 2.8.0 ships to PyPI.
+[tool.uv.sources]
+imbi-common = { git = "https://github.com/AWeber-Imbi/imbi-common.git", branch = "feature/project-lifecycle-plugin-contract" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -236,8 +236,8 @@ exclude-newer-package = { "clickhouse-connect" = false, "imbi-common" = false, "
 url = "https://pypi.org/simple"
 default = true
 
-# Pinned to the imbi-common feature branch while the new lifecycle
-# plugin contract (PR AWeber-Imbi/imbi-common#138) is unreleased.
-# Revert this block when imbi-common 2.8.0 ships to PyPI.
+# Pinned to imbi-common main while 2.8.0 is unreleased — #138 has
+# merged but no PyPI release has been cut yet.  Remove this block when
+# imbi-common 2.8.0 ships to PyPI.
 [tool.uv.sources]
-imbi-common = { git = "https://github.com/AWeber-Imbi/imbi-common.git", branch = "feature/project-lifecycle-plugin-contract" }
+imbi-common = { git = "https://github.com/AWeber-Imbi/imbi-common.git", branch = "main" }

--- a/src/imbi_api/endpoints/_helpers.py
+++ b/src/imbi_api/endpoints/_helpers.py
@@ -246,37 +246,39 @@ async def update_project_link(
     return True
 
 
-async def heal_relocated_link(db: graph.Graph, ctx: PluginContext) -> None:
-    """Persist a repository rename a plugin reported on ``ctx``.
+async def persist_link_writeback(db: graph.Graph, ctx: PluginContext) -> None:
+    """Persist a project-link URL a plugin reported on ``ctx``.
 
-    A deployment / lifecycle plugin sets ``ctx.repository_relocation``
-    when the remote reports the repository has permanently moved (e.g. a
-    GitHub ``301`` after a rename). Rewrite the project's stored link so
-    later calls skip the redirect and the UI shows the current name.
-    Best-effort: a write failure is logged and swallowed so self-healing
-    never fails the user-facing request whose result we already have.
+    A deployment / lifecycle plugin sets ``ctx.link_writeback`` when the
+    canonical URL for one of the project's external links has changed --
+    e.g. after creating a new repo, after a rename that returned a
+    ``301``, or after a transfer to a new owner. Rewrite the project's
+    stored link so later calls hit the canonical URL and the UI shows
+    the current name. Best-effort: a write failure is logged and
+    swallowed so persistence never fails the user-facing request whose
+    result we already have.
     """
-    reloc = ctx.repository_relocation
-    if reloc is None:
+    writeback = ctx.link_writeback
+    if writeback is None:
         return
     try:
         changed = await update_project_link(
-            db, ctx.project_id, reloc.link_key, reloc.new_url
+            db, ctx.project_id, writeback.link_key, writeback.new_url
         )
     except Exception:  # noqa: BLE001
         LOGGER.warning(
-            'Failed to self-heal relocated repository link for project %s',
+            'Failed to persist link writeback for project %s',
             ctx.project_id,
             exc_info=True,
         )
         return
     if changed:
         LOGGER.info(
-            'Self-healed %s link for project %s after repo rename %s -> %s',
-            reloc.link_key,
+            'Persisted %s link for project %s (%s -> %s)',
+            writeback.link_key,
             ctx.project_id,
-            reloc.old_owner_repo,
-            reloc.new_owner_repo,
+            writeback.old_owner_repo,
+            writeback.new_owner_repo,
         )
 
 

--- a/src/imbi_api/endpoints/project_deployments.py
+++ b/src/imbi_api/endpoints/project_deployments.py
@@ -39,10 +39,10 @@ from imbi_common.plugins.errors import PluginCredentialsMissing
 
 from imbi_api.auth import permissions
 from imbi_api.endpoints._helpers import (
-    heal_relocated_link,
     lookup_project_links,
     lookup_project_slugs,
     lookup_project_type_slugs,
+    persist_link_writeback,
 )
 from imbi_api.endpoints.releases import (
     AppendOutcome,
@@ -655,7 +655,7 @@ async def resync_for_project(
                 'list_recent_deployments.'
             ),
         ) from exc
-    await heal_relocated_link(db, ctx)
+    await persist_link_writeback(db, ctx)
     summary.observed = len(observations)
     # Track identities we've already touched so ``releases_created`` /
     # ``releases_updated`` are counted once per distinct
@@ -828,7 +828,7 @@ async def list_refs(
     refs = await call_with_timeout(
         handler.list_refs(ctx, credentials, kind=kind, query=q)
     )
-    await heal_relocated_link(db, ctx)
+    await persist_link_writeback(db, ctx)
     return refs
 
 
@@ -855,7 +855,7 @@ async def list_commits(
     commits = await call_with_timeout(
         handler.list_commits(ctx, credentials, ref=ref, limit=limit)
     )
-    await heal_relocated_link(db, ctx)
+    await persist_link_writeback(db, ctx)
     return commits
 
 
@@ -881,7 +881,7 @@ async def resolve_commit(
     commit = await call_with_timeout(
         handler.resolve_committish(ctx, credentials, committish)
     )
-    await heal_relocated_link(db, ctx)
+    await persist_link_writeback(db, ctx)
     return commit
 
 
@@ -908,7 +908,7 @@ async def compare_refs(
     result = await call_with_timeout(
         handler.compare(ctx, credentials, base=base, head=head)
     )
-    await heal_relocated_link(db, ctx)
+    await persist_link_writeback(db, ctx)
     return result
 
 
@@ -1105,7 +1105,7 @@ async def _handle_deploy(
     run = await call_with_identity_retry(
         db, ctx, resolved, auth, fn=_trigger, attached=True
     )
-    await heal_relocated_link(db, ctx)
+    await persist_link_writeback(db, ctx)
     LOGGER.info(
         'Deployment triggered: project=%s env=%s ref=%s plugin=%s '
         'action=%s actor=%s run_id=%s',
@@ -1421,7 +1421,7 @@ async def _handle_promote(
             warning='; '.join(warnings) if warnings else None,
         )
 
-    await heal_relocated_link(db, ctx)
+    await persist_link_writeback(db, ctx)
 
     # 4. Upsert the Release node so future deploys of the same tag
     #    can attach a DeploymentEvent.

--- a/src/imbi_api/plugins/lifecycle_dispatch.py
+++ b/src/imbi_api/plugins/lifecycle_dispatch.py
@@ -24,8 +24,8 @@ from imbi_common.clickhouse import client as ch_client
 from imbi_common.plugins.base import (
     LifecyclePlugin,
     LifecycleResult,
+    LinkWriteback,
     PluginContext,
-    RepositoryRelocation,
 )
 from imbi_common.plugins.errors import PluginCredentialsMissing
 
@@ -130,17 +130,17 @@ async def _invoke_one(
 
     # call_with_identity_retry re-attaches identity onto a fresh context
     # before invoking ``_call`` (attached defaults to False here), so the
-    # plugin mutates that inner context, not ``ctx``. Capture any
-    # relocation it reports through the closure so we can self-heal the
+    # plugin mutates that inner context, not ``ctx``. Capture any link
+    # writeback it reports through the closure so we can persist the
     # link after the call regardless of which context instance was used.
-    captured_relocation: list[RepositoryRelocation] = []
+    captured_writeback: list[LinkWriteback] = []
 
     async def _call(c: PluginContext) -> LifecycleResult:
         credentials = await _resolve_credentials(db, c, resolved)
         method = getattr(handler, method_name)
         res: LifecycleResult = await call_with_timeout(method(c, credentials))
-        if c.repository_relocation is not None:
-            captured_relocation.append(c.repository_relocation)
+        if c.link_writeback is not None:
+            captured_writeback.append(c.link_writeback)
         return res
 
     try:
@@ -193,13 +193,13 @@ async def _invoke_one(
             message=f'{type(exc).__name__}: {exc}',
         )
 
-    if captured_relocation:
+    if captured_writeback:
         # Lazy import to avoid the endpoints/_helpers <-> this-module
         # cycle described above.
-        from imbi_api.endpoints._helpers import heal_relocated_link
+        from imbi_api.endpoints._helpers import persist_link_writeback
 
-        ctx.repository_relocation = captured_relocation[-1]
-        await heal_relocated_link(db, ctx)
+        ctx.link_writeback = captured_writeback[-1]
+        await persist_link_writeback(db, ctx)
 
     return LifecycleInvocation(
         plugin_id=resolved.plugin_id,

--- a/tests/endpoints/test_project_deployments.py
+++ b/tests/endpoints/test_project_deployments.py
@@ -14,12 +14,12 @@ from imbi_common.plugins.base import (
     CompareResult,
     DeploymentPlugin,
     DeploymentRun,
+    LinkWriteback,
     PluginManifest,
     Ref,
     RefInfo,
     ReleaseInfo,
     RemoteDeployment,
-    RepositoryRelocation,
 )
 from imbi_common.plugins.registry import RegistryEntry
 
@@ -29,7 +29,7 @@ from imbi_api.endpoints import _helpers
 from imbi_api.endpoints.project_deployments import (
     DraftReleaseNotes,
     _EnvFlags,
-    heal_relocated_link,
+    persist_link_writeback,
 )
 from imbi_api.llm.dependencies import _get_anthropic_client
 from imbi_api.plugins.resolution import ResolvedPlugin
@@ -127,12 +127,12 @@ class _RelocatingDeploymentPlugin(_FakeDeploymentPlugin):
     """Deployment plugin that reports a repo rename on every call.
 
     Mirrors how the real GitHub plugin stashes a
-    ``RepositoryRelocation`` on ``ctx`` after following a 301.
+    ``LinkWriteback`` on ``ctx`` after following a 301.
     """
 
     @staticmethod
     def _report(ctx: typing.Any) -> None:
-        ctx.repository_relocation = RepositoryRelocation(
+        ctx.link_writeback = LinkWriteback(
             link_key='github-repository',
             new_url='https://github.com/octo/renamed',
             old_owner_repo='octo/demo',
@@ -1519,9 +1519,9 @@ def _relocating_resolved() -> ResolvedPlugin:
     )
 
 
-class RepositoryRelocationHealingTestCase(ProjectDeploymentsTestCase):
-    """The endpoint self-heals the stored link when a plugin reports a
-    repository rename on ``ctx.repository_relocation``.
+class LinkWritebackPersistTestCase(ProjectDeploymentsTestCase):
+    """The endpoint persists the stored link when a plugin reports a
+    canonical-URL change on ``ctx.link_writeback``.
     """
 
     def setUp(self) -> None:
@@ -1532,7 +1532,7 @@ class RepositoryRelocationHealingTestCase(ProjectDeploymentsTestCase):
             mock.patch(_UPDATE_LINK, return_value=True)
         )
 
-    def test_list_commits_heals_relocated_link(self) -> None:
+    def test_list_commits_persists_link_writeback(self) -> None:
         with testclient.TestClient(self.test_app) as client:
             response = client.get(
                 '/organizations/myorg/projects/proj1/deployments/'
@@ -1545,7 +1545,7 @@ class RepositoryRelocationHealingTestCase(ProjectDeploymentsTestCase):
         self.assertEqual(args[2], 'github-repository')
         self.assertEqual(args[3], 'https://github.com/octo/renamed')
 
-    def test_trigger_deploy_heals_relocated_link(self) -> None:
+    def test_trigger_deploy_persists_link_writeback(self) -> None:
         with testclient.TestClient(self.test_app) as client:
             response = client.post(
                 '/organizations/myorg/projects/proj1/deployments',
@@ -1564,38 +1564,38 @@ class RepositoryRelocationHealingTestCase(ProjectDeploymentsTestCase):
         )
 
 
-class HealRelocatedLinkTestCase(unittest.IsolatedAsyncioTestCase):
-    """Unit coverage for ``heal_relocated_link``."""
+class PersistLinkWritebackTestCase(unittest.IsolatedAsyncioTestCase):
+    """Unit coverage for ``persist_link_writeback``."""
 
-    def _ctx(self, reloc: RepositoryRelocation | None) -> mock.MagicMock:
+    def _ctx(self, wb: LinkWriteback | None) -> mock.MagicMock:
         ctx = mock.MagicMock()
         ctx.project_id = 'proj1'
-        ctx.repository_relocation = reloc
+        ctx.link_writeback = wb
         return ctx
 
-    async def test_noop_when_no_relocation(self) -> None:
+    async def test_noop_when_no_writeback(self) -> None:
         db = mock.AsyncMock()
         with mock.patch(_UPDATE_LINK) as update_link:
-            await heal_relocated_link(db, self._ctx(None))
+            await persist_link_writeback(db, self._ctx(None))
         update_link.assert_not_called()
 
-    async def test_writes_when_relocation_present(self) -> None:
+    async def test_writes_when_writeback_present(self) -> None:
         db = mock.AsyncMock()
-        reloc = RepositoryRelocation(
+        wb = LinkWriteback(
             link_key='github-repository',
             new_url='https://github.com/octo/renamed',
             old_owner_repo='octo/demo',
             new_owner_repo='octo/renamed',
         )
         with mock.patch(_UPDATE_LINK, return_value=True) as update_link:
-            await heal_relocated_link(db, self._ctx(reloc))
+            await persist_link_writeback(db, self._ctx(wb))
         update_link.assert_awaited_once_with(
             db, 'proj1', 'github-repository', 'https://github.com/octo/renamed'
         )
 
     async def test_swallows_write_failure(self) -> None:
         db = mock.AsyncMock()
-        reloc = RepositoryRelocation(
+        wb = LinkWriteback(
             link_key='github-repository',
             new_url='https://github.com/octo/renamed',
         )
@@ -1603,8 +1603,8 @@ class HealRelocatedLinkTestCase(unittest.IsolatedAsyncioTestCase):
             _UPDATE_LINK,
             side_effect=RuntimeError('graph down'),
         ):
-            # Must not raise — self-heal is best-effort.
-            await heal_relocated_link(db, self._ctx(reloc))
+            # Must not raise — persistence is best-effort.
+            await persist_link_writeback(db, self._ctx(wb))
 
 
 class UpdateProjectLinkTestCase(unittest.IsolatedAsyncioTestCase):

--- a/tests/test_lifecycle_dispatch.py
+++ b/tests/test_lifecycle_dispatch.py
@@ -14,8 +14,8 @@ from imbi_common.plugins.base import (
     ConfigurationPlugin,
     LifecyclePlugin,
     LifecycleResult,
+    LinkWriteback,
     PluginManifest,
-    RepositoryRelocation,
 )
 from imbi_common.plugins.registry import RegistryEntry
 
@@ -141,16 +141,16 @@ class DispatchLifecycleTestCase(unittest.TestCase):
         )
         insert.assert_awaited_once()
 
-    def test_archive_heals_relocated_link(self) -> None:
-        # A lifecycle plugin that reports a repo rename on ctx triggers a
-        # self-heal of the stored link via update_project_link.
+    def test_archive_persists_link_writeback(self) -> None:
+        # A lifecycle plugin that reports a link writeback on ctx
+        # triggers a persist of the stored link via update_project_link.
         class _Reloc(LifecyclePlugin):
             manifest = PluginManifest(
                 slug='gh', name='gh', plugin_type='lifecycle'
             )
 
             async def on_project_archived(self, ctx, credentials):  # type: ignore[override]
-                ctx.repository_relocation = RepositoryRelocation(
+                ctx.link_writeback = LinkWriteback(
                     link_key='github-repository',
                     new_url='https://github.com/octo/renamed',
                     old_owner_repo='octo/demo',
@@ -174,7 +174,8 @@ class DispatchLifecycleTestCase(unittest.TestCase):
             results, _ = self._run([_resolved(entry)])
         self.assertEqual(results[0].status, 'ok')
         update_link.assert_awaited_once()
-        # heal_relocated_link(db, project_id, link_key, new_url)
+        # persist_link_writeback(db, ctx) -> update_project_link(
+        #     db, project_id, link_key, new_url)
         args = update_link.await_args.args
         self.assertEqual(args[2], 'github-repository')
         self.assertEqual(args[3], 'https://github.com/octo/renamed')

--- a/uv.lock
+++ b/uv.lock
@@ -1095,7 +1095,7 @@ requires-dist = [
   { name = "fastapi" },
   { name = "filetype" },
   { name = "httpx", specifier = ">=0.28.1,<1" },
-  { name = "imbi-common", extras = ["databases", "llm", "sentry", "server"], git = "https://github.com/AWeber-Imbi/imbi-common.git?branch=feature%2Fproject-lifecycle-plugin-contract" },
+  { name = "imbi-common", extras = ["databases", "llm", "sentry", "server"], git = "https://github.com/AWeber-Imbi/imbi-common.git?branch=main" },
   { name = "imbi-plugin-aws", marker = "extra == 'plugins'", specifier = ">=1.0.0" },
   { name = "imbi-plugin-github", marker = "extra == 'plugins'", specifier = ">=1.0.0" },
   { name = "imbi-plugin-logzio", marker = "extra == 'plugins'", specifier = ">=1.0.0" },
@@ -1149,7 +1149,7 @@ docs = [
 [[package]]
 name = "imbi-common"
 version = "2.8.0"
-source = { git = "https://github.com/AWeber-Imbi/imbi-common.git?branch=feature%2Fproject-lifecycle-plugin-contract#ca572deaeb674e09c412b41535c1ad98ca5ee439" }
+source = { git = "https://github.com/AWeber-Imbi/imbi-common.git?branch=main#d21cc8818f238cfe02625ac6f292091c526ed787" }
 dependencies = [
   { name = "cryptography" },
   { name = "httpx" },

--- a/uv.lock
+++ b/uv.lock
@@ -7,7 +7,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-05-21T13:28:51.887969Z"
+exclude-newer = "0001-01-01T00:00:00Z"  # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
@@ -1095,7 +1095,7 @@ requires-dist = [
   { name = "fastapi" },
   { name = "filetype" },
   { name = "httpx", specifier = ">=0.28.1,<1" },
-  { name = "imbi-common", extras = ["databases", "llm", "sentry", "server"], specifier = ">=2.7.0" },
+  { name = "imbi-common", extras = ["databases", "llm", "sentry", "server"], git = "https://github.com/AWeber-Imbi/imbi-common.git?branch=feature%2Fproject-lifecycle-plugin-contract" },
   { name = "imbi-plugin-aws", marker = "extra == 'plugins'", specifier = ">=1.0.0" },
   { name = "imbi-plugin-github", marker = "extra == 'plugins'", specifier = ">=1.0.0" },
   { name = "imbi-plugin-logzio", marker = "extra == 'plugins'", specifier = ">=1.0.0" },
@@ -1148,8 +1148,8 @@ docs = [
 
 [[package]]
 name = "imbi-common"
-version = "2.7.0"
-source = { registry = "https://pypi.org/simple" }
+version = "2.8.0"
+source = { git = "https://github.com/AWeber-Imbi/imbi-common.git?branch=feature%2Fproject-lifecycle-plugin-contract#ca572deaeb674e09c412b41535c1ad98ca5ee439" }
 dependencies = [
   { name = "cryptography" },
   { name = "httpx" },
@@ -1163,10 +1163,6 @@ dependencies = [
   { name = "pyjwt" },
   { name = "python-slugify" },
   { name = "typer" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/4b/b0/5f28ac0670d239c885822e5a7c9a94b2bb9c1ea205dccba82ac2ae36f329/imbi_common-2.7.0.tar.gz", hash = "sha256:723d2a7ecffef3f0cf86828173586a9721931b95068718c7b0c7cff768c7f764", size = 303583, upload-time = "2026-05-28T12:56:17.525Z" }
-wheels = [
-  { url = "https://files.pythonhosted.org/packages/ce/33/e801c0e9d7ecfef434ca1f178291584f4dce1e55f34590c9425c2086c4f6/imbi_common-2.7.0-py3-none-any.whl", hash = "sha256:c475153119376753d5f09b18de686eb872464625fdaf073aa893fec38b3956ab", size = 98903, upload-time = "2026-05-28T12:56:16.147Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

Mechanical rename to track the imbi-common 2.8.0 contract change in AWeber-Imbi/imbi-common#138. Follow-ups (dispatcher widening for create / update / delete / relocate events, endpoint wiring, and the lifecycle-preview endpoint for the project-type → repo-relocate scenario) are deliberately split out — this PR is the contract follow-along only.

## Problem

imbi-common renamed the link-writeback side-channel from \`RepositoryRelocation\` (rename-301 specific) to \`LinkWriteback\` (covers create / rename / transfer / discovery). Every consumer that read \`ctx.repository_relocation\` or imported \`RepositoryRelocation\` breaks at \`uv sync\` until renamed.

## Solution

- \`pyproject.toml\` — bump pin to \`imbi-common>=2.8.0\`; temporary \`[tool.uv.sources]\` block points at the imbi-common feature branch so CI passes before 2.8.0 ships.
- \`plugins/lifecycle_dispatch.py\` — capture and persist \`ctx.link_writeback\` instead of \`ctx.repository_relocation\`; lazy-import \`persist_link_writeback\` instead of \`heal_relocated_link\`. No behavior change.
- \`endpoints/_helpers.py\` — rename \`heal_relocated_link\` → \`persist_link_writeback\` and broaden the docstring from rename-301 to the create / rename / transfer / discovery surface. The function body is unchanged (still calls \`update_project_link\`).
- \`endpoints/project_deployments.py\` — pick up the new name at the import + seven call sites in the deployment dispatch path.
- Tests renamed and reworded along the same lines.

## Test plan

- [x] \`uv run python -m pytest tests/test_lifecycle_dispatch.py tests/endpoints/test_project_deployments.py\` — 141 passed
- [x] \`just lint\` (ruff + ruff format + tombi-format + mypy) clean
- [x] No remaining references to \`RepositoryRelocation\` / \`repository_relocation\` / \`heal_relocated_link\` in src or tests
- [ ] CI passes against the imbi-common feature branch (PR AWeber-Imbi/imbi-common#138)
- [ ] Follow-up commit: revert \`[tool.uv.sources]\` block once imbi-common 2.8.0 ships to PyPI
- [ ] Coordinated landing: imbi-plugin-github needs the same rename (separate PR) before this can merge cleanly

## Blocked on

- AWeber-Imbi/imbi-common#138 merging + 2.8.0 release
- AWeber-Imbi/imbi-plugin-github sibling-rename PR (TBD — \`lifecycle.py\` and \`deployment.py\` still set \`ctx.repository_relocation\`)