### PR TITLE
Add /lifecycle/preview endpoint + transfer_repository opt-in for relocate

### DIFF
--- a/src/imbi_api/endpoints/projects.py
+++ b/src/imbi_api/endpoints/projects.py
@@ -2451,6 +2451,22 @@ async def preview_lifecycle(
     broken plugin must not block the rest of the preview.
     """
     del auth  # read-only preview; authorization handled by the dependency.
+    exists_query: typing.LiteralString = (
+        'MATCH (p:Project {{id: {project_id}}}) '
+        '-[:OWNED_BY]->(:Team) '
+        '-[:BELONGS_TO]->(:Organization {{slug: {org_slug}}}) '
+        'RETURN p.id AS id'
+    )
+    exists = await db.execute(
+        exists_query,
+        {'project_id': project_id, 'org_slug': org_slug},
+        ['id'],
+    )
+    if not exists:
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail=f'Project {project_id!r} not found',
+        )
     bundle = await build_lifecycle_context_bundle(db, project_id)
     resolved = await resolve_all_plugins(db, project_id, 'lifecycle')
     if not resolved:

--- a/src/imbi_api/endpoints/projects.py
+++ b/src/imbi_api/endpoints/projects.py
@@ -17,6 +17,11 @@ import psycopg
 import pydantic
 from imbi_common import blueprints, graph, models
 from imbi_common.clickhouse import client as ch_client
+from imbi_common.plugins.base import (
+    LifecyclePlugin,
+    PluginContext,
+    RelocationTarget,
+)
 from imbi_common.scoring import compute_score
 
 from imbi_api import blueprint_attributes
@@ -35,6 +40,7 @@ from imbi_api.plugins.lifecycle_dispatch import (
     build_lifecycle_context_bundle,
     dispatch_lifecycle,
 )
+from imbi_api.plugins.resolution import resolve_all_plugins
 from imbi_api.relationships import RelationshipSpec, build_relationships
 from imbi_api.scoring import OptionalValkeyClient
 from imbi_api.scoring import queue as score_queue
@@ -281,6 +287,36 @@ class ProjectDeletedResponse(pydantic.BaseModel):
     """
 
     lifecycle_results: list[LifecycleInvocation] = []
+
+
+class LifecyclePreviewEntry(pydantic.BaseModel):
+    """One row of the ``/lifecycle/preview`` response.
+
+    Lets the UI decide whether to surface a "move repository" affordance
+    for the hypothetical ``project_type_slugs`` set: ``would_relocate``
+    is true when the plugin would route the link somewhere different
+    than where it points today.  ``current_target`` may be ``None`` if
+    the project has no project types assigned today (a brand-new
+    project being type-tagged for the first time).
+    """
+
+    plugin_id: str
+    plugin_slug: str
+    current_target: RelocationTarget | None = None
+    next_target: RelocationTarget | None = None
+    would_relocate: bool = False
+
+
+class LifecyclePreviewResponse(pydantic.BaseModel):
+    """Per-plugin preview for a hypothetical project-type change.
+
+    Empty ``previews`` when the project has no lifecycle plugins
+    assigned, or when none of the assigned plugins implement
+    :meth:`LifecyclePlugin.resolve_relocation_target` (the default
+    base implementation returns ``None``).
+    """
+
+    previews: list[LifecyclePreviewEntry] = []
 
 
 def _build_project_ui_url(org_slug: str, project_id: str) -> str | None:
@@ -2178,6 +2214,7 @@ async def patch_project(
             permissions.require_permission('project:write'),
         ),
     ],
