### PR TITLE
Fix identity connect callback redirecting to the API host

### DIFF
--- a/src/imbi_api/identity/endpoints.py
+++ b/src/imbi_api/identity/endpoints.py
@@ -222,11 +222,18 @@ async def callback(
             status_code=404, detail=f'Plugin {plugin_id!r} not available'
         ) from exc
 
-    target: str = (
+    # The callback is served by the API, but the landing page is a UI
+    # route. Absolutize against ``ui_url`` so the browser resolves the
+    # 302 against the UI origin rather than the API host. ``ui_url`` is
+    # empty in same-origin deployments, yielding a relative path the
+    # browser resolves against the current host.
+    path: str = (
         return_to
         if return_to is not None and _is_safe_return_to(return_to)
         else '/settings/connections'
     )
+    ui_url = settings.get_server_config().ui_url
+    target = f'{ui_url}{path}' if ui_url else path
     return fastapi.responses.RedirectResponse(target, status_code=302)
 
 

--- a/tests/identity/test_endpoints.py
+++ b/tests/identity/test_endpoints.py
@@ -283,6 +283,75 @@ class CallbackEndpointTestCase(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response.headers['location'], '/settings/connections')
 
+    async def test_absolutizes_return_to_against_ui_url(self) -> None:
+        from imbi_common.plugins.base import (
+            IdentityCredentials,
+            IdentityProfile,
+        )
+
+        db = mock.AsyncMock()
+        with (
+            mock.patch.object(
+                endpoints.flows,
+                'complete_flow',
+                new=mock.AsyncMock(
+                    return_value=(
+                        IdentityProfile(subject='s'),
+                        IdentityCredentials(access_token='at'),
+                        'plugin-1',
+                        '/projects/x',
+                    )
+                ),
+            ),
+            mock.patch.object(
+                endpoints.settings,
+                'get_server_config',
+                return_value=mock.MagicMock(ui_url='https://ui.imbi.test'),
+            ),
+        ):
+            response = await endpoints.callback(
+                'plugin-1', 'code', 'st', db, mock.AsyncMock()
+            )
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(
+            response.headers['location'], 'https://ui.imbi.test/projects/x'
+        )
+
+    async def test_absolutizes_default_against_ui_url(self) -> None:
+        from imbi_common.plugins.base import (
+            IdentityCredentials,
+            IdentityProfile,
+        )
+
+        db = mock.AsyncMock()
+        with (
+            mock.patch.object(
+                endpoints.flows,
+                'complete_flow',
+                new=mock.AsyncMock(
+                    return_value=(
+                        IdentityProfile(subject='s'),
+                        IdentityCredentials(access_token='at'),
+                        'plugin-1',
+                        None,
+                    )
+                ),
+            ),
+            mock.patch.object(
+                endpoints.settings,
+                'get_server_config',
+                return_value=mock.MagicMock(ui_url='https://ui.imbi.test'),
+            ),
+        ):
+            response = await endpoints.callback(
+                'plugin-1', 'code', 'st', db, mock.AsyncMock()
+            )
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(
+            response.headers['location'],
+            'https://ui.imbi.test/settings/connections',
+        )
+
     async def test_maps_invalid_state_to_400(self) -> None:
         db = mock.AsyncMock()
         with mock.patch.object(


### PR DESCRIPTION
## Problem

The `GET /me/identities/{plugin_id}/callback` handler returned a
**relative** redirect target (`return_to` or `/settings/connections`).
Because the callback is served by the API, the browser resolved the 302
against the API origin and landed on the API host
(e.g. `https://api-host/settings/connections`) — a UI route the API does
not serve — instead of the UI.

## Fix

Absolutize the redirect target against `ui_url` so the browser is sent to
the UI origin, mirroring the existing `_login_redirect_url` pattern in
`endpoints/auth.py`. When `ui_url` is unset (same-origin deployments) the
target stays relative, preserving prior behavior. The open-redirect guard
on `return_to` (`_is_safe_return_to`) is unchanged.

The login OAuth callback in `endpoints/auth.py` is unaffected — its
`return_to` is an origin-validated absolute client redirect_uri, not a
relative path.

## Tests

Added two regression tests asserting the `Location` header is absolutized
against a configured `ui_url`, for both the `return_to` and default
`/settings/connections` cases. Verified manually end-to-end: the GitHub
connect flow now lands on the UI origin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)