### PR TITLE
Derive OAuth issuer and callbacks from the request host

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -56,7 +56,7 @@ Configured by [`ServerConfig`](https://github.com/AWeber-Imbi/imbi-api/blob/main
 | `ENVIRONMENT` | `development` | Deployment environment (`development`, `staging`, `production`). Unprefixed — picks up whatever the platform (Vercel, ECS, GHA, etc.) already exports. Currently drives Mailpit dev auto-config. |
 | `IMBI_API_HOST` | `localhost` | Server bind address |
 | `IMBI_API_PORT` | `8000` | Server bind port. Strings of the form `tcp://ip:port` (injected by Kubernetes service discovery) are parsed and the port extracted, so the `<SERVICE>_PORT=tcp://…` pattern does not collide with this field. |
-| `IMBI_API_CORS_ALLOWED_ORIGINS` | `[]` | JSON array of allowed CORS origins. Credentials and the `Authorization` header are allowed for cross-origin requests from these origins. |
+| `IMBI_API_CORS_ALLOWED_ORIGINS` | `[]` | JSON array of allowed CORS origins. Credentials and the `Authorization` header are allowed for cross-origin requests from these origins. Also the allow-list of trusted hosts for per-request OAuth URL derivation in multi-host deployments (see "OAuth2 Authorization Server"). |
 | `IMBI_API_FORWARDED_ALLOW_IPS` | `''` | Comma-separated list (or `*`) of trusted proxy IPs whose `X-Forwarded-*` headers are honored. Required when running behind a reverse proxy so rate limiting keys on the real client IP. Empty disables the middleware. |
 | `IMBI_API_URL` | `''` | Public URL where the API is reachable from a browser, including any path prefix it is mounted under (e.g. `https://imbi.example.com/api`). Drives FastAPI route mounting, hypermedia links, and OAuth redirect URIs. Falls back to `http://{host}:{port}` (no prefix) for dev loopback. `/docs` and `/openapi.json` are always served at the root regardless of prefix. |
 
@@ -207,6 +207,36 @@ configured upstream IdP), so MCP login inherits MFA and provider rules.
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `IMBI_AUTH_DCR_ENABLED` | `true` | Allow OAuth clients to self-register at `/auth/register` (RFC 7591). Disable to require clients to be provisioned out of band. |
+
+#### Multi-host deployments (separate public login host)
+
+A deployment may be reachable on more than one host — e.g. an internal
+host that serves the SPA and a separate internet-facing host that fronts
+the MCP OAuth login for a remote client (Claude Desktop and other remote
+connectors reach the server from the vendor's cloud, not the user's
+machine, so the MCP and OAuth endpoints must be publicly reachable).
+
+The issuer and endpoints in the discovery document, the post-login
+`return_to`/login redirect, and the upstream-IdP callback URL are all
+derived **per request** from the host the caller actually reached, rather
+than from the single `IMBI_API_URL`. To prevent a spoofed `Host` header
+from redirecting freshly minted tokens off-origin, a request host is only
+honored when it is a **trusted origin**: the origin of `IMBI_API_URL` plus
+every entry in `IMBI_API_CORS_ALLOWED_ORIGINS`. Untrusted hosts fall back
+to `IMBI_API_URL`. This also requires `IMBI_API_FORWARDED_ALLOW_IPS` to be
+set so the request scheme/host are trusted from the proxy.
+
+To enable a separate public login host:
+
+1. Add the public origin to `IMBI_API_CORS_ALLOWED_ORIGINS`
+   (e.g. `https://imbi-public.example.com`). `IMBI_API_URL` stays pointed
+   at the internal host, so internal SPA traffic is unaffected.
+2. Route `/mcp`, `/.well-known/oauth-*`, and `/api/auth/*` (plus the SPA
+   login shell) to the service on that public host.
+3. If login uses an upstream IdP (Google/GitHub/OIDC), register the public
+   host's callback — `https://<public-host>/api/auth/oauth/<slug>/callback`
+   — with that provider in addition to the internal one, since the
+   callback now names whichever host the user logged in from.
 
 ## Other Settings
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -231,12 +231,23 @@ To enable a separate public login host:
 1. Add the public origin to `IMBI_API_CORS_ALLOWED_ORIGINS`
    (e.g. `https://imbi-public.example.com`). `IMBI_API_URL` stays pointed
    at the internal host, so internal SPA traffic is unaffected.
