### PR TITLE
Add page-level document comment endpoints

### DIFF
--- a/src/imbi_api/auth/seed.py
+++ b/src/imbi_api/auth/seed.py
@@ -277,6 +277,25 @@ STANDARD_PERMISSIONS: list[tuple[str, str, str, str]] = [
         'delete',
         'Delete project documents',
     ),
+    # Comment management
+    (
+        'comment:create',
+        'comment',
+        'create',
+        'Create document comments',
+    ),
+    (
+        'comment:write',
+        'comment',
+        'write',
+        'Update document comments',
+    ),
+    (
+        'comment:delete',
+        'comment',
+        'delete',
+        'Delete document comments',
+    ),
     # Auth provider (login-eligible ServiceApplication) management
     (
         'auth_providers:read',
@@ -480,6 +499,9 @@ DEFAULT_ROLES: list[tuple[str, str, str, int, list[str], bool]] = [
             'document:read',
             'document:write',
             'document:delete',
+            'comment:create',
+            'comment:write',
+            'comment:delete',
             'document_template:read',
             'me:identities:manage',
             'search:read',

--- a/src/imbi_api/endpoints/comments.py
+++ b/src/imbi_api/endpoints/comments.py
@@ -99,7 +99,7 @@ class CommentThreadListResponse(pydantic.BaseModel):
 
 
 class CommentThreadCreate(pydantic.BaseModel):
-    kind: typing.Literal['page', 'inline'] = 'page'
+    kind: typing.Literal['page'] = 'page'
     body: str = pydantic.Field(min_length=1)
     anchor: AnchorModel | None = None
     mentions: list[str] = []
@@ -373,7 +373,7 @@ async def create_comment_thread(
             'project_id': project_id,
             'org_slug': org_slug,
             'thread_id': thread_id,
-            'kind': data.kind,
+            'kind': 'page',
             'resolved': False,
             'resolved_by': None,
             'resolved_at': None,

--- a/src/imbi_api/endpoints/comments.py
+++ b/src/imbi_api/endpoints/comments.py
@@ -1,0 +1,771 @@
+"""Page-level threaded comments on project documents.
+
+Comments hang off a project ``Document`` via a ``CommentThread`` vertex
+(``ON_DOCUMENT`` edge) containing one or more ``Comment`` vertices
+(``IN_THREAD`` edge). The root comment is the oldest comment in a thread;
+replies follow in ``created_at`` order.
+
+Phase 1 only creates ``kind='page'`` threads — the anchor properties are
+persisted as empty strings / ``0`` and surfaced as ``anchor: null``.
+Inline-anchored threads are a later phase.
+
+Modeled on :mod:`imbi_api.endpoints.documents`: raw Cypher via
+``db.execute(...)`` + ``graph.parse_agtype(...)`` with local Pydantic
+request/response models (no dependency on ``imbi_common.models`` comment
+types).
+"""
+
+import datetime
+import logging
+import typing
+
+import fastapi
+import nanoid
+import pydantic
+from imbi_common import graph
+
+from imbi_api import patch as json_patch
+from imbi_api.auth import permissions
+
+LOGGER = logging.getLogger(__name__)
+
+comments_router = fastapi.APIRouter(tags=['Comments'])
+
+# Every thread field except ``/resolved`` is read-only over the PATCH API.
+_THREAD_READONLY_PATHS: frozenset[str] = frozenset(
+    [
+        '/id',
+        '/document_id',
+        '/kind',
+        '/anchor',
+        '/resolved_by',
+        '/resolved_at',
+        '/created_by',
+        '/created_at',
+        '/updated_at',
+    ]
+)
+
+# Every comment field except ``/body`` is read-only over the PATCH API.
+_COMMENT_READONLY_PATHS: frozenset[str] = frozenset(
+    [
+        '/id',
+        '/thread_id',
+        '/author',
+        '/mentions',
+        '/acknowledged_by',
+        '/edited',
+        '/created_at',
+        '/updated_at',
+    ]
+)
+
+
+class AnchorModel(pydantic.BaseModel):
+    quote: str
+    prefix: str
+    suffix: str
+    start: int
+
+
+class CommentResponse(pydantic.BaseModel):
+    id: str
+    thread_id: str
+    author: str
+    body: str
+    mentions: list[str] = []
+    acknowledged_by: list[str] = []
+    edited: bool = False
+    created_at: datetime.datetime
+    updated_at: datetime.datetime | None = None
+
+
+class CommentThreadResponse(pydantic.BaseModel):
+    id: str
+    document_id: str
+    kind: str
+    resolved: bool
+    resolved_by: str | None = None
+    resolved_at: datetime.datetime | None = None
+    anchor: AnchorModel | None = None
+    created_by: str
+    created_at: datetime.datetime
+    updated_at: datetime.datetime | None = None
+    comments: list[CommentResponse] = []
+
+
+class CommentThreadListResponse(pydantic.BaseModel):
+    data: list[CommentThreadResponse]
+
+
+class CommentThreadCreate(pydantic.BaseModel):
+    kind: typing.Literal['page', 'inline'] = 'page'
+    body: str = pydantic.Field(min_length=1)
+    anchor: AnchorModel | None = None
+    mentions: list[str] = []
+
+
+class CommentBodyCreate(pydantic.BaseModel):
+    body: str = pydantic.Field(min_length=1)
+    mentions: list[str] = []
+
+
+def _str_list(value: typing.Any) -> list[str]:
+    """Coerce a parsed agtype value into a list of strings."""
+    if not isinstance(value, list):
+        return []
+    items = typing.cast('list[object]', value)
+    return [str(v) for v in items]
+
+
+def _parse_comment(record: typing.Any) -> dict[str, typing.Any]:
+    """Build a ``CommentResponse``-shaped dict from a parsed comment map."""
+    comment: dict[str, typing.Any] = graph.parse_agtype(record)
+    return {
+        'id': comment['id'],
+        'thread_id': comment.get('thread_id', ''),
+        'author': comment.get('author', ''),
+        'body': comment.get('body', ''),
+        'mentions': _str_list(comment.get('mentions')),
+        'acknowledged_by': _str_list(comment.get('acknowledged_by')),
+        'edited': bool(comment.get('edited', False)),
+        'created_at': comment.get('created_at'),
+        'updated_at': comment.get('updated_at'),
+    }
+
+
+def _parse_thread_row(record: dict[str, typing.Any]) -> dict[str, typing.Any]:
+    """Build a ``CommentThreadResponse``-shaped dict from a thread row.
+
+    Expects columns ``t`` (thread), ``d`` (document), and ``comments``
+    (a list of comment maps already ordered oldest-first).
+    """
+    thread: dict[str, typing.Any] = graph.parse_agtype(record['t'])
+    document: dict[str, typing.Any] = graph.parse_agtype(record['d'])
+    raw_comments: list[typing.Any] = graph.parse_agtype(record['comments'])
+    comments = [
+        _parse_comment(c) for c in (raw_comments or []) if isinstance(c, dict)
+    ]
+    kind = thread.get('kind', 'page')
+    anchor: dict[str, typing.Any] | None = None
+    quote = thread.get('anchor_quote') or ''
+    if kind != 'page' and quote:
+        anchor = {
+            'quote': str(quote),
+            'prefix': str(thread.get('anchor_prefix') or ''),
+            'suffix': str(thread.get('anchor_suffix') or ''),
+            'start': int(thread.get('anchor_start') or 0),
+        }
+    return {
+        'id': thread['id'],
+        'document_id': document.get('id', ''),
+        'kind': kind,
+        'resolved': bool(thread.get('resolved', False)),
+        'resolved_by': thread.get('resolved_by'),
+        'resolved_at': thread.get('resolved_at'),
+        'anchor': anchor,
+        'created_by': thread.get('created_by', ''),
+        'created_at': thread.get('created_at'),
+        'updated_at': thread.get('updated_at'),
+        'comments': comments,
+    }
+
+
+# Tail fragment that collects a thread's comments oldest-first. Runs with
+# ``t, d`` in scope and emits ``t, d, comments``.
+_COMMENTS_TAIL: typing.LiteralString = """
+    OPTIONAL MATCH (c:Comment)-[:IN_THREAD]->(t)
+    WITH t, d, c ORDER BY c.created_at ASC, c.id ASC
+    WITH t, d, collect(CASE WHEN c IS NOT NULL THEN c END) AS raw_comments
+    WITH t, d, [x IN raw_comments WHERE x IS NOT NULL] AS comments
+    RETURN t, d, comments
+"""
+
+# Document-ownership join used by every query to scope to project -> org.
+_DOC_JOIN: typing.LiteralString = """
+    MATCH (d:Document {{id: {document_id}}})
+          -[:ATTACHED_TO]->(:Project {{id: {project_id}}})
+          -[:OWNED_BY]->(:Team)
+          -[:BELONGS_TO]->(:Organization {{slug: {org_slug}}})
+"""
+
+
+async def _verify_document(
+    db: graph.Pool,
+    org_slug: str,
+    project_id: str,
+    document_id: str,
+) -> None:
+    """Raise 404 unless the document belongs to the project -> org."""
+    query: str = _DOC_JOIN + 'RETURN d.id AS id'
+    records = await db.execute(
+        query,
+        {
+            'document_id': document_id,
+            'project_id': project_id,
+            'org_slug': org_slug,
+        },
+        columns=['id'],
+    )
+    if not records:
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail=f'Document {document_id!r} not found',
+        )
+
+
+async def _fetch_thread(
+    db: graph.Pool,
+    org_slug: str,
+    project_id: str,
+    document_id: str,
+    thread_id: str,
+) -> dict[str, typing.Any] | None:
+    """Return a single thread (with ordered comments) or ``None``."""
+    query: str = (
+        _DOC_JOIN
+        + """
+    MATCH (t:CommentThread {{id: {thread_id}}})-[:ON_DOCUMENT]->(d)
+    WITH DISTINCT t, d
+    """
+        + _COMMENTS_TAIL
+    )
+    records = await db.execute(
+        query,
+        {
+            'document_id': document_id,
+            'project_id': project_id,
+            'org_slug': org_slug,
+            'thread_id': thread_id,
+        },
+        columns=['t', 'd', 'comments'],
+    )
+    if not records:
+        return None
+    return _parse_thread_row(records[0])
+
+
+async def _fetch_comment(
+    db: graph.Pool,
+    org_slug: str,
+    project_id: str,
+    document_id: str,
+    thread_id: str,
+    comment_id: str,
+) -> dict[str, typing.Any] | None:
+    """Return a single comment dict or ``None``."""
+    query: str = (
+        _DOC_JOIN
+        + """
+    MATCH (c:Comment {{id: {comment_id}}})
+          -[:IN_THREAD]->(t:CommentThread {{id: {thread_id}}})
+          -[:ON_DOCUMENT]->(d)
+    RETURN c
+    """
+    )
+    records = await db.execute(
+        query,
+        {
+            'document_id': document_id,
+            'project_id': project_id,
+            'org_slug': org_slug,
+            'thread_id': thread_id,
+            'comment_id': comment_id,
+        },
+        columns=['c'],
+    )
+    if not records:
+        return None
+    return _parse_comment(records[0]['c'])
+
+
+@comments_router.get('', response_model=CommentThreadListResponse)
+async def list_comment_threads(
+    org_slug: str,
+    project_id: str,
+    document_id: str,
+    db: graph.Pool,
+    _auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(permissions.require_permission('document:read')),
+    ],
+) -> dict[str, typing.Any]:
+    """List every comment thread on a document, comments oldest-first."""
+    await _verify_document(db, org_slug, project_id, document_id)
+    query: str = (
+        _DOC_JOIN
+        + """
+    MATCH (t:CommentThread)-[:ON_DOCUMENT]->(d)
+    WITH DISTINCT t, d, t.created_at AS sort_ts, t.id AS sort_id
+    ORDER BY sort_ts ASC, sort_id ASC
+    """
+        + _COMMENTS_TAIL
+    )
+    records = await db.execute(
+        query,
+        {
+            'document_id': document_id,
+            'project_id': project_id,
+            'org_slug': org_slug,
+        },
+        columns=['t', 'd', 'comments'],
+    )
+    return {'data': [_parse_thread_row(r) for r in records]}
+
+
+@comments_router.post(
+    '', status_code=201, response_model=CommentThreadResponse
+)
+async def create_comment_thread(
+    org_slug: str,
+    project_id: str,
+    document_id: str,
+    data: CommentThreadCreate,
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(permissions.require_permission('comment:create')),
+    ],
+) -> dict[str, typing.Any]:
+    """Create a thread, its ``ON_DOCUMENT`` edge, and the root comment."""
+    await _verify_document(db, org_slug, project_id, document_id)
+
+    now = datetime.datetime.now(datetime.UTC)
+    thread_id = nanoid.generate()
+    comment_id = nanoid.generate()
+    query: typing.LiteralString = (
+        _DOC_JOIN
+        + """
+    CREATE (t:CommentThread {{
+        id: {thread_id},
+        kind: {kind},
+        resolved: {resolved},
+        resolved_by: {resolved_by},
+        resolved_at: {resolved_at},
+        anchor_quote: {anchor_quote},
+        anchor_prefix: {anchor_prefix},
+        anchor_suffix: {anchor_suffix},
+        anchor_start: {anchor_start},
+        created_by: {created_by},
+        created_at: {created_at},
+        updated_at: {updated_at}
+    }})
+    CREATE (t)-[:ON_DOCUMENT]->(d)
+    CREATE (c:Comment {{
+        id: {comment_id},
+        thread_id: {thread_id},
+        author: {author},
+        body: {body},
+        mentions: {mentions},
+        acknowledged_by: {acknowledged_by},
+        edited: {edited},
+        created_at: {created_at},
+        updated_at: {updated_at}
+    }})
+    CREATE (c)-[:IN_THREAD]->(t)
+    RETURN t.id AS id
+    """
+    )
+    records = await db.execute(
+        query,
+        {
+            'document_id': document_id,
+            'project_id': project_id,
+            'org_slug': org_slug,
+            'thread_id': thread_id,
+            'kind': data.kind,
+            'resolved': False,
+            'resolved_by': None,
+            'resolved_at': None,
+            'anchor_quote': '',
+            'anchor_prefix': '',
+            'anchor_suffix': '',
+            'anchor_start': 0,
+            'created_by': auth.principal_name,
+            'created_at': now.isoformat(),
+            'updated_at': None,
+            'comment_id': comment_id,
+            'author': auth.principal_name,
+            'body': data.body,
+            'mentions': list(data.mentions),
+            'acknowledged_by': [],
+            'edited': False,
+        },
+        columns=['id'],
+    )
+    if not records:
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail=f'Document {document_id!r} not found',
+        )
+    thread = await _fetch_thread(
+        db, org_slug, project_id, document_id, thread_id
+    )
+    if thread is None:
+        raise fastapi.HTTPException(
+            status_code=500,
+            detail='Thread created but could not be read back',
+        )
+    return thread
+
+
+@comments_router.post(
+    '/{thread_id}/comments',
+    status_code=201,
+    response_model=CommentResponse,
+)
+async def create_reply(
+    org_slug: str,
+    project_id: str,
+    document_id: str,
+    thread_id: str,
+    data: CommentBodyCreate,
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(permissions.require_permission('comment:create')),
+    ],
+) -> dict[str, typing.Any]:
+    """Add a reply comment to an existing thread."""
+    now = datetime.datetime.now(datetime.UTC)
+    comment_id = nanoid.generate()
+    query: typing.LiteralString = (
+        _DOC_JOIN
+        + """
+    MATCH (t:CommentThread {{id: {thread_id}}})-[:ON_DOCUMENT]->(d)
+    CREATE (c:Comment {{
+        id: {comment_id},
+        thread_id: {thread_id},
+        author: {author},
+        body: {body},
+        mentions: {mentions},
+        acknowledged_by: {acknowledged_by},
+        edited: {edited},
+        created_at: {created_at},
+        updated_at: {updated_at}
+    }})
+    CREATE (c)-[:IN_THREAD]->(t)
+    RETURN c
+    """
+    )
+    records = await db.execute(
+        query,
+        {
+            'document_id': document_id,
+            'project_id': project_id,
+            'org_slug': org_slug,
+            'thread_id': thread_id,
+            'comment_id': comment_id,
+            'author': auth.principal_name,
+            'body': data.body,
+            'mentions': list(data.mentions),
+            'acknowledged_by': [],
+            'edited': False,
+            'created_at': now.isoformat(),
+            'updated_at': None,
+        },
+        columns=['c'],
+    )
+    if not records:
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail=f'Thread {thread_id!r} not found',
+        )
+    return _parse_comment(records[0]['c'])
+
+
+@comments_router.patch('/{thread_id}', response_model=CommentThreadResponse)
+async def patch_comment_thread(
+    org_slug: str,
+    project_id: str,
+    document_id: str,
+    thread_id: str,
+    operations: list[json_patch.PatchOperation],
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(permissions.require_permission('comment:write')),
+    ],
+) -> dict[str, typing.Any]:
+    """Resolve or reopen a thread via JSON Patch (only ``/resolved``)."""
+    existing = await _fetch_thread(
+        db, org_slug, project_id, document_id, thread_id
+    )
+    if existing is None:
+        raise fastapi.HTTPException(
+            status_code=404, detail=f'Thread {thread_id!r} not found'
+        )
+
+    current = {'resolved': bool(existing.get('resolved', False))}
+    patched = json_patch.apply_patch(
+        current, operations, _THREAD_READONLY_PATHS
+    )
+    resolved = patched.get('resolved')
+    if not isinstance(resolved, bool):
+        raise fastapi.HTTPException(
+            status_code=400, detail='resolved must be a boolean'
+        )
+
+    now = datetime.datetime.now(datetime.UTC)
+    resolved_by = auth.principal_name if resolved else None
+    resolved_at = now.isoformat() if resolved else None
+    query: typing.LiteralString = (
+        _DOC_JOIN
+        + """
+    MATCH (t:CommentThread {{id: {thread_id}}})-[:ON_DOCUMENT]->(d)
+    SET t.resolved = {resolved},
+        t.resolved_by = {resolved_by},
+        t.resolved_at = {resolved_at},
+        t.updated_at = {updated_at}
+    RETURN t.id AS id
+    """
+    )
+    records = await db.execute(
+        query,
+        {
+            'document_id': document_id,
+            'project_id': project_id,
+            'org_slug': org_slug,
+            'thread_id': thread_id,
+            'resolved': resolved,
+            'resolved_by': resolved_by,
+            'resolved_at': resolved_at,
+            'updated_at': now.isoformat(),
+        },
+        columns=['id'],
+    )
+    if not records:
+        raise fastapi.HTTPException(
+            status_code=404, detail=f'Thread {thread_id!r} not found'
+        )
+    thread = await _fetch_thread(
+        db, org_slug, project_id, document_id, thread_id
+    )
+    if thread is None:
+        raise fastapi.HTTPException(
+            status_code=404, detail=f'Thread {thread_id!r} not found'
+        )
+    return thread
+
+
+@comments_router.patch(
+    '/{thread_id}/comments/{comment_id}',
+    response_model=CommentResponse,
+)
+async def patch_comment(
+    org_slug: str,
+    project_id: str,
+    document_id: str,
+    thread_id: str,
+    comment_id: str,
+    operations: list[json_patch.PatchOperation],
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(permissions.require_permission('comment:write')),
+    ],
+) -> dict[str, typing.Any]:
+    """Edit a comment body via JSON Patch (only ``/body``). Author-only."""
+    existing = await _fetch_comment(
+        db, org_slug, project_id, document_id, thread_id, comment_id
+    )
+    if existing is None:
+        raise fastapi.HTTPException(
+            status_code=404, detail=f'Comment {comment_id!r} not found'
+        )
+    if existing['author'] != auth.principal_name:
+        raise fastapi.HTTPException(
+            status_code=403,
+            detail='Only the comment author may edit it',
+        )
+
+    current = {'body': existing['body']}
+    patched = json_patch.apply_patch(
+        current, operations, _COMMENT_READONLY_PATHS
+    )
+    try:
+        update = CommentBodyCreate(body=patched.get('body'))  # type: ignore[arg-type]
+    except pydantic.ValidationError as e:
+        raise fastapi.HTTPException(
+            status_code=400,
+            detail=f'Validation error: {e.errors()}',
+        ) from e
+
+    now = datetime.datetime.now(datetime.UTC)
+    query: typing.LiteralString = (
+        _DOC_JOIN
+        + """
+    MATCH (c:Comment {{id: {comment_id}}})
+          -[:IN_THREAD]->(:CommentThread {{id: {thread_id}}})
+          -[:ON_DOCUMENT]->(d)
+    SET c.body = {body},
+        c.edited = {edited},
+        c.updated_at = {updated_at}
+    RETURN c
+    """
+    )
+    records = await db.execute(
+        query,
+        {
+            'document_id': document_id,
+            'project_id': project_id,
+            'org_slug': org_slug,
+            'thread_id': thread_id,
+            'comment_id': comment_id,
+            'body': update.body,
+            'edited': True,
+            'updated_at': now.isoformat(),
+        },
+        columns=['c'],
+    )
+    if not records:
+        raise fastapi.HTTPException(
+            status_code=404, detail=f'Comment {comment_id!r} not found'
+        )
+    return _parse_comment(records[0]['c'])
+
+
+@comments_router.post(
+    '/{thread_id}/comments/{comment_id}/acknowledge',
+    response_model=CommentResponse,
+)
+async def acknowledge_comment(
+    org_slug: str,
+    project_id: str,
+    document_id: str,
+    thread_id: str,
+    comment_id: str,
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(permissions.require_permission('comment:write')),
+    ],
+) -> dict[str, typing.Any]:
+    """Toggle the principal in the comment's ``acknowledged_by`` array."""
+    existing = await _fetch_comment(
+        db, org_slug, project_id, document_id, thread_id, comment_id
+    )
+    if existing is None:
+        raise fastapi.HTTPException(
+            status_code=404, detail=f'Comment {comment_id!r} not found'
+        )
+
+    # Toggle app-side, then write the whole array back (avoids AGE list
+    # manipulation in Cypher).
+    acknowledged = list(existing.get('acknowledged_by', []))
+    principal = auth.principal_name
+    if principal in acknowledged:
+        acknowledged = [a for a in acknowledged if a != principal]
+    else:
+        acknowledged.append(principal)
+
+    query: typing.LiteralString = (
+        _DOC_JOIN
+        + """
+    MATCH (c:Comment {{id: {comment_id}}})
+          -[:IN_THREAD]->(:CommentThread {{id: {thread_id}}})
+          -[:ON_DOCUMENT]->(d)
+    SET c.acknowledged_by = {acknowledged_by}
+    RETURN c
+    """
+    )
+    records = await db.execute(
+        query,
+        {
+            'document_id': document_id,
+            'project_id': project_id,
+            'org_slug': org_slug,
+            'thread_id': thread_id,
+            'comment_id': comment_id,
+            'acknowledged_by': acknowledged,
+        },
+        columns=['c'],
+    )
+    if not records:
+        raise fastapi.HTTPException(
+            status_code=404, detail=f'Comment {comment_id!r} not found'
+        )
+    return _parse_comment(records[0]['c'])
+
+
+@comments_router.delete('/{thread_id}/comments/{comment_id}', status_code=204)
+async def delete_comment(
+    org_slug: str,
+    project_id: str,
+    document_id: str,
+    thread_id: str,
+    comment_id: str,
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(permissions.require_permission('comment:delete')),
+    ],
+) -> None:
+    """Delete a comment. Author-only. Deletes the thread if it was the
+    root and no other comments remain.
+    """
+    existing = await _fetch_comment(
+        db, org_slug, project_id, document_id, thread_id, comment_id
+    )
+    if existing is None:
+        raise fastapi.HTTPException(
+            status_code=404, detail=f'Comment {comment_id!r} not found'
+        )
+    if existing['author'] != auth.principal_name:
+        raise fastapi.HTTPException(
+            status_code=403,
+            detail='Only the comment author may delete it',
+        )
+
+    # Determine whether this is the root (oldest) comment and whether any
+    # other comments remain in the thread.
+    thread = await _fetch_thread(
+        db, org_slug, project_id, document_id, thread_id
+    )
+    if thread is None:
+        raise fastapi.HTTPException(
+            status_code=404, detail=f'Thread {thread_id!r} not found'
+        )
+    comments = thread.get('comments', [])
+    is_root = bool(comments) and comments[0]['id'] == comment_id
+    is_only = len(comments) <= 1
+
+    if is_root and is_only:
+        # Remove the whole thread (and its ON_DOCUMENT edge) plus the
+        # root comment.
+        query: typing.LiteralString = (
+            _DOC_JOIN
+            + """
+    MATCH (c:Comment {{id: {comment_id}}})
+          -[:IN_THREAD]->(t:CommentThread {{id: {thread_id}}})
+          -[:ON_DOCUMENT]->(d)
+    DETACH DELETE c, t
+    RETURN 1 AS deleted
+    """
+        )
+    else:
+        query = (
+            _DOC_JOIN
+            + """
+    MATCH (c:Comment {{id: {comment_id}}})
+          -[:IN_THREAD]->(:CommentThread {{id: {thread_id}}})
+          -[:ON_DOCUMENT]->(d)
+    DETACH DELETE c
+    RETURN 1 AS deleted
+    """
+        )
+    records = await db.execute(
+        query,
+        {
+            'document_id': document_id,
+            'project_id': project_id,
+            'org_slug': org_slug,
+            'thread_id': thread_id,
+            'comment_id': comment_id,
+        },
+        columns=['deleted'],
+    )
+    if not records:
+        raise fastapi.HTTPException(
+            status_code=404, detail=f'Comment {comment_id!r} not found'
+        )

