### PR TITLE
Widen lifecycle dispatch to created/updated/deleted + capture-before-delete

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -236,8 +236,9 @@ exclude-newer-package = { "clickhouse-connect" = false, "imbi-common" = false, "
 url = "https://pypi.org/simple"
 default = true
 
-# Pinned to imbi-common main while 2.8.0 is unreleased — #138 has
-# merged but no PyPI release has been cut yet.  Remove this block when
+# Pinned to the imbi-common #138 merge commit while 2.8.0 is
+# unreleased.  An immutable rev is used (instead of branch = "main")
+# so the build is reproducible.  Remove this entire block when
 # imbi-common 2.8.0 ships to PyPI.
 [tool.uv.sources]
-imbi-common = { git = "https://github.com/AWeber-Imbi/imbi-common.git", branch = "main" }
+imbi-common = { git = "https://github.com/AWeber-Imbi/imbi-common.git", rev = "d21cc8818f238cfe02625ac6f292091c526ed787" }

--- a/src/imbi_api/endpoints/projects.py
+++ b/src/imbi_api/endpoints/projects.py
@@ -32,11 +32,13 @@ from imbi_api.endpoints._json_fields import (
 from imbi_api.graph_sql import escape_prop, props_template, set_clause
 from imbi_api.plugins.lifecycle_dispatch import (
     LifecycleInvocation,
+    build_lifecycle_context_bundle,
     dispatch_lifecycle,
 )
 from imbi_api.relationships import RelationshipSpec, build_relationships
 from imbi_api.scoring import OptionalValkeyClient
 from imbi_api.scoring import queue as score_queue
+from imbi_api.settings import get_server_config
 
 LOGGER = logging.getLogger(__name__)
 
@@ -247,6 +249,52 @@ class ProjectResponse(pydantic.BaseModel):
         if isinstance(value, str):
             return json.loads(value)
         return value
+
+
+class ProjectMutationResponse(ProjectResponse):
+    """Response for any project mutation that triggers a lifecycle dispatch.
+
+    Mirrors :class:`ProjectResponse` and appends one
+    :class:`LifecycleInvocation` per assigned lifecycle plugin so the
+    UI can surface third-party outcomes (GitHub repo created /
+    renamed, archive succeeded, etc.) without a follow-up request.
+    Used by create / patch / archive / unarchive.  Empty when no
+    lifecycle plugins are assigned.
+    """
+
+    lifecycle_results: list[LifecycleInvocation] = []
+
+
+# Back-compat alias: pre-2.8 the archive / unarchive endpoints
+# returned ``ArchiveProjectResponse``.  The shape is now shared with
+# create / patch so the canonical name is ``ProjectMutationResponse``;
+# this alias keeps OpenAPI clients and existing tests building.
+ArchiveProjectResponse = ProjectMutationResponse
+
+
+class ProjectDeletedResponse(pydantic.BaseModel):
+    """Response for a successful project delete.
+
+    The project node is gone by the time the response is built, so
+    the body carries only the per-plugin lifecycle results -- empty
+    when ``delete_repository=false`` short-circuits the dispatch.
+    """
+
+    lifecycle_results: list[LifecycleInvocation] = []
+
+
+def _build_project_ui_url(org_slug: str, project_id: str) -> str | None:
+    """Resolve the canonical UI deep link for a project.
+
+    Returns ``None`` when ``IMBI_UI_URL`` is unset so lifecycle plugins
+    can skip writing the equivalent of a GitHub repo ``homepage``
+    without falling back to a localhost URL that would point at
+    nothing meaningful for a third party.
+    """
+    base = get_server_config().ui_url
+    if not base:
+        return None
+    return f'{base}/organizations/{org_slug}/projects/{project_id}'
 
 
 # -- Helpers ------------------------------------------------------------
@@ -834,7 +882,7 @@ async def create_project(
             permissions.require_permission('project:create'),
         ),
     ],
-) -> ProjectResponse:
+) -> ProjectMutationResponse:
     """Create a new project in an organization."""
     dynamic_model = await blueprints.get_model(
         db,
@@ -997,7 +1045,32 @@ async def create_project(
     await score_queue.enqueue_recompute(
         valkey_client, project_id, 'attribute_change'
     )
-    return ProjectResponse.model_validate(project_data)
+    # Fire the lifecycle ``created`` event so plugins (e.g. the
+    # GitHub lifecycle plugin) can provision the backing repo and
+    # write the resulting canonical link back via ``LinkWriteback``.
+    # The project node already committed; never let a dispatch hiccup
+    # turn a successful create into a 500.
+    lifecycle_results: list[LifecycleInvocation] = []
+    try:
+        lifecycle_results = await dispatch_lifecycle(
+            db,
+            project_id,
+            org_slug,
+            'created',
+            auth,
+            project_name=project.name,
+            project_description=project.description,
+            project_ui_url=_build_project_ui_url(org_slug, project_id),
+        )
+    except Exception:
+        LOGGER.exception(
+            'Lifecycle dispatch failed after creating project %s',
+            project_id,
+        )
+    return ProjectMutationResponse(
+        **ProjectResponse.model_validate(project_data).model_dump(),
+        lifecycle_results=lifecycle_results,
+    )
 
 
 def _attach_project_relationships(
@@ -2105,7 +2178,7 @@ async def patch_project(
             permissions.require_permission('project:write'),
         ),
     ],
-) -> ProjectResponse:
+) -> ProjectMutationResponse:
     """Partially update a project using JSON Patch (RFC 6902).
 
     Parameters:
@@ -2229,7 +2302,39 @@ async def patch_project(
         before_snapshot,
         patched,
     )
-    return response
+    # Only dispatch ``updated`` when the slug or description actually
+    # changed: lifecycle plugins translate those into remote rename /
+    # description writes, and firing on every PATCH (e.g. an icon
+    # change) would pay an HTTP round trip for nothing.  Name does not
+    # gate the dispatch because GitHub has no display-name field --
+    # the plugin would always no-op.
+    previous_slug = str(before_snapshot.get('slug') or '') or None
+    previous_description = before_snapshot.get('description')
+    slug_changed = previous_slug is not None and response.slug != previous_slug
+    description_changed = response.description != previous_description
+    lifecycle_results: list[LifecycleInvocation] = []
+    if slug_changed or description_changed:
+        try:
+            lifecycle_results = await dispatch_lifecycle(
+                db,
+                project_id,
+                org_slug,
+                'updated',
+                auth,
+                previous_project_slug=previous_slug if slug_changed else None,
+                project_name=response.name,
+                project_description=response.description,
+                project_ui_url=_build_project_ui_url(org_slug, project_id),
+            )
+        except Exception:
+            LOGGER.exception(
+                'Lifecycle dispatch failed after updating project %s',
+                project_id,
+            )
+    return ProjectMutationResponse(
+        **response.model_dump(),
+        lifecycle_results=lifecycle_results,
+    )
 
 
 async def _set_archived_state(
@@ -2280,18 +2385,6 @@ async def _set_archived_state(
         graph.parse_agtype(records[0]['inbound_count']),
     )
     return ProjectResponse.model_validate(project_data)
-
-
-class ArchiveProjectResponse(ProjectResponse):
-    """Response for archive / unarchive, with per-plugin lifecycle results.
-
-    Mirrors :class:`ProjectResponse` and appends one
-    :class:`LifecycleInvocation` per assigned lifecycle plugin so the
-    UI can surface third-party outcomes (GitHub archive succeeded,
-    AWS shutdown failed, ...) without a follow-up request.
-    """
-
-    lifecycle_results: list[LifecycleInvocation] = []
 
 
 @projects_router.post('/{project_id}/archive')
@@ -2364,7 +2457,7 @@ async def unarchive_project(
     )
 
 
-@projects_router.delete('/{project_id}', status_code=204)
+@projects_router.delete('/{project_id}')
 async def delete_project(
     org_slug: str,
     project_id: str,
@@ -2375,8 +2468,33 @@ async def delete_project(
             permissions.require_permission('project:delete'),
         ),
     ],
-) -> None:
-    """Delete a project."""
+    delete_repository: bool = True,
+) -> ProjectDeletedResponse:
+    """Delete a project.
+
+    When ``delete_repository`` is true (the default), each assigned
+    lifecycle plugin's ``on_project_deleted`` hook is also invoked so
+    the backing remote (e.g. a GitHub repo) is removed alongside the
+    Imbi project node.  Set ``delete_repository=false`` to keep the
+    remote in place -- useful when the repository has historical value
+    that should survive the project being retired.
+
+    Returns a 200 with the per-plugin :class:`LifecycleInvocation`
+    list rather than the bare 204 the pre-2.8 endpoint emitted.  An
+    empty ``lifecycle_results`` list means either no lifecycle plugins
+    were assigned, or ``delete_repository=false`` short-circuited the
+    dispatch.
+    """
+    # Capture the lifecycle context bundle *before* the DETACH DELETE
+    # so the project's links / slug / type slugs survive the write and
+    # the downstream dispatcher doesn't try to look them up against a
+    # node that no longer exists.
+    bundle = (
+        await build_lifecycle_context_bundle(db, project_id)
+        if delete_repository
+        else None
+    )
+
     query: typing.LiteralString = """
     MATCH (p:Project {{id: {project_id}}})
           -[:OWNED_BY]->(:Team)
