### PR TITLE
Persist @mention emails + fix empty comment lists (Phase 3)

### DIFF
--- a/src/imbi_api/endpoints/comments.py
+++ b/src/imbi_api/endpoints/comments.py
@@ -184,10 +184,22 @@ def _parse_thread_row(record: dict[str, typing.Any]) -> dict[str, typing.Any]:
 
 # Tail fragment that collects a thread's comments oldest-first. Runs with
 # ``t, d`` in scope and emits ``t, d, comments``.
+#
+# Comments are collected as **map projections** (``c{.id, ...}``), never as
+# raw vertices: ``graph.parse_agtype`` only strips a trailing ``::vertex``
+# suffix, so a ``collect()`` of raw vertices yields a list-string with inner
+# ``::vertex`` suffixes that ``json.loads`` rejects -- it falls back to the
+# raw string, which then iterates character-by-character into an empty list.
+# Map projections serialize as plain JSON maps and round-trip cleanly. This
+# mirrors ``documents.py`` ``_TAGS_TAIL``.
 _COMMENTS_TAIL: typing.LiteralString = """
     OPTIONAL MATCH (c:Comment)-[:IN_THREAD]->(t)
     WITH t, d, c ORDER BY c.created_at ASC, c.id ASC
-    WITH t, d, collect(CASE WHEN c IS NOT NULL THEN c END) AS raw_comments
+    WITH t, d, collect(CASE WHEN c IS NOT NULL
+                            THEN c{{.id, .thread_id, .author, .body,
+                                    .mentions, .acknowledged_by, .edited,
+                                    .created_at, .updated_at}}
+                            END) AS raw_comments
     WITH t, d, [x IN raw_comments WHERE x IS NOT NULL] AS comments
     RETURN t, d, comments
 """

--- a/src/imbi_api/endpoints/comments.py
+++ b/src/imbi_api/endpoints/comments.py
@@ -46,13 +46,13 @@ _THREAD_READONLY_PATHS: frozenset[str] = frozenset(
     ]
 )
 
