### PR TITLE
Reuse one FastAPI app across tests to cut suite time

### DIFF
--- a/tests/auth/test_authentication.py
+++ b/tests/auth/test_authentication.py
@@ -9,9 +9,10 @@ import jwt
 from imbi_common import graph
 from imbi_common.auth import core
 
-from imbi_api import app, models, settings
+from imbi_api import models, settings
 from imbi_api.auth import password
 from imbi_api.middleware import rate_limit
+from tests import support
 
 
 class PasswordHashingTestCase(unittest.TestCase):
@@ -140,12 +141,12 @@ class JWTTokenTestCase(unittest.TestCase):
             )
 
 
-class LoginEndpointTestCase(unittest.TestCase):
+class LoginEndpointTestCase(support.SharedAppTestCase):
     """Test login endpoint."""
 
     def setUp(self) -> None:
         """Set up TestClient and test User."""
-        self.application = app.create_app()
+        self.application = self.test_app
         self.client = fastapi.testclient.TestClient(self.application)
         self.mock_db = mock.AsyncMock()
         # Override graph dependency
@@ -286,12 +287,12 @@ class LoginEndpointTestCase(unittest.TestCase):
         self.assertIn('Invalid credentials', response.json()['detail'])
 
 
-class TokenRefreshEndpointTestCase(unittest.TestCase):
+class TokenRefreshEndpointTestCase(support.SharedAppTestCase):
     """Test token refresh endpoint."""
 
     def setUp(self) -> None:
         """Prepare test fixtures."""
