### PR TITLE
Accept inline-anchored comment threads (Phase 2)

### DIFF
--- a/src/imbi_api/endpoints/comments.py
+++ b/src/imbi_api/endpoints/comments.py
@@ -5,9 +5,9 @@ Comments hang off a project ``Document`` via a ``CommentThread`` vertex
 (``IN_THREAD`` edge). The root comment is the oldest comment in a thread;
 replies follow in ``created_at`` order.
 
-Phase 1 only creates ``kind='page'`` threads — the anchor properties are
-persisted as empty strings / ``0`` and surfaced as ``anchor: null``.
-Inline-anchored threads are a later phase.
+``kind='page'`` threads persist the anchor properties as empty strings /
+``0`` and surface ``anchor: null``. ``kind='inline'`` threads carry an
+anchor (quote/prefix/suffix/start) and round-trip it on read.
 
 Modeled on :mod:`imbi_api.endpoints.documents`: raw Cypher via
 ``db.execute(...)`` + ``graph.parse_agtype(...)`` with local Pydantic
@@ -99,10 +99,21 @@ class CommentThreadListResponse(pydantic.BaseModel):
 
 
 class CommentThreadCreate(pydantic.BaseModel):
-    kind: typing.Literal['page'] = 'page'
+    kind: typing.Literal['page', 'inline'] = 'page'
     body: str = pydantic.Field(min_length=1)
     anchor: AnchorModel | None = None
     mentions: list[str] = []
+
+    @pydantic.model_validator(mode='after')
+    def _validate_anchor(self) -> typing.Self:
+        if self.kind == 'inline':
+            if self.anchor is None or not self.anchor.quote.strip():
+                raise ValueError(
+                    'inline threads require an anchor with a non-empty quote'
+                )
+        else:
+            self.anchor = None
+        return self
 
 
 class CommentBodyCreate(pydantic.BaseModel):
