### PR TITLE
Accept access token via cookie for upload-serving GETs

### DIFF
--- a/src/imbi_api/auth/permissions.py
+++ b/src/imbi_api/auth/permissions.py
@@ -24,6 +24,14 @@ LOGGER = logging.getLogger(__name__)
 # OAuth2 scheme for extracting Bearer tokens from Authorization header
 oauth2_scheme = security.HTTPBearer(auto_error=False)
 
+# Name of the cookie that mirrors the access token. The SPA authenticates
+# with a Bearer header on fetch/XHR; this cookie exists solely so browser
+# subresource requests (``<img src>`` to the upload-serving endpoints),
+# which cannot set an Authorization header, still carry credentials. It is
+# set by the auth endpoints and honored only by the cookie-fallback
+# dependency below.
+ACCESS_COOKIE_NAME = 'imbi_access_token'
+
 
 class IdentityInfo(pydantic.BaseModel):
     """A single third-party identity connection for an authenticated user."""
@@ -634,19 +642,62 @@ async def get_current_user(
             detail='Missing authentication credentials',
             headers={'WWW-Authenticate': 'Bearer'},
         )
+    return await _authenticate_token(
+        db, credentials.credentials, settings.get_auth_settings()
+    )
 
-    auth_settings = settings.get_auth_settings()
-    token = credentials.credentials
 
-    # Detect API key format (ik_<id>_<secret>)
+async def _authenticate_token(
+    db: graph.Graph,
+    token: str,
+    auth_settings: settings.Auth,
+) -> AuthContext:
+    """Resolve an AuthContext from a raw bearer token.
+
+    Detects the API key format (``ik_<id>_<secret>``) and otherwise
+    treats the token as a JWT.
+    """
     if token.startswith('ik_'):
         return await authenticate_api_key(db, token, auth_settings)
-    else:
-        return await authenticate_jwt(db, token, auth_settings)
+    return await authenticate_jwt(db, token, auth_settings)
+
+
+async def get_current_user_cookie_fallback(
+    db: graph.Pool,
+    request: fastapi.Request,
+    credentials: security.HTTPAuthorizationCredentials
+    | None = fastapi.Depends(oauth2_scheme),  # noqa: B008
+) -> AuthContext:
+    """Like ``get_current_user`` but also accepts the access cookie.
+
+    Browser subresource requests (e.g. ``<img src>``) cannot set an
+    ``Authorization`` header, so for the upload-serving GET endpoints the
+    access token is also read from the :data:`ACCESS_COOKIE_NAME` cookie
+    when the header is absent. The Bearer header still takes precedence.
+
+    Raises:
+        fastapi.HTTPException: If neither a header nor cookie token is
+            present.
+
+    """
+    token = (
+        credentials.credentials
+        if credentials
+        else request.cookies.get(ACCESS_COOKIE_NAME)
+    )
+    if not token:
+        raise fastapi.HTTPException(
+            status_code=401,
+            detail='Missing authentication credentials',
+            headers={'WWW-Authenticate': 'Bearer'},
+        )
+    return await _authenticate_token(db, token, settings.get_auth_settings())
 
 
 def require_permission(
     permission: str,
+    *,
+    allow_cookie: bool = False,
 ) -> typing.Callable[[AuthContext], collections.abc.Awaitable[AuthContext]]:
     """
     Create a FastAPI dependency that enforces a specific permission.
@@ -659,6 +710,11 @@ def require_permission(
     Parameters:
         permission (str): Permission name to require (e.g.,
             "blueprint:read").
+        allow_cookie (bool): When True, the access token may also be
+            supplied via the :data:`ACCESS_COOKIE_NAME` cookie instead of
+            the Authorization header. Intended only for endpoints loaded
+            as browser subresources (``<img src>``), which cannot send a
+            Bearer header.
 
     Returns:
         Callable[[AuthContext], Awaitable[AuthContext]]: A dependency
@@ -669,9 +725,12 @@ def require_permission(
         fastapi.HTTPException: Raised with status code 403 if the
             current user lacks the required permission.
     """
