### PR TITLE
Flag config endpoints as excluded from AI toolset building

### DIFF
--- a/src/imbi_api/openapi.py
+++ b/src/imbi_api/openapi.py
@@ -55,6 +55,14 @@ _schema_cache: dict[str, typing.Any] | None = None
 # half-built schemas being observed mid-population.
 _schema_cache_lock = threading.Lock()
 
+# OpenAPI operation tags whose endpoints must not be exposed as AI
+# tools by downstream consumers (imbi-mcp, imbi-assistant). Operations
+# carrying any of these tags are stamped with ``x-imbi-ai-tool: false``
+# in the generated schema; the AI services read that extension to drop
+# the endpoint from the toolset they build off ``/openapi.json``. Add a
+# tag here to hide every operation that carries it from AI tooling.
+AI_TOOL_EXCLUDED_TAGS: frozenset[str] = frozenset({'Project: Configuration'})
+
 # Mapping of API paths to their model types
 PATH_MODEL_MAPPING: dict[str, str] = {
     '/organizations/{org_slug}/teams/': 'Team',
@@ -328,7 +336,32 @@ def _build_schema(
     if _edge_models:
         _hoist_defs_to_components(schemas)
 
+    _mark_ai_excluded_operations(openapi_schema)
+
     return openapi_schema, had_failure
+
+
+def _mark_ai_excluded_operations(
+    openapi_schema: dict[str, typing.Any],
+) -> None:
+    """Flag operations that must not be built into AI tools.
+
+    Stamps ``x-imbi-ai-tool: false`` on every operation whose tags
+    intersect :data:`AI_TOOL_EXCLUDED_TAGS`. Downstream consumers
+    (imbi-mcp, imbi-assistant) read this extension to exclude the
+    endpoint from the toolset they build from ``/openapi.json``.
+    """
+    paths: dict[str, typing.Any] = openapi_schema.get('paths', {})
+    for path_ops in paths.values():
+        if not isinstance(path_ops, dict):
+            continue
+        ops = typing.cast(dict[str, typing.Any], path_ops)
+        for operation in ops.values():
+            if not isinstance(operation, dict):
+                continue
+            op = typing.cast(dict[str, typing.Any], operation)
+            if AI_TOOL_EXCLUDED_TAGS.intersection(op.get('tags', ())):
+                op['x-imbi-ai-tool'] = False
 
 
 def _hoist_defs_to_components(

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -379,6 +379,75 @@ class CreateCustomOpenapiTestCase(unittest.TestCase):
         self.assertIn('items', json_schema)
 
 
+class MarkAiExcludedOperationsTestCase(unittest.TestCase):
+    """Test cases for _mark_ai_excluded_operations."""
+
+    def setUp(self) -> None:
+        """Reset module state before each test."""
+        _reset_openapi_module_state()
+
+    def tearDown(self) -> None:
+        _reset_openapi_module_state()
+
+    def test_stamps_flag_on_excluded_tag(self) -> None:
+        """Operations carrying an excluded tag get x-imbi-ai-tool."""
+        excluded = next(iter(openapi.AI_TOOL_EXCLUDED_TAGS))
+        schema = {
+            'paths': {
+                '/secret': {
+                    'get': {'tags': [excluded]},
+                    'delete': {'tags': [excluded]},
+                },
+                '/public': {'get': {'tags': ['Teams']}},
+            }
+        }
+
+        openapi._mark_ai_excluded_operations(schema)
+
+        secret = schema['paths']['/secret']
+        self.assertIs(secret['get']['x-imbi-ai-tool'], False)
+        self.assertIs(secret['delete']['x-imbi-ai-tool'], False)
+        self.assertNotIn('x-imbi-ai-tool', schema['paths']['/public']['get'])
+
+    def test_ignores_non_operation_values(self) -> None:
+        """Path-item parameters and untagged ops are left untouched."""
+        schema = {
+            'paths': {
+                '/items': {
+                    'parameters': [{'name': 'id', 'in': 'query'}],
+                    'get': {'tags': ['Items']},
+                }
+            }
+        }
+
+        openapi._mark_ai_excluded_operations(schema)
+
+        self.assertNotIn('x-imbi-ai-tool', schema['paths']['/items']['get'])
+
+    def test_excluded_tag_marks_endpoint_in_full_schema(self) -> None:
+        """End-to-end: a tagged route is flagged in the built schema."""
+        openapi._blueprint_models = {}
+        excluded = next(iter(openapi.AI_TOOL_EXCLUDED_TAGS))
+
+        app = fastapi.FastAPI(title='Test', version='1.0.0')
+
+        @app.get('/configuration/', tags=[excluded])
+        async def get_configuration() -> dict:
+            return {}
+
+        @app.get('/teams/', tags=['Teams'])
+        async def list_teams() -> list[dict]:
+            return []
+
+        schema = openapi.create_custom_openapi(app)()
+
+        self.assertIs(
+            schema['paths']['/configuration/']['get']['x-imbi-ai-tool'],
+            False,
+        )
+        self.assertNotIn('x-imbi-ai-tool', schema['paths']['/teams/']['get'])
+
+
 class HoistDefsToComponentsTestCase(unittest.TestCase):
     """Test cases for _hoist_defs_to_components."""
 


### PR DESCRIPTION
## Summary

Make imbi-api the source of truth for which endpoints AI services may turn into tools, and use it to hide the project-level Configuration endpoints (AWS SSM Parameter Store).

## Problem

`imbi-mcp` and `imbi-assistant` build their AI toolsets by turning every operation in `/openapi.json` into a callable tool. The project Configuration tab endpoints manage AWS SSM Parameter Store values and must never be driven by the AI. There was no mechanism to keep a specific endpoint out of those toolsets — each consumer only had a duplicated regex path denylist, decoupled from the API that actually knows which endpoints are sensitive.

## Solution

During OpenAPI schema generation (`_build_schema`), stamp `x-imbi-ai-tool: false` on every operation whose tags intersect the new `AI_TOOL_EXCLUDED_TAGS` set (currently `{'Project: Configuration'}`). The Configuration router already carries that tag, so all four of its endpoints are covered with no per-route edits.

Downstream consumers read this extension to drop the endpoint from the toolset they build, so hiding a future endpoint is just a matter of tagging it (or, for a one-off, `openapi_extra={'x-imbi-ai-tool': False}` on the decorator).

Companion PRs honor the flag:
- AWeber-Imbi/imbi-mcp#13
- AWeber-Imbi/imbi-assistant#18

Added unit + end-to-end schema tests in `tests/test_openapi.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)