@@ -333,6 +344,7 @@ async def create_comment_thread(
     now = datetime.datetime.now(datetime.UTC)
     thread_id = nanoid.generate()
     comment_id = nanoid.generate()
+    anchor = data.anchor
     query: typing.LiteralString = (
         _DOC_JOIN
         + """
@@ -373,14 +385,14 @@ async def create_comment_thread(
             'project_id': project_id,
             'org_slug': org_slug,
             'thread_id': thread_id,
-            'kind': 'page',
+            'kind': data.kind,
             'resolved': False,
             'resolved_by': None,
             'resolved_at': None,
-            'anchor_quote': '',
-            'anchor_prefix': '',
-            'anchor_suffix': '',
-            'anchor_start': 0,
+            'anchor_quote': anchor.quote if anchor else '',
+            'anchor_prefix': anchor.prefix if anchor else '',
+            'anchor_suffix': anchor.suffix if anchor else '',
+            'anchor_start': anchor.start if anchor else 0,
             'created_by': auth.principal_name,
             'created_at': now.isoformat(),
             'updated_at': None,

--- a/tests/endpoints/test_comments.py
+++ b/tests/endpoints/test_comments.py
@@ -201,6 +201,123 @@ class CommentEndpointsTestCase(support.SharedAppTestCase):
         response = self.client.post(_BASE, json={'body': ''})
         self.assertEqual(response.status_code, 422)
 
+    # -- Create inline thread ------------------------------------------
+
+    def test_create_inline_thread_with_anchor(self) -> None:
+        inline_thread = self._thread(
+            kind='inline',
+            anchor_quote='the disputed phrase',
+            anchor_prefix='before ',
+            anchor_suffix=' after',
+            anchor_start=42,
+        )
+        # 1: verify_document, 2: create, 3: _fetch_thread
+        self.mock_db.execute.side_effect = [
+            [{'id': 'doc-1'}],
+            [{'id': 'thread-1'}],
+            [self._thread_row(thread=inline_thread)],
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.post(
+                _BASE,
+                json={
+                    'kind': 'inline',
+                    'body': 'Inline!',
+                    'anchor': {
+                        'quote': 'the disputed phrase',
+                        'prefix': 'before ',
+                        'suffix': ' after',
+                        'start': 42,
+                    },
+                },
+            )
+        self.assertEqual(response.status_code, 201)
+        body = response.json()
+        self.assertEqual(body['kind'], 'inline')
+        self.assertEqual(body['anchor']['quote'], 'the disputed phrase')
+        self.assertEqual(body['anchor']['prefix'], 'before ')
+        self.assertEqual(body['anchor']['suffix'], ' after')
+        self.assertEqual(body['anchor']['start'], 42)
+        # Persisted params carry the anchor scalars.
+        create_call = self.mock_db.execute.await_args_list[1]
+        self.assertEqual(create_call.args[1]['kind'], 'inline')
+        self.assertEqual(
+            create_call.args[1]['anchor_quote'], 'the disputed phrase'
+        )
+        self.assertEqual(create_call.args[1]['anchor_prefix'], 'before ')
+        self.assertEqual(create_call.args[1]['anchor_suffix'], ' after')
+        self.assertEqual(create_call.args[1]['anchor_start'], 42)
+
+    def test_create_page_thread_has_no_anchor(self) -> None:
+        # Regression: page threads round-trip anchor=None.
+        self.mock_db.execute.side_effect = [
+            [{'id': 'doc-1'}],
+            [{'id': 'thread-1'}],
+            [self._thread_row()],
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.post(_BASE, json={'body': 'First!'})
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.json()['kind'], 'page')
+        self.assertIsNone(response.json()['anchor'])
+
+    def test_create_inline_thread_missing_anchor_rejected(self) -> None:
+        response = self.client.post(
+            _BASE, json={'kind': 'inline', 'body': 'x'}
+        )
+        self.assertEqual(response.status_code, 422)
+
+    def test_create_inline_thread_blank_quote_rejected(self) -> None:
+        response = self.client.post(
+            _BASE,
+            json={
+                'kind': 'inline',
+                'body': 'x',
+                'anchor': {
+                    'quote': '   ',
+                    'prefix': '',
+                    'suffix': '',
+                    'start': 0,
+                },
+            },
+        )
+        self.assertEqual(response.status_code, 422)
+
+    def test_create_page_thread_ignores_anchor(self) -> None:
+        # A page thread with an anchor in the body persists empty scalars
+        # and round-trips anchor=None.
+        self.mock_db.execute.side_effect = [
+            [{'id': 'doc-1'}],
+            [{'id': 'thread-1'}],
+            [self._thread_row()],
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.post(
+                _BASE,
+                json={
+                    'kind': 'page',
+                    'body': 'First!',
+                    'anchor': {
+                        'quote': 'ignored',
+                        'prefix': '',
+                        'suffix': '',
+                        'start': 7,
+                    },
+                },
+            )
+        self.assertEqual(response.status_code, 201)
+        self.assertIsNone(response.json()['anchor'])
+        create_call = self.mock_db.execute.await_args_list[1]
+        self.assertEqual(create_call.args[1]['kind'], 'page')
+        self.assertEqual(create_call.args[1]['anchor_quote'], '')
+        self.assertEqual(create_call.args[1]['anchor_start'], 0)
+
     # -- Reply ---------------------------------------------------------
 
     def test_create_reply(self) -> None:


### PR DESCRIPTION
## Summary

Phase 2 (backend slice) of Document Comments. Reverses the Phase 1 page-only restriction so the comments API can create **inline-anchored** threads. Small, surgical change to `endpoints/comments.py` — no imbi-common, permissions, or other endpoints touched. `kind='inline'` uses the same `comment:create` permission as page threads.

Pairs with the imbi-ui Phase 2 PR (inline highlight overlay + right-margin card bar).

## Changes

- `CommentThreadCreate.kind` relaxed from `Literal['page']` back to `Literal['page', 'inline']` (default `'page'`).
- Added optional `anchor: AnchorModel | None`.
- `model_validator(mode='after')`:
  - `kind='inline'` → `anchor` required and `anchor.quote` must be non-empty (else 422).
  - `kind='page'` → `anchor` forced to `None` (page threads can never carry an anchor).
- Create handler persists `kind` as sent and writes `anchor_quote/prefix/suffix/start` from the anchor when present (empty/`0` otherwise). Cypher style unchanged (double-braced maps, `{param}` placeholders, ISO timestamps).
- The Phase 1 response builder already emits a populated `AnchorModel` for inline threads — verified by round-trip test, no change needed.

## Tests

`tests/endpoints/test_comments.py`: **36 passed** (31 prior + 5 new): inline create with valid anchor (201, echoes anchor + `kind='inline'`, asserts persisted params); page create regression (anchor `None`); inline without anchor → 422; inline with empty/whitespace quote → 422; page-with-anchor → anchor ignored. `comments.py` coverage **95%**. ruff + basedpyright + mypy clean.

## ⚠️ Caveats

- Tests mock `graph.execute`, so the actual AGE persistence/read-back of the anchor scalars is **not** exercised against a live DB — same caveat class as Phase 1's delete/acknowledge Cypher. Recommend the planned integration pass via `just test` against the Okteto stack before relying on it.
- Local-only: the suite 404s if the orchestrator `.env` (`IMBI_API_URL=/api`) is picked up; CI has no such var and is unaffected (verified the same 404s on the unmodified Phase 1 base).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>