+    resolver = (
+        get_current_user_cookie_fallback if allow_cookie else get_current_user
+    )
 
     async def check_permission(
-        auth: typing.Annotated[AuthContext, fastapi.Depends(get_current_user)],
+        auth: typing.Annotated[AuthContext, fastapi.Depends(resolver)],
     ) -> AuthContext:
         """Enforce that the principal has the required permission.
 

--- a/src/imbi_api/endpoints/auth.py
+++ b/src/imbi_api/endpoints/auth.py
@@ -127,6 +127,47 @@ def _clear_refresh_cookie(response: fastapi.Response) -> None:
     response.delete_cookie(_REFRESH_COOKIE, path=_refresh_cookie_path())
 
 
+def _access_cookie_path() -> str:
+    """Browser-visible path the access cookie is scoped to.
+
+    Unlike the refresh cookie (scoped to ``/auth``), the access cookie must
+    reach the upload-serving GET endpoints (``{prefix}/uploads/...``) so the
+    browser includes it on ``<img>`` requests, which cannot carry an
+    ``Authorization`` header. Scope it to the whole API prefix (``/`` in the
+    dev-loopback case where the prefix is empty).
+    """
+    return settings.get_server_config().api_prefix or '/'
+
+
+def _set_access_cookie(response: fastapi.Response, access_token: str) -> None:
+    """Mirror the access token into a short-lived cookie.
+
+    The SPA still sends the access token as a Bearer header on fetch/XHR;
+    this cookie exists only so browser subresource requests (``<img src>``
+    to the upload-serving endpoints) carry credentials. Its lifetime
+    matches the access-token TTL and it is refreshed on every token
+    rotation. ``Secure`` outside development; ``SameSite=Strict`` is safe
+    because the UI and API share one origin behind the ingress.
+    """
+    auth_settings = settings.get_auth_settings()
+    response.set_cookie(
+        permissions.ACCESS_COOKIE_NAME,
+        access_token,
+        max_age=auth_settings.access_token_expire_seconds,
+        path=_access_cookie_path(),
+        httponly=True,
+        secure=settings.get_server_config().environment != 'development',
+        samesite='strict',
+    )
+
+
+def _clear_access_cookie(response: fastapi.Response) -> None:
+    """Remove the access-token cookie (logout)."""
+    response.delete_cookie(
+        permissions.ACCESS_COOKIE_NAME, path=_access_cookie_path()
+    )
+
+
 auth_router = fastapi.APIRouter(prefix='/auth', tags=['Authentication'])
 
 
@@ -500,6 +541,7 @@ async def login(
     LOGGER.info('User %s logged in successfully', _redact_email(user.email))
 
     _set_refresh_cookie(response, refresh_token)
+    _set_access_cookie(response, access_token)
     return auth_models.TokenResponse(
         access_token=access_token,
         refresh_token=refresh_token,
@@ -729,6 +771,7 @@ async def refresh_token(
     )
 
     _set_refresh_cookie(response, new_refresh_token)
+    _set_access_cookie(response, access_token)
     return auth_models.TokenResponse(
         access_token=access_token,
         refresh_token=new_refresh_token,  # Phase 5: Return NEW
@@ -759,8 +802,9 @@ async def logout(
     """
     now_str = datetime.datetime.now(datetime.UTC).isoformat()
 
-    # Clear the browser refresh cookie (C2) regardless of revoke scope.
+    # Clear the browser refresh + access cookies regardless of revoke scope.
     _clear_refresh_cookie(response)
+    _clear_access_cookie(response)
 
     # Revoke current access token
     query: typing.LiteralString = """
@@ -1165,6 +1209,7 @@ async def oauth_callback(
         )
         redirect = fastapi.responses.RedirectResponse(url=redirect_url)
         _set_refresh_cookie(redirect, rt)
+        _set_access_cookie(redirect, at)
         return redirect
 
     except (
@@ -1297,6 +1342,7 @@ async def _identity_plugin_login_callback(
     )
     redirect = fastapi.responses.RedirectResponse(url=redirect_url)
     _set_refresh_cookie(redirect, rt)
+    _set_access_cookie(redirect, at)
     return redirect
 
 

--- a/src/imbi_api/endpoints/uploads.py
+++ b/src/imbi_api/endpoints/uploads.py
@@ -196,7 +196,7 @@ async def list_uploads(
 
     uploads = await db.match(
         models.Upload,
-        parameters if parameters else None,
+        parameters or None,
         order_by='created_at',
     )
     return [_upload_response(u) for u in uploads]
@@ -209,7 +209,9 @@ async def get_upload(
     db: graph.Pool,
     _auth: typing.Annotated[
         permissions.AuthContext,
-        fastapi.Depends(permissions.require_permission('upload:read')),
+        fastapi.Depends(
+            permissions.require_permission('upload:read', allow_cookie=True)
+        ),
     ],
 ) -> fastapi.responses.Response:
     """Serve the uploaded file.
