### PR TITLE
Emit comment activity to the ClickHouse events table

### DIFF
--- a/src/imbi_api/endpoints/comments.py
+++ b/src/imbi_api/endpoints/comments.py
@@ -38,6 +38,7 @@ _COMMENT_EVENT_TYPE: typing.LiteralString = 'document-comment'
 
 
 async def _emit_comment_event(
+    *,
     project_id: str,
     document_id: str,
     thread_id: str,
@@ -491,14 +492,14 @@ async def create_comment_thread(
             detail='Thread created but could not be read back',
         )
     await _emit_comment_event(
-        project_id,
-        document_id,
-        thread_id,
-        comment_id,
-        data.kind,
-        'created',
-        auth.principal_name,
-        data.body,
+        project_id=project_id,
+        document_id=document_id,
+        thread_id=thread_id,
+        comment_id=comment_id,
+        kind=data.kind,
+        action='created',
+        principal=auth.principal_name,
+        body=data.body,
     )
     return thread
 
@@ -566,14 +567,14 @@ async def create_reply(
             detail=f'Thread {thread_id!r} not found',
         )
     await _emit_comment_event(
-        project_id,
-        document_id,
-        thread_id,
-        comment_id,
-        '',
-        'replied',
-        auth.principal_name,
-        data.body,
+        project_id=project_id,
+        document_id=document_id,
+        thread_id=thread_id,
+        comment_id=comment_id,
+        kind='',
+        action='replied',
+        principal=auth.principal_name,
+        body=data.body,
     )
     return _parse_comment(records[0]['c'])
 

--- a/src/imbi_api/endpoints/comments.py
+++ b/src/imbi_api/endpoints/comments.py
@@ -23,6 +23,7 @@ import fastapi
 import nanoid
 import pydantic
 from imbi_common import graph
+from imbi_common.clickhouse import client as ch_client
 
 from imbi_api import patch as json_patch
 from imbi_api.auth import permissions
@@ -30,6 +31,65 @@ from imbi_api.auth import permissions
 LOGGER = logging.getLogger(__name__)
 
 comments_router = fastapi.APIRouter(tags=['Comments'])
+
+# Event type written to the ClickHouse ``events`` table so comment activity
+# surfaces in the project + user activity feeds.
+_COMMENT_EVENT_TYPE: typing.LiteralString = 'document-comment'
+
+
+async def _emit_comment_event(
+    project_id: str,
+    document_id: str,
+    thread_id: str,
+    comment_id: str,
+    kind: str,
+    action: str,
+    principal: str,
+    body: str,
+) -> None:
+    """Best-effort: record a comment as an ``events`` row.
+
+    Mirrors the project-change emit in ``projects.py``. Never raises -- a
+    failed analytics write must not fail the comment request.
+    """
+    try:
+        await ch_client.Clickhouse.get_instance().insert(
+            'events',
+            [
+                [
+                    nanoid.generate(),
+                    project_id,
+                    datetime.datetime.now(datetime.UTC),
+                    _COMMENT_EVENT_TYPE,
+                    'internal',
+                    principal,
+                    {},
+                    {
+                        'document_id': document_id,
+                        'thread_id': thread_id,
+                        'comment_id': comment_id,
+                        'kind': kind,
+                        'action': action,
+                        'excerpt': body[:140],
+                    },
+                ]
+            ],
+            [
+                'id',
+                'project_id',
+                'recorded_at',
+                'type',
+                'third_party_service',
+                'attributed_to',
+                'metadata',
+                'payload',
+            ],
+        )
+    except Exception:
+        LOGGER.exception(
+            'Failed to emit comment event for document %s', document_id
+        )
+
 
 # Every thread field except ``/resolved`` is read-only over the PATCH API.
 _THREAD_READONLY_PATHS: frozenset[str] = frozenset(
@@ -430,6 +490,16 @@ async def create_comment_thread(
             status_code=500,
             detail='Thread created but could not be read back',
         )
+    await _emit_comment_event(
+        project_id,
+        document_id,
+        thread_id,
+        comment_id,
+        data.kind,
+        'created',
+        auth.principal_name,
+        data.body,
+    )
     return thread
 
 
@@ -495,6 +565,16 @@ async def create_reply(
             status_code=404,
             detail=f'Thread {thread_id!r} not found',
         )
+    await _emit_comment_event(
+        project_id,
+        document_id,
+        thread_id,
+        comment_id,
+        '',
+        'replied',
+        auth.principal_name,
+        data.body,
+    )
     return _parse_comment(records[0]['c'])
 
 

--- a/tests/endpoints/test_comments.py
+++ b/tests/endpoints/test_comments.py
@@ -189,6 +189,37 @@ class CommentEndpointsTestCase(support.SharedAppTestCase):
         self.assertEqual(create_call.args[1]['anchor_quote'], '')
         self.assertEqual(create_call.args[1]['anchor_start'], 0)
 
+    def test_create_thread_emits_event(self) -> None:
+        # Creating a comment writes a 'document-comment' row to the
+        # ClickHouse events table so it surfaces in the activity feeds.
+        self.mock_db.execute.side_effect = [
+            [{'id': 'doc-1'}],
+            [{'id': 'thread-1'}],
+            [self._thread_row()],
+        ]
+        ch = mock.AsyncMock()
+        with (
+            mock.patch(
+                'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+            ),
+            mock.patch(
+                'imbi_api.endpoints.comments.ch_client.Clickhouse'
+                '.get_instance',
+                return_value=ch,
+            ),
+        ):
+            response = self.client.post(_BASE, json={'body': 'First!'})
+        self.assertEqual(response.status_code, 201)
+        ch.insert.assert_awaited_once()
+        table, rows, columns = ch.insert.await_args.args
+        self.assertEqual(table, 'events')
+        record = dict(zip(columns, rows[0], strict=True))
+        self.assertEqual(record['type'], 'document-comment')
+        self.assertEqual(record['project_id'], 'proj-abc')
+        self.assertEqual(record['attributed_to'], 'alice@example.com')
+        self.assertEqual(record['payload']['action'], 'created')
+        self.assertEqual(record['payload']['document_id'], 'doc-1')
+
     def test_create_thread_persists_mentions(self) -> None:
         self.mock_db.execute.side_effect = [
             [{'id': 'doc-1'}],

--- a/tests/endpoints/test_comments.py
+++ b/tests/endpoints/test_comments.py
@@ -220,6 +220,84 @@ class CommentEndpointsTestCase(support.SharedAppTestCase):
         self.assertEqual(record['payload']['action'], 'created')
         self.assertEqual(record['payload']['document_id'], 'doc-1')
 
+    def test_create_thread_clickhouse_failure_is_best_effort(self) -> None:
+        # A failed ClickHouse insert must not fail the comment request.
+        self.mock_db.execute.side_effect = [
+            [{'id': 'doc-1'}],
+            [{'id': 'thread-1'}],
+            [self._thread_row()],
+        ]
+        ch = mock.AsyncMock()
+        ch.insert.side_effect = Exception('boom')
+        with (
+            mock.patch(
+                'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+            ),
+            mock.patch(
+                'imbi_api.endpoints.comments.ch_client.Clickhouse'
+                '.get_instance',
+                return_value=ch,
+            ),
+        ):
+            response = self.client.post(_BASE, json={'body': 'First!'})
+        self.assertEqual(response.status_code, 201)
+        ch.insert.assert_awaited_once()
+
+    def test_create_reply_emits_event(self) -> None:
+        # Replying writes a 'document-comment' row with action 'replied'
+        # and an empty kind.
+        self.mock_db.execute.return_value = [
+            {'c': self._comment(id='c2', body='reply')}
+        ]
+        ch = mock.AsyncMock()
+        with (
+            mock.patch(
+                'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+            ),
+            mock.patch(
+                'imbi_api.endpoints.comments.ch_client.Clickhouse'
+                '.get_instance',
+                return_value=ch,
+            ),
+        ):
+            response = self.client.post(
+                f'{_BASE}/thread-1/comments', json={'body': 'reply'}
+            )
+        self.assertEqual(response.status_code, 201)
+        ch.insert.assert_awaited_once()
+        columns, rows = (
+            ch.insert.await_args.args[2],
+            ch.insert.await_args.args[1],
+        )
+        record = dict(zip(columns, rows[0], strict=True))
+        self.assertEqual(record['type'], 'document-comment')
+        self.assertEqual(record['payload']['action'], 'replied')
+        self.assertEqual(record['payload']['kind'], '')
+        self.assertEqual(record['payload']['thread_id'], 'thread-1')
+
+    def test_create_reply_clickhouse_failure_is_best_effort(self) -> None:
+        # A failed ClickHouse insert must not fail the reply request.
+        self.mock_db.execute.return_value = [
+            {'c': self._comment(id='c2', body='reply')}
+        ]
+        ch = mock.AsyncMock()
+        ch.insert.side_effect = Exception('boom')
+        with (
+            mock.patch(
+                'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+            ),
+            mock.patch(
+                'imbi_api.endpoints.comments.ch_client.Clickhouse'
+                '.get_instance',
+                return_value=ch,
+            ),
+        ):
+            response = self.client.post(
+                f'{_BASE}/thread-1/comments', json={'body': 'reply'}
+            )
+        self.assertEqual(response.status_code, 201)
+        ch.insert.assert_awaited_once()
+
     def test_create_thread_persists_mentions(self) -> None:
         self.mock_db.execute.side_effect = [
             [{'id': 'doc-1'}],


### PR DESCRIPTION
Adding a comment (a new thread or a reply) now writes a `document-comment` row to the ClickHouse `events` table, so the activity surfaces in the project and user activity feeds (`ProjectActivityLog`, the user profile activity that aggregates `events`).

## Notes
- Mirrors the project-change emit in `projects.py`; uses the same `events` columns. **No schema change** — `events.type` is a free string and `payload` is a flexible map.
- The write is **best-effort** (try/except + log): a failed analytics insert must never fail the comment request.
- Payload: `document_id`, `thread_id`, `comment_id`, `kind`, `action` (`created`|`replied`), and a short `excerpt`.
- Added a test asserting thread creation emits the event with the right type/project/principal/payload (the existing tests mock `graph.execute` and never exercised this path).

Note: the dashboard `RecentActivityWidget` calls a `/activity-feed` endpoint that isn't implemented in imbi-api; this PR feeds the implemented surfaces (`/events`, `/users/{email}/activity`). A dedicated activity-feed renderer for the `document-comment` type can follow in imbi-ui.

🤖 Generated with [Claude Code](https://claude.com/claude-code)