--- a/src/imbi_api/endpoints/organizations.py
+++ b/src/imbi_api/endpoints/organizations.py
@@ -13,6 +13,7 @@ from imbi_api.auth import permissions
 from imbi_api.endpoints._helpers import conflict_on_unique_violation
 from imbi_api.relationships import RelationshipSpec, build_relationships
 
+from .comments import comments_router
 from .document_templates import document_templates_router
 from .documents import documents_project_router, documents_router
 from .environments import environments_router
@@ -97,6 +98,12 @@ organizations_router.include_router(
 organizations_router.include_router(
     documents_project_router,
     prefix='/{org_slug}/projects/{project_id}/documents',
+)
+organizations_router.include_router(
+    comments_router,
+    prefix=(
+        '/{org_slug}/projects/{project_id}/documents/{document_id}/comments'
+    ),
 )
 organizations_router.include_router(
     document_templates_router,

--- a/tests/endpoints/test_comments.py
+++ b/tests/endpoints/test_comments.py
@@ -1,0 +1,567 @@
+"""Tests for document comment thread + comment endpoints."""
+
+import datetime
+import typing
+import unittest
+from unittest import mock
+
+from fastapi.testclient import TestClient
+from imbi_common import graph
+
+from imbi_api import models
+from tests import support
+
+_BASE = '/organizations/engineering/projects/proj-abc/documents/doc-1/comments'
+
+
+class CommentEndpointsTestCase(support.SharedAppTestCase):
+    """Test cases for comment threads and comments CRUD."""
+
+    def setUp(self) -> None:
+        from imbi_api.auth import permissions
+
+        self.user = models.User(
+            email='alice@example.com',
+            display_name='Alice',
+            password_hash='$argon2id$hashed',
+            is_active=True,
+            is_admin=False,
+            is_service_account=False,
+            created_at=datetime.datetime.now(datetime.UTC),
+        )
+        self.auth_context = permissions.AuthContext(
+            user=self.user,
+            session_id='test-session',
+            auth_method='jwt',
+            permissions={
+                'document:read',
+                'comment:create',
+                'comment:write',
+                'comment:delete',
+            },
+        )
+
+        async def mock_get_current_user():
+            return self.auth_context
+
+        self.test_app.dependency_overrides[permissions.get_current_user] = (
+            mock_get_current_user
+        )
+
+        self.mock_db = mock.AsyncMock(spec=graph.Graph)
+        self.test_app.dependency_overrides[graph._inject_graph] = lambda: (
+            self.mock_db
+        )
+
+        self.client = TestClient(self.test_app)
+
+    def _set_permissions(self, perms: set[str]) -> None:
+        from imbi_api.auth import permissions
+
+        self.auth_context = permissions.AuthContext(
+            user=self.user,
+            session_id='test-session',
+            auth_method='jwt',
+            permissions=perms,
+        )
+
+        async def mock_get_current_user():
+            return self.auth_context
+
+        self.test_app.dependency_overrides[permissions.get_current_user] = (
+            mock_get_current_user
+        )
+
+    def _document(self, **overrides: typing.Any) -> dict:
+        data: dict[str, typing.Any] = {'id': 'doc-1', 'slug': 'runbook'}
+        data.update(overrides)
+        return data
+
+    def _thread(self, **overrides: typing.Any) -> dict:
+        data: dict[str, typing.Any] = {
+            'id': 'thread-1',
+            'kind': 'page',
+            'resolved': False,
+            'resolved_by': None,
+            'resolved_at': None,
+            'anchor_quote': '',
+            'anchor_prefix': '',
+            'anchor_suffix': '',
+            'anchor_start': 0,
+            'created_by': 'alice@example.com',
+            'created_at': '2026-03-17T12:00:00Z',
+            'updated_at': None,
+        }
+        data.update(overrides)
+        return data
+
+    def _comment(self, **overrides: typing.Any) -> dict:
+        data: dict[str, typing.Any] = {
+            'id': 'comment-1',
+            'thread_id': 'thread-1',
+            'author': 'alice@example.com',
+            'body': 'First!',
+            'mentions': [],
+            'acknowledged_by': [],
+            'edited': False,
+            'created_at': '2026-03-17T12:00:00Z',
+            'updated_at': None,
+        }
+        data.update(overrides)
+        return data
+
+    def _thread_row(
+        self,
+        thread: dict | None = None,
+        comments: list[dict] | None = None,
+    ) -> dict:
+        return {
+            't': thread or self._thread(),
+            'd': self._document(),
+            'comments': comments
+            if comments is not None
+            else [self._comment()],
+        }
+
+    # -- List ----------------------------------------------------------
+
+    def test_list_threads(self) -> None:
+        # 1: _verify_document, 2: list query
+        self.mock_db.execute.side_effect = [
+            [{'id': 'doc-1'}],
+            [
+                self._thread_row(
+                    comments=[
+                        self._comment(
+                            id='c1', created_at='2026-03-17T12:00:00Z'
+                        ),
+                        self._comment(
+                            id='c2',
+                            body='reply',
+                            created_at='2026-03-17T12:05:00Z',
+                        ),
+                    ]
+                ),
+            ],
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.get(_BASE)
+        self.assertEqual(response.status_code, 200)
+        data = response.json()['data']
+        self.assertEqual(len(data), 1)
+        # Root is first; comments preserved in oldest-first order.
+        self.assertEqual([c['id'] for c in data[0]['comments']], ['c1', 'c2'])
+        self.assertIsNone(data[0]['anchor'])
+
+    def test_list_document_not_found(self) -> None:
+        self.mock_db.execute.return_value = []
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.get(_BASE)
+        self.assertEqual(response.status_code, 404)
+
+    # -- Create thread -------------------------------------------------
+
+    def test_create_thread_and_root(self) -> None:
+        # 1: verify_document, 2: create, 3: _fetch_thread
+        self.mock_db.execute.side_effect = [
+            [{'id': 'doc-1'}],
+            [{'id': 'thread-1'}],
+            [self._thread_row()],
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.post(_BASE, json={'body': 'First!'})
+        self.assertEqual(response.status_code, 201)
+        body = response.json()
+        self.assertEqual(body['document_id'], 'doc-1')
+        self.assertEqual(body['kind'], 'page')
+        self.assertFalse(body['resolved'])
+        self.assertEqual(len(body['comments']), 1)
+        self.assertEqual(body['comments'][0]['body'], 'First!')
+        # Root comment authored by principal.
+        create_call = self.mock_db.execute.await_args_list[1]
+        self.assertEqual(create_call.args[1]['author'], 'alice@example.com')
+        self.assertEqual(create_call.args[1]['anchor_quote'], '')
+        self.assertEqual(create_call.args[1]['anchor_start'], 0)
+
+    def test_create_thread_document_not_found(self) -> None:
+        self.mock_db.execute.return_value = []
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.post(_BASE, json={'body': 'x'})
+        self.assertEqual(response.status_code, 404)
+
+    def test_create_thread_empty_body_rejected(self) -> None:
+        response = self.client.post(_BASE, json={'body': ''})
+        self.assertEqual(response.status_code, 422)
+
+    # -- Reply ---------------------------------------------------------
+
+    def test_create_reply(self) -> None:
+        self.mock_db.execute.return_value = [
+            {
+                'c': self._comment(
+                    id='c2', body='reply', author='alice@example.com'
+                )
+            }
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.post(
+                f'{_BASE}/thread-1/comments', json={'body': 'reply'}
+            )
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.json()['body'], 'reply')
+        self.assertEqual(response.json()['id'], 'c2')
+
+    def test_create_reply_thread_not_found(self) -> None:
+        self.mock_db.execute.return_value = []
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.post(
+                f'{_BASE}/ghost/comments', json={'body': 'reply'}
+            )
+        self.assertEqual(response.status_code, 404)
+
+    # -- Resolve / reopen ----------------------------------------------
+
+    def test_resolve_thread(self) -> None:
+        # 1: _fetch_thread (existing), 2: SET, 3: _fetch_thread (final)
+        self.mock_db.execute.side_effect = [
+            [self._thread_row()],
+            [{'id': 'thread-1'}],
+            [
+                self._thread_row(
+                    thread=self._thread(
+                        resolved=True,
+                        resolved_by='alice@example.com',
+                        resolved_at='2026-03-18T09:00:00Z',
+                    )
+                )
+            ],
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.patch(
+                f'{_BASE}/thread-1',
+                json=[{'op': 'replace', 'path': '/resolved', 'value': True}],
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.json()['resolved'])
+        self.assertEqual(response.json()['resolved_by'], 'alice@example.com')
+        set_call = self.mock_db.execute.await_args_list[1]
+        self.assertTrue(set_call.args[1]['resolved'])
+        self.assertEqual(set_call.args[1]['resolved_by'], 'alice@example.com')
+        self.assertIsNotNone(set_call.args[1]['resolved_at'])
+
+    def test_reopen_thread_clears_resolution(self) -> None:
+        resolved = self._thread(
+            resolved=True,
+            resolved_by='alice@example.com',
+            resolved_at='2026-03-18T09:00:00Z',
+        )
+        self.mock_db.execute.side_effect = [
+            [self._thread_row(thread=resolved)],
+            [{'id': 'thread-1'}],
+            [self._thread_row()],
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.patch(
+                f'{_BASE}/thread-1',
+                json=[{'op': 'replace', 'path': '/resolved', 'value': False}],
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.json()['resolved'])
+        set_call = self.mock_db.execute.await_args_list[1]
+        self.assertFalse(set_call.args[1]['resolved'])
+        self.assertIsNone(set_call.args[1]['resolved_by'])
+        self.assertIsNone(set_call.args[1]['resolved_at'])
+
+    def test_patch_thread_readonly_path_rejected(self) -> None:
+        self.mock_db.execute.return_value = [self._thread_row()]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.patch(
+                f'{_BASE}/thread-1',
+                json=[
+                    {
+                        'op': 'replace',
+                        'path': '/resolved_by',
+                        'value': 'attacker',
+                    }
+                ],
+            )
+        self.assertEqual(response.status_code, 400)
+
+    def test_patch_thread_not_found(self) -> None:
+        self.mock_db.execute.return_value = []
+        response = self.client.patch(
+            f'{_BASE}/ghost',
+            json=[{'op': 'replace', 'path': '/resolved', 'value': True}],
+        )
+        self.assertEqual(response.status_code, 404)
+
+    def test_patch_thread_non_bool_rejected(self) -> None:
+        self.mock_db.execute.return_value = [self._thread_row()]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.patch(
+                f'{_BASE}/thread-1',
+                json=[{'op': 'replace', 'path': '/resolved', 'value': 'yes'}],
+            )
+        self.assertEqual(response.status_code, 400)
+
+    # -- Edit comment body ---------------------------------------------
+
+    def test_edit_comment_body(self) -> None:
+        # 1: _fetch_comment, 2: SET
+        self.mock_db.execute.side_effect = [
+            [{'c': self._comment()}],
+            [{'c': self._comment(body='edited', edited=True)}],
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.patch(
+                f'{_BASE}/thread-1/comments/comment-1',
+                json=[{'op': 'replace', 'path': '/body', 'value': 'edited'}],
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()['body'], 'edited')
+        self.assertTrue(response.json()['edited'])
+        set_call = self.mock_db.execute.await_args_list[1]
+        self.assertEqual(set_call.args[1]['body'], 'edited')
+        self.assertTrue(set_call.args[1]['edited'])
+
+    def test_edit_comment_non_author_forbidden(self) -> None:
+        self.mock_db.execute.return_value = [
+            {'c': self._comment(author='bob@example.com')}
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.patch(
+                f'{_BASE}/thread-1/comments/comment-1',
+                json=[{'op': 'replace', 'path': '/body', 'value': 'edited'}],
+            )
+        self.assertEqual(response.status_code, 403)
+
+    def test_edit_comment_not_found(self) -> None:
+        self.mock_db.execute.return_value = []
+        response = self.client.patch(
+            f'{_BASE}/thread-1/comments/ghost',
+            json=[{'op': 'replace', 'path': '/body', 'value': 'x'}],
+        )
+        self.assertEqual(response.status_code, 404)
+
+    def test_edit_comment_empty_body_rejected(self) -> None:
+        self.mock_db.execute.return_value = [{'c': self._comment()}]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.patch(
+                f'{_BASE}/thread-1/comments/comment-1',
+                json=[{'op': 'replace', 'path': '/body', 'value': ''}],
+            )
+        self.assertEqual(response.status_code, 400)
+
+    def test_edit_comment_readonly_path_rejected(self) -> None:
+        self.mock_db.execute.return_value = [{'c': self._comment()}]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.patch(
+                f'{_BASE}/thread-1/comments/comment-1',
+                json=[
+                    {'op': 'replace', 'path': '/author', 'value': 'attacker'}
+                ],
+            )
+        self.assertEqual(response.status_code, 400)
+
+    # -- Acknowledge toggle --------------------------------------------
+
+    def test_acknowledge_adds_principal(self) -> None:
+        # 1: _fetch_comment, 2: SET
+        self.mock_db.execute.side_effect = [
+            [{'c': self._comment(acknowledged_by=[])}],
+            [{'c': self._comment(acknowledged_by=['alice@example.com'])}],
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.post(
+                f'{_BASE}/thread-1/comments/comment-1/acknowledge'
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('alice@example.com', response.json()['acknowledged_by'])
+        set_call = self.mock_db.execute.await_args_list[1]
+        self.assertEqual(
+            set_call.args[1]['acknowledged_by'], ['alice@example.com']
+        )
+
+    def test_acknowledge_removes_principal(self) -> None:
+        self.mock_db.execute.side_effect = [
+            [{'c': self._comment(acknowledged_by=['alice@example.com'])}],
+            [{'c': self._comment(acknowledged_by=[])}],
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.post(
+                f'{_BASE}/thread-1/comments/comment-1/acknowledge'
+            )
+        self.assertEqual(response.status_code, 200)
+        set_call = self.mock_db.execute.await_args_list[1]
+        self.assertEqual(set_call.args[1]['acknowledged_by'], [])
+
+    def test_acknowledge_comment_not_found(self) -> None:
+        self.mock_db.execute.return_value = []
+        response = self.client.post(
+            f'{_BASE}/thread-1/comments/ghost/acknowledge'
+        )
+        self.assertEqual(response.status_code, 404)
+
+    # -- Delete --------------------------------------------------------
+
+    def test_delete_reply_keeps_thread(self) -> None:
+        # 1: _fetch_comment, 2: _fetch_thread (root + reply), 3: DELETE
+        thread_with_two = self._thread_row(
+            comments=[
+                self._comment(
+                    id='comment-1', created_at='2026-03-17T12:00:00Z'
+                ),
+                self._comment(
+                    id='comment-2', created_at='2026-03-17T12:05:00Z'
+                ),
+            ]
+        )
+        self.mock_db.execute.side_effect = [
+            [{'c': self._comment(id='comment-2')}],
+            [thread_with_two],
+            [{'deleted': 1}],
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.delete(
+                f'{_BASE}/thread-1/comments/comment-2'
+            )
+        self.assertEqual(response.status_code, 204)
+        # The DELETE query must only delete the comment (not the thread).
+        delete_query = self.mock_db.execute.await_args_list[2].args[0]
+        self.assertNotIn('DETACH DELETE c, t', delete_query)
+
+    def test_delete_root_only_comment_removes_thread(self) -> None:
+        self.mock_db.execute.side_effect = [
+            [{'c': self._comment(id='comment-1')}],
+            [self._thread_row(comments=[self._comment(id='comment-1')])],
+            [{'deleted': 1}],
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.delete(
+                f'{_BASE}/thread-1/comments/comment-1'
+            )
+        self.assertEqual(response.status_code, 204)
+        delete_query = self.mock_db.execute.await_args_list[2].args[0]
+        self.assertIn('DETACH DELETE c, t', delete_query)
+
+    def test_delete_root_with_replies_keeps_thread(self) -> None:
+        thread_with_two = self._thread_row(
+            comments=[
+                self._comment(
+                    id='comment-1', created_at='2026-03-17T12:00:00Z'
+                ),
+                self._comment(
+                    id='comment-2', created_at='2026-03-17T12:05:00Z'
+                ),
+            ]
+        )
+        self.mock_db.execute.side_effect = [
+            [{'c': self._comment(id='comment-1')}],
+            [thread_with_two],
+            [{'deleted': 1}],
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.delete(
+                f'{_BASE}/thread-1/comments/comment-1'
+            )
+        self.assertEqual(response.status_code, 204)
+        delete_query = self.mock_db.execute.await_args_list[2].args[0]
+        self.assertNotIn('DETACH DELETE c, t', delete_query)
+
+    def test_delete_non_author_forbidden(self) -> None:
+        self.mock_db.execute.return_value = [
+            {'c': self._comment(author='bob@example.com')}
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.delete(
+                f'{_BASE}/thread-1/comments/comment-1'
+            )
+        self.assertEqual(response.status_code, 403)
+
+    def test_delete_comment_not_found(self) -> None:
+        self.mock_db.execute.return_value = []
+        response = self.client.delete(f'{_BASE}/thread-1/comments/ghost')
+        self.assertEqual(response.status_code, 404)
+
+    # -- Permission failures -------------------------------------------
+
+    def test_create_thread_requires_comment_create(self) -> None:
+        self._set_permissions({'document:read'})
+        response = self.client.post(_BASE, json={'body': 'x'})
+        self.assertEqual(response.status_code, 403)
+
+    def test_reply_requires_comment_create(self) -> None:
+        self._set_permissions({'document:read'})
+        response = self.client.post(
+            f'{_BASE}/thread-1/comments', json={'body': 'x'}
+        )
+        self.assertEqual(response.status_code, 403)
+
+    def test_patch_thread_requires_comment_write(self) -> None:
+        self._set_permissions({'document:read'})
+        response = self.client.patch(
+            f'{_BASE}/thread-1',
+            json=[{'op': 'replace', 'path': '/resolved', 'value': True}],
+        )
+        self.assertEqual(response.status_code, 403)
+
+    def test_acknowledge_requires_comment_write(self) -> None:
+        self._set_permissions({'document:read'})
+        response = self.client.post(
+            f'{_BASE}/thread-1/comments/comment-1/acknowledge'
+        )
+        self.assertEqual(response.status_code, 403)
+
+    def test_delete_requires_comment_delete(self) -> None:
+        self._set_permissions({'document:read', 'comment:write'})
+        response = self.client.delete(f'{_BASE}/thread-1/comments/comment-1')
+        self.assertEqual(response.status_code, 403)
+
+    def test_list_requires_document_read(self) -> None:
+        self._set_permissions({'comment:create'})
+        response = self.client.get(_BASE)
+        self.assertEqual(response.status_code, 403)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

Phase 1 of the Document Comments feature (imbi-api side). Adds the REST surface for page-level threaded discussion on project Documents. Depends on the `CommentThread`/`Comment` models in imbi-common (AWeber-Imbi/imbi-common#144) — but uses raw Cypher and imports no new imbi-common symbols, so it's independently testable.

## Routes

Mounted at `/{org_slug}/projects/{project_id}/documents/{document_id}/comments`; every handler enforces the document→project→team→org join.

| Method | Path | Result | Permission |
|---|---|---|---|
| GET | `""` | `{data: CommentThreadResponse[]}` | `document:read` |
| POST | `""` | thread + root comment | `comment:create` |
| POST | `"/{thread_id}/comments"` | reply | `comment:create` |
| PATCH | `"/{thread_id}"` | resolve/reopen (JSON-Patch, `/resolved` only) | `comment:write` |
| PATCH | `"/{thread_id}/comments/{comment_id}"` | edit body (JSON-Patch `/body`, author-only) | `comment:write` |
| POST | `"/{thread_id}/comments/{comment_id}/acknowledge"` | toggle ack | `comment:write` |
| DELETE | `"/{thread_id}/comments/{comment_id}"` | author-only; root+sole comment removes the thread | `comment:delete` |

New scopes `comment:create`/`comment:write`/`comment:delete` added to `STANDARD_PERMISSIONS` and granted to `developer` (admin inherits). Resolve is open to anyone with `comment:write`; edit/delete additionally enforce `author == auth.principal_name`.

Phase 1 is page-only: `kind` is persisted as sent but anchor fields stay empty (inline anchoring lands in Phase 2).

## Tests

`tests/endpoints/test_comments.py`: **31 passed**, `comments.py` coverage **91%**. No regressions — documents/organizations/auth/seed all green. ruff + basedpyright (strict) + mypy (strict) clean.

## ⚠️ Caveats — unverified against live AGE

Tests mock `graph.execute`, so the Cypher never runs against Apache AGE. Not yet exercised end-to-end:

- **Delete root/thread logic** — `DETACH DELETE c, t` removing the thread + its `ON_DOCUMENT` edge.
- **Acknowledge array write** — `SET c.acknowledged_by = {param}` binding a Python list as an agtype array.
- **`_COMMENTS_TAIL` ordering** — the `ORDER BY ... ASC` + `collect(CASE WHEN c IS NOT NULL ...)` pattern (modeled on documents' `_TAGS_TAIL`).

These follow documented AGE rules + the `documents.py` precedent. Recommend an integration pass via `just test` against the Okteto stack before merge.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