@@ -290,7 +292,9 @@ async def get_upload_thumbnail(
     db: graph.Pool,
     _auth: typing.Annotated[
         permissions.AuthContext,
-        fastapi.Depends(permissions.require_permission('upload:read')),
+        fastapi.Depends(
+            permissions.require_permission('upload:read', allow_cookie=True)
+        ),
     ],
 ) -> fastapi.responses.Response:
     """Serve the upload thumbnail.

--- a/tests/auth/test_api_key_auth.py
+++ b/tests/auth/test_api_key_auth.py
@@ -505,6 +505,72 @@ class GetCurrentUserTestCase(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(auth_context.auth_method, 'api_key')
 
 
+class GetCurrentUserCookieFallbackTestCase(unittest.IsolatedAsyncioTestCase):
+    """Test ``get_current_user_cookie_fallback`` token resolution."""
+
+    def setUp(self) -> None:
+        """Set up test fixtures."""
+        self.auth_settings = settings.Auth(
+            jwt_secret='test-secret-key-min-32-chars-long',
+        )
+        self.ctx = permissions.AuthContext(auth_method='jwt')
+
+    def _request(self, cookies: dict[str, str]) -> fastapi.Request:
+        """Build a minimal Request carrying the given cookies."""
+        return mock.Mock(spec=fastapi.Request, cookies=cookies)
+
+    async def test_bearer_header_takes_precedence(self) -> None:
+        """A present Authorization header is used over any cookie."""
+        credentials = security.HTTPAuthorizationCredentials(
+            scheme='Bearer', credentials='header-token'
+        )
+        request = self._request({permissions.ACCESS_COOKIE_NAME: 'cookie'})
+        with (
+            mock.patch('imbi_api.settings.get_auth_settings') as mock_settings,
+            mock.patch.object(
+                permissions, '_authenticate_token', new=mock.AsyncMock()
+            ) as mock_auth,
+        ):
+            mock_settings.return_value = self.auth_settings
+            mock_auth.return_value = self.ctx
+            result = await permissions.get_current_user_cookie_fallback(
+                mock.AsyncMock(), request, credentials
+            )
+        self.assertIs(result, self.ctx)
+        self.assertEqual(mock_auth.await_args.args[1], 'header-token')
+
+    async def test_falls_back_to_cookie(self) -> None:
+        """With no header, the access cookie supplies the token."""
+        request = self._request(
+            {permissions.ACCESS_COOKIE_NAME: 'cookie-token'}
+        )
+        with (
+            mock.patch('imbi_api.settings.get_auth_settings') as mock_settings,
+            mock.patch.object(
+                permissions, '_authenticate_token', new=mock.AsyncMock()
+            ) as mock_auth,
+        ):
+            mock_settings.return_value = self.auth_settings
+            mock_auth.return_value = self.ctx
+            result = await permissions.get_current_user_cookie_fallback(
+                mock.AsyncMock(), request, None
+            )
+        self.assertIs(result, self.ctx)
+        self.assertEqual(mock_auth.await_args.args[1], 'cookie-token')
+
+    async def test_missing_header_and_cookie_raises_401(self) -> None:
+        """Neither a header nor a cookie yields a 401."""
+        request = self._request({})
+        with self.assertRaises(fastapi.HTTPException) as exc:
+            await permissions.get_current_user_cookie_fallback(
+                mock.AsyncMock(), request, None
+            )
+        self.assertEqual(exc.exception.status_code, 401)
+        self.assertEqual(
+            exc.exception.detail, 'Missing authentication credentials'
+        )
+
+
 class StampApiKeyLastUsedTestCase(unittest.IsolatedAsyncioTestCase):
     """Test ``_stamp_api_key_last_used`` throttling behavior."""
 

--- a/tests/endpoints/test_auth.py
+++ b/tests/endpoints/test_auth.py
@@ -1091,6 +1091,7 @@ class OAuthCallbackSuccessTestCase(unittest.TestCase):
             self.assertNotIn('refresh_token=', location)
             set_cookie = response.headers.get('set-cookie', '')
             self.assertIn('imbi_refresh_token=', set_cookie)
+            self.assertIn('imbi_access_token=', set_cookie)
             self.assertIn('HttpOnly', set_cookie)
             self.assertIn('SameSite=strict', set_cookie)
             self.assertIn('Path=/auth', set_cookie)
@@ -1195,6 +1196,7 @@ class OAuthCallbackSuccessTestCase(unittest.TestCase):
             self.assertNotIn('refresh_token=', location)
             set_cookie = response.headers.get('set-cookie', '')
             self.assertIn('imbi_refresh_token=', set_cookie)
+            self.assertIn('imbi_access_token=', set_cookie)
             self.assertIn('HttpOnly', set_cookie)
             self.assertIn('SameSite=strict', set_cookie)
             self.assertIn('Path=/auth', set_cookie)
@@ -1691,6 +1693,9 @@ class TokenRefreshTestCase(unittest.TestCase):
         self.assertIn('HttpOnly', set_cookie)
         self.assertIn('SameSite=strict', set_cookie)
         self.assertIn('Path=/auth', set_cookie)
+        # The access cookie is refreshed too so <img> subresource loads of
+        # the upload-serving endpoints keep working after rotation.
+        self.assertIn('imbi_access_token=', set_cookie)
 
     def test_refresh_token_missing_returns_401(self) -> None:
         """No cookie and no body yields 401 rather than a 422."""

--- a/tests/endpoints/test_uploads.py
+++ b/tests/endpoints/test_uploads.py
@@ -43,6 +43,12 @@ class UploadEndpointsTestCase(unittest.TestCase):
         self.test_app.dependency_overrides[permissions.get_current_user] = (
             mock_get_current_user
         )
+        # The byte-serving GETs authenticate via the cookie-fallback
+        # resolver so they can be loaded as <img> subresources; override
+        # it too so those endpoints see the same test auth context.
+        self.test_app.dependency_overrides[
+            permissions.get_current_user_cookie_fallback
+        ] = mock_get_current_user
 
         self.mock_db = mock.AsyncMock(spec=graph.Graph)
         self.test_app.dependency_overrides[graph._inject_graph] = (
@@ -397,6 +403,9 @@ class UploadEndpointsTestCase(unittest.TestCase):
         self.test_app.dependency_overrides[permissions.get_current_user] = (
             _non_admin
         )
+        self.test_app.dependency_overrides[
+            permissions.get_current_user_cookie_fallback
+        ] = _non_admin
         try:
             for path in (
                 '/uploads/test-uuid-1234',
@@ -414,6 +423,9 @@ class UploadEndpointsTestCase(unittest.TestCase):
 
             self.test_app.dependency_overrides[
                 permissions.get_current_user
+            ] = _restore
+            self.test_app.dependency_overrides[
+                permissions.get_current_user_cookie_fallback
             ] = _restore
 
     def test_requires_authentication(self) -> None:


### PR DESCRIPTION
## Summary

Fixes 401 `{"detail":"Missing authentication credentials"}` when the UI loads uploaded icons/avatars.

## Problem

The byte-serving upload endpoints — `GET /uploads/{id}` and `GET /uploads/{id}/thumbnail` — are consumed by the UI as `<img src>` URLs (`imbi-ui` `lib/icons.ts` → `createImgComponent`). Browsers **do not** attach the `Authorization: Bearer` header to image subresource requests, and the access token lives in JS memory rather than a cookie the API reads. With only `HTTPBearer` auth on those endpoints, the requests arrived with no credentials and `get_current_user` returned `401 Missing authentication credentials`.

This is **not** an S3/IRSA problem — auth fails in the application layer before any `storage_client`/S3 call runs. Upload *creation* (POST via `fetch`) was unaffected because it sends the Bearer header.

## Solution

Mirror the access token into a short-lived `HttpOnly` cookie and let only the two byte-serving GETs accept it as a fallback to the Bearer header:

- **`auth/permissions.py`** — add `ACCESS_COOKIE_NAME`; extract `_authenticate_token`; add `get_current_user_cookie_fallback` (Bearer header takes precedence, then the access cookie, else 401); add `require_permission(..., allow_cookie=True)`.
- **`endpoints/auth.py`** — set the access cookie wherever the refresh cookie is set (login, refresh, both OAuth redirects) and clear it on logout. Scoped to the API prefix so it reaches `/api/uploads/...`; `SameSite=Strict`, `Secure` outside dev, TTL matches the access-token lifetime.
- **`endpoints/uploads.py`** — only the two byte-serving GETs opt into `allow_cookie=True`; `list`/`meta`/`create`/`delete` stay Bearer-only, so the auth surface for state-changing endpoints is unchanged. Also simplifies a ternary flagged by ruff (`FURB110`).

No UI change required — the browser sends the cookie automatically on `<img>` requests, and the SPA's refresh cycle keeps the short-lived cookie fresh. Existing sessions pick up the cookie on their next token refresh.

## Testing

- `tests/auth` + `tests/endpoints/test_uploads.py` + `tests/endpoints/test_auth.py` pass, including new coverage: resolver unit tests (header precedence / cookie fallback / 401), serving-endpoint cookie-override tests, and login/refresh/OAuth access-cookie emission assertions.
- ruff, mypy, basedpyright clean on changed files (pre-commit hooks pass).