### PR TITLE
Add GET /users/me returning caller profile and permissions

### DIFF
--- a/src/imbi_api/domain/models.py
+++ b/src/imbi_api/domain/models.py
@@ -437,6 +437,18 @@ class UserResponse(pydantic.BaseModel):
     organizations: list[OrgMembership] = []
 
 
+class CurrentUserResponse(UserResponse):
+    """Response model for the authenticated user's own profile.
+
+    Extends ``UserResponse`` with the caller's effective permission set
+    so the UI can gate features in a single request. Only exposed via
+    ``GET /users/me`` — the per-email endpoint deliberately omits
+    permissions to avoid disclosing one user's grants to another.
+    """
+
+    permissions: list[str] = []
+
+
 class PasswordChangeRequest(pydantic.BaseModel):
     """Request model for changing user passwords."""
 

--- a/src/imbi_api/endpoints/users.py
+++ b/src/imbi_api/endpoints/users.py
@@ -421,6 +421,45 @@ async def get_user_by_identity(
     )
 
 
+@users_router.get('/me', response_model=models.CurrentUserResponse)
+async def get_current_user_profile(
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(permissions.get_current_user),
+    ],
+) -> models.CurrentUserResponse:
+    """Return the authenticated user's own profile and permissions.
+
+    Unlike ``GET /users/{email}``, this includes the caller's effective
+    permission set so the UI can gate features without a second request.
+    Requires a human user; service-account tokens receive HTTP 403.
+
+    Returns:
+        models.CurrentUserResponse: The caller's profile with loaded
+            organization memberships and effective permissions.
+
+    """
+    user = auth.require_user
+
+    memberships = await _load_user_memberships(db, user.email)
+    organizations = [models.OrgMembership(**m) for m in memberships]
+
+    return models.CurrentUserResponse(
+        email=user.email,
+        display_name=user.display_name,
+        is_active=user.is_active,
+        is_admin=user.is_admin,
+        is_service_account=user.is_service_account,
+        created_at=user.created_at,
+        last_login=user.last_login,
+        avatar_url=user.avatar_url,
+        email_notifications=user.email_notifications,
+        organizations=organizations,
+        permissions=sorted(auth.permissions),
+    )
+
+
 @users_router.get('/{email}', response_model=models.UserResponse)
 async def get_user(
     email: str,

--- a/src/imbi_api/models.py
+++ b/src/imbi_api/models.py
@@ -56,6 +56,7 @@ ClientCredential = _domain.ClientCredential
 ClientCredentialCreate = _domain.ClientCredentialCreate
 ClientCredentialCreateResponse = _domain.ClientCredentialCreateResponse
 ClientCredentialResponse = _domain.ClientCredentialResponse
+CurrentUserResponse = _domain.CurrentUserResponse
 EmptyRelationship = _domain.EmptyRelationship
 MembershipProperties = _domain.MembershipProperties
 OAuth2TokenResponse = _domain.OAuth2TokenResponse

--- a/tests/endpoints/test_users.py
+++ b/tests/endpoints/test_users.py
@@ -317,6 +317,81 @@ class UserEndpointsTestCase(unittest.TestCase):
             'developer',
         )
 
+    def test_get_current_user_profile_success(self) -> None:
+        """GET /users/me returns the caller's profile and permissions."""
+        from imbi_api.auth import permissions
+
+        member_user = models.User(
+            email='member@example.com',
+            display_name='Member User',
+            is_active=True,
+            is_admin=False,
+            is_service_account=False,
+            created_at=datetime.datetime.now(datetime.UTC),
+        )
+
+        async def mock_get_current_user():
+            return permissions.AuthContext(
+                user=member_user,
+                session_id='test-session',
+                auth_method='jwt',
+                permissions={'scoring_policy:rescore', 'project:read'},
+            )
+
+        self.test_app.dependency_overrides[permissions.get_current_user] = (
+            mock_get_current_user
+        )
+        self.mock_db.execute.return_value = [
+            {
+                'org_name': 'Default',
+                'org_slug': 'default',
+                'role': 'developer',
+            },
+        ]
+
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            response = self.client.get('/users/me')
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data['email'], 'member@example.com')
+        self.assertFalse(data['is_admin'])
+        # Permissions are carried through and returned sorted.
+        self.assertEqual(
+            data['permissions'],
+            ['project:read', 'scoring_policy:rescore'],
+        )
+        self.assertEqual(len(data['organizations']), 1)
+
+    def test_get_current_user_profile_rejects_service_account(self) -> None:
+        """GET /users/me requires a human user, not a service account."""
+        from imbi_api.auth import permissions
+
+        service_account = models.ServiceAccount(
+            slug='ci-bot',
+            display_name='CI Bot',
+            is_active=True,
+        )
+
+        async def mock_get_current_user():
+            return permissions.AuthContext(
+                service_account=service_account,
+                session_id='test-session',
+                auth_method='client_credentials',
+                permissions={'project:read'},
+            )
+
+        self.test_app.dependency_overrides[permissions.get_current_user] = (
+            mock_get_current_user
+        )
+
+        response = self.client.get('/users/me')
+
+        self.assertEqual(response.status_code, 403)
+
     def test_get_user_not_found(self) -> None:
         """Test retrieving non-existent user."""
         self.mock_db.match.return_value = []


### PR DESCRIPTION
## Summary

The UI gates features — e.g. **Recompute Score** and **Sync Deployments** on the project settings tab — on the current user's permission set (`user.permissions`). But `GET /users/{email}` never returned a `permissions` field, so non-admin users always fell back to an empty list and the controls were hidden. Permissions were already computed server-side in `AuthContext`; they just weren't exposed to the client.

## Problem

`useAuth` in imbi-ui fetches the current user via `GET /users/{username}`, and `UserResponse` has no `permissions` field. Result: only `is_admin` users ever saw permission-gated UI; everyone else silently failed every `permissions.includes(...)` check.

## Solution

- Add `CurrentUserResponse` extending `UserResponse` with `permissions: list[str]`.
- Add `GET /users/me` (registered **before** `/{email}` so the path param doesn't capture `me`) returning the caller's own profile, organizations, and effective permissions (`sorted(auth.permissions)`).
- Leave `GET /users/{email}` unchanged so one user's grants aren't disclosed to another; service-account tokens receive HTTP 403 via `require_user`.
- Add tests covering permission pass-through and the service-account rejection.

Follow-up (separate imbi-ui PR): repoint `useAuth` from `GET /users/{username}` to `GET /users/me`.