+    transfer_repository: bool = False,
 ) -> ProjectMutationResponse:
     """Partially update a project using JSON Patch (RFC 6902).
 
@@ -2185,6 +2222,13 @@ async def patch_project(
         org_slug: Organization slug from URL path.
         project_id: Project nano-ID from URL.
         operations: JSON Patch operations list.
+        transfer_repository: When the patch changes
+            ``project_type_slugs`` and the operator opted in (via the
+            ``/lifecycle/preview`` UI affordance), also dispatch
+            ``'relocated'`` so lifecycle plugins can move the backing
+            remote (e.g. a GitHub repo transfer) to the new mapping.
+            Defaults to ``False`` so a type change alone never moves
+            the remote.
 
     Returns:
         The updated project.
@@ -2331,10 +2375,150 @@ async def patch_project(
                 'Lifecycle dispatch failed after updating project %s',
                 project_id,
             )
+    # ``transfer_repository`` is a deliberate opt-in: it never fires for
+    # an unchanged project-type set, and never fires implicitly on a
+    # type change.  The UI surfaces the would-relocate preview from
+    # ``/lifecycle/preview`` and only sets this flag when the operator
+    # checks the "Also move repository" box.
+    new_type_slugs_raw: typing.Any = patched.get('project_type_slugs') or []
+    new_type_slugs: list[str] = [
+        s
+        for s in typing.cast(list[typing.Any], new_type_slugs_raw)
+        if isinstance(s, str) and s
+    ]
+    types_changed = set(new_type_slugs) != set(current_type_slugs)
+    if transfer_repository and types_changed:
+        try:
+            relocate_results = await dispatch_lifecycle(
+                db,
+                project_id,
+                org_slug,
+                'relocated',
+                auth,
+                previous_project_slug=previous_slug if slug_changed else None,
+                previous_project_type_slugs=current_type_slugs,
+                project_name=response.name,
+                project_description=response.description,
+                project_ui_url=_build_project_ui_url(org_slug, project_id),
+            )
+            lifecycle_results = [*lifecycle_results, *relocate_results]
+        except Exception:
+            LOGGER.exception(
+                'Lifecycle relocate dispatch failed after updating project %s',
+                project_id,
+            )
     return ProjectMutationResponse(
         **response.model_dump(),
         lifecycle_results=lifecycle_results,
     )
+
+
+@projects_router.get('/{project_id}/lifecycle/preview')
+async def preview_lifecycle(
+    org_slug: str,
+    project_id: str,
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('project:read'),
+        ),
+    ],
+    project_type_slugs: typing.Annotated[
+        list[str],
+        fastapi.Query(
+            description=(
+                'Hypothetical project-type slug set to evaluate. '
+                'Repeatable, e.g. '
+                '``?project_type_slugs=api&project_type_slugs=consumer``.'
+            ),
+        ),
+    ],
+) -> LifecyclePreviewResponse:
+    """Preview the relocation outcome of a project-type change.
+
+    Resolves every lifecycle plugin assigned to the project (project- +
+    project-type-level), then asks each plugin's
+    :meth:`LifecyclePlugin.resolve_relocation_target` what target it
+    would route to *today* vs *given the hypothetical type set*.  The UI
+    uses ``would_relocate=True`` rows to surface the "Also move
+    repository to ``<display>``?" opt-in checkbox on the project-type
+    edit dialog.
+
+    The plugin contract requires ``resolve_relocation_target`` to be
+    local-only (no remote calls), so this endpoint is cheap to poll on
+    every selection change.  Per-plugin exceptions are swallowed -- a
+    broken plugin must not block the rest of the preview.
+    """
+    del auth  # read-only preview; authorization handled by the dependency.
+    bundle = await build_lifecycle_context_bundle(db, project_id)
+    resolved = await resolve_all_plugins(db, project_id, 'lifecycle')
+    if not resolved:
+        return LifecyclePreviewResponse(previews=[])
+
+    # Strip empties + duplicates while preserving order so the
+    # hypothetical type set behaves like the stored one.
+    next_types: list[str] = []
+    seen: set[str] = set()
+    for slug in project_type_slugs:
+        slug = slug.strip()
+        if slug and slug not in seen:
+            next_types.append(slug)
+            seen.add(slug)
+
+    previews: list[LifecyclePreviewEntry] = []
+    for plugin in resolved:
+        handler = typing.cast(LifecyclePlugin, plugin.entry.handler_cls())
+        current_ctx = PluginContext(
+            project_id=project_id,
+            project_slug=bundle.project_slug,
+            org_slug=org_slug,
+            team_slug=bundle.team_slug,
+            assignment_options=plugin.options,
+            project_links=bundle.project_links,
+            project_type_slugs=bundle.project_type_slugs,
+        )
+        next_ctx = current_ctx.model_copy(
+            update={'project_type_slugs': next_types}
+        )
+        current_target = await _safe_resolve_target(handler, current_ctx)
+        next_target = await _safe_resolve_target(handler, next_ctx)
+        would_relocate = next_target is not None and (
+            current_target is None
+            or current_target.identifier != next_target.identifier
+        )
+        previews.append(
+            LifecyclePreviewEntry(
+                plugin_id=plugin.plugin_id,
+                plugin_slug=plugin.plugin_slug,
+                current_target=current_target,
+                next_target=next_target,
+                would_relocate=would_relocate,
+            )
+        )
+    return LifecyclePreviewResponse(previews=previews)
+
+
+async def _safe_resolve_target(
+    handler: LifecyclePlugin,
+    ctx: PluginContext,
+) -> RelocationTarget | None:
+    """Call ``resolve_relocation_target``, swallowing plugin errors.
+
+    A broken plugin must not poison the preview for the others; log and
+    return ``None`` so the row reports ``would_relocate=False``.  The
+    plugin contract guarantees the call is local-only, so credentials
+    can be an empty dict.
+    """
+    try:
+        return await handler.resolve_relocation_target(ctx, {})
+    except Exception:
+        LOGGER.exception(
+            'resolve_relocation_target raised for plugin %s on project %s',
+            handler.manifest.slug,
+            ctx.project_id,
+        )
+        return None
 
 
 async def _set_archived_state(

--- a/tests/endpoints/test_projects.py
+++ b/tests/endpoints/test_projects.py
@@ -1655,6 +1655,7 @@ class ProjectEndpointsTestCase(unittest.TestCase):
             entry=mock.MagicMock(handler_cls=lambda: plugin_b_handler),
         )
 
+        self.mock_db.execute.side_effect = [[{'id': PROJECT_ID}]]
         with (
             mock.patch(
                 'imbi_api.endpoints.projects.build_lifecycle_context_bundle',
@@ -1687,6 +1688,7 @@ class ProjectEndpointsTestCase(unittest.TestCase):
     def test_preview_returns_empty_when_no_lifecycle_plugins(self) -> None:
         """No assigned lifecycle plugins → empty previews list."""
         self._bundle_patcher.stop()
+        self.mock_db.execute.side_effect = [[{'id': PROJECT_ID}]]
         with (
             mock.patch(
                 'imbi_api.endpoints.projects.build_lifecycle_context_bundle',
@@ -1711,6 +1713,29 @@ class ProjectEndpointsTestCase(unittest.TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {'previews': []})
+
+    def test_preview_returns_404_when_project_missing(self) -> None:
+        """Missing project → 404 instead of silently empty previews."""
+        self._bundle_patcher.stop()
+        self.mock_db.execute.side_effect = [[]]
+        with (
+            mock.patch(
+                'imbi_api.endpoints.projects.build_lifecycle_context_bundle',
+                new=mock.AsyncMock(),
+            ) as mock_bundle,
+            mock.patch(
+                'imbi_api.endpoints.projects.resolve_all_plugins',
+                new=mock.AsyncMock(return_value=[]),
+            ) as mock_resolve,
+        ):
+            response = self.client.get(
+                f'/organizations/engineering/projects/{PROJECT_ID}'
+                '/lifecycle/preview?project_type_slugs=worker',
+            )
+
+        self.assertEqual(response.status_code, 404)
+        mock_bundle.assert_not_awaited()
+        mock_resolve.assert_not_awaited()
 
 
 class _RelationshipsTestBase(unittest.TestCase):

--- a/tests/endpoints/test_projects.py
+++ b/tests/endpoints/test_projects.py
@@ -1458,6 +1458,123 @@ class ProjectEndpointsTestCase(unittest.TestCase):
         self.assertEqual(call.args[3], 'updated')
         self.assertEqual(call.kwargs['previous_project_slug'], 'my-api')
 
+    def test_patch_dispatches_relocated_when_transfer_repository_set(
+        self,
+    ) -> None:
+        """``?transfer_repository=true`` + type change → relocate dispatch.
+
+        Asserts the dispatcher is called with ``event='relocated'`` and
+        the previous types are carried through so plugins can decide
+        between transfer and no-op.  The ``updated`` dispatch path is
+        not exercised here (slug/description are unchanged), so the
+        single dispatch await is the relocate call.
+        """
+        existing = self._project_data()
+        updated = self._project_data(
+            project_types=[
+                {
+                    'name': 'Worker',
+                    'slug': 'worker',
+                    'organization': {
+                        'name': 'Engineering',
+                        'slug': 'engineering',
+                    },
+                },
+            ],
+        )
+        self.mock_db.execute.side_effect = [
+            [{'project': existing, 'outbound_count': 0, 'inbound_count': 0}],
+            [{'slug': 'platform'}],
+            [{'pt_slug': 'worker', 'found': True}],
+            [{'project': updated, 'outbound_count': 0, 'inbound_count': 0}],
+        ]
+        self._dispatch_patcher.stop()
+        with (
+            mock.patch('imbi_common.blueprints.get_model') as mock_get_model,
+            mock.patch(
+                'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+            ),
+            mock.patch(
+                'imbi_api.endpoints.projects.dispatch_lifecycle',
+                new=mock.AsyncMock(return_value=[]),
+            ) as mock_dispatch,
+        ):
+            mock_get_model.return_value = models.Project
+            response = self.client.patch(
+                f'/organizations/engineering/projects/{PROJECT_ID}'
+                '?transfer_repository=true',
+                json=[
+                    {
+                        'op': 'replace',
+                        'path': '/project_type_slugs',
+                        'value': ['worker'],
+                    },
+                ],
+            )
+
+        self.assertEqual(response.status_code, 200)
+        mock_dispatch.assert_awaited_once()
+        call = mock_dispatch.await_args
+        self.assertEqual(call.args[3], 'relocated')
+        self.assertEqual(
+            call.kwargs['previous_project_type_slugs'], ['api-service']
+        )
+
+    def test_patch_skips_relocate_without_transfer_repository_flag(
+        self,
+    ) -> None:
+        """Default behaviour: type change alone never relocates.
+
+        Without ``?transfer_repository=true`` a project-type swap is
+        considered metadata-only -- plugins do not get a relocate
+        event.  Guards against accidentally moving repos when an
+        operator just retags a project.
+        """
+        existing = self._project_data()
+        updated = self._project_data(
+            project_types=[
+                {
+                    'name': 'Worker',
+                    'slug': 'worker',
+                    'organization': {
+                        'name': 'Engineering',
+                        'slug': 'engineering',
+                    },
+                },
+            ],
+        )
+        self.mock_db.execute.side_effect = [
+            [{'project': existing, 'outbound_count': 0, 'inbound_count': 0}],
+            [{'slug': 'platform'}],
+            [{'pt_slug': 'worker', 'found': True}],
+            [{'project': updated, 'outbound_count': 0, 'inbound_count': 0}],
+        ]
+        self._dispatch_patcher.stop()
+        with (
+            mock.patch('imbi_common.blueprints.get_model') as mock_get_model,
+            mock.patch(
+                'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+            ),
+            mock.patch(
+                'imbi_api.endpoints.projects.dispatch_lifecycle',
+                new=mock.AsyncMock(return_value=[]),
+            ) as mock_dispatch,
+        ):
+            mock_get_model.return_value = models.Project
+            response = self.client.patch(
+                f'/organizations/engineering/projects/{PROJECT_ID}',
+                json=[
+                    {
+                        'op': 'replace',
+                        'path': '/project_type_slugs',
+                        'value': ['worker'],
+                    },
+                ],
+            )
+
+        self.assertEqual(response.status_code, 200)
+        mock_dispatch.assert_not_awaited()
+
     def test_delete_with_delete_repository_false_skips_dispatch(
         self,
     ) -> None:
@@ -1489,6 +1606,111 @@ class ProjectEndpointsTestCase(unittest.TestCase):
         self.assertEqual(response.json(), {'lifecycle_results': []})
         mock_dispatch.assert_not_awaited()
         mock_bundle.assert_not_awaited()
+
+    def test_preview_returns_would_relocate_per_plugin(self) -> None:
+        """``GET /lifecycle/preview`` fans out per plugin and flags diffs.
+
+        Stubs ``resolve_all_plugins`` with two plugins whose handlers
+        return different ``resolve_relocation_target`` outputs for the
+        current vs hypothetical type set, and asserts the preview rows
+        carry the expected ``would_relocate`` flags.
+        """
+        from imbi_common.plugins.base import RelocationTarget
+
+        self._bundle_patcher.stop()
+        bundle_value = mock.MagicMock(
+            project_slug='my-api',
+            team_slug='platform',
+            project_links={},
+            project_type_slugs=['api-service'],
+        )
+
+        plugin_a_handler = mock.AsyncMock()
+        plugin_a_handler.resolve_relocation_target.side_effect = [
+            RelocationTarget(
+                link_key='github-repository', identifier='apis/my-api'
+            ),
+            RelocationTarget(
+                link_key='github-repository', identifier='workers/my-api'
+            ),
+        ]
+        plugin_b_handler = mock.AsyncMock()
+        plugin_b_handler.resolve_relocation_target.side_effect = [
+            None,
+            None,
+        ]
+        plugin_a_handler.manifest = mock.MagicMock(slug='gh-a')
+        plugin_b_handler.manifest = mock.MagicMock(slug='gh-b')
+
+        plugin_a = mock.MagicMock(
+            plugin_id='p-a',
+            plugin_slug='gh-a',
+            options={},
+            entry=mock.MagicMock(handler_cls=lambda: plugin_a_handler),
+        )
+        plugin_b = mock.MagicMock(
+            plugin_id='p-b',
+            plugin_slug='gh-b',
+            options={},
+            entry=mock.MagicMock(handler_cls=lambda: plugin_b_handler),
+        )
+
+        with (
+            mock.patch(
+                'imbi_api.endpoints.projects.build_lifecycle_context_bundle',
+                new=mock.AsyncMock(return_value=bundle_value),
+            ),
+            mock.patch(
+                'imbi_api.endpoints.projects.resolve_all_plugins',
+                new=mock.AsyncMock(return_value=[plugin_a, plugin_b]),
+            ),
+        ):
+            response = self.client.get(
+                f'/organizations/engineering/projects/{PROJECT_ID}'
+                '/lifecycle/preview?project_type_slugs=worker',
+            )
+
+        self.assertEqual(response.status_code, 200)
+        body = response.json()
+        self.assertEqual(len(body['previews']), 2)
+
+        rows_by_plugin = {row['plugin_slug']: row for row in body['previews']}
+        row_a = rows_by_plugin['gh-a']
+        self.assertTrue(row_a['would_relocate'])
+        self.assertEqual(row_a['current_target']['identifier'], 'apis/my-api')
+        self.assertEqual(row_a['next_target']['identifier'], 'workers/my-api')
+        row_b = rows_by_plugin['gh-b']
+        self.assertFalse(row_b['would_relocate'])
+        self.assertIsNone(row_b['current_target'])
+        self.assertIsNone(row_b['next_target'])
+
+    def test_preview_returns_empty_when_no_lifecycle_plugins(self) -> None:
+        """No assigned lifecycle plugins → empty previews list."""
+        self._bundle_patcher.stop()
+        with (
+            mock.patch(
+                'imbi_api.endpoints.projects.build_lifecycle_context_bundle',
+                new=mock.AsyncMock(
+                    return_value=mock.MagicMock(
+                        project_slug='my-api',
+                        team_slug='platform',
+                        project_links={},
+                        project_type_slugs=['api-service'],
+                    ),
+                ),
+            ),
+            mock.patch(
+                'imbi_api.endpoints.projects.resolve_all_plugins',
+                new=mock.AsyncMock(return_value=[]),
+            ),
+        ):
+            response = self.client.get(
+                f'/organizations/engineering/projects/{PROJECT_ID}'
+                '/lifecycle/preview?project_type_slugs=worker',
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {'previews': []})
 
 
 class _RelationshipsTestBase(unittest.TestCase):


### PR DESCRIPTION
## Summary

Closes the remaining gap in the cross-repo project-lifecycle contract (`docs/lifecycle-project-create-rename-delete.md`) so the UI can preview a project-type retag's effect on the backing repository and the operator can opt in to actually moving it:

- **`GET /organizations/{org}/projects/{id}/lifecycle/preview?project_type_slugs=...`** — read-only. Resolves every lifecycle plugin assigned to the project and asks each plugin's `resolve_relocation_target` what target it would route to *today* vs under the hypothetical type set. Returns one `LifecyclePreviewEntry` per plugin with the two `RelocationTarget` snapshots and a `would_relocate` flag the UI uses to gate the "Also move repository to `<display>`?" opt-in checkbox.
- **`PATCH /organizations/{org}/projects/{id}?transfer_repository=true`** — new optional query param. Default `false` so a type retag never moves the repo implicitly. When set and the patch actually changed `project_type_slugs`, the endpoint dispatches `'relocated'` after the graph write (carrying `previous_project_type_slugs` + `previous_project_slug` when slug also changed) so plugins can transfer the remote.

The plugin contract requires `resolve_relocation_target` to be local-only (no remote calls), so the preview is cheap to poll on every selection change and per-plugin exceptions are swallowed via `_safe_resolve_target` to prevent one broken plugin from poisoning the rest of the preview.

## Why

Pair with `imbi-plugin-github#23` (the GitHub plugin's `on_project_relocated` + `resolve_relocation_target` implementation). With both landed the project-type-edit dialog in `imbi-ui` (#11) can show the preview and surface the opt-in.

## Test plan

- [x] 4 new tests in `ProjectEndpointsTestCase`: dispatch on flag+type-change, skip without flag, preview happy path across two plugins, preview empty when no plugins. **All 4 pass.**
- [x] `basedpyright` on `src/imbi_api/endpoints/projects.py` — 0 errors.
- [x] `pre-commit run --files src/imbi_api/endpoints/projects.py tests/endpoints/test_projects.py` — ruff check + format + mypy all green.
- [ ] Full `just test` (CI will run).