@@ -2397,3 +2515,25 @@ async def delete_project(
             status_code=404,
             detail=f'Project {project_id!r} not found',
         )
+
+    # Project node is gone; never let a dispatch hiccup turn a
+    # successful delete into a 500.  ``delete_repository=false`` skips
+    # the dispatch entirely so the operator can retire the project
+    # without nuking the remote.
+    lifecycle_results: list[LifecycleInvocation] = []
+    if delete_repository and bundle is not None:
+        try:
+            lifecycle_results = await dispatch_lifecycle(
+                db,
+                project_id,
+                org_slug,
+                'deleted',
+                auth,
+                bundle=bundle,
+            )
+        except Exception:
+            LOGGER.exception(
+                'Lifecycle dispatch failed after deleting project %s',
+                project_id,
+            )
+    return ProjectDeletedResponse(lifecycle_results=lifecycle_results)

--- a/src/imbi_api/plugins/lifecycle_dispatch.py
+++ b/src/imbi_api/plugins/lifecycle_dispatch.py
@@ -14,6 +14,7 @@ state change -- the operator's intent is authoritative.
 
 from __future__ import annotations
 
+import asyncio
 import dataclasses
 import datetime
 import logging
@@ -103,9 +104,17 @@ async def build_lifecycle_context_bundle(
         lookup_project_type_slugs,
     )
 