-2. Route `/mcp`, `/.well-known/oauth-*`, and `/api/auth/*` (plus the SPA
-   login shell) to the service on that public host.
+2. Route `/mcp`, `/.well-known/oauth-*`, and `/api/auth/*` to the service
+   on that public host. If the public host should support browser-based
+   login (not just MCP), also serve the SPA's login UI assets — the SPA
+   entry document (`index.html`) served at `/` and `/login`, plus its
+   static assets (`*.js`, `*.css`, images) — so the login page renders on
+   that host.
 3. If login uses an upstream IdP (Google/GitHub/OIDC), register the public
    host's callback — `https://<public-host>/api/auth/oauth/<slug>/callback`
    — with that provider in addition to the internal one, since the
    callback now names whichever host the user logged in from.
+
+!!! note "Known limitation"
+    Standard OAuth provider logins (Google/GitHub/OIDC) and MCP OAuth
+    client flows are fully per-host aware. The identity-plugin *connect*
+    flow (linking an additional identity from the account settings UI) is
+    not yet derived per host and continues to use `IMBI_API_URL`, so its
+    callback must remain registered against the `IMBI_API_URL` origin.
 
 ## Other Settings
 

--- a/src/imbi_api/endpoints/_request_urls.py
+++ b/src/imbi_api/endpoints/_request_urls.py
@@ -1,0 +1,58 @@
+"""Request-aware public URL derivation.
+
+A deployment may be reachable on more than one host -- e.g. an internal
+host that fronts the SPA plus a separate internet-facing host that fronts
+the MCP OAuth login. Absolute URLs advertised in :rfc:`8414` metadata or
+handed to OAuth clients/IdPs must name the host the caller actually
+reached, not a single global ``IMBI_API_URL``; otherwise discovery fails
+its issuer check and IdP callbacks land on the wrong (often unreachable)
+host.
+
+The externally-visible origin is taken from the request as rewritten by
+the proxy-headers middleware -- honored only for ``forwarded_allow_ips``
+-- but is used only when it is an explicitly *trusted* origin (the
+configured ``public_base_url`` plus ``cors_allowed_origins``). Anything
+else falls back to the static ``public_base_url`` so a spoofed ``Host``
+header can never redirect freshly minted tokens off-origin.
+"""
+
+from urllib import parse as urlparse
+
+import fastapi
+
+from imbi_api import settings
+
+
+def trusted_origins() -> set[str]:
+    """``scheme://host`` origins the deployment will speak as itself."""
+    cfg = settings.get_server_config()
+    origins = {o.rstrip('/') for o in cfg.cors_allowed_origins}
+    parsed = urlparse.urlparse(cfg.public_base_url)
+    if parsed.scheme and parsed.netloc:
+        origins.add(f'{parsed.scheme}://{parsed.netloc}')
+    return origins
+
+
+def request_origin(request: fastapi.Request) -> str | None:
+    """Trusted ``scheme://host`` for *request*, or ``None`` if untrusted.
+
+    Scheme and host come from the (proxy-validated) request, so this is
+    the origin the client actually used. Returned only when it is a
+    configured trusted origin.
+    """
+    origin = f'{request.url.scheme}://{request.url.netloc}'
+    return origin if origin in trusted_origins() else None
+
+
+def public_base_url_for_request(request: fastapi.Request) -> str:
+    """``public_base_url`` rebased onto the request's trusted origin.
+
+    Preserves the configured API path prefix (e.g. ``/api``). Falls back
+    to the static ``public_base_url`` when the request origin is not
+    trusted.
+    """
+    cfg = settings.get_server_config()
+    origin = request_origin(request)
+    if origin is None:
+        return cfg.public_base_url
+    return f'{origin}{cfg.api_prefix}'