-        self.application = app.create_app()
+        self.application = self.test_app
         self.client = fastapi.testclient.TestClient(self.application)
         self.mock_db = mock.AsyncMock()
         self.application.dependency_overrides[graph._inject_graph] = lambda: (
@@ -436,11 +437,11 @@ class TokenRefreshEndpointTestCase(unittest.TestCase):
         self.assertIn('revoked', response.json()['detail'].lower())
 
 
-class LogoutEndpointTestCase(unittest.TestCase):
+class LogoutEndpointTestCase(support.SharedAppTestCase):
     """Test logout endpoint."""
 
     def setUp(self) -> None:
-        self.application = app.create_app()
+        self.application = self.test_app
         self.client = fastapi.testclient.TestClient(self.application)
         self.mock_db = mock.AsyncMock()
         self.application.dependency_overrides[graph._inject_graph] = lambda: (

--- a/tests/auth/test_authorization.py
+++ b/tests/auth/test_authorization.py
@@ -8,8 +8,9 @@ import fastapi
 from imbi_common import graph
 from imbi_common.auth import core
 
-from imbi_api import app, models, settings
+from imbi_api import models, settings
 from imbi_api.auth import password, permissions
+from tests import support
 
 
 class PermissionLoadingTestCase(unittest.IsolatedAsyncioTestCase):
@@ -280,12 +281,12 @@ class AuthenticateJWTTestCase(unittest.IsolatedAsyncioTestCase):
         self.assertIn('not found', str(ctx.exception.detail).lower())
 
 
-class ProtectedEndpointTestCase(unittest.TestCase):
+class ProtectedEndpointTestCase(support.SharedAppTestCase):
     """Test protected endpoints require authentication."""
 
     def setUp(self) -> None:
         """Prepare TestClient and auth settings."""
-        self.app = app.create_app()
+        self.app = self.test_app
         self.client = fastapi.testclient.TestClient(self.app)
         self.auth_settings = settings.Auth(
             jwt_secret='test-secret-key-32-characters!',

--- a/tests/endpoints/test_admin.py
+++ b/tests/endpoints/test_admin.py
@@ -1,22 +1,21 @@
 """Tests for admin settings endpoint."""
 
 import datetime
-import unittest
 from unittest import mock
 
 from fastapi import testclient
 from imbi_common import graph
 
-from imbi_api import app, models, settings
+from imbi_api import models, settings
 from imbi_api.auth import password, permissions
+from tests import support
 
 
-class AdminSettingsEndpointTestCase(unittest.TestCase):
+class AdminSettingsEndpointTestCase(support.SharedAppTestCase):
     """Test cases for GET /admin/settings endpoint."""
 
     def setUp(self) -> None:
         """Set up test client, auth settings, and test user."""
-        self.test_app = app.create_app()
 
         self.auth_settings = settings.Auth(
             jwt_secret='test-secret-key-min-32-chars-long',

--- a/tests/endpoints/test_admin_plugins.py
+++ b/tests/endpoints/test_admin_plugins.py
@@ -1,22 +1,21 @@
 """Tests for admin plugin management endpoints."""
 
 import datetime
-import unittest
 from unittest import mock
 
 from fastapi import testclient
 from imbi_common import graph
 
-from imbi_api import app, models
+from imbi_api import models
 from imbi_api.auth import password, permissions
 from imbi_api.endpoints import plugin_edges as _plugin_edges
+from tests import support
 
 
-class AdminPluginsEndpointTestCase(unittest.TestCase):
+class AdminPluginsEndpointTestCase(support.SharedAppTestCase):
     """Test cases for /admin/plugins admin endpoints."""
 
     def setUp(self) -> None:
-        self.test_app = app.create_app()
         self.test_user = models.User(
             email='admin@example.com',
             display_name='Admin User',

--- a/tests/endpoints/test_api_keys.py
+++ b/tests/endpoints/test_api_keys.py
@@ -1,22 +1,21 @@
 """Tests for API key management endpoints."""
 
 import datetime
-import unittest
 from unittest import mock
 
 from fastapi import testclient
 from imbi_common import graph
 
-from imbi_api import app, models, settings
+from imbi_api import models, settings
 from imbi_api.auth import password, permissions
+from tests import support
 
 
-class APIKeysEndpointsTestCase(unittest.TestCase):
+class APIKeysEndpointsTestCase(support.SharedAppTestCase):
     """Test API keys endpoint functionality."""
 
     def setUp(self) -> None:
         """Set up test fixtures."""
-        self.test_app = app.create_app()
 
         # Create test user
         self.test_user = models.User(

--- a/tests/endpoints/test_auth.py
+++ b/tests/endpoints/test_auth.py
@@ -8,12 +8,13 @@ import pydantic
 from fastapi import testclient
 from imbi_common import graph
 
-from imbi_api import app, settings
+from imbi_api import settings
 from imbi_api.auth import local_auth, login_providers
 from imbi_api.auth import models as auth_models
 from imbi_api.domain import models as domain_models
 from imbi_api.endpoints import auth as auth_endpoints
 from imbi_api.middleware import rate_limit
+from tests import support
 
 
 def _stub_provider(
@@ -191,13 +192,12 @@ class RedactEmailTestCase(unittest.TestCase):
         self.assertEqual(_redact_email(''), '<redacted>')
 
 
-class AuthProvidersEndpointTestCase(unittest.TestCase):
+class AuthProvidersEndpointTestCase(support.SharedAppTestCase):
     """Test cases for GET /auth/providers endpoint."""
 
     def setUp(self) -> None:
         """Set up test client and mock settings."""
         settings._auth_settings = None
-        self.test_app = app.create_app()
         self.mock_db = mock.AsyncMock(spec=graph.Graph)
         self.test_app.dependency_overrides[graph._inject_graph] = lambda: (
             self.mock_db
@@ -294,14 +294,13 @@ class AuthProvidersEndpointTestCase(unittest.TestCase):
         )
 
 
-class OAuthFlowTestCase(unittest.TestCase):
+class OAuthFlowTestCase(support.SharedAppTestCase):
     """Test cases for OAuth login flow endpoints."""
 
     def setUp(self) -> None:
         """Set up test client."""
         settings._auth_settings = None
         rate_limit.limiter.reset()
-        self.test_app = app.create_app()
 
         self.mock_db = mock.AsyncMock(spec=graph.Graph)
         self.test_app.dependency_overrides[graph._inject_graph] = lambda: (
@@ -460,13 +459,12 @@ class OAuthFlowTestCase(unittest.TestCase):
         self.assertIn('client_id=oidc-id', location)
 
 
-class LoginPasswordRehashTestCase(unittest.TestCase):
+class LoginPasswordRehashTestCase(support.SharedAppTestCase):
     """Test password rehashing during login."""
 
     def setUp(self) -> None:
         """Set up test client."""
         settings._auth_settings = None
-        self.test_app = app.create_app()
 
         self.mock_db = mock.AsyncMock(spec=graph.Graph)
         self.test_app.dependency_overrides[graph._inject_graph] = lambda: (
@@ -539,13 +537,12 @@ class LoginPasswordRehashTestCase(unittest.TestCase):
             )
 
 
-class LoginMFATestCase(unittest.TestCase):
+class LoginMFATestCase(support.SharedAppTestCase):
     """Test MFA integration in login endpoint."""
 
     def setUp(self) -> None:
         """Set up test client."""
         settings._auth_settings = None
-        self.test_app = app.create_app()
 
         self.mock_db = mock.AsyncMock(spec=graph.Graph)
         self.test_app.dependency_overrides[graph._inject_graph] = lambda: (
@@ -931,13 +928,12 @@ class LoginMFATestCase(unittest.TestCase):
         )
 
 
-class OAuthCallbackSuccessTestCase(unittest.TestCase):
+class OAuthCallbackSuccessTestCase(support.SharedAppTestCase):
     """Test OAuth callback success path."""
 
     def setUp(self) -> None:
         """Set up test client."""
         settings._auth_settings = None
-        self.test_app = app.create_app()
 
         self.mock_db = mock.AsyncMock(spec=graph.Graph)
         self.test_app.dependency_overrides[graph._inject_graph] = lambda: (
@@ -1576,13 +1572,12 @@ class OAuthCallbackSuccessTestCase(unittest.TestCase):
             )
 
 
-class TokenRefreshTestCase(unittest.TestCase):
+class TokenRefreshTestCase(support.SharedAppTestCase):
     """Test token refresh endpoint."""
 
     def setUp(self) -> None:
         """Set up test client."""
         settings._auth_settings = None
-        self.test_app = app.create_app()
 
         self.mock_db = mock.AsyncMock(spec=graph.Graph)
         self.test_app.dependency_overrides[graph._inject_graph] = lambda: (
@@ -1935,14 +1930,13 @@ class TokenRefreshTestCase(unittest.TestCase):
         self.assertEqual(third_call_params['family_id'], 'fam-leak')
 
 
-class LogoutTestCase(unittest.TestCase):
+class LogoutTestCase(support.SharedAppTestCase):
     """Test logout endpoint."""
 
     def setUp(self) -> None:
         """Set up test client."""
 
         settings._auth_settings = None
-        self.test_app = app.create_app()
 
         self.mock_db = mock.AsyncMock(spec=graph.Graph)
         self.test_app.dependency_overrides[graph._inject_graph] = lambda: (
@@ -2102,7 +2096,7 @@ class LogoutTestCase(unittest.TestCase):
             )
 
 
-class ServiceAccountAuthTestCase(unittest.TestCase):
+class ServiceAccountAuthTestCase(support.SharedAppTestCase):
     """Test service account authentication guardrails."""
 
     def setUp(self) -> None:
@@ -2110,7 +2104,6 @@ class ServiceAccountAuthTestCase(unittest.TestCase):
         from imbi_api import models
 
         settings._auth_settings = None
-        self.test_app = app.create_app()
 
         self.mock_db = mock.AsyncMock(spec=graph.Graph)
         self.test_app.dependency_overrides[graph._inject_graph] = lambda: (
@@ -2460,7 +2453,7 @@ class ServiceAccountAuthTestCase(unittest.TestCase):
             )
 
 
-class IdentityPluginLoginFlowTestCase(unittest.TestCase):
+class IdentityPluginLoginFlowTestCase(support.SharedAppTestCase):
     """Cover the identity-plugin branch of /auth/oauth/{provider}.
 
     Exercises both the start (``oauth_login``) and callback
@@ -2480,7 +2473,6 @@ class IdentityPluginLoginFlowTestCase(unittest.TestCase):
         self._identity_repository = identity_repository
 
         settings._auth_settings = None
-        self.test_app = app.create_app()
         self.mock_db = mock.AsyncMock(spec=graph.Graph)
         self.test_app.dependency_overrides[graph._inject_graph] = lambda: (
             self.mock_db

--- a/tests/endpoints/test_blueprints.py
+++ b/tests/endpoints/test_blueprints.py
@@ -1,17 +1,17 @@
 """Tests for blueprint CRUD endpoints"""
 
 import datetime
-import unittest
 from unittest import mock
 
 import psycopg.errors
 from fastapi import testclient
 from imbi_common import graph
 
-from imbi_api import app, models
+from imbi_api import models
+from tests import support
 
 
-class BlueprintEndpointsTestCase(unittest.TestCase):
+class BlueprintEndpointsTestCase(support.SharedAppTestCase):
     """Test cases for blueprint CRUD endpoints."""
 
     def setUp(self) -> None:
@@ -22,8 +22,6 @@ class BlueprintEndpointsTestCase(unittest.TestCase):
         Blueprint model.
         """
         from imbi_api.auth import permissions
-
-        self.test_app = app.create_app()
 
         # Create an admin user for authentication
         self.admin_user = models.User(

--- a/tests/endpoints/test_client_credentials.py
+++ b/tests/endpoints/test_client_credentials.py
@@ -1,22 +1,21 @@
 """Tests for client credentials CRUD endpoints."""
 
 import datetime
-import unittest
 from unittest import mock
 
 from fastapi import testclient
 from imbi_common import graph
 
-from imbi_api import app, models, settings
+from imbi_api import models, settings
 from imbi_api.auth import password, permissions
+from tests import support
 
 
-class ClientCredentialsEndpointsTestCase(unittest.TestCase):
+class ClientCredentialsEndpointsTestCase(support.SharedAppTestCase):
     """Test client credentials endpoint functionality."""
 
     def setUp(self) -> None:
         """Set up test fixtures."""
-        self.test_app = app.create_app()
 
         self.test_user = models.User(
             email='admin@example.com',

--- a/tests/endpoints/test_document_templates.py
+++ b/tests/endpoints/test_document_templates.py
@@ -2,22 +2,20 @@
 
 import datetime
 import typing
-import unittest
 from unittest import mock
 
 from fastapi.testclient import TestClient
 from imbi_common import graph
 
-from imbi_api import app, models
+from imbi_api import models
+from tests import support
 
 
-class DocumentTemplateEndpointsTestCase(unittest.TestCase):
+class DocumentTemplateEndpointsTestCase(support.SharedAppTestCase):
     """Test cases for document template CRUD."""
 
     def setUp(self) -> None:
         from imbi_api.auth import permissions
-
-        self.test_app = app.create_app()
 
         self.admin_user = models.User(
             email='admin@example.com',

--- a/tests/endpoints/test_documents.py
+++ b/tests/endpoints/test_documents.py
@@ -8,16 +8,15 @@ from unittest import mock
 from fastapi.testclient import TestClient
 from imbi_common import graph
 
-from imbi_api import app, models
+from imbi_api import models
+from tests import support
 
 
-class DocumentEndpointsTestCase(unittest.TestCase):
+class DocumentEndpointsTestCase(support.SharedAppTestCase):
     """Test cases for documents CRUD + cross-project search."""
 
     def setUp(self) -> None:
         from imbi_api.auth import permissions
-
-        self.test_app = app.create_app()
 
         self.admin_user = models.User(
             email='admin@example.com',

--- a/tests/endpoints/test_environments.py
+++ b/tests/endpoints/test_environments.py
@@ -1,24 +1,22 @@
 """Tests for environment CRUD endpoints."""
 
 import datetime
-import unittest
 from unittest import mock
 
 import psycopg.errors
 from fastapi import testclient
 from imbi_common import graph
 
-from imbi_api import app, models
+from imbi_api import models
+from tests import support
 
 
-class EnvironmentEndpointsTestCase(unittest.TestCase):
+class EnvironmentEndpointsTestCase(support.SharedAppTestCase):
     """Test cases for environment CRUD endpoints."""
 
     def setUp(self) -> None:
         """Set up test app with admin authentication."""
         from imbi_api.auth import permissions
-
-        self.test_app = app.create_app()
 
         self.admin_user = models.User(
             email='admin@example.com',

--- a/tests/endpoints/test_events.py
+++ b/tests/endpoints/test_events.py
@@ -10,10 +10,10 @@ from unittest import mock
 from fastapi import testclient
 from imbi_common import graph
 
-from imbi_api import app
 from imbi_api import models as api_models
 from imbi_api.auth import permissions as api_permissions
 from imbi_api.endpoints import events
+from tests import support
 
 
 def _row(
@@ -35,9 +35,8 @@ def _row(
     }
 
 
-class _EventsTestBase(unittest.TestCase):
+class _EventsTestBase(support.SharedAppTestCase):
     def setUp(self) -> None:
-        self.test_app = app.create_app()
         self.user = api_models.User(
             email='alice@example.com',
             display_name='Alice',

--- a/tests/endpoints/test_graph_query.py
+++ b/tests/endpoints/test_graph_query.py
@@ -2,15 +2,15 @@
 
 import datetime
 import json
-import unittest
 from unittest import mock
 
 import psycopg
 from fastapi import testclient
 from imbi_common import graph
 
-from imbi_api import app, models
+from imbi_api import models
 from imbi_api.auth import password, permissions
+from tests import support
 
 
 def _build_user(*, is_admin: bool) -> models.User:
@@ -24,11 +24,10 @@ def _build_user(*, is_admin: bool) -> models.User:
     )
 
 
-class GraphQueryEndpointTestCase(unittest.TestCase):
+class GraphQueryEndpointTestCase(support.SharedAppTestCase):
     """Tests for ``POST /admin/graph/query``."""
 
     def setUp(self) -> None:
-        self.test_app = app.create_app()
         self.auth_context = permissions.AuthContext(
             user=_build_user(is_admin=True),
             session_id='test-session',
@@ -259,11 +258,10 @@ class GraphQueryEndpointTestCase(unittest.TestCase):
         self.assertEqual(call.args[1], {'email': 'admin@example.com'})
 
 
-class GraphSchemaEndpointTestCase(unittest.TestCase):
+class GraphSchemaEndpointTestCase(support.SharedAppTestCase):
     """Tests for ``GET /admin/graph/schema``."""
 
     def setUp(self) -> None:
-        self.test_app = app.create_app()
         self.auth_context = permissions.AuthContext(
             user=_build_user(is_admin=True),
             session_id='test-session',

--- a/tests/endpoints/test_link_definitions.py
+++ b/tests/endpoints/test_link_definitions.py
@@ -2,24 +2,22 @@
 
 import datetime
 import typing
-import unittest
 from unittest import mock
 
 import psycopg.errors
 from fastapi.testclient import TestClient
 from imbi_common import graph
 
-from imbi_api import app, models
+from imbi_api import models
+from tests import support
 
 
-class LinkDefinitionEndpointsTestCase(unittest.TestCase):
+class LinkDefinitionEndpointsTestCase(support.SharedAppTestCase):
     """Test cases for link definition CRUD endpoints."""
 
     def setUp(self) -> None:
         """Set up test app with admin authentication."""
         from imbi_api.auth import permissions
-
-        self.test_app = app.create_app()
 
         self.admin_user = models.User(
             email='admin@example.com',

--- a/tests/endpoints/test_mcp_servers.py
+++ b/tests/endpoints/test_mcp_servers.py
@@ -2,24 +2,23 @@
 
 import datetime
 import typing
-import unittest
 from unittest import mock
 
 import psycopg.errors
 from fastapi.testclient import TestClient
 from imbi_common import graph
 
-from imbi_api import app, models
+from imbi_api import models
 from imbi_api.auth import permissions
 from imbi_api.mcp_test import ConnectionTestResult
+from tests import support
 
 
-class MCPServerEndpointsTestCase(unittest.TestCase):
+class MCPServerEndpointsTestCase(support.SharedAppTestCase):
     """Test cases for MCP server CRUD endpoints."""
 
     def setUp(self) -> None:
         """Set up test app with admin authentication."""
-        self.test_app = app.create_app()
 
         self.admin_user = models.User(
             email='admin@example.com',
@@ -541,12 +540,11 @@ class MCPServerEndpointsTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 404)
 
 
-class MCPServerPermissionTestCase(unittest.TestCase):
+class MCPServerPermissionTestCase(support.SharedAppTestCase):
     """Non-admin permission enforcement for MCP server endpoints."""
 
     def setUp(self) -> None:
         """Set up the app with a non-admin, unprivileged principal."""
-        self.test_app = app.create_app()
 
         self.user = models.User(
             email='user@example.com',

--- a/tests/endpoints/test_mfa.py
+++ b/tests/endpoints/test_mfa.py
@@ -2,19 +2,19 @@
 
 import base64
 import datetime
-import unittest
 from unittest import mock
 
 import pyotp
 from fastapi import testclient
 from imbi_common import graph
 
-from imbi_api import app, models, settings
+from imbi_api import models, settings
 from imbi_api.auth import password, permissions
 from imbi_api.middleware import rate_limit
+from tests import support
 
 
-class MFAEndpointsTestCase(unittest.TestCase):
+class MFAEndpointsTestCase(support.SharedAppTestCase):
     """Test MFA endpoint functionality."""
 
     def setUp(self) -> None:
@@ -23,7 +23,6 @@ class MFAEndpointsTestCase(unittest.TestCase):
         # doesn't bleed across tests in this suite (TestClient reuses
         # 127.0.0.1, which is the limiter key).
         rate_limit.limiter.reset()
-        self.test_app = app.create_app()
 
         # Create test user
         self.test_user = models.User(

--- a/tests/endpoints/test_operations_log.py
+++ b/tests/endpoints/test_operations_log.py
@@ -8,10 +8,10 @@ from unittest import mock
 from fastapi import testclient
 from imbi_common import clickhouse as imbi_clickhouse
 
-from imbi_api import app
 from imbi_api import models as api_models
 from imbi_api.auth import permissions as api_permissions
 from imbi_api.endpoints import operations_log
+from tests import support
 
 ALL_OPSLOG_PERMS: set[str] = {
     'operations_log:create',
@@ -52,13 +52,12 @@ def _sample_row(**overrides: typing.Any) -> dict[str, typing.Any]:
     return base
 
 
-class _OpsLogTestBase(unittest.TestCase):
+class _OpsLogTestBase(support.SharedAppTestCase):
     """Shared setup for operations-log endpoint tests."""
 
     permissions_granted: set[str] = ALL_OPSLOG_PERMS
 
     def setUp(self) -> None:
-        self.test_app = app.create_app()
         self.admin = api_models.User(
             email='alice@example.com',
             display_name='Alice',

--- a/tests/endpoints/test_organizations.py
+++ b/tests/endpoints/test_organizations.py
@@ -1,24 +1,22 @@
 """Tests for organization CRUD endpoints."""
 
 import datetime
-import unittest
 from unittest import mock
 
 import psycopg.errors
 from fastapi import testclient
 from imbi_common import graph
 
-from imbi_api import app, models
+from imbi_api import models
+from tests import support
 
 
-class OrganizationEndpointsTestCase(unittest.TestCase):
+class OrganizationEndpointsTestCase(support.SharedAppTestCase):
     """Test cases for organization CRUD endpoints."""
 
     def setUp(self) -> None:
         """Set up test app with admin authentication context."""
         from imbi_api.auth import permissions
-
-        self.test_app = app.create_app()
 
         self.admin_user = models.User(
             email='admin@example.com',

--- a/tests/endpoints/test_plugins.py
+++ b/tests/endpoints/test_plugins.py
@@ -1,21 +1,20 @@
 """Tests for non-admin plugin manifest endpoint."""
 
 import datetime
-import unittest
 from unittest import mock
 
 from fastapi import testclient
 from imbi_common import graph
 
-from imbi_api import app, models
+from imbi_api import models
 from imbi_api.auth import password, permissions
+from tests import support
 
 
-class PluginManifestEndpointTestCase(unittest.TestCase):
+class PluginManifestEndpointTestCase(support.SharedAppTestCase):
     """Test cases for ``GET /plugins/{slug}/manifest``."""
 
     def setUp(self) -> None:
-        self.test_app = app.create_app()
         self.test_user = models.User(
             email='editor@example.com',
             display_name='Project Editor',

--- a/tests/endpoints/test_project_deployments.py
+++ b/tests/endpoints/test_project_deployments.py
@@ -23,7 +23,7 @@ from imbi_common.plugins.base import (
 )
 from imbi_common.plugins.registry import RegistryEntry
 
-from imbi_api import app, models
+from imbi_api import models
 from imbi_api.auth import password, permissions
 from imbi_api.endpoints import _helpers
 from imbi_api.endpoints.project_deployments import (
@@ -33,6 +33,7 @@ from imbi_api.endpoints.project_deployments import (
 )
 from imbi_api.llm.dependencies import _get_anthropic_client
 from imbi_api.plugins.resolution import ResolvedPlugin
+from tests import support
 
 
 class _FakeDeploymentPlugin(DeploymentPlugin):
@@ -167,9 +168,8 @@ _MODULE = 'imbi_api.endpoints.project_deployments'
 _UPDATE_LINK = 'imbi_api.endpoints._helpers.update_project_link'
 
 
-class ProjectDeploymentsTestCase(unittest.TestCase):
+class ProjectDeploymentsTestCase(support.SharedAppTestCase):
     def setUp(self) -> None:
-        self.test_app = app.create_app()
         self.test_user = models.User(
             email='admin@example.com',
             display_name='Admin User',

--- a/tests/endpoints/test_project_logs.py
+++ b/tests/endpoints/test_project_logs.py
@@ -18,9 +18,10 @@ from imbi_common.plugins.errors import (
 )
 from imbi_common.plugins.registry import RegistryEntry
 
-from imbi_api import app, models
+from imbi_api import models
 from imbi_api.auth import password, permissions
 from imbi_api.plugins.resolution import ResolvedPlugin
+from tests import support
 
 
 class _FakeLogsPlugin(LogsPlugin):
@@ -59,9 +60,8 @@ def _entry() -> RegistryEntry:
     )
 
 
-class ProjectLogsEndpointTestCase(unittest.TestCase):
+class ProjectLogsEndpointTestCase(support.SharedAppTestCase):
     def setUp(self) -> None:
-        self.test_app = app.create_app()
         self.test_user = models.User(
             email='admin@example.com',
             display_name='Admin User',

--- a/tests/endpoints/test_project_plugins.py
+++ b/tests/endpoints/test_project_plugins.py
@@ -2,19 +2,18 @@
 
 import datetime
 import json
-import unittest
 from unittest import mock
 
 from fastapi import testclient
 from imbi_common import graph
 
-from imbi_api import app, models
+from imbi_api import models
 from imbi_api.auth import password, permissions
+from tests import support
 
 
-class ProjectPluginsEndpointTestCase(unittest.TestCase):
+class ProjectPluginsEndpointTestCase(support.SharedAppTestCase):
     def setUp(self) -> None:
-        self.test_app = app.create_app()
         self.test_user = models.User(
             email='admin@example.com',
             display_name='Admin User',

--- a/tests/endpoints/test_project_type_plugins.py
+++ b/tests/endpoints/test_project_type_plugins.py
@@ -2,19 +2,18 @@
 
 import datetime
 import json
-import unittest
 from unittest import mock
 
 from fastapi import testclient
 from imbi_common import graph
 
-from imbi_api import app, models
+from imbi_api import models
 from imbi_api.auth import password, permissions
+from tests import support
 
 
-class ProjectTypePluginsEndpointTestCase(unittest.TestCase):
+class ProjectTypePluginsEndpointTestCase(support.SharedAppTestCase):
     def setUp(self) -> None:
-        self.test_app = app.create_app()
         self.test_user = models.User(
             email='admin@example.com',
             display_name='Admin User',

--- a/tests/endpoints/test_project_types.py
+++ b/tests/endpoints/test_project_types.py
@@ -1,24 +1,22 @@
 """Tests for project type CRUD endpoints."""
 
 import datetime
-import unittest
 from unittest import mock
 
 import psycopg.errors
 from fastapi import testclient
 from imbi_common import graph
 
-from imbi_api import app, models
+from imbi_api import models
+from tests import support
 
 
-class ProjectTypeEndpointsTestCase(unittest.TestCase):
+class ProjectTypeEndpointsTestCase(support.SharedAppTestCase):
     """Test cases for project type CRUD endpoints."""
 
     def setUp(self) -> None:
         """Set up test app with admin authentication."""
         from imbi_api.auth import permissions
-
-        self.test_app = app.create_app()
 
         self.admin_user = models.User(
             email='admin@example.com',

--- a/tests/endpoints/test_projects.py
+++ b/tests/endpoints/test_projects.py
@@ -9,19 +9,18 @@ import psycopg.errors
 from fastapi.testclient import TestClient
 from imbi_common import graph
 
-from imbi_api import app, models
+from imbi_api import models
+from tests import support
 
 PROJECT_ID = 'abc123nanoid'
 
 
-class ProjectEndpointsTestCase(unittest.TestCase):
+class ProjectEndpointsTestCase(support.SharedAppTestCase):
     """Test cases for project CRUD endpoints."""
 
     def setUp(self) -> None:
         """Set up test app with admin authentication."""
         from imbi_api.auth import permissions
-
-        self.test_app = app.create_app()
 
         self.admin_user = models.User(
             email='admin@example.com',
@@ -1491,15 +1490,13 @@ class ProjectEndpointsTestCase(unittest.TestCase):
         mock_bundle.assert_not_awaited()
 
 
-class _RelationshipsTestBase(unittest.TestCase):
+class _RelationshipsTestBase(support.SharedAppTestCase):
     """Shared setup for relationship endpoint tests."""
 
     _permissions: typing.ClassVar[set[str]] = set()
 
     def setUp(self) -> None:
         from imbi_api.auth import permissions
-
-        self.test_app = app.create_app()
 
         self.test_user = models.User(
             email='user@example.com',

--- a/tests/endpoints/test_pull_requests.py
+++ b/tests/endpoints/test_pull_requests.py
@@ -2,13 +2,13 @@
 
 import datetime
 import typing
-import unittest
 from unittest import mock
 
 import fastapi.testclient
 from imbi_common import graph
 
-from imbi_api import app, models
+from imbi_api import models
+from tests import support
 
 ORG = 'engineering'
 PROJECT_ID = 'proj123nanoid'
@@ -39,15 +39,13 @@ def _pr_row(**overrides: typing.Any) -> dict[str, typing.Any]:
     return data
 
 
-class _PullRequestsTestBase(unittest.TestCase):
+class _PullRequestsTestBase(support.SharedAppTestCase):
     """Shared setup mounting pull request endpoints with admin auth."""
 
     permissions_granted: typing.ClassVar[set[str]] = {'project:read'}
 
     def setUp(self) -> None:
         from imbi_api.auth import permissions
-
-        self.test_app = app.create_app()
 
         self.admin_user = models.User(
             email='alice@example.com',

--- a/tests/endpoints/test_releases.py
+++ b/tests/endpoints/test_releases.py
@@ -3,13 +3,13 @@
 import datetime
 import json
 import typing
-import unittest
 from unittest import mock
 
 import fastapi.testclient
 from imbi_common import graph
 
-from imbi_api import app, models
+from imbi_api import models
+from tests import support
 
 PROJECT_ID = 'proj123nanoid'
 RELEASE_ID = 'rel456nanoid'
@@ -35,7 +35,7 @@ def _release_row(**overrides: typing.Any) -> dict[str, typing.Any]:
     return data
 
 
-class _ReleasesTestBase(unittest.TestCase):
+class _ReleasesTestBase(support.SharedAppTestCase):
     """Shared setup mounting release endpoints with admin auth."""
 
     permissions_granted: typing.ClassVar[set[str]] = {
@@ -45,8 +45,6 @@ class _ReleasesTestBase(unittest.TestCase):
 
     def setUp(self) -> None:
         from imbi_api.auth import permissions
-
-        self.test_app = app.create_app()
 
         self.admin_user = models.User(
             email='alice@example.com',

--- a/tests/endpoints/test_roles.py
+++ b/tests/endpoints/test_roles.py
@@ -1,24 +1,22 @@
 """Tests for role CRUD endpoints"""
 
 import datetime
-import unittest
 from unittest import mock
 
 import psycopg.errors
 from fastapi import testclient
 from imbi_common import graph
 
-from imbi_api import app, models
+from imbi_api import models
+from tests import support
 
 
-class RoleEndpointsTestCase(unittest.TestCase):
+class RoleEndpointsTestCase(support.SharedAppTestCase):
     """Test cases for role CRUD endpoints."""
 
     def setUp(self) -> None:
         """Set up test app with admin authentication."""
         from imbi_api.auth import permissions
-
-        self.test_app = app.create_app()
 
         self.admin_user = models.User(
             email='admin@example.com',

--- a/tests/endpoints/test_sa_api_keys.py
+++ b/tests/endpoints/test_sa_api_keys.py
@@ -1,22 +1,21 @@
 """Tests for service account API key management endpoints."""
 
 import datetime
-import unittest
 from unittest import mock
 
 from fastapi import testclient
 from imbi_common import graph
 
-from imbi_api import app, models, settings
+from imbi_api import models, settings
 from imbi_api.auth import password, permissions
+from tests import support
 
 
-class SAAPIKeysEndpointsTestCase(unittest.TestCase):
+class SAAPIKeysEndpointsTestCase(support.SharedAppTestCase):
     """Test service account API key endpoint functionality."""
 
     def setUp(self) -> None:
         """Set up test fixtures."""
-        self.test_app = app.create_app()
 
         self.test_user = models.User(
             email='admin@example.com',

--- a/tests/endpoints/test_scoring.py
+++ b/tests/endpoints/test_scoring.py
@@ -3,14 +3,14 @@
 from __future__ import annotations
 
 import datetime
-import unittest
 from unittest import mock
 
 from fastapi.testclient import TestClient
 from imbi_common import graph
 
-from imbi_api import app, models
+from imbi_api import models
 from imbi_api import scoring as scoring_di
+from tests import support
 
 
 class _PipelineProxy:
@@ -51,11 +51,9 @@ class _PipelineProxy:
         return results
 
 
-class ScoringEndpointsTestCase(unittest.TestCase):
+class ScoringEndpointsTestCase(support.SharedAppTestCase):
     def setUp(self) -> None:
         from imbi_api.auth import permissions
-
-        self.test_app = app.create_app()
 
         self.user = models.User(
             email='admin@example.com',

--- a/tests/endpoints/test_scoring_policies.py
+++ b/tests/endpoints/test_scoring_policies.py
@@ -4,21 +4,19 @@ from __future__ import annotations
 
 import datetime
 import typing
-import unittest
 from unittest import mock
 
 from fastapi.testclient import TestClient
 from imbi_common import graph
 
-from imbi_api import app, models
+from imbi_api import models
 from imbi_api import scoring as scoring_di
+from tests import support
 
 
-class ScoringPolicyEndpointsTestCase(unittest.TestCase):
+class ScoringPolicyEndpointsTestCase(support.SharedAppTestCase):
     def setUp(self) -> None:
         from imbi_api.auth import permissions
-
-        self.test_app = app.create_app()
 
         self.admin_user = models.User(
             email='admin@example.com',

--- a/tests/endpoints/test_search.py
+++ b/tests/endpoints/test_search.py
@@ -8,17 +8,16 @@ from fastapi.testclient import TestClient
 from imbi_common import graph
 from imbi_common.graph.client import SearchResult
 
-from imbi_api import app, models
+from imbi_api import models
 from imbi_api.auth import permissions
+from tests import support
 
 _ORG_SLUG = 'test-org'
 _BASE_URL = f'/organizations/{_ORG_SLUG}/search'
 
 
-class SearchEndpointTestCase(unittest.TestCase):
+class SearchEndpointTestCase(support.SharedAppTestCase):
     def setUp(self) -> None:
-        self.test_app = app.create_app()
-
         admin_user = models.User(
             email='admin@example.com',
             display_name='Admin User',

--- a/tests/endpoints/test_service_accounts.py
+++ b/tests/endpoints/test_service_accounts.py
@@ -1,25 +1,23 @@
 """Tests for service account management endpoints."""
 
 import datetime
-import unittest
 from unittest import mock
 
 import psycopg.errors
 from fastapi import testclient
 from imbi_common import graph
 
-from imbi_api import app, models
+from imbi_api import models
 from imbi_api.auth import password
+from tests import support
 
 
-class ServiceAccountsEndpointsTestCase(unittest.TestCase):
+class ServiceAccountsEndpointsTestCase(support.SharedAppTestCase):
     """Test service account endpoint functionality."""
 
     def setUp(self) -> None:
         """Set up test fixtures."""
         from imbi_api.auth import permissions
-
-        self.test_app = app.create_app()
 
         self.test_user = models.User(
             email='admin@example.com',

--- a/tests/endpoints/test_service_plugins.py
+++ b/tests/endpoints/test_service_plugins.py
@@ -8,13 +8,13 @@ from unittest import mock
 from fastapi import testclient
 from imbi_common import graph
 
-from imbi_api import app, models
+from imbi_api import models
 from imbi_api.auth import password, permissions
+from tests import support
 
 
-class ServicePluginsEndpointTestCase(unittest.TestCase):
+class ServicePluginsEndpointTestCase(support.SharedAppTestCase):
     def setUp(self) -> None:
-        self.test_app = app.create_app()
         self.test_user = models.User(
             email='admin@example.com',
             display_name='Admin User',
@@ -958,7 +958,7 @@ class ServicePluginsEndpointTestCase(unittest.TestCase):
         )
 
 
-class ReplacePluginAssignmentsTestCase(unittest.TestCase):
+class ReplacePluginAssignmentsTestCase(support.SharedAppTestCase):
     """Tests for ``PUT /{plugin_id}/assignments`` (fused replace)."""
 
     BASE = (
@@ -967,7 +967,6 @@ class ReplacePluginAssignmentsTestCase(unittest.TestCase):
     )
 
     def setUp(self) -> None:
-        self.test_app = app.create_app()
         self.test_user = models.User(
             email='admin@example.com',
             display_name='Admin User',

--- a/tests/endpoints/test_status.py
+++ b/tests/endpoints/test_status.py
@@ -3,8 +3,8 @@ import unittest
 
 from fastapi import testclient
 
-from imbi_api import app
 from imbi_api.endpoints import status
+from tests import support
 
 _StatusLiteral = typing.Literal['ok', 'initializing', 'error']
 
@@ -35,12 +35,12 @@ class StatusResponseModelTestCase(unittest.TestCase):
             self.assertEqual(response.status, status_value)
 
 
-class StatusEndpointTestCase(unittest.TestCase):
+class StatusEndpointTestCase(support.SharedAppTestCase):
     """Test cases for status endpoint."""
 
     def setUp(self) -> None:
         """Set up test client."""
-        self.client = testclient.TestClient(app.create_app())
+        self.client = testclient.TestClient(self.test_app)
 
     def test_get_status(self) -> None:
         """Test GET /status endpoint returns ok status."""

--- a/tests/endpoints/test_tags.py
+++ b/tests/endpoints/test_tags.py
@@ -9,16 +9,15 @@ import psycopg.errors
 from fastapi.testclient import TestClient
 from imbi_common import graph
 
-from imbi_api import app, models
+from imbi_api import models
+from tests import support
 
 
-class TagEndpointsTestCase(unittest.TestCase):
+class TagEndpointsTestCase(support.SharedAppTestCase):
     """Test cases for tag CRUD endpoints."""
 
     def setUp(self) -> None:
         from imbi_api.auth import permissions
-
-        self.test_app = app.create_app()
 
         self.admin_user = models.User(
             email='admin@example.com',

--- a/tests/endpoints/test_teams.py
+++ b/tests/endpoints/test_teams.py
@@ -1,24 +1,22 @@
 """Tests for team CRUD endpoints and membership."""
 
 import datetime
-import unittest
 from unittest import mock
 
 import psycopg.errors
 from fastapi import testclient
 from imbi_common import graph
 
-from imbi_api import app, models
+from imbi_api import models
+from tests import support
 
 
-class TeamEndpointsTestCase(unittest.TestCase):
+class TeamEndpointsTestCase(support.SharedAppTestCase):
     """Test cases for team CRUD endpoints."""
 
     def setUp(self) -> None:
         """Set up test app with admin authentication."""
         from imbi_api.auth import permissions
-
-        self.test_app = app.create_app()
 
         self.admin_user = models.User(
             email='admin@example.com',
@@ -534,14 +532,12 @@ class TeamEndpointsTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 404)
 
 
-class TeamMembershipTestCase(unittest.TestCase):
+class TeamMembershipTestCase(support.SharedAppTestCase):
     """Test cases for team membership endpoints."""
 
     def setUp(self) -> None:
         """Set up test app with admin authentication."""
         from imbi_api.auth import permissions
-
-        self.test_app = app.create_app()
 
         self.admin_user = models.User(
             email='admin@example.com',

--- a/tests/endpoints/test_third_party_services.py
+++ b/tests/endpoints/test_third_party_services.py
@@ -3,23 +3,21 @@
 import datetime
 import json
 import typing
-import unittest
 from unittest import mock
 
 import psycopg.errors
 from fastapi import testclient
 from imbi_common import graph
 
-from imbi_api import app, models
+from imbi_api import models
+from tests import support
 
 
-class ThirdPartyServiceEndpointsTestCase(unittest.TestCase):
+class ThirdPartyServiceEndpointsTestCase(support.SharedAppTestCase):
     """Test cases for ThirdPartyService CRUD endpoints."""
 
     def setUp(self) -> None:
         from imbi_api.auth import permissions
-
-        self.test_app = app.create_app()
 
         self.admin_user = models.User(
             email='admin@example.com',
@@ -641,13 +639,11 @@ class ThirdPartyServiceEndpointsTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 403)
 
 
-class ServiceWebhooksEndpointsTestCase(unittest.TestCase):
+class ServiceWebhooksEndpointsTestCase(support.SharedAppTestCase):
     """Test cases for list_service_webhooks endpoint."""
 
     def setUp(self) -> None:
         from imbi_api.auth import permissions
-
-        self.test_app = app.create_app()
 
         self.admin_user = models.User(
             email='admin@example.com',
@@ -1011,13 +1007,11 @@ class ServiceWebhooksEndpointsTestCase(unittest.TestCase):
         )
 
 
-class ServiceApplicationEndpointsTestCase(unittest.TestCase):
+class ServiceApplicationEndpointsTestCase(support.SharedAppTestCase):
     """Test cases for ServiceApplication CRUD endpoints."""
 
     def setUp(self) -> None:
         from imbi_api.auth import permissions
-
-        self.test_app = app.create_app()
 
         self.admin_user = models.User(
             email='admin@example.com',

--- a/tests/endpoints/test_uploads.py
+++ b/tests/endpoints/test_uploads.py
@@ -1,24 +1,22 @@
 """Tests for upload CRUD endpoints."""
 
 import datetime
-import unittest
 from unittest import mock
 
 from fastapi import testclient
 from imbi_common import graph
 
-from imbi_api import app, models
+from imbi_api import models
 from imbi_api.storage.client import StorageClient
 from imbi_api.storage.dependencies import _get_storage_client
+from tests import support
 
 
-class UploadEndpointsTestCase(unittest.TestCase):
+class UploadEndpointsTestCase(support.SharedAppTestCase):
     """Test cases for upload CRUD endpoints."""
 
     def setUp(self) -> None:
         from imbi_api.auth import permissions
-
-        self.test_app = app.create_app()
 
         self.admin_user = models.User(
             email='admin@example.com',

--- a/tests/endpoints/test_user_activity.py
+++ b/tests/endpoints/test_user_activity.py
@@ -11,10 +11,10 @@ from unittest import mock
 from fastapi import testclient
 from imbi_common import graph
 
-from imbi_api import app
 from imbi_api import models as api_models
 from imbi_api.auth import permissions as api_permissions
 from imbi_api.endpoints import user_activity
+from tests import support
 
 
 def _make_auth(
@@ -38,9 +38,8 @@ def _make_auth(
     )
 
 
-class _Base(unittest.TestCase):
+class _Base(support.SharedAppTestCase):
     def setUp(self) -> None:
-        self.test_app = app.create_app()
         self.auth = _make_auth()
 
         async def _current_user() -> api_permissions.AuthContext:
@@ -490,11 +489,10 @@ class GraphActivityExecuteTests(_Base):
                 )
 
 
-class PermissionTests(unittest.TestCase):
+class PermissionTests(support.SharedAppTestCase):
     """Endpoints must require user:read."""
 
     def setUp(self) -> None:
-        self.test_app = app.create_app()
         self.auth = _make_auth(perms=(), is_admin=False)  # no permissions
 
         async def _current_user() -> api_permissions.AuthContext:

--- a/tests/endpoints/test_users.py
+++ b/tests/endpoints/test_users.py
@@ -7,17 +7,16 @@ from unittest import mock
 from fastapi import testclient
 from imbi_common import graph
 
-from imbi_api import app, models
+from imbi_api import models
+from tests import support
 
 
-class UserEndpointsTestCase(unittest.TestCase):
+class UserEndpointsTestCase(support.SharedAppTestCase):
     """Test cases for user CRUD endpoints."""
 
     def setUp(self) -> None:
         """Set up test app with admin authentication context."""
         from imbi_api.auth import permissions
-
-        self.test_app = app.create_app()
 
         # Create an admin user for authentication
         self.admin_user = models.User(
@@ -969,14 +968,12 @@ class UserEndpointsTestCase(unittest.TestCase):
         self.assertIsNone(merged_user.password_hash)
 
 
-class OrgMembershipEndpointsTestCase(unittest.TestCase):
+class OrgMembershipEndpointsTestCase(support.SharedAppTestCase):
     """Test org membership endpoints on users."""
 
     def setUp(self) -> None:
         """Set up test app with admin authentication context."""
         from imbi_api.auth import permissions
-
-        self.test_app = app.create_app()
 
         self.admin_user = models.User(
             email='admin@example.com',
@@ -1421,14 +1418,12 @@ class ReconcileMembershipsTestCase(unittest.IsolatedAsyncioTestCase):
         db.execute.assert_not_called()
 
 
-class ServiceAccountGuardRailsTestCase(unittest.TestCase):
+class ServiceAccountGuardRailsTestCase(support.SharedAppTestCase):
     """Test guardrails for invalid service account operations."""
 
     def setUp(self) -> None:
         """Set up test app with admin authentication context."""
         from imbi_api.auth import permissions
-
-        self.test_app = app.create_app()
 
         self.admin_user = models.User(
             email='admin@example.com',

--- a/tests/endpoints/test_webhooks.py
+++ b/tests/endpoints/test_webhooks.py
@@ -4,14 +4,14 @@ import copy
 import datetime
 import json
 import typing
-import unittest
 from unittest import mock
 
 import psycopg.errors
 from fastapi import testclient
 from imbi_common import graph
 
-from imbi_api import app, models
+from imbi_api import models
+from tests import support
 
 
 class _WebhookDetails(typing.TypedDict):
@@ -40,13 +40,11 @@ class _WebhookRecord(typing.TypedDict):
     rules: list[_WebhookRule | None]
 
 
-class WebhookEndpointsTestCase(unittest.TestCase):
+class WebhookEndpointsTestCase(support.SharedAppTestCase):
     """Test cases for Webhook CRUD endpoints."""
 
     def setUp(self) -> None:
         from imbi_api.auth import permissions
-
-        self.test_app = app.create_app()
 
         self.admin_user = models.User(
             email='admin@example.com',
@@ -1370,13 +1368,11 @@ class WebhookEndpointsTestCase(unittest.TestCase):
         self.assertTrue(all(c in valid_chars for c in generated))
 
 
-class ProjectServicesEndpointsTestCase(unittest.TestCase):
+class ProjectServicesEndpointsTestCase(support.SharedAppTestCase):
     """Test cases for Project EXISTS_IN service endpoints."""
 
     def setUp(self) -> None:
         from imbi_api.auth import permissions
-
-        self.test_app = app.create_app()
 
         self.admin_user = models.User(
             email='admin@example.com',

--- a/tests/support.py
+++ b/tests/support.py
@@ -5,24 +5,50 @@ Building the FastAPI app via :func:`imbi_api.app.create_app` costs
 app is ``dependency_overrides``. Rebuilding it in every ``setUp`` adds
 up to minutes across the suite, so share a single instance and reset
 the overrides between tests instead.
+
+Because the app is shared across every test in the process, per-test
+state must be torn down reliably even when a subclass overrides
+``setUp``/``tearDown`` without chaining to ``super()``. The reset is
+therefore registered in :meth:`run` (via ``addCleanup``), which always
+runs regardless of subclass overrides:
+
+* ``dependency_overrides`` is cleared so mocked dependencies cannot leak
+  into the next test that reuses the cached app.
+* Any :class:`starlette.testclient.TestClient` stored as an instance
+  attribute is closed so its portal thread/transport is not leaked.
 """
 
 import functools
 import unittest
 
 import fastapi
-
-from imbi_api import app
+from starlette import testclient
 
 
 @functools.cache
 def shared_app() -> fastapi.FastAPI:
     """Return a process-wide :class:`fastapi.FastAPI` instance."""
+    from imbi_api import app
+
     return app.create_app()
 
 
+def _reset(case: unittest.TestCase, test_app: fastapi.FastAPI) -> None:
+    """Clear shared-app state and close any per-test TestClient."""
+    test_app.dependency_overrides.clear()
+    for value in list(vars(case).values()):
+        if isinstance(value, testclient.TestClient):
+            value.close()
+
+
 class SharedAppTestCase(unittest.TestCase):
-    """Base case that reuses one app and clears overrides per test."""
+    """Base case that reuses one app and resets per-test state.
+
+    The reset (clearing ``dependency_overrides`` and closing any
+    ``TestClient`` attributes) is registered as a cleanup so it runs even
+    when subclasses override ``setUp``/``tearDown`` without calling
+    ``super()``.
+    """
 
     test_app: fastapi.FastAPI
 
@@ -31,9 +57,9 @@ class SharedAppTestCase(unittest.TestCase):
         super().setUpClass()
         cls.test_app = shared_app()
 
-    def tearDown(self) -> None:
-        self.test_app.dependency_overrides.clear()
-        super().tearDown()
+    def run(self, result=None):  # type: ignore[no-untyped-def]
+        self.addCleanup(_reset, self, self.test_app)
+        return super().run(result)
 
 
 class SharedAppAsyncTestCase(unittest.IsolatedAsyncioTestCase):
@@ -46,6 +72,6 @@ class SharedAppAsyncTestCase(unittest.IsolatedAsyncioTestCase):
         super().setUpClass()
         cls.test_app = shared_app()
 
-    def tearDown(self) -> None:
-        self.test_app.dependency_overrides.clear()
-        super().tearDown()
+    def run(self, result=None):  # type: ignore[no-untyped-def]
+        self.addCleanup(_reset, self, self.test_app)
+        return super().run(result)

--- a/tests/support.py
+++ b/tests/support.py
@@ -1,0 +1,51 @@
+"""Shared test helpers.
+
+Building the FastAPI app via :func:`imbi_api.app.create_app` costs
+~130 ms (it registers 255 routes), and the only per-test state on the
+app is ``dependency_overrides``. Rebuilding it in every ``setUp`` adds
+up to minutes across the suite, so share a single instance and reset
+the overrides between tests instead.
+"""
+
+import functools
+import unittest
+
+import fastapi
+
+from imbi_api import app
+
+
+@functools.cache
+def shared_app() -> fastapi.FastAPI:
+    """Return a process-wide :class:`fastapi.FastAPI` instance."""
+    return app.create_app()
+
+
+class SharedAppTestCase(unittest.TestCase):
+    """Base case that reuses one app and clears overrides per test."""
+
+    test_app: fastapi.FastAPI
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        super().setUpClass()
+        cls.test_app = shared_app()
+
+    def tearDown(self) -> None:
+        self.test_app.dependency_overrides.clear()
+        super().tearDown()
+
+
+class SharedAppAsyncTestCase(unittest.IsolatedAsyncioTestCase):
+    """``IsolatedAsyncioTestCase`` variant of :class:`SharedAppTestCase`."""
+
+    test_app: fastapi.FastAPI
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        super().setUpClass()
+        cls.test_app = shared_app()
+
+    def tearDown(self) -> None:
+        self.test_app.dependency_overrides.clear()
+        super().tearDown()

--- a/tests/support.py
+++ b/tests/support.py
@@ -57,7 +57,9 @@ class SharedAppTestCase(unittest.TestCase):
         super().setUpClass()
         cls.test_app = shared_app()
 
-    def run(self, result=None):  # type: ignore[no-untyped-def]
+    def run(
+        self, result: unittest.result.TestResult | None = None
+    ) -> unittest.result.TestResult | None:
         self.addCleanup(_reset, self, self.test_app)
         return super().run(result)
 
@@ -72,6 +74,8 @@ class SharedAppAsyncTestCase(unittest.IsolatedAsyncioTestCase):
         super().setUpClass()
         cls.test_app = shared_app()
 
-    def run(self, result=None):  # type: ignore[no-untyped-def]
+    def run(
+        self, result: unittest.result.TestResult | None = None
+    ) -> unittest.result.TestResult | None:
         self.addCleanup(_reset, self, self.test_app)
         return super().run(result)


### PR DESCRIPTION
## Summary

The unit test suite rebuilt the FastAPI app in **every** `setUp` via `app.create_app()`. That call costs ~134ms (it registers 255 routes), and with ~1,110 test methods doing it, the suite spent **~149s rebuilding an identical app** whose only per-test state is `dependency_overrides`.

## Problem

`create_app()` was the dominant cost of the suite. It was invoked once per test method across 47 files, even though every unit test mocks the stack and the resulting app differs only by its dependency overrides.

## Solution

- Add `tests/support.py` with `SharedAppTestCase` and `SharedAppAsyncTestCase`. They build the app **once per process** (`functools.cache`) via `setUpClass` and clear `dependency_overrides` in `tearDown`, so tests stay isolated (they run sequentially, each `setUp` re-establishes its own overrides).
- Convert 41 endpoint/auth test files to inherit the shared bases (most via an AST-aware transform; a few by hand for `self.application` / `self.app` / inline-build variants).
- **Left unconverted by design:**
  - `test_app.py`, `test_lifespans.py` — they test `create_app()`/lifespans directly.
  - `test_project_configuration.py` — real Valkey + ClickHouse integration test that enters the lifespan; `create_app` isn't its bottleneck.
  - `test_local_auth.py`, `test_auth_providers.py` — a factory builds multiple distinct apps within a single test (comparing permission sets), so sharing would make them collide, for only ~2-3s of savings.

## Results

Full suite (with coverage, Docker stack up):

| | Tests | Time |
|---|---|---|
| Before | 2018 passed, 2 failed, 1 skipped | **251.1s** |
| After | 2018 passed, 2 failed, 1 skipped | **45.5s** |

**~5.5× faster**, identical results. The 2 failures (`test_project_configuration.py`) are pre-existing on `main` and untouched by this PR. Coverage unchanged at 86% (above the 85% gate). No production code changed — tests only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)