-    project_slug, team_slug = await lookup_project_slugs(db, project_id)
-    project_links = await lookup_project_links(db, project_id)
-    project_type_slugs = await lookup_project_type_slugs(db, project_id)
+    # Three independent DB lookups; gather them concurrently so each
+    # lifecycle dispatch pays one round-trip latency rather than three.
+    (
+        (project_slug, team_slug),
+        project_links,
+        project_type_slugs,
+    ) = await asyncio.gather(
+        lookup_project_slugs(db, project_id),
+        lookup_project_links(db, project_id),
+        lookup_project_type_slugs(db, project_id),
+    )
     return LifecycleContextBundle(
         project_slug=project_slug,
         team_slug=team_slug,
@@ -202,6 +211,32 @@ async def _invoke_one(
     handler = typing.cast(LifecyclePlugin, resolved.entry.handler_cls())
     method_name = _EVENT_METHOD[event]
 
+    # Detect a truly-unimplemented hook (the plugin inherits the base
+    # ``LifecyclePlugin`` stub) *before* we call into it.  This lets a
+    # real ``NotImplementedError`` raised by an implemented hook surface
+    # as ``status='failed'`` via the generic exception handler instead of
+    # being misreported as ``skipped``.  ``on_project_archived`` is the
+    # only required hook -- a missing impl there still maps to ``failed``.
+    method = getattr(handler, method_name)
+    base_method = getattr(LifecyclePlugin, method_name, None)
+    if (
+        base_method is not None
+        and getattr(method, '__func__', method) is base_method
+    ):
+        if event == 'archived':
+            return LifecycleInvocation(
+                plugin_id=resolved.plugin_id,
+                plugin_slug=resolved.plugin_slug,
+                status='failed',
+                message=f'Plugin does not implement {method_name}',
+            )
+        return LifecycleInvocation(
+            plugin_id=resolved.plugin_id,
+            plugin_slug=resolved.plugin_slug,
+            status='skipped',
+            message=f'Plugin does not implement {method_name}',
+        )
+
     # call_with_identity_retry re-attaches identity onto a fresh context
     # before invoking ``_call`` (attached defaults to False here), so the
     # plugin mutates that inner context, not ``ctx``. Capture any link
@@ -220,24 +255,6 @@ async def _invoke_one(
     try:
         result = await call_with_identity_retry(
             db, ctx, resolved, auth, fn=_call
-        )
-    except NotImplementedError as exc:
-        # ``on_project_archived`` is the only required hook on
-        # :class:`LifecyclePlugin`; every other event's missing
-        # implementation is just "this plugin doesn't speak that event"
-        # and maps to a clean ``skipped`` rather than a hard failure.
-        if event == 'archived':
-            return LifecycleInvocation(
-                plugin_id=resolved.plugin_id,
-                plugin_slug=resolved.plugin_slug,
-                status='failed',
-                message=f'NotImplementedError: {exc}',
-            )
-        return LifecycleInvocation(
-            plugin_id=resolved.plugin_id,
-            plugin_slug=resolved.plugin_slug,
-            status='skipped',
-            message=f'Plugin does not implement {method_name}',
         )
     except fastapi.HTTPException as exc:
         return LifecycleInvocation(

--- a/src/imbi_api/plugins/lifecycle_dispatch.py
+++ b/src/imbi_api/plugins/lifecycle_dispatch.py
@@ -1,17 +1,20 @@
 """Lifecycle plugin fan-out for project state-change endpoints.
 
-When a project transitions to / from the archived state the API
-dispatches the change to every plugin assigned to ``tab='lifecycle'``
-(at the project or project-type level).  Plugins receive a normal
-:class:`PluginContext` with hydrated identity and return a
-:class:`LifecycleResult` describing their per-plugin outcome.
+When a project state changes -- create, update, archive, unarchive,
+delete, or relocate -- the API dispatches the event to every plugin
+assigned to ``tab='lifecycle'`` (at the project or project-type level).
+Plugins receive a :class:`PluginContext` with hydrated identity and
+return a :class:`LifecycleResult` describing their per-plugin outcome.
 
-Failure of one plugin never poisons the others and never rolls back
-the Imbi-side state change — the operator's intent is authoritative.
+Only ``on_project_archived`` is a required plugin hook; every other
+event's missing hook resolves to ``status='skipped'``.  Failure of one
+plugin never poisons the others and never rolls back the Imbi-side
+state change -- the operator's intent is authoritative.
 """
 
 from __future__ import annotations
 
+import dataclasses
 import datetime
 import logging
 import typing
@@ -44,11 +47,75 @@ from imbi_api.plugins.resolution import ResolvedPlugin, resolve_all_plugins
 
 LOGGER = logging.getLogger(__name__)
 
-LifecycleEvent = typing.Literal['archived', 'unarchived']
+LifecycleEvent = typing.Literal[
+    'created',
+    'updated',
+    'archived',
+    'unarchived',
+    'deleted',
+    'relocated',
+]
+
+#: Map of lifecycle events to the matching ``LifecyclePlugin`` hook
+#: name.  Centralized here so both the dispatcher and any future
+#: capability checks read from the same source.
+_EVENT_METHOD: dict[LifecycleEvent, str] = {
+    'created': 'on_project_created',
+    'updated': 'on_project_updated',
+    'archived': 'on_project_archived',
+    'unarchived': 'on_project_unarchived',
+    'deleted': 'on_project_deleted',
+    'relocated': 'on_project_relocated',
+}
+
+
+@dataclasses.dataclass(slots=True)
+class LifecycleContextBundle:
+    """Pre-fetched project context for the lifecycle dispatcher.
+
+    The delete endpoint needs the project's slug / links / type slugs
+    *before* ``DETACH DELETE`` runs (otherwise the helpers would look
+    up a project that no longer exists).  Callers that already hold the
+    data -- including the rest of the lifecycle path that could
+    short-circuit a round trip -- pass a bundle through to
+    :func:`dispatch_lifecycle`.  Callers that don't hold it can let the
+    dispatcher fetch it implicitly (the archive / unarchive path still
+    does this for back-compat).
+    """
+
+    project_slug: str
+    team_slug: str | None
+    project_links: dict[str, str]
+    project_type_slugs: list[str]
+
+
+async def build_lifecycle_context_bundle(
+    db: graph.Graph, project_id: str
+) -> LifecycleContextBundle:
+    """Pre-fetch lifecycle context the dispatcher would otherwise look up.
+
+    Use this before a ``DETACH DELETE`` so the bundle survives the
+    write, and pass it as ``bundle=`` to :func:`dispatch_lifecycle`.
+    """
+    from imbi_api.endpoints._helpers import (
+        lookup_project_links,
+        lookup_project_slugs,
+        lookup_project_type_slugs,
+    )
+
+    project_slug, team_slug = await lookup_project_slugs(db, project_id)
+    project_links = await lookup_project_links(db, project_id)
+    project_type_slugs = await lookup_project_type_slugs(db, project_id)
+    return LifecycleContextBundle(
+        project_slug=project_slug,
+        team_slug=team_slug,
+        project_links=project_links,
+        project_type_slugs=project_type_slugs,
+    )
 
 
 class LifecycleInvocation(pydantic.BaseModel):
-    """Per-plugin outcome surfaced to the operator after archive/unarchive."""
+    """Per-plugin outcome surfaced to the operator after a lifecycle event."""
 
     plugin_id: str
     plugin_slug: str
@@ -63,6 +130,13 @@ async def dispatch_lifecycle(
     org_slug: str,
     event: LifecycleEvent,
     auth: permissions.AuthContext,
+    *,
+    bundle: LifecycleContextBundle | None = None,
+    previous_project_slug: str | None = None,
+    previous_project_type_slugs: list[str] | None = None,
+    project_name: str | None = None,
+    project_description: str | None = None,
+    project_ui_url: str | None = None,
 ) -> list[LifecycleInvocation]:
     """Invoke every lifecycle plugin assigned to ``project_id``.
 
@@ -70,31 +144,35 @@ async def dispatch_lifecycle(
     when no lifecycle plugins are assigned.  All exceptions are caught
     and translated into a ``status='failed'`` result so the caller can
     surface them without rolling back the Imbi state change.
-    """
-    from imbi_api.endpoints._helpers import (
-        lookup_project_links,
-        lookup_project_slugs,
-        lookup_project_type_slugs,
-    )
 
+    Pass ``bundle`` for events like ``'deleted'`` where the caller
+    needs to capture project context before a destructive write;
+    otherwise the dispatcher looks the data up.  The optional
+    ``previous_*`` fields populate :class:`PluginContext` for plugins
+    that need a before/after view (``'updated'`` / ``'relocated'``).
+    """
     resolved_plugins = await resolve_all_plugins(db, project_id, 'lifecycle')
     if not resolved_plugins:
         return []
 
-    project_slug, team_slug = await lookup_project_slugs(db, project_id)
-    project_links = await lookup_project_links(db, project_id)
-    project_type_slugs = await lookup_project_type_slugs(db, project_id)
+    if bundle is None:
+        bundle = await build_lifecycle_context_bundle(db, project_id)
 
     results: list[LifecycleInvocation] = []
     for resolved in resolved_plugins:
         ctx = PluginContext(
             project_id=project_id,
-            project_slug=project_slug,
+            project_slug=bundle.project_slug,
             org_slug=org_slug,
-            team_slug=team_slug,
+            team_slug=bundle.team_slug,
             assignment_options=resolved.options,
-            project_links=project_links,
-            project_type_slugs=project_type_slugs,
+            project_links=bundle.project_links,
+            project_type_slugs=bundle.project_type_slugs,
+            previous_project_slug=previous_project_slug,
+            previous_project_type_slugs=previous_project_type_slugs or [],
+            project_name=project_name,
+            project_description=project_description,
+            project_ui_url=project_ui_url,
         )
         invocation = await _invoke_one(db, ctx, resolved, event, auth)
         results.append(invocation)
@@ -117,16 +195,12 @@ async def _invoke_one(
     """Run a single plugin and return its :class:`LifecycleInvocation`.
 
     Failures from the plugin, missing credentials, missing identity,
-    timeouts, and ``NotImplementedError`` (for plugins without an
-    unarchive inverse) are all translated to a
+    timeouts, and ``NotImplementedError`` (for plugins without a hook
+    for this event) are all translated to a
     :class:`LifecycleInvocation` instead of bubbling.
     """
     handler = typing.cast(LifecyclePlugin, resolved.entry.handler_cls())
-    method_name = (
-        'on_project_archived'
-        if event == 'archived'
-        else 'on_project_unarchived'
-    )
+    method_name = _EVENT_METHOD[event]
 
     # call_with_identity_retry re-attaches identity onto a fresh context
     # before invoking ``_call`` (attached defaults to False here), so the
@@ -148,21 +222,22 @@ async def _invoke_one(
             db, ctx, resolved, auth, fn=_call
         )
     except NotImplementedError as exc:
-        # Only the unarchive inverse hook is optional; archive hooks are
-        # the plugin's primary contract, so a missing implementation is
-        # a real failure, not a skip.
-        if event == 'unarchived':
+        # ``on_project_archived`` is the only required hook on
+        # :class:`LifecyclePlugin`; every other event's missing
+        # implementation is just "this plugin doesn't speak that event"
+        # and maps to a clean ``skipped`` rather than a hard failure.
+        if event == 'archived':
             return LifecycleInvocation(
                 plugin_id=resolved.plugin_id,
                 plugin_slug=resolved.plugin_slug,
-                status='skipped',
-                message=f'Plugin does not implement {method_name}',
+                status='failed',
+                message=f'NotImplementedError: {exc}',
             )
         return LifecycleInvocation(
             plugin_id=resolved.plugin_id,
             plugin_slug=resolved.plugin_slug,
-            status='failed',
-            message=f'NotImplementedError: {exc}',
+            status='skipped',
+            message=f'Plugin does not implement {method_name}',
         )
     except fastapi.HTTPException as exc:
         return LifecycleInvocation(

--- a/src/imbi_api/settings.py
+++ b/src/imbi_api/settings.py
@@ -61,8 +61,15 @@ class ServerConfig(pydantic_settings.BaseSettings):
     # runs work out of the box. The /docs and /openapi.json endpoints
     # are always served at the root regardless of the prefix.
     url: str = pydantic.Field(default='', validation_alias='IMBI_API_URL')
+    # Public URL of the Imbi UI (no path -- routes are appended by
+    # callers).  Used to build deep links the API hands to third
+    # parties: lifecycle plugins receive ``project_ui_url`` so they can
+    # populate the equivalent of a GitHub repo ``homepage``.  Falls
+    # back to the empty string, in which case ``project_ui_url`` is
+    # ``None`` and plugins skip the homepage write.
+    ui_url: str = pydantic.Field(default='', validation_alias='IMBI_UI_URL')
 
-    @pydantic.field_validator('url')
+    @pydantic.field_validator('url', 'ui_url')
     @classmethod
     def _normalize_url(cls, value: str) -> str:
         return value.rstrip('/')

--- a/tests/endpoints/test_projects.py
+++ b/tests/endpoints/test_projects.py
@@ -1363,7 +1363,9 @@ class ProjectEndpointsTestCase(unittest.TestCase):
                 },
             ],
         ]
-        self._dispatch_patcher.stop()
+        # The setUp patcher is registered via addCleanup; nest a new
+        # ``mock.patch`` on the same target so its return value wins for
+        # the duration of this test without double-stopping the cleanup.
         with (
             mock.patch(
                 'imbi_common.blueprints.get_model',
@@ -1422,7 +1424,9 @@ class ProjectEndpointsTestCase(unittest.TestCase):
                 },
             ],
         ]
-        self._dispatch_patcher.stop()
+        # Nest a fresh ``dispatch_lifecycle`` patch over the setUp one --
+        # the inner mock.patch wins for the duration of the with-block
+        # and addCleanup handles teardown of the outer patcher.
         with (
             mock.patch(
                 'imbi_common.blueprints.get_model',
@@ -1459,8 +1463,9 @@ class ProjectEndpointsTestCase(unittest.TestCase):
     ) -> None:
         """``delete_repository=false`` short-circuits the dispatch."""
         self.mock_db.execute.return_value = [{'deleted': 1}]
-        self._dispatch_patcher.stop()
-        self._bundle_patcher.stop()
+        # Nest fresh patches over the setUp ones -- the inner mock.patch
+        # wins for the duration of the with-block; addCleanup handles
+        # teardown of the outer patchers without a double-stop.
         with (
             mock.patch(
                 'imbi_common.graph.parse_agtype',

--- a/tests/endpoints/test_projects.py
+++ b/tests/endpoints/test_projects.py
@@ -57,6 +57,36 @@ class ProjectEndpointsTestCase(unittest.TestCase):
             self.mock_db
         )
 
+        # Stub ``dispatch_lifecycle`` so tests that don't care about
+        # plugin fan-out (the bulk of CRUD tests) aren't forced to seed
+        # an extra db.execute side-effect for ``resolve_all_plugins``.
+        # Tests that want to assert dispatch behaviour override this
+        # patch locally (see the archive / unarchive cases).
+        self._dispatch_patcher = mock.patch(
+            'imbi_api.endpoints.projects.dispatch_lifecycle',
+            new=mock.AsyncMock(return_value=[]),
+        )
+        self._dispatch_patcher.start()
+        self.addCleanup(self._dispatch_patcher.stop)
+
+        # ``delete_project`` reads the lifecycle context bundle before
+        # the DETACH DELETE; stub it so test fixtures don't need to
+        # provide three extra ``db.execute`` side-effects for the
+        # lookups.
+        self._bundle_patcher = mock.patch(
+            'imbi_api.endpoints.projects.build_lifecycle_context_bundle',
+            new=mock.AsyncMock(
+                return_value=mock.MagicMock(
+                    project_slug='my-api',
+                    team_slug='platform',
+                    project_links={},
+                    project_type_slugs=['api-service'],
+                ),
+            ),
+        )
+        self._bundle_patcher.start()
+        self.addCleanup(self._bundle_patcher.stop)
+
         self.client = TestClient(self.test_app)
 
     def _project_data(self, **overrides: typing.Any) -> dict:
@@ -1018,7 +1048,8 @@ class ProjectEndpointsTestCase(unittest.TestCase):
                 f'/organizations/engineering/projects/{PROJECT_ID}',
             )
 
-        self.assertEqual(response.status_code, 204)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {'lifecycle_results': []})
 
     def test_delete_not_found(self) -> None:
         """Test deleting nonexistent project."""
@@ -1316,6 +1347,143 @@ class ProjectEndpointsTestCase(unittest.TestCase):
         response = self._list_with_filter('filter=framework:ne')
         self.assertEqual(response.status_code, 400)
         self.assertIn('requires a value', response.json()['detail'])
+
+    # -- Lifecycle dispatch wiring ------------------------------------
+
+    def test_create_dispatches_lifecycle_created(self) -> None:
+        """``create_project`` fans out a ``created`` lifecycle event."""
+        record = self._project_data()
+        self.mock_db.execute.side_effect = [
+            [{'pt_slug': 'api-service', 'found': True}],
+            [
+                {
+                    'project': record,
+                    'outbound_count': 0,
+                    'inbound_count': 0,
+                },
+            ],
+        ]
+        self._dispatch_patcher.stop()
+        with (
+            mock.patch(
+                'imbi_common.blueprints.get_model',
+            ) as mock_get_model,
+            mock.patch(
+                'imbi_common.graph.parse_agtype',
+                side_effect=lambda x: x,
+            ),
+            mock.patch(
+                'imbi_api.endpoints.projects.nanoid.generate',
+                return_value=PROJECT_ID,
+            ),
+            mock.patch(
+                'imbi_api.endpoints.projects.dispatch_lifecycle',
+                new=mock.AsyncMock(return_value=[]),
+            ) as mock_dispatch,
+        ):
+            mock_get_model.return_value = models.Project
+            response = self.client.post(
+                '/organizations/engineering/projects/',
+                json={
+                    'name': 'My API',
+                    'slug': 'my-api',
+                    'description': 'An example API',
+                    'team_slug': 'platform',
+                    'project_type_slugs': ['api-service'],
+                },
+            )
+
+        self.assertEqual(response.status_code, 201)
+        mock_dispatch.assert_awaited_once()
+        call = mock_dispatch.await_args
+        self.assertEqual(call.args[3], 'created')
+        self.assertEqual(call.kwargs['project_name'], 'My API')
+        self.assertEqual(call.kwargs['project_description'], 'An example API')
+
+    def test_patch_dispatches_lifecycle_on_slug_change(self) -> None:
+        """Slug change passes ``previous_project_slug`` to dispatch."""
+        existing = self._project_data()
+        updated = self._project_data(slug='my-api-v2')
+        self.mock_db.execute.side_effect = [
+            [
+                {
+                    'project': existing,
+                    'outbound_count': 0,
+                    'inbound_count': 0,
+                },
+            ],
+            [{'slug': 'platform'}],
+            [{'pt_slug': 'api-service', 'found': True}],
+            [
+                {
+                    'project': updated,
+                    'outbound_count': 0,
+                    'inbound_count': 0,
+                },
+            ],
+        ]
+        self._dispatch_patcher.stop()
+        with (
+            mock.patch(
+                'imbi_common.blueprints.get_model',
+            ) as mock_get_model,
+            mock.patch(
+                'imbi_common.graph.parse_agtype',
+                side_effect=lambda x: x,
+            ),
+            mock.patch(
+                'imbi_api.endpoints.projects.dispatch_lifecycle',
+                new=mock.AsyncMock(return_value=[]),
+            ) as mock_dispatch,
+        ):
+            mock_get_model.return_value = models.Project
+            response = self.client.patch(
+                f'/organizations/engineering/projects/{PROJECT_ID}',
+                json=[
+                    {
+                        'op': 'replace',
+                        'path': '/slug',
+                        'value': 'my-api-v2',
+                    },
+                ],
+            )
+
+        self.assertEqual(response.status_code, 200)
+        mock_dispatch.assert_awaited_once()
+        call = mock_dispatch.await_args
+        self.assertEqual(call.args[3], 'updated')
+        self.assertEqual(call.kwargs['previous_project_slug'], 'my-api')
+
+    def test_delete_with_delete_repository_false_skips_dispatch(
+        self,
+    ) -> None:
+        """``delete_repository=false`` short-circuits the dispatch."""
+        self.mock_db.execute.return_value = [{'deleted': 1}]
+        self._dispatch_patcher.stop()
+        self._bundle_patcher.stop()
+        with (
+            mock.patch(
+                'imbi_common.graph.parse_agtype',
+                side_effect=lambda x: x,
+            ),
+            mock.patch(
+                'imbi_api.endpoints.projects.dispatch_lifecycle',
+                new=mock.AsyncMock(return_value=[]),
+            ) as mock_dispatch,
+            mock.patch(
+                'imbi_api.endpoints.projects.build_lifecycle_context_bundle',
+                new=mock.AsyncMock(),
+            ) as mock_bundle,
+        ):
+            response = self.client.delete(
+                f'/organizations/engineering/projects/{PROJECT_ID}'
+                '?delete_repository=false',
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {'lifecycle_results': []})
+        mock_dispatch.assert_not_awaited()
+        mock_bundle.assert_not_awaited()
 
 
 class _RelationshipsTestBase(unittest.TestCase):

--- a/tests/test_lifecycle_dispatch.py
+++ b/tests/test_lifecycle_dispatch.py
@@ -35,9 +35,19 @@ def _make_lifecycle_entry(
     slug: str,
     *,
     archive_status: str = 'ok',
-    unarchive_raises: type[BaseException] | None = NotImplementedError,
+    unarchive_raises: type[BaseException] | None = None,
     archive_raises: type[BaseException] | None = None,
 ) -> RegistryEntry:
+    """Build a registry entry for a synthetic lifecycle plugin.
+
+    ``unarchive_raises`` defaults to ``None`` so the fixture inherits the
+    base ``LifecyclePlugin.on_project_unarchived`` stub (which raises
+    :class:`NotImplementedError`); the dispatcher detects the missing
+    hook by identity and reports ``status='skipped'`` without invoking.
+    Pass an exception class to install an *implemented* override that
+    raises -- exercising the runtime-failure path.
+    """
+
     class _FakeLifecycle(LifecyclePlugin):
         manifest = PluginManifest(
             slug=slug,
@@ -54,10 +64,13 @@ def _make_lifecycle_entry(
                 artifacts={'repo_url': 'https://github.com/o/r'},
             )
 
-        async def on_project_unarchived(self, ctx, credentials):  # type: ignore[override]
-            if unarchive_raises is not None:
-                raise unarchive_raises('unarchive boom')
-            return LifecycleResult(status='ok')
+    if unarchive_raises is not None:
+        _exc = unarchive_raises
+
+        async def _on_unarchived(self, ctx, credentials):  # type: ignore[no-untyped-def]
+            raise _exc('unarchive boom')
+
+        _FakeLifecycle.on_project_unarchived = _on_unarchived  # type: ignore[method-assign]
 
     return RegistryEntry(
         handler_cls=_FakeLifecycle,

--- a/tests/test_lifecycle_dispatch.py
+++ b/tests/test_lifecycle_dispatch.py
@@ -6,6 +6,7 @@ event errors not poisoning the response.
 """
 
 import asyncio
+import typing
 import unittest
 import unittest.mock as mock
 
@@ -15,13 +16,16 @@ from imbi_common.plugins.base import (
     LifecyclePlugin,
     LifecycleResult,
     LinkWriteback,
+    PluginContext,
     PluginManifest,
 )
 from imbi_common.plugins.registry import RegistryEntry
 
 from imbi_api.plugins.lifecycle_dispatch import (
+    LifecycleContextBundle,
     LifecycleEvent,
     LifecycleInvocation,
+    build_lifecycle_context_bundle,
     dispatch_lifecycle,
 )
 from imbi_api.plugins.resolution import ResolvedPlugin
@@ -318,3 +322,271 @@ class ConfigurationPluginIsNotLifecycle(unittest.TestCase):
 
     def test_configuration_plugin_no_archive_method(self) -> None:
         self.assertFalse(hasattr(ConfigurationPlugin, 'on_project_archived'))
+
+
+class WidenedEventNotImplementedTestCase(unittest.TestCase):
+    """The new lifecycle events skip when a plugin doesn't implement them.
+
+    Only ``archived`` is a required hook on :class:`LifecyclePlugin`; the
+    rest of the events resolve to ``status='skipped'`` when the plugin
+    doesn't implement them, so plugins can opt into per-event support
+    incrementally without breaking the dispatch.
+    """
+
+    def _run_with_bare_plugin(
+        self, event: LifecycleEvent
+    ) -> LifecycleInvocation:
+        class _Bare(LifecyclePlugin):
+            manifest = PluginManifest(
+                slug='bare', name='bare', plugin_type='lifecycle'
+            )
+
+            async def on_project_archived(self, ctx, credentials):  # type: ignore[override]
+                return LifecycleResult(status='ok')
+
+            async def on_project_unarchived(self, ctx, credentials):  # type: ignore[override]
+                raise NotImplementedError
+
+        entry = RegistryEntry(
+            handler_cls=_Bare,
+            manifest=_Bare.manifest,
+            package_name='imbi-plugin-bare',
+            package_version='1.0.0',
+        )
+        resolved = ResolvedPlugin(
+            plugin_id='p1',
+            plugin_slug='bare',
+            entry=entry,
+            options={},
+            identity_plugin_id=None,
+        )
+        mock_db = mock.AsyncMock()
+        auth = _make_auth()
+        with (
+            mock.patch(
+                'imbi_api.plugins.lifecycle_dispatch.resolve_all_plugins',
+                mock.AsyncMock(return_value=[resolved]),
+            ),
+            mock.patch(
+                'imbi_api.endpoints._helpers.lookup_project_slugs',
+                mock.AsyncMock(return_value=('p', 't')),
+            ),
+            mock.patch(
+                'imbi_api.endpoints._helpers.lookup_project_links',
+                mock.AsyncMock(return_value={}),
+            ),
+            mock.patch(
+                'imbi_api.endpoints._helpers.lookup_project_type_slugs',
+                mock.AsyncMock(return_value=[]),
+            ),
+            mock.patch(
+                'imbi_api.plugins.lifecycle_dispatch.call_with_identity_retry',
+                new=_passthrough_identity_retry,
+            ),
+            mock.patch(
+                'imbi_api.plugins.lifecycle_dispatch._resolve_credentials',
+                mock.AsyncMock(return_value={'access_token': 't'}),
+            ),
+            mock.patch(
+                'imbi_api.plugins.lifecycle_dispatch.ch_client.Clickhouse.'
+                'get_instance'
+            ) as ch_get,
+        ):
+            ch_get.return_value.insert = mock.AsyncMock()
+            results = asyncio.run(
+                dispatch_lifecycle(mock_db, 'proj-1', 'org-1', event, auth)
+            )
+        return results[0]
+
+    def test_created_not_implemented_is_skipped(self) -> None:
+        inv = self._run_with_bare_plugin('created')
+        self.assertEqual(inv.status, 'skipped')
+        self.assertIn('on_project_created', inv.message or '')
+
+    def test_updated_not_implemented_is_skipped(self) -> None:
+        inv = self._run_with_bare_plugin('updated')
+        self.assertEqual(inv.status, 'skipped')
+        self.assertIn('on_project_updated', inv.message or '')
+
+    def test_deleted_not_implemented_is_skipped(self) -> None:
+        inv = self._run_with_bare_plugin('deleted')
+        self.assertEqual(inv.status, 'skipped')
+        self.assertIn('on_project_deleted', inv.message or '')
+
+    def test_relocated_not_implemented_is_skipped(self) -> None:
+        inv = self._run_with_bare_plugin('relocated')
+        self.assertEqual(inv.status, 'skipped')
+        self.assertIn('on_project_relocated', inv.message or '')
+
+
+class BundleAndContextPropagationTestCase(unittest.TestCase):
+    """The dispatcher honours pre-fetched bundles and the new ctx kwargs."""
+
+    def _capture_ctx(
+        self,
+        *,
+        event: LifecycleEvent,
+        bundle: LifecycleContextBundle | None = None,
+        **dispatch_kwargs: typing.Any,
+    ) -> mock.MagicMock:
+        captured: dict[str, PluginContext] = {}
+
+        class _Capture(LifecyclePlugin):
+            manifest = PluginManifest(
+                slug='cap', name='cap', plugin_type='lifecycle'
+            )
+
+            async def on_project_created(self, ctx, credentials):  # type: ignore[override]
+                captured['ctx'] = ctx
+                return LifecycleResult(status='ok')
+
+            async def on_project_updated(self, ctx, credentials):  # type: ignore[override]
+                captured['ctx'] = ctx
+                return LifecycleResult(status='ok')
+
+            async def on_project_deleted(self, ctx, credentials):  # type: ignore[override]
+                captured['ctx'] = ctx
+                return LifecycleResult(status='ok')
+
+            async def on_project_archived(self, ctx, credentials):  # type: ignore[override]
+                return LifecycleResult(status='ok')
+
+            async def on_project_unarchived(self, ctx, credentials):  # type: ignore[override]
+                raise NotImplementedError
+
+        entry = RegistryEntry(
+            handler_cls=_Capture,
+            manifest=_Capture.manifest,
+            package_name='imbi-plugin-cap',
+            package_version='1.0.0',
+        )
+        resolved = ResolvedPlugin(
+            plugin_id='p1',
+            plugin_slug='cap',
+            entry=entry,
+            options={},
+            identity_plugin_id=None,
+        )
+        mock_db = mock.AsyncMock()
+        auth = _make_auth()
+        slugs_lookup = mock.AsyncMock(return_value=('fetched', 'team-x'))
+        links_lookup = mock.AsyncMock(return_value={})
+        types_lookup = mock.AsyncMock(return_value=[])
+        with (
+            mock.patch(
+                'imbi_api.plugins.lifecycle_dispatch.resolve_all_plugins',
+                mock.AsyncMock(return_value=[resolved]),
+            ),
+            mock.patch(
+                'imbi_api.endpoints._helpers.lookup_project_slugs',
+                slugs_lookup,
+            ),
+            mock.patch(
+                'imbi_api.endpoints._helpers.lookup_project_links',
+                links_lookup,
+            ),
+            mock.patch(
+                'imbi_api.endpoints._helpers.lookup_project_type_slugs',
+                types_lookup,
+            ),
+            mock.patch(
+                'imbi_api.plugins.lifecycle_dispatch.call_with_identity_retry',
+                new=_passthrough_identity_retry,
+            ),
+            mock.patch(
+                'imbi_api.plugins.lifecycle_dispatch._resolve_credentials',
+                mock.AsyncMock(return_value={'access_token': 't'}),
+            ),
+            mock.patch(
+                'imbi_api.plugins.lifecycle_dispatch.ch_client.Clickhouse.'
+                'get_instance'
+            ) as ch_get,
+        ):
+            ch_get.return_value.insert = mock.AsyncMock()
+            asyncio.run(
+                dispatch_lifecycle(
+                    mock_db,
+                    'proj-1',
+                    'org-1',
+                    event,
+                    auth,
+                    bundle=bundle,
+                    **dispatch_kwargs,
+                )
+            )
+        return mock.MagicMock(
+            ctx=captured.get('ctx'),
+            slugs_lookup=slugs_lookup,
+            links_lookup=links_lookup,
+            types_lookup=types_lookup,
+        )
+
+    def test_provided_bundle_bypasses_helper_lookups(self) -> None:
+        bundle = LifecycleContextBundle(
+            project_slug='captured-slug',
+            team_slug='captured-team',
+            project_links={'github-repository': 'https://x'},
+            project_type_slugs=['api-service'],
+        )
+        out = self._capture_ctx(event='deleted', bundle=bundle)
+        # Bundle short-circuits the three helpers entirely.
+        out.slugs_lookup.assert_not_called()
+        out.links_lookup.assert_not_called()
+        out.types_lookup.assert_not_called()
+        # And the captured ctx mirrors the bundle.
+        self.assertEqual(out.ctx.project_slug, 'captured-slug')
+        self.assertEqual(out.ctx.team_slug, 'captured-team')
+        self.assertEqual(
+            out.ctx.project_links, {'github-repository': 'https://x'}
+        )
+        self.assertEqual(out.ctx.project_type_slugs, ['api-service'])
+
+    def test_updated_propagates_previous_slug_and_metadata(self) -> None:
+        out = self._capture_ctx(
+            event='updated',
+            previous_project_slug='old-slug',
+            project_name='New Name',
+            project_description='New description',
+            project_ui_url='https://imbi.example.com/projects/proj-1',
+        )
+        self.assertEqual(out.ctx.previous_project_slug, 'old-slug')
+        self.assertEqual(out.ctx.project_name, 'New Name')
+        self.assertEqual(out.ctx.project_description, 'New description')
+        self.assertEqual(
+            out.ctx.project_ui_url,
+            'https://imbi.example.com/projects/proj-1',
+        )
+
+
+class BuildLifecycleContextBundleTestCase(unittest.TestCase):
+    """:func:`build_lifecycle_context_bundle` packages the three lookups."""
+
+    def test_packages_slug_team_links_and_type_slugs(self) -> None:
+        mock_db = mock.AsyncMock()
+        with (
+            mock.patch(
+                'imbi_api.endpoints._helpers.lookup_project_slugs',
+                mock.AsyncMock(return_value=('my-api', 'platform')),
+            ),
+            mock.patch(
+                'imbi_api.endpoints._helpers.lookup_project_links',
+                mock.AsyncMock(
+                    return_value={'github-repository': 'https://gh/o/r'},
+                ),
+            ),
+            mock.patch(
+                'imbi_api.endpoints._helpers.lookup_project_type_slugs',
+                mock.AsyncMock(return_value=['api-service', 'consumer']),
+            ),
+        ):
+            bundle = asyncio.run(
+                build_lifecycle_context_bundle(mock_db, 'proj-1')
+            )
+        self.assertEqual(bundle.project_slug, 'my-api')
+        self.assertEqual(bundle.team_slug, 'platform')
+        self.assertEqual(
+            bundle.project_links, {'github-repository': 'https://gh/o/r'}
+        )
+        self.assertEqual(
+            bundle.project_type_slugs, ['api-service', 'consumer']
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -1095,7 +1095,7 @@ requires-dist = [
   { name = "fastapi" },
   { name = "filetype" },
   { name = "httpx", specifier = ">=0.28.1,<1" },
-  { name = "imbi-common", extras = ["databases", "llm", "sentry", "server"], git = "https://github.com/AWeber-Imbi/imbi-common.git?branch=main" },
+  { name = "imbi-common", extras = ["databases", "llm", "sentry", "server"], git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=d21cc8818f238cfe02625ac6f292091c526ed787" },
   { name = "imbi-plugin-aws", marker = "extra == 'plugins'", specifier = ">=1.0.0" },
   { name = "imbi-plugin-github", marker = "extra == 'plugins'", specifier = ">=1.0.0" },
   { name = "imbi-plugin-logzio", marker = "extra == 'plugins'", specifier = ">=1.0.0" },
@@ -1149,7 +1149,7 @@ docs = [
 [[package]]
 name = "imbi-common"
 version = "2.8.0"
-source = { git = "https://github.com/AWeber-Imbi/imbi-common.git?branch=main#d21cc8818f238cfe02625ac6f292091c526ed787" }
+source = { git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=d21cc8818f238cfe02625ac6f292091c526ed787#d21cc8818f238cfe02625ac6f292091c526ed787" }
 dependencies = [
   { name = "cryptography" },
   { name = "httpx" },


### PR DESCRIPTION
## Summary

- Widens `LifecycleEvent` to `created` / `updated` / `deleted` / `relocated` alongside the existing `archived` / `unarchived`; `NotImplementedError` from a hook now resolves to `skipped` for every event except `archived` so plugins can opt into events incrementally.
- New `LifecycleContextBundle` + `build_lifecycle_context_bundle` helper lets the delete endpoint capture project slug / team / links / type-slugs *before* `DETACH DELETE` so the dispatcher can still run after the project node is gone; `dispatch_lifecycle` accepts a `bundle=` plus new ctx kwargs (`previous_project_slug`, `project_name`, `project_description`, `project_ui_url`, ...) for `updated` / `relocated`.
- Wires the new events into `create_project`, `patch_project`, and `delete_project`; `delete_project` now returns 200 with a `lifecycle_results` body and accepts `delete_repository=false` to short-circuit the dispatch. `ProjectMutationResponse` (a `ProjectResponse` subclass with `lifecycle_results`) flows back from create/patch; `ArchiveProjectResponse` is an alias for back-compat.
- Adds `ServerConfig.ui_url` (`IMBI_UI_URL`) so plugins receive a `project_ui_url` (the GitHub-`homepage` equivalent).
- Hardens the `imbi-common` source pin from `branch = "main"` to the immutable rev of #138's merge commit so the build is reproducible (block still removable when `imbi-common` 2.8.0 ships to PyPI).

## Why

Required by the cross-repo `docs/lifecycle-project-create-rename-delete.md` design — once landed, the GitHub plugin (#22 follow-up) can react to the full project lifecycle (create the repo, rename it, transfer/delete it) instead of just archive/unarchive.

## Test plan

- [x] `uv run python -m pytest tests/test_lifecycle_dispatch.py` — **18 passed** (11 existing + 7 new covering `created`/`updated`/`deleted`/`relocated` skip behaviour, bundle short-circuit, ctx-kwarg propagation, and `build_lifecycle_context_bundle` packaging).
- [x] `uv run python -m pytest tests/endpoints/test_projects.py::ProjectEndpointsTestCase::test_create_dispatches_lifecycle_created` + `::test_patch_dispatches_lifecycle_on_slug_change` + `::test_delete_with_delete_repository_false_skips_dispatch` — **3 passed**.
- [x] `uv run python -m pytest tests/endpoints/test_projects.py::ProjectEndpointsTestCase::test_delete_success` + the 9 previously-failing CRUD tests under the new `setUp` patches — **10 passed**.
- [x] `pre-commit run` on every touched file: ruff check + format + tombi-format + mypy all green.
- [x] `basedpyright` on `src/imbi_api/plugins/lifecycle_dispatch.py` + `endpoints/projects.py` + `settings.py` + the two test files: 0 errors / 0 warnings.
- [ ] Full `just test` after this lands (CI will run it).