-# Every comment field except ``/body`` is read-only over the PATCH API.
+# Every comment field except ``/body`` and ``/mentions`` is read-only over
+# the PATCH API.
 _COMMENT_READONLY_PATHS: frozenset[str] = frozenset(
     [
         '/id',
         '/thread_id',
         '/author',
-        '/mentions',
         '/acknowledged_by',
         '/edited',
         '/created_at',
@@ -577,7 +577,10 @@ async def patch_comment(
         fastapi.Depends(permissions.require_permission('comment:write')),
     ],
 ) -> dict[str, typing.Any]:
-    """Edit a comment body via JSON Patch (only ``/body``). Author-only."""
+    """Edit a comment via JSON Patch (only ``/body`` and ``/mentions``).
+
+    Author-only.
+    """
     existing = await _fetch_comment(
         db, org_slug, project_id, document_id, thread_id, comment_id
     )
@@ -591,12 +594,18 @@ async def patch_comment(
             detail='Only the comment author may edit it',
         )
 
-    current = {'body': existing['body']}
+    current = {
+        'body': existing['body'],
+        'mentions': list(existing['mentions']),
+    }
     patched = json_patch.apply_patch(
         current, operations, _COMMENT_READONLY_PATHS
     )
     try:
-        update = CommentBodyCreate(body=patched.get('body'))  # type: ignore[arg-type]
+        update = CommentBodyCreate(
+            body=patched.get('body'),  # type: ignore[arg-type]
+            mentions=patched.get('mentions'),  # type: ignore[arg-type]
+        )
     except pydantic.ValidationError as e:
         raise fastapi.HTTPException(
             status_code=400,
@@ -611,6 +620,7 @@ async def patch_comment(
           -[:IN_THREAD]->(:CommentThread {{id: {thread_id}}})
           -[:ON_DOCUMENT]->(d)
     SET c.body = {body},
+        c.mentions = {mentions},
         c.edited = {edited},
         c.updated_at = {updated_at}
     RETURN c
@@ -625,6 +635,7 @@ async def patch_comment(
             'thread_id': thread_id,
             'comment_id': comment_id,
             'body': update.body,
+            'mentions': list(update.mentions),
             'edited': True,
             'updated_at': now.isoformat(),
         },

--- a/tests/endpoints/test_comments.py
+++ b/tests/endpoints/test_comments.py
@@ -832,5 +832,58 @@ class CommentEndpointsTestCase(support.SharedAppTestCase):
         self.assertEqual(response.status_code, 403)
 
 
+class ThreadRowParsingTestCase(unittest.TestCase):
+    """Parse a thread row from the **raw agtype strings** AGE returns.
+
+    The endpoint tests mock ``graph.execute`` and hand back pre-parsed
+    dicts, so they never exercise ``graph.parse_agtype``. This case feeds
+    ``_parse_thread_row`` the wire form -- vertex strings for ``t``/``d``
+    and a JSON array of map projections for ``comments`` -- which is what
+    ``_COMMENTS_TAIL`` actually emits. It guards the regression where the
+    tail collected raw vertices: ``parse_agtype`` could not decode the
+    resulting ``::vertex``-suffixed list-string, fell back to the raw
+    string, and the comment list came back empty.
+    """
+
+    def test_comments_round_trip_from_agtype(self) -> None:
+        from imbi_api.endpoints import comments
+
+        thread_vertex = (
+            '{"id": 0, "label": "CommentThread", "properties": '
+            '{"id": "thread-1", "kind": "page", "resolved": false, '
+            '"resolved_by": null, "resolved_at": null, '
+            '"anchor_quote": "", "anchor_prefix": "", '
+            '"anchor_suffix": "", "anchor_start": 0, '
+            '"created_by": "alice@example.com", '
+            '"created_at": "2026-03-17T12:00:00Z", '
+            '"updated_at": null}}::vertex'
+        )
+        document_vertex = (
+            '{"id": 1, "label": "Document", "properties": '
+            '{"id": "doc-1", "slug": "runbook"}}::vertex'
+        )
+        # Map projections serialize as plain JSON maps (no ::vertex).
+        comments_column = (
+            '[{"id": "c1", "thread_id": "thread-1", '
+            '"author": "alice@example.com", "body": "First!", '
+            '"mentions": [], "acknowledged_by": [], "edited": false, '
+            '"created_at": "2026-03-17T12:00:00Z", "updated_at": null}]'
+        )
+
+        row = comments._parse_thread_row(
+            {
+                't': thread_vertex,
+                'd': document_vertex,
+                'comments': comments_column,
+            }
+        )
+
+        self.assertEqual(row['id'], 'thread-1')
+        self.assertEqual(row['document_id'], 'doc-1')
+        self.assertEqual(len(row['comments']), 1)
+        self.assertEqual(row['comments'][0]['id'], 'c1')
+        self.assertEqual(row['comments'][0]['body'], 'First!')
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/endpoints/test_comments.py
+++ b/tests/endpoints/test_comments.py
@@ -189,6 +189,51 @@ class CommentEndpointsTestCase(support.SharedAppTestCase):
         self.assertEqual(create_call.args[1]['anchor_quote'], '')
         self.assertEqual(create_call.args[1]['anchor_start'], 0)
 
+    def test_create_thread_persists_mentions(self) -> None:
+        self.mock_db.execute.side_effect = [
+            [{'id': 'doc-1'}],
+            [{'id': 'thread-1'}],
+            [
+                self._thread_row(
+                    comments=[self._comment(mentions=['a@x.com', 'b@x.com'])]
+                )
+            ],
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.post(
+                _BASE,
+                json={
+                    'body': 'First!',
+                    'mentions': ['a@x.com', 'b@x.com'],
+                },
+            )
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(
+            response.json()['comments'][0]['mentions'],
+            ['a@x.com', 'b@x.com'],
+        )
+        create_call = self.mock_db.execute.await_args_list[1]
+        self.assertEqual(
+            create_call.args[1]['mentions'], ['a@x.com', 'b@x.com']
+        )
+
+    def test_create_thread_defaults_mentions_empty(self) -> None:
+        self.mock_db.execute.side_effect = [
+            [{'id': 'doc-1'}],
+            [{'id': 'thread-1'}],
+            [self._thread_row()],
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.post(_BASE, json={'body': 'First!'})
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.json()['comments'][0]['mentions'], [])
+        create_call = self.mock_db.execute.await_args_list[1]
+        self.assertEqual(create_call.args[1]['mentions'], [])
+
     def test_create_thread_document_not_found(self) -> None:
         self.mock_db.execute.return_value = []
         with mock.patch(
@@ -338,6 +383,43 @@ class CommentEndpointsTestCase(support.SharedAppTestCase):
         self.assertEqual(response.json()['body'], 'reply')
         self.assertEqual(response.json()['id'], 'c2')
 
+    def test_create_reply_persists_mentions(self) -> None:
+        self.mock_db.execute.return_value = [
+            {
+                'c': self._comment(
+                    id='c2',
+                    body='reply',
+                    mentions=['c@x.com'],
+                )
+            }
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.post(
+                f'{_BASE}/thread-1/comments',
+                json={'body': 'reply', 'mentions': ['c@x.com']},
+            )
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.json()['mentions'], ['c@x.com'])
+        create_call = self.mock_db.execute.await_args_list[0]
+        self.assertEqual(create_call.args[1]['mentions'], ['c@x.com'])
+
+    def test_create_reply_defaults_mentions_empty(self) -> None:
+        self.mock_db.execute.return_value = [
+            {'c': self._comment(id='c2', body='reply')}
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.post(
+                f'{_BASE}/thread-1/comments', json={'body': 'reply'}
+            )
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.json()['mentions'], [])
+        create_call = self.mock_db.execute.await_args_list[0]
+        self.assertEqual(create_call.args[1]['mentions'], [])
+
     def test_create_reply_thread_not_found(self) -> None:
         self.mock_db.execute.return_value = []
         with mock.patch(
@@ -462,6 +544,76 @@ class CommentEndpointsTestCase(support.SharedAppTestCase):
         set_call = self.mock_db.execute.await_args_list[1]
         self.assertEqual(set_call.args[1]['body'], 'edited')
         self.assertTrue(set_call.args[1]['edited'])
+
+    def test_edit_comment_replaces_mentions(self) -> None:
+        # 1: _fetch_comment, 2: SET
+        self.mock_db.execute.side_effect = [
+            [{'c': self._comment(mentions=['old@x.com'])}],
+            [{'c': self._comment(mentions=['new@x.com'], edited=True)}],
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.patch(
+                f'{_BASE}/thread-1/comments/comment-1',
+                json=[
+                    {
+                        'op': 'replace',
+                        'path': '/mentions',
+                        'value': ['new@x.com'],
+                    }
+                ],
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()['mentions'], ['new@x.com'])
+        self.assertTrue(response.json()['edited'])
+        set_call = self.mock_db.execute.await_args_list[1]
+        self.assertEqual(set_call.args[1]['mentions'], ['new@x.com'])
+        self.assertTrue(set_call.args[1]['edited'])
+
+    def test_edit_comment_mentions_non_author_forbidden(self) -> None:
+        self.mock_db.execute.return_value = [
+            {'c': self._comment(author='bob@example.com')}
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.patch(
+                f'{_BASE}/thread-1/comments/comment-1',
+                json=[
+                    {
+                        'op': 'replace',
+                        'path': '/mentions',
+                        'value': ['new@x.com'],
+                    }
+                ],
+            )
+        self.assertEqual(response.status_code, 403)
+
+    def test_edit_comment_body_keeps_mentions(self) -> None:
+        # Regression: editing only /body preserves existing mentions.
+        self.mock_db.execute.side_effect = [
+            [{'c': self._comment(mentions=['keep@x.com'])}],
+            [
+                {
+                    'c': self._comment(
+                        body='edited',
+                        mentions=['keep@x.com'],
+                        edited=True,
+                    )
+                }
+            ],
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.patch(
+                f'{_BASE}/thread-1/comments/comment-1',
+                json=[{'op': 'replace', 'path': '/body', 'value': 'edited'}],
+            )
+        self.assertEqual(response.status_code, 200)
+        set_call = self.mock_db.execute.await_args_list[1]
+        self.assertEqual(set_call.args[1]['mentions'], ['keep@x.com'])
 
     def test_edit_comment_non_author_forbidden(self) -> None:
         self.mock_db.execute.return_value = [


### PR DESCRIPTION
Phase 3 of document comments (replaces #417, which auto-closed when #416's base branch was deleted on merge). Rebased onto squashed main.

## Changes
- **Persist `@mention` emails** on comment create/edit (`/mentions` allowed in the edit JSON-Patch).
- **Fix empty comment lists** (`_COMMENTS_TAIL`): collected raw `Comment` vertices, but `graph.parse_agtype` only strips a trailing `::vertex` suffix — a `collect()` of vertices yields a list-string with inner `::vertex` suffixes that `json.loads` rejects, so it fell back to the raw string and `_parse_thread_row` dropped every comment. Now collects map projections (`c{.id, ...}`), mirroring `documents.py` `_TAGS_TAIL`. This was live on main (Phase 1 #415 shipped it): threads showed in the count but rendered blank.
- Added `ThreadRowParsingTestCase` exercising `_parse_thread_row` against the raw agtype wire form (the endpoint tests mock `graph.execute` with pre-parsed dicts and never hit `parse_agtype`).

Verified locally: `ruff format`/`check`, 44 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)