--- a/src/imbi_api/endpoints/auth.py
+++ b/src/imbi_api/endpoints/auth.py
@@ -29,6 +29,7 @@ from imbi_api.auth import (
 from imbi_api.auth import models as auth_models
 from imbi_api.auth import password as password_auth
 from imbi_api.auth.totp import fetch_totp_secret, verify_totp_code
+from imbi_api.endpoints import _request_urls
 from imbi_api.identity import flows as identity_flows
 from imbi_api.identity import repository as identity_repository
 from imbi_api.middleware import rate_limit
@@ -528,20 +529,25 @@ def _authorize_request_principal(request: fastapi.Request) -> str | None:
 
 def _public_authorize_url(request: fastapi.Request) -> str:
     """Absolute, public URL of this /authorize request (for return_to)."""
-    base = settings.get_server_config().public_base_url
+    base = _request_urls.public_base_url_for_request(request)
     query = request.url.query
     suffix = f'?{query}' if query else ''
     return f'{base}/auth/authorize{suffix}'
 
 
-def _login_redirect_url(return_to: str) -> str:
+def _login_redirect_url(request: fastapi.Request, return_to: str) -> str:
     """SPA login URL that returns to *return_to* after authentication.
 
-    ``ui_url`` is empty in same-origin deployments, yielding a relative
-    ``/login`` that the browser resolves against the current host.
+    The login page is the SPA served on the same host as this request, so
+    the redirect targets the request's trusted origin -- which keeps the
+    login leg same-origin whether the deployment is fronted by one host or
+    several. Falls back to ``ui_url`` (empty -> a relative ``/login`` the
+    browser resolves against the current host) when the origin is untrusted.
     """
-    ui = settings.get_server_config().ui_url
-    return f'{ui}/login?{urlparse.urlencode({"return_to": return_to})}'
+    base = _request_urls.request_origin(request)
+    if base is None:
+        base = settings.get_server_config().ui_url
+    return f'{base}/login?{urlparse.urlencode({"return_to": return_to})}'
 
 
 @auth_router.get('/authorize')
@@ -601,7 +607,7 @@ async def authorize(
         # Not logged in to Imbi: bounce through the SPA login and return
         # here via a full-page navigation so the access cookie is sent.
         return fastapi.responses.RedirectResponse(
-            url=_login_redirect_url(_public_authorize_url(request)),
+            url=_login_redirect_url(request, _public_authorize_url(request)),
             status_code=302,
         )
 
@@ -1283,6 +1289,13 @@ async def oauth_login(
     own = urlparse.urlparse(server_config.public_base_url)
     if own.scheme and own.netloc:
         allowed_origins.append(f'{own.scheme}://{own.netloc}')
+    # On a multi-host deployment the SPA's same-origin callback is on the
+    # host this request reached, not public_base_url's, so trust that
+    # origin too (it is validated against the configured trusted set).
+    request_base = _request_urls.public_base_url_for_request(request)
+    request_own = _request_urls.request_origin(request)
+    if request_own is not None:
+        allowed_origins.append(request_own)
     if not _is_safe_redirect_uri(redirect_uri, allowed_origins):
         raise fastapi.HTTPException(
             status_code=400,
@@ -1299,7 +1312,9 @@ async def oauth_login(
                 status_code=500,
                 detail=f'Identity plugin row {provider!r} missing plugin_id',
             )
-        callback_url = settings.oauth_callback_url(provider)
+        callback_url = settings.oauth_callback_url(
+            provider, base_url=request_base
+        )
         try:
             url, _state, _polling = await identity_flows.start_flow(
                 db,
@@ -1325,7 +1340,7 @@ async def oauth_login(
         provider, redirect_uri, auth_settings
     )
 
-    callback_url = settings.oauth_callback_url(provider)
+    callback_url = settings.oauth_callback_url(provider, base_url=request_base)
 
     auth_url = ''
     if app.oauth_app_type == 'google':
@@ -1454,8 +1469,14 @@ async def oauth_callback(
         if state_data.provider != provider:
             raise ValueError('Provider mismatch')
 
-        # Exchange code for tokens
-        callback_url = settings.oauth_callback_url(provider)
+        # Exchange code for tokens. The redirect_uri must byte-match the
+        # one sent at authorize time; both derive from the request's
+        # trusted origin, and the IdP redirected the browser back to this
+        # same host, so they agree on a multi-host deployment.
+        callback_url = settings.oauth_callback_url(
+            provider,
+            base_url=_request_urls.public_base_url_for_request(request),
+        )
         token_response = await oauth.exchange_oauth_code(
             provider, code, callback_url, db
         )

--- a/src/imbi_api/endpoints/oauth_metadata.py
+++ b/src/imbi_api/endpoints/oauth_metadata.py
@@ -11,7 +11,7 @@ from urllib import parse as urlparse
 
 import fastapi
 
-from imbi_api import settings
+from imbi_api.endpoints import _request_urls
 
 oauth_metadata_router = fastapi.APIRouter(tags=['Authentication'])
 
@@ -20,9 +20,16 @@ oauth_metadata_router = fastapi.APIRouter(tags=['Authentication'])
     '/.well-known/oauth-authorization-server',
     include_in_schema=False,
 )
-async def authorization_server_metadata() -> dict[str, object]:
-    """Return RFC 8414 Authorization Server metadata."""
-    base = settings.get_server_config().public_base_url
+async def authorization_server_metadata(
+    request: fastapi.Request,
+) -> dict[str, object]:
+    """Return RFC 8414 Authorization Server metadata.
+
+    The issuer and endpoints name the (trusted) host the client reached,
+    so discovery validates whether the deployment is fronted by one host
+    or several. See :mod:`imbi_api.endpoints._request_urls`.
+    """
+    base = _request_urls.public_base_url_for_request(request)
     parsed = urlparse.urlparse(base)
     issuer = f'{parsed.scheme}://{parsed.netloc}'
     return {

--- a/src/imbi_api/settings.py
+++ b/src/imbi_api/settings.py
@@ -280,16 +280,20 @@ def clear_caches() -> None:
     _storage_settings = None
 
 
-def oauth_callback_url(provider_slug: str) -> str:
+def oauth_callback_url(provider_slug: str, base_url: str | None = None) -> str:
     """Build the public OAuth callback URL for a provider slug.
 
     Appends the canonical ``/auth/oauth/{slug}/callback`` route to
-    ``IMBI_API_URL`` (or the local host:port fallback).
+    *base_url* when given (the request's trusted public base, for
+    multi-host deployments), otherwise to ``IMBI_API_URL`` (or the local
+    host:port fallback).
     """
-    return (
-        f'{get_server_config().public_base_url}'
-        f'/auth/oauth/{provider_slug}/callback'
+    base = (
+        base_url
+        if base_url is not None
+        else get_server_config().public_base_url
     )
+    return f'{base.rstrip("/")}/auth/oauth/{provider_slug}/callback'
 
 
 class APIConfiguration(settings.Configuration):  # type: ignore[misc]

--- a/tests/auth/test_oauth_server.py
+++ b/tests/auth/test_oauth_server.py
@@ -73,6 +73,46 @@ class OAuthServerTestCase(support.SharedAppTestCase):
         self.assertEqual(body['code_challenge_methods_supported'], ['S256'])
         self.assertIn('authorization_code', body['grant_types_supported'])
 
+    def test_metadata_reflects_trusted_request_host(self) -> None:
+        """Issuer/endpoints name the trusted host the client reached.
+
+        A multi-host deployment fronts the MCP login on a separate public
+        host; the discovery document must advertise that host (not the
+        internal ``IMBI_API_URL``) or the client's issuer check fails.
+        """
+        cfg = mock.MagicMock()
+        cfg.public_base_url = 'https://imbi.internal/api'
+        cfg.cors_allowed_origins = ['https://imbi-public.test']
+        cfg.api_prefix = '/api'
+        with mock.patch(
+            'imbi_api.settings.get_server_config', return_value=cfg
+        ):
+            client = testclient.TestClient(
+                self.test_app, base_url='https://imbi-public.test'
+            )
+            resp = client.get('/.well-known/oauth-authorization-server')
+        body = resp.json()
+        self.assertEqual(body['issuer'], 'https://imbi-public.test')
+        self.assertEqual(
+            body['authorization_endpoint'],
+            'https://imbi-public.test/api/auth/authorize',
+        )
+
+    def test_metadata_ignores_untrusted_request_host(self) -> None:
+        """A spoofed Host falls back to the configured public base URL."""
+        cfg = mock.MagicMock()
+        cfg.public_base_url = 'https://imbi.internal/api'
+        cfg.cors_allowed_origins = []
+        cfg.api_prefix = '/api'
+        with mock.patch(
+            'imbi_api.settings.get_server_config', return_value=cfg
+        ):
+            client = testclient.TestClient(
+                self.test_app, base_url='https://evil.example'
+            )
+            resp = client.get('/.well-known/oauth-authorization-server')
+        self.assertEqual(resp.json()['issuer'], 'https://imbi.internal')
+
     # -- registration (DCR) ----------------------------------------------
 
     def test_register_success(self) -> None:

--- a/tests/endpoints/test_request_urls.py
+++ b/tests/endpoints/test_request_urls.py
@@ -1,0 +1,103 @@
+"""Tests for request-aware public URL derivation."""
+
+import unittest
+import urllib.parse
+from unittest import mock
+
+import fastapi
+
+from imbi_api.endpoints import _request_urls
+
+
+def _request(scheme: str, host: str, *, query: bytes = b'') -> fastapi.Request:
+    return fastapi.Request(
+        {
+            'type': 'http',
+            'method': 'GET',
+            'scheme': scheme,
+            'path': '/',
+            'raw_path': b'/',
+            'query_string': query,
+            'headers': [(b'host', host.encode())],
+            'server': (host, 443 if scheme == 'https' else 80),
+            'client': ('127.0.0.1', 0),
+        }
+    )
+
+
+def _cfg(public_base_url: str, cors: tuple[str, ...] = ()) -> mock.MagicMock:
+    cfg = mock.MagicMock()
+    cfg.public_base_url = public_base_url
+    cfg.cors_allowed_origins = list(cors)
+    cfg.api_prefix = urllib.parse.urlparse(public_base_url).path.rstrip('/')
+    return cfg
+
+
+class RequestUrlsTestCase(unittest.TestCase):
+    def _patch_cfg(self, cfg: mock.MagicMock) -> None:
+        patcher = mock.patch(
+            'imbi_api.settings.get_server_config', return_value=cfg
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def test_public_base_url_origin_is_always_trusted(self) -> None:
+        self._patch_cfg(_cfg('https://imbi.internal/api'))
+        req = _request('https', 'imbi.internal')
+        self.assertEqual(
+            _request_urls.request_origin(req), 'https://imbi.internal'
+        )
+
+    def test_cors_origin_is_trusted(self) -> None:
+        self._patch_cfg(
+            _cfg('https://imbi.internal/api', ('https://imbi-public.test',))
+        )
+        req = _request('https', 'imbi-public.test')
+        self.assertEqual(
+            _request_urls.request_origin(req), 'https://imbi-public.test'
+        )
+
+    def test_untrusted_origin_returns_none(self) -> None:
+        self._patch_cfg(_cfg('https://imbi.internal/api'))
+        req = _request('https', 'evil.example')
+        self.assertIsNone(_request_urls.request_origin(req))
+
+    def test_scheme_must_match(self) -> None:
+        """An http origin is not the same trusted origin as https."""
+        self._patch_cfg(
+            _cfg('https://imbi.internal/api', ('https://imbi-public.test',))
+        )
+        req = _request('http', 'imbi-public.test')
+        self.assertIsNone(_request_urls.request_origin(req))
+
+    def test_base_url_rebased_onto_trusted_origin(self) -> None:
+        self._patch_cfg(
+            _cfg('https://imbi.internal/api', ('https://imbi-public.test',))
+        )
+        req = _request('https', 'imbi-public.test')
+        self.assertEqual(
+            _request_urls.public_base_url_for_request(req),
+            'https://imbi-public.test/api',
+        )
+
+    def test_base_url_falls_back_when_untrusted(self) -> None:
+        self._patch_cfg(_cfg('https://imbi.internal/api'))
+        req = _request('https', 'evil.example')
+        self.assertEqual(
+            _request_urls.public_base_url_for_request(req),
+            'https://imbi.internal/api',
+        )
+
+    def test_base_url_preserves_empty_prefix(self) -> None:
+        self._patch_cfg(
+            _cfg('https://imbi.internal', ('https://imbi-public.test',))
+        )
+        req = _request('https', 'imbi-public.test')
+        self.assertEqual(
+            _request_urls.public_base_url_for_request(req),
+            'https://imbi-public.test',
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

The OAuth2 authorization-server metadata `issuer`, the authorize/token/register endpoints, the login redirect, and the IdP callback URLs are all currently built from the single global `public_base_url` (env `IMBI_API_URL`). That makes a **multi-host** deployment impossible: if Imbi is also reachable on a second host (e.g. an internet-facing host for a cloud MCP client), the AS-metadata `issuer` fetched *from that host* still advertises the internal host, which violates RFC 8414 issuer matching and points the OAuth client at a host it can't reach.

This PR resolves those URLs **per request** instead.

## What changed

- New `src/imbi_api/endpoints/_request_urls.py`:
  - `public_base_url_for_request(request)` rebases the public base onto the host the caller actually reached — **but only when that origin is trusted**.
  - `request_origin(request)` / `trusted_origins()` — trusted = `origin(IMBI_API_URL)` ∪ `IMBI_API_CORS_ALLOWED_ORIGINS`.
  - An **untrusted** `Host` falls back to the configured `public_base_url`, so this cannot be used to spoof the issuer. Correctness relies on the existing `forwarded_allow_ips` handling making `request.url` proxy-accurate.
- `oauth_metadata.py` — issuer + endpoints derived per request.
- `auth.py` — `_public_authorize_url`, `_login_redirect_url`, the `oauth_login` allow-list + callback, and `oauth_callback` token exchange are all request-aware.
- `settings.oauth_callback_url(provider, base_url=None)` — accepts an explicit base.
- Docs: `docs/configuration.md` gains a *Multi-host deployments* section and an updated `IMBI_API_CORS_ALLOWED_ORIGINS` row.

## Behavior

- **Internal traffic is unchanged** — its origin resolves to `IMBI_API_URL`.
- A **trusted second host** now gets a self-consistent issuer / authorize / token / register / OAuth callback.
- `IMBI_API_URL` itself is **not** changed.

## Tests

- New `tests/endpoints/test_request_urls.py` (trusted/untrusted origin, scheme match, rebase, fallback, empty prefix).
- `tests/auth/test_oauth_server.py` — metadata reflects a trusted request host / ignores an untrusted one.
- Full suite: **2113 passed, 1 skipped**, coverage **86.1%** (gate 85%).

## Known limitation

The identity-plugin connect/login callback is **not yet** per-host. AWeber uses Google OAuth login, which is unaffected.

## Operational notes (for the consumer deployment)

To actually serve a second host, the deployment must:
- set `IMBI_API_CORS_ALLOWED_ORIGINS` to include the public origin (this is what makes that host *trusted*),
- register the public host's `/auth/oauth/<provider>/callback` in the IdP (Google) console,
- and pair with the UI change (AWeber-Imbi/imbi-ui#400).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
