### PR TITLE
Add admin dashboard status + metrics endpoints; org-scope score reports

### DIFF
--- a/src/imbi_api/auth/seed.py
+++ b/src/imbi_api/auth/seed.py
@@ -448,6 +448,13 @@ STANDARD_PERMISSIONS: list[tuple[str, str, str, str]] = [
         'events:read',
         'List events across every organization (audit / support)',
     ),
+    # System health dashboard
+    (
+        'admin:dashboard:read',
+        'admin',
+        'dashboard:read',
+        'View the admin system-health dashboard',
+    ),
 ]
 
 # Default role definitions.

--- a/src/imbi_api/endpoints/__init__.py
+++ b/src/imbi_api/endpoints/__init__.py
@@ -12,6 +12,7 @@ from .auth import auth_router
 from .auth_providers import auth_providers_router
 from .blueprints import blueprint_router
 from .client_credentials import client_credentials_router
+from .dashboard import dashboard_router
 from .events import events_router
 from .graph_query import graph_query_router
 from .local_auth import local_auth_router
@@ -39,6 +40,7 @@ prefixed_routers: list[fastapi.APIRouter] = [
     auth_router,
     blueprint_router,
     client_credentials_router,
+    dashboard_router,
     events_router,
     graph_query_router,
     local_auth_router,

--- a/src/imbi_api/endpoints/dashboard.py
+++ b/src/imbi_api/endpoints/dashboard.py
@@ -118,7 +118,12 @@ async def _check_postgres(db: graph.Graph) -> DatastoreStatus:
             detail=str(err),
         )
     latency = _ms(start)
-    size = await asyncio.wait_for(_postgres_size(db), _CHECK_TIMEOUT)
+    # Size is best-effort; a timeout must not fail the (already-ok) check.
+    try:
+        size = await asyncio.wait_for(_postgres_size(db), _CHECK_TIMEOUT)
+    except TimeoutError:
+        LOGGER.warning('PostgreSQL size probe timed out')
+        size = None
     return DatastoreStatus(
         name='PostgreSQL',
         role='Primary data',

--- a/src/imbi_api/endpoints/dashboard.py
+++ b/src/imbi_api/endpoints/dashboard.py
@@ -1,0 +1,350 @@
+"""Admin dashboard system-health status endpoint.
+
+Probes the datastores in-process (PostgreSQL/AGE, ClickHouse, Valkey)
+and the sibling HTTP services via their ``/status`` endpoints. Every
+check runs concurrently with a short timeout so the endpoint never
+blocks on a degraded dependency.
+"""
+
+import asyncio
+import datetime
+import logging
+import time
+import typing
+
+import fastapi
+import httpx
+import pydantic
+from imbi_common import clickhouse, graph, valkey
+
+from imbi_api import settings, version
+from imbi_api.auth import permissions
+
+LOGGER = logging.getLogger(__name__)
+
+dashboard_router = fastapi.APIRouter(prefix='/admin/dashboard', tags=['Admin'])
+
+# Per-check timeout, in seconds. Keeps the endpoint responsive even when
+# a dependency is hung rather than cleanly down.
+_CHECK_TIMEOUT = 2.0
+
+
+class DatastoreStatus(pydantic.BaseModel):
+    """Health of a single backing datastore."""
+
+    name: str
+    role: str
+    status: typing.Literal['ok', 'error']
+    latency_ms: float | None = None
+    # Bytes on disk (Postgres/ClickHouse) or resident memory (Valkey,
+    # which is in-memory). ``None`` when the size probe failed.
+    size_bytes: int | None = None
+    detail: str | None = None
+
+
+class ServiceStatus(pydantic.BaseModel):
+    """Health of a single Imbi service."""
+
+    name: str
+    status: typing.Literal['up', 'down']
+    version: str | None = None
+    latency_ms: float | None = None
+    detail: str | None = None
+
+
+class DashboardStatus(pydantic.BaseModel):
+    """Aggregate system-health snapshot for the admin dashboard."""
+
+    checked_at: datetime.datetime
+    datastores: list[DatastoreStatus]
+    services: list[ServiceStatus]
+
+
+class MetricSeries(pydantic.BaseModel):
+    """A windowed count plus per-day counts (oldest day first)."""
+
+    total: int
+    daily: list[int]
+
+
+class EnvironmentCount(pydantic.BaseModel):
+    """Release count for one environment over the window."""
+
+    slug: str
+    count: int
+
+
+class DashboardMetrics(pydantic.BaseModel):
+    """7-day activity metrics with daily breakdowns for the tiles."""
+
+    since: datetime.datetime
+    releases: MetricSeries
+    events: MetricSeries
+    ops_log: MetricSeries
+    pull_requests: MetricSeries
+    releases_by_environment: list[EnvironmentCount]
+
+
+def _ms(start: float) -> float:
+    """Milliseconds elapsed since *start* (``time.perf_counter()``)."""
+    return round((time.perf_counter() - start) * 1000, 1)
+
+
+async def _postgres_size(db: graph.Graph) -> int | None:
+    """Total on-disk size of the current PostgreSQL database, in bytes."""
+    try:
+        async with db.pool.connection() as conn:
+            cursor = await conn.execute(
+                'SELECT pg_database_size(current_database())'
+            )
+            row = await cursor.fetchone()
+        return int(row[0]) if row and row[0] is not None else None
+    except Exception as err:  # noqa: BLE001
+        LOGGER.warning('PostgreSQL size probe failed: %s', err)
+        return None
+
+
+async def _check_postgres(db: graph.Graph) -> DatastoreStatus:
+    """Round-trip a trivial Cypher query through AGE/PostgreSQL."""
+    start = time.perf_counter()
+    try:
+        await asyncio.wait_for(db.execute('RETURN 1'), _CHECK_TIMEOUT)
+    except Exception as err:  # noqa: BLE001
+        LOGGER.warning('PostgreSQL health check failed: %s', err)
+        return DatastoreStatus(
+            name='PostgreSQL',
+            role='Primary data',
+            status='error',
+            detail=str(err),
+        )
+    latency = _ms(start)
+    size = await asyncio.wait_for(_postgres_size(db), _CHECK_TIMEOUT)
+    return DatastoreStatus(
+        name='PostgreSQL',
+        role='Primary data',
+        status='ok',
+        latency_ms=latency,
+        size_bytes=size,
+    )
+
+
+async def _check_clickhouse() -> DatastoreStatus:
+    """Probe ClickHouse and read total on-disk size of active parts."""
+    start = time.perf_counter()
+    try:
+        rows = await asyncio.wait_for(
+            clickhouse.query(
+                'SELECT sum(bytes_on_disk) AS size FROM system.parts'
+                " WHERE active AND database != 'system'"
+            ),
+            _CHECK_TIMEOUT,
+        )
+    except Exception as err:  # noqa: BLE001
+        LOGGER.warning('ClickHouse health check failed: %s', err)
+        return DatastoreStatus(
+            name='ClickHouse',
+            role='Timeseries data',
+            status='error',
+            detail=str(err),
+        )
+    raw = rows[0].get('size') if rows else None
+    size = int(raw) if raw is not None else None
+    return DatastoreStatus(
+        name='ClickHouse',
+        role='Timeseries data',
+        status='ok',
+        latency_ms=_ms(start),
+        size_bytes=size,
+    )
+
+
+async def _check_valkey() -> DatastoreStatus:
+    """Read Valkey ``INFO memory`` for liveness and resident size."""
+    start = time.perf_counter()
+    try:
+        client = valkey.get_client()
+        info = await asyncio.wait_for(
+            client.info('memory'),  # pyright: ignore[reportUnknownMemberType]
+            _CHECK_TIMEOUT,
+        )
+    except Exception as err:  # noqa: BLE001
+        LOGGER.warning('Valkey health check failed: %s', err)
+        return DatastoreStatus(
+            name='Valkey',
+            role='Cache, Session, & Queues',
+            status='error',
+            detail=str(err),
+        )
+    mem = (
+        typing.cast('dict[str, typing.Any]', info)
+        if isinstance(info, dict)
+        else {}
+    )
+    raw = mem.get('used_memory')
+    size = int(raw) if raw is not None else None
+    return DatastoreStatus(
+        name='Valkey',
+        role='Cache, Session, & Queues',
+        status='ok',
+        latency_ms=_ms(start),
+        size_bytes=size,
+    )
+
+
+async def _check_service(
+    client: httpx.AsyncClient, name: str, base_url: str
+) -> ServiceStatus:
+    """Probe a sibling service's ``/status`` endpoint for liveness."""
+    if not base_url:
+        return ServiceStatus(name=name, status='down', detail='not configured')
+    start = time.perf_counter()
+    try:
+        response = await client.get(
+            f'{base_url}/status', timeout=_CHECK_TIMEOUT
+        )
+        response.raise_for_status()
+        payload = response.json()
+    except Exception as err:  # noqa: BLE001
+        LOGGER.warning('%s health check failed: %s', name, err)
+        return ServiceStatus(
+            name=name, status='down', latency_ms=_ms(start), detail=str(err)
+        )
+    return ServiceStatus(
+        name=name,
+        status='up',
+        version=payload.get('version'),
+        latency_ms=_ms(start),
+    )
+
+
+@dashboard_router.get('/status', response_model=DashboardStatus)
+async def get_dashboard_status(
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('admin:dashboard:read')
+        ),
+    ],
+) -> DashboardStatus:
+    """Return a system-health snapshot of datastores and services."""
+    internal = settings.get_internal_services()
+    async with httpx.AsyncClient() as http_client:
+        datastores, services = await asyncio.gather(
+            asyncio.gather(
+                _check_postgres(db),
+                _check_clickhouse(),
+                _check_valkey(),
+            ),
+            asyncio.gather(
+                _check_service(
+                    http_client, 'Assistant', internal.assistant_url
+                ),
+                _check_service(http_client, 'Gateway', internal.gateway_url),
+                _check_service(http_client, 'MCP', internal.mcp_url),
+                _check_service(http_client, 'Slackbot', internal.slackbot_url),
+            ),
+        )
+    # The API is this process -- report its own version without an HTTP hop.
+    api_status = ServiceStatus(
+        name='API', status='up', version=version, latency_ms=0.0
+    )
+    return DashboardStatus(
+        checked_at=datetime.datetime.now(datetime.UTC),
+        datastores=list(datastores),
+        services=[api_status, *services],
+    )
+
+
+_METRICS_WINDOW_DAYS = 7
+
+
+def _build_series(
+    rows: list[dict[str, typing.Any]], days: list[str]
+) -> MetricSeries:
+    """Align ``{day, c}`` ClickHouse rows onto the *days* grid."""
+    counts: dict[str, int] = {}
+    for row in rows:
+        counts[str(row.get('day'))[:10]] = int(row.get('c') or 0)
+    daily = [counts.get(day, 0) for day in days]
+    return MetricSeries(total=sum(daily), daily=daily)
+
+
+@dashboard_router.get('/metrics', response_model=DashboardMetrics)
+async def get_dashboard_metrics(
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('admin:dashboard:read')
+        ),
+    ],
+) -> DashboardMetrics:
+    """Return 7-day activity metrics with per-day counts for the tiles."""
+    today = datetime.datetime.now(datetime.UTC).date()
+    start_date = today - datetime.timedelta(days=_METRICS_WINDOW_DAYS - 1)
+    since = datetime.datetime.combine(
+        start_date, datetime.time.min, tzinfo=datetime.UTC
+    )
+    days = [
+        (start_date + datetime.timedelta(days=offset)).isoformat()
+        for offset in range(_METRICS_WINDOW_DAYS)
+    ]
+    params: dict[str, typing.Any] = {'since': since}
+    # One scan of the (FINAL, merge-on-read) deploy rows yields both the
+    # per-day series and the per-environment rollup.
+    deploys, events, ops, prs = await asyncio.gather(
+        clickhouse.query(
+            'SELECT toDate(occurred_at) AS day,'
+            ' environment_slug AS slug, count() AS c'
+            ' FROM operations_log FINAL'
+            " WHERE is_deleted = 0 AND entry_type = 'Deployed'"
+            ' AND occurred_at >= {since:DateTime64(3)}'
+            ' GROUP BY day, environment_slug',
+            params,
+        ),
+        clickhouse.query(
+            'SELECT toDate(recorded_at) AS day, count() AS c'
+            ' FROM events WHERE recorded_at >= {since:DateTime64(3)}'
+            ' GROUP BY day',
+            params,
+        ),
+        clickhouse.query(
+            'SELECT toDate(occurred_at) AS day, count() AS c'
+            ' FROM operations_log FINAL'
+            ' WHERE is_deleted = 0'
+            ' AND occurred_at >= {since:DateTime64(3)}'
+            ' GROUP BY day',
+            params,
+        ),
+        clickhouse.query(
+            'SELECT toDate(created_at) AS day, count() AS c'
+            ' FROM pull_requests FINAL'
+            ' WHERE created_at >= {since:DateTime64(3)}'
+            ' GROUP BY day',
+            params,
+        ),
+    )
+    releases_by_day: dict[str, int] = {}
+    by_env: dict[str, int] = {}
+    for row in deploys:
+        count = int(row.get('c') or 0)
+        day = str(row.get('day'))[:10]
+        releases_by_day[day] = releases_by_day.get(day, 0) + count
+        slug = row.get('slug')
+        if slug:
+            by_env[str(slug)] = by_env.get(str(slug), 0) + count
+    releases_daily = [releases_by_day.get(day, 0) for day in days]
+    environments = [
+        EnvironmentCount(slug=slug, count=count)
+        for slug, count in sorted(
+            by_env.items(), key=lambda item: item[1], reverse=True
+        )
+    ]
+    return DashboardMetrics(
+        since=since,
+        releases=MetricSeries(total=sum(releases_daily), daily=releases_daily),
+        events=_build_series(events, days),
+        ops_log=_build_series(ops, days),
+        pull_requests=_build_series(prs, days),
+        releases_by_environment=environments,
+    )

--- a/src/imbi_api/endpoints/scoring.py
+++ b/src/imbi_api/endpoints/scoring.py
@@ -159,18 +159,23 @@ async def get_score_trend(
     )
 
 
+# Project → dimension-key mappings, scoped to a single organization
+# (the {org} slug) so aggregates never span tenants.
 _DIMENSION_QUERY: dict[str, typing.LiteralString] = {
     'team': (
         'MATCH (p:Project)-[:OWNED_BY]->(t:Team)'
+        '-[:BELONGS_TO]->(:Organization {{slug: {org}}})'
         ' RETURN p.id AS project_id, t.slug AS dim_key'
     ),
     'project_type': (
         'MATCH (p:Project)-[:TYPE]->(pt:ProjectType)'
+        ' MATCH (p)-[:OWNED_BY]->(:Team)'
+        '-[:BELONGS_TO]->(:Organization {{slug: {org}}})'
         ' RETURN p.id AS project_id, pt.slug AS dim_key'
     ),
     'organization': (
         'MATCH (p:Project)-[:OWNED_BY]->(:Team)'
-        '-[:BELONGS_TO]->(o:Organization)'
+        '-[:BELONGS_TO]->(o:Organization {{slug: {org}}})'
         ' RETURN p.id AS project_id, o.slug AS dim_key'
     ),
 }
@@ -183,16 +188,17 @@ async def score_rollup(
         permissions.AuthContext,
         fastapi.Depends(permissions.require_permission('project:read')),
     ],
+    org: str,
     dimension: typing.Literal['team', 'project_type', 'organization'] = 'team',
 ) -> list[scoring_models.ScoreRollupRow]:
-    """Return current-score rollup grouped by the requested dimension.
+    """Return current-score rollup for *org*, grouped by *dimension*.
 
     Uses ``score_latest`` (one row per project, current score only)
     so projects with many history entries do not skew aggregates.
     """
     # Fetch project → dimension key mapping from the graph
     dim_records = await db.execute(
-        _DIMENSION_QUERY[dimension], {}, ['project_id', 'dim_key']
+        _DIMENSION_QUERY[dimension], {'org': org}, ['project_id', 'dim_key']
     )
     project_dim: dict[str, str] = {}
     for rec in dim_records:
@@ -255,6 +261,7 @@ async def score_monthly_improvement(
         permissions.AuthContext,
         fastapi.Depends(permissions.require_permission('project:read')),
     ],
+    org: str,
     year: int = fastapi.Query(ge=2020, le=2100),
     month: int = fastapi.Query(ge=1, le=12),
     dimension: typing.Literal['team', 'project_type', 'organization'] = 'team',
@@ -276,7 +283,7 @@ async def score_monthly_improvement(
         prev_start = datetime.datetime(year, month - 1, 1, tzinfo=datetime.UTC)
 
     dim_records = await db.execute(
-        _DIMENSION_QUERY[dimension], {}, ['project_id', 'dim_key']
+        _DIMENSION_QUERY[dimension], {'org': org}, ['project_id', 'dim_key']
     )
     project_dim: dict[str, str] = {}
     for rec in dim_records:
@@ -362,15 +369,16 @@ async def score_history_by_team(
         permissions.AuthContext,
         fastapi.Depends(permissions.require_permission('project:read')),
     ],
+    org: str,
     granularity: typing.Literal['hour', 'day'] = 'day',
     from_: typing.Annotated[
         datetime.datetime | None, fastapi.Query(alias='from')
     ] = None,
     to: datetime.datetime | None = None,
 ) -> scoring_models.ScoreHistoryByTeamResponse:
-    """Return avg score history per team, bucketed by granularity."""
+    """Return avg score history per team for *org*, bucketed by granularity."""
     dim_records = await db.execute(
-        _DIMENSION_QUERY['team'], {}, ['project_id', 'dim_key']
+        _DIMENSION_QUERY['team'], {'org': org}, ['project_id', 'dim_key']
     )
     project_team: dict[str, str] = {}
     for rec in dim_records:
@@ -434,18 +442,20 @@ async def score_history_feed(
         permissions.AuthContext,
         fastapi.Depends(permissions.require_permission('project:read')),
     ],
+    org: str,
     from_: typing.Annotated[
         datetime.datetime | None, fastapi.Query(alias='from')
     ] = None,
     to: datetime.datetime | None = None,
     limit: typing.Annotated[int, fastapi.Query(ge=1, le=500)] = 200,
 ) -> list[scoring_models.GlobalScoreEvent]:
-    """Return recent raw score change events across all projects."""
+    """Return recent raw score change events for *org*'s projects."""
     project_records = await db.execute(
         'MATCH (p:Project)-[:OWNED_BY]->(t:Team)'
+        '-[:BELONGS_TO]->(:Organization {{slug: {org}}})'
         ' RETURN p.id AS project_id, p.name AS project_name,'
         ' t.slug AS team_slug',
-        {},
+        {'org': org},
         ['project_id', 'project_name', 'team_slug'],
     )
     project_info: dict[str, tuple[str, str]] = {}

--- a/src/imbi_api/settings.py
+++ b/src/imbi_api/settings.py
@@ -213,10 +213,34 @@ class Storage(pydantic_settings.BaseSettings):
     thumbnail_quality: int = 85
 
 
+class InternalServices(pydantic_settings.BaseSettings):
+    """Internal base URLs of sibling services, for health probing.
+
+    Set per-deployment (cluster service URLs in compose/k8s). Empty
+    values mark a service as not deployed -- the dashboard status check
+    skips probing it.
+    """
+
+    model_config = settings.base_settings_config(env_prefix='IMBI_INTERNAL_')
+
+    assistant_url: str = ''
+    gateway_url: str = ''
+    mcp_url: str = ''
+    slackbot_url: str = ''
+
+    @pydantic.field_validator(
+        'assistant_url', 'gateway_url', 'mcp_url', 'slackbot_url'
+    )
+    @classmethod
+    def _strip_slash(cls, value: str) -> str:
+        return value.rstrip('/')
+
+
 # Module-level singletons for extended settings
 _auth_settings: Auth | None = None
 _server_config: ServerConfig | None = None
 _storage_settings: Storage | None = None
+_internal_services: InternalServices | None = None
 
 
 def get_auth_settings() -> Auth:
@@ -248,7 +272,7 @@ def get_server_config() -> ServerConfig:
     if _server_config is None:
         try:
             _server_config = load_config().server
-        except (FileNotFoundError, OSError, ValueError, TypeError):
+        except FileNotFoundError, OSError, ValueError, TypeError:
             _server_config = ServerConfig()
     return _server_config
 
@@ -263,9 +287,17 @@ def get_storage_settings() -> Storage:
     if _storage_settings is None:
         try:
             _storage_settings = load_config().storage
-        except (FileNotFoundError, OSError, ValueError, TypeError):
+        except FileNotFoundError, OSError, ValueError, TypeError:
             _storage_settings = Storage()
     return _storage_settings
+
+
+def get_internal_services() -> InternalServices:
+    """Get the singleton InternalServices settings instance."""
+    global _internal_services
+    if _internal_services is None:
+        _internal_services = InternalServices()
+    return _internal_services
 
 
 def clear_caches() -> None:
@@ -275,9 +307,11 @@ def clear_caches() -> None:
     which lazily initialize once per process.
     """
     global _auth_settings, _server_config, _storage_settings
+    global _internal_services
     _auth_settings = None
     _server_config = None
     _storage_settings = None
+    _internal_services = None
 
 
 def oauth_callback_url(provider_slug: str, base_url: str | None = None) -> str:

--- a/tests/endpoints/test_dashboard.py
+++ b/tests/endpoints/test_dashboard.py
@@ -1,0 +1,270 @@
+"""Tests for the admin dashboard status endpoint."""
+
+import datetime
+from unittest import mock
+
+import httpx
+from fastapi import testclient
+from imbi_common import graph
+
+from imbi_api import models, settings
+from imbi_api.auth import password, permissions
+from imbi_api.endpoints import dashboard
+from tests import support
+
+
+def _ok_status_handler(request: httpx.Request) -> httpx.Response:
+    """MockTransport handler: every /status answers ok with a version."""
+    if request.url.path == '/status':
+        return httpx.Response(
+            200,
+            json={'service': 'svc', 'status': 'ok', 'version': '2.8.0'},
+        )
+    return httpx.Response(404)
+
+
+_REAL_ASYNC_CLIENT = httpx.AsyncClient
+
+
+def _patch_async_client(handler) -> mock._patch:
+    """Patch the module's httpx.AsyncClient to use a MockTransport."""
+    return mock.patch.object(
+        dashboard.httpx,
+        'AsyncClient',
+        lambda *a, **k: _REAL_ASYNC_CLIENT(
+            transport=httpx.MockTransport(handler)
+        ),
+    )
+
+
+class DashboardStatusEndpointTestCase(support.SharedAppTestCase):
+    """Test cases for GET /admin/dashboard/status."""
+
+    def setUp(self) -> None:
+        self.test_user = models.User(
+            email='admin@example.com',
+            display_name='Admin User',
+            is_active=True,
+            is_admin=True,
+            password_hash=password.hash_password('testpassword123'),
+            created_at=datetime.datetime.now(datetime.UTC),
+        )
+        self.admin_context = permissions.AuthContext(
+            user=self.test_user,
+            session_id='test-session',
+            auth_method='jwt',
+            permissions=set(),
+        )
+
+        async def mock_get_current_user():
+            return self.admin_context
+
+        self.test_app.dependency_overrides[permissions.get_current_user] = (
+            mock_get_current_user
+        )
+
+        self.mock_db = mock.AsyncMock(spec=graph.Graph)
+        self.mock_db.execute.return_value = [{'n': 1}]
+        self.test_app.dependency_overrides[graph._inject_graph] = lambda: (
+            self.mock_db
+        )
+
+        self.client = testclient.TestClient(self.test_app)
+
+        # Datastore client patches.
+        self.clickhouse_patch = mock.patch.object(
+            dashboard.clickhouse,
+            'query',
+            new=mock.AsyncMock(return_value=[{'size': 2048}]),
+        )
+        valkey_client = mock.AsyncMock()
+        valkey_client.info = mock.AsyncMock(
+            return_value={'redis_version': '7', 'used_memory': 1024}
+        )
+        self.valkey_patch = mock.patch.object(
+            dashboard.valkey, 'get_client', return_value=valkey_client
+        )
+        # Postgres size reads the psycopg pool directly; patch the helper
+        # rather than mock the async connection/cursor protocol.
+        self.pg_size_patch = mock.patch.object(
+            dashboard, '_postgres_size', mock.AsyncMock(return_value=4096)
+        )
+        # All four sibling services configured.
+        self.services_patch = mock.patch.object(
+            dashboard.settings,
+            'get_internal_services',
+            return_value=settings.InternalServices(
+                assistant_url='http://assistant:8002',
+                gateway_url='http://gateway:8003',
+                mcp_url='http://mcp:8001',
+                slackbot_url='http://slackbot:8004',
+            ),
+        )
+        self.clickhouse_patch.start()
+        self.valkey_patch.start()
+        self.services_patch.start()
+        self.pg_size_patch.start()
+        self.addCleanup(self.clickhouse_patch.stop)
+        self.addCleanup(self.valkey_patch.stop)
+        self.addCleanup(self.services_patch.stop)
+        self.addCleanup(self.pg_size_patch.stop)
+
+    def test_all_healthy(self) -> None:
+        """Every datastore ok and every service up."""
+        with _patch_async_client(_ok_status_handler):
+            response = self.client.get('/admin/dashboard/status')
+        self.assertEqual(200, response.status_code)
+        body = response.json()
+        self.assertIn('checked_at', body)
+
+        datastores = {d['name']: d for d in body['datastores']}
+        self.assertEqual(
+            {'PostgreSQL', 'ClickHouse', 'Valkey'}, set(datastores)
+        )
+        for entry in datastores.values():
+            self.assertEqual('ok', entry['status'])
+            self.assertIsNotNone(entry['latency_ms'])
+        # Size on disk (or resident memory for Valkey) is surfaced.
+        self.assertEqual(4096, datastores['PostgreSQL']['size_bytes'])
+        self.assertEqual(2048, datastores['ClickHouse']['size_bytes'])
+        self.assertEqual(1024, datastores['Valkey']['size_bytes'])
+
+        services = {s['name']: s for s in body['services']}
+        self.assertEqual(
+            {'API', 'Assistant', 'Gateway', 'MCP', 'Slackbot'}, set(services)
+        )
+        for entry in services.values():
+            self.assertEqual('up', entry['status'])
+        # API reports its own version without an HTTP hop.
+        self.assertEqual(0.0, services['API']['latency_ms'])
+        self.assertEqual('2.8.0', services['Assistant']['version'])
+
+    def test_datastore_error_reported(self) -> None:
+        """A failing datastore check returns status=error, not a 500."""
+        self.mock_db.execute.side_effect = RuntimeError('pool closed')
+        with _patch_async_client(_ok_status_handler):
+            response = self.client.get('/admin/dashboard/status')
+        self.assertEqual(200, response.status_code)
+        datastores = {d['name']: d for d in response.json()['datastores']}
+        self.assertEqual('error', datastores['PostgreSQL']['status'])
+        self.assertEqual('pool closed', datastores['PostgreSQL']['detail'])
+        self.assertEqual('ok', datastores['ClickHouse']['status'])
+
+    def test_service_down_reported(self) -> None:
+        """A non-200 from a service marks it down without failing others."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.host == 'gateway':
+                return httpx.Response(503)
+            return _ok_status_handler(request)
+
+        with _patch_async_client(handler):
+            response = self.client.get('/admin/dashboard/status')
+        self.assertEqual(200, response.status_code)
+        services = {s['name']: s for s in response.json()['services']}
+        self.assertEqual('down', services['Gateway']['status'])
+        self.assertEqual('up', services['Assistant']['status'])
+
+    def test_unconfigured_service_marked_down(self) -> None:
+        """An empty internal URL marks the service down as not configured."""
+        self.services_patch.stop()
+        with mock.patch.object(
+            dashboard.settings,
+            'get_internal_services',
+            return_value=settings.InternalServices(
+                assistant_url='http://assistant:8002',
+            ),
+        ):
+            with _patch_async_client(_ok_status_handler):
+                response = self.client.get('/admin/dashboard/status')
+        services = {s['name']: s for s in response.json()['services']}
+        self.assertEqual('down', services['Slackbot']['status'])
+        self.assertEqual('not configured', services['Slackbot']['detail'])
+
+    def test_requires_permission(self) -> None:
+        """A non-admin without admin:dashboard:read is forbidden."""
+        self.admin_context.user.is_admin = False
+        self.admin_context.permissions = set()
+        with _patch_async_client(_ok_status_handler):
+            response = self.client.get('/admin/dashboard/status')
+        self.assertEqual(403, response.status_code)
+
+
+class DashboardMetricsEndpointTestCase(support.SharedAppTestCase):
+    """Test cases for GET /admin/dashboard/metrics."""
+
+    def setUp(self) -> None:
+        self.test_user = models.User(
+            email='admin@example.com',
+            display_name='Admin User',
+            is_active=True,
+            is_admin=True,
+            password_hash=password.hash_password('testpassword123'),
+            created_at=datetime.datetime.now(datetime.UTC),
+        )
+        self.admin_context = permissions.AuthContext(
+            user=self.test_user,
+            session_id='test-session',
+            auth_method='jwt',
+            permissions=set(),
+        )
+
+        async def mock_get_current_user():
+            return self.admin_context
+
+        self.test_app.dependency_overrides[permissions.get_current_user] = (
+            mock_get_current_user
+        )
+        self.client = testclient.TestClient(self.test_app)
+
+    def test_metrics_aggregates_and_aligns_daily(self) -> None:
+        today = datetime.datetime.now(datetime.UTC).date().isoformat()
+        # gather() evaluates args in order: deploys, events, ops, prs. The
+        # deploys scan carries both the day series and the env rollup.
+        query = mock.AsyncMock(
+            side_effect=[
+                [
+                    {'day': today, 'slug': 'production', 'c': 4},
+                    {'day': today, 'slug': 'staging', 'c': 1},
+                ],
+                [{'day': today, 'c': 5}],
+                [{'day': today, 'c': 8}],
+                [{'day': today, 'c': 2}],
+            ]
+        )
+        with mock.patch.object(dashboard.clickhouse, 'query', query):
+            response = self.client.get('/admin/dashboard/metrics')
+        self.assertEqual(200, response.status_code, response.text)
+        body = response.json()
+        self.assertEqual(5, body['releases']['total'])
+        self.assertEqual(5, body['events']['total'])
+        self.assertEqual(8, body['ops_log']['total'])
+        self.assertEqual(2, body['pull_requests']['total'])
+        # Seven daily buckets, today (last) carrying the summed value.
+        self.assertEqual(7, len(body['releases']['daily']))
+        self.assertEqual(5, body['releases']['daily'][-1])
+        self.assertEqual(0, body['releases']['daily'][0])
+        # Environments derived from the same scan, sorted by count desc.
+        self.assertEqual(
+            [
+                {'slug': 'production', 'count': 4},
+                {'slug': 'staging', 'count': 1},
+            ],
+            body['releases_by_environment'],
+        )
+
+    def test_metrics_empty(self) -> None:
+        query = mock.AsyncMock(side_effect=[[], [], [], []])
+        with mock.patch.object(dashboard.clickhouse, 'query', query):
+            response = self.client.get('/admin/dashboard/metrics')
+        self.assertEqual(200, response.status_code, response.text)
+        body = response.json()
+        self.assertEqual(0, body['events']['total'])
+        self.assertEqual([0] * 7, body['ops_log']['daily'])
+        self.assertEqual([], body['releases_by_environment'])
+
+    def test_metrics_requires_permission(self) -> None:
+        self.admin_context.user.is_admin = False
+        self.admin_context.permissions = set()
+        response = self.client.get('/admin/dashboard/metrics')
+        self.assertEqual(403, response.status_code)

--- a/tests/endpoints/test_scoring.py
+++ b/tests/endpoints/test_scoring.py
@@ -88,8 +88,8 @@ class ScoringEndpointsTestCase(support.SharedAppTestCase):
             side_effect=lambda **_kw: _PipelineProxy(self.mock_valkey)
         )
 
-        self.test_app.dependency_overrides[graph._inject_graph] = (
-            lambda: self.mock_db
+        self.test_app.dependency_overrides[graph._inject_graph] = lambda: (
+            self.mock_db
         )
         self.test_app.dependency_overrides[
             scoring_di._inject_optional_client
@@ -157,7 +157,7 @@ class ScoringEndpointsTestCase(support.SharedAppTestCase):
             ),
         ):
             response = self.client.get(
-                '/scores/rollup', params={'dimension': 'team'}
+                '/scores/rollup', params={'org': 'acme', 'dimension': 'team'}
             )
         self.assertEqual(response.status_code, 200, response.text)
         body = response.json()
@@ -169,7 +169,7 @@ class ScoringEndpointsTestCase(support.SharedAppTestCase):
     def test_rollup_empty_when_no_projects(self) -> None:
         self.mock_db.execute = mock.AsyncMock(return_value=[])
         response = self.client.get(
-            '/scores/rollup', params={'dimension': 'team'}
+            '/scores/rollup', params={'org': 'acme', 'dimension': 'team'}
         )
         self.assertEqual(response.status_code, 200, response.text)
         self.assertEqual(response.json(), [])
@@ -429,7 +429,12 @@ class ScoringEndpointsTestCase(support.SharedAppTestCase):
         ):
             response = self.client.get(
                 '/scores/monthly-improvement',
-                params={'year': 2026, 'month': 4, 'dimension': 'team'},
+                params={
+                    'org': 'acme',
+                    'year': 2026,
+                    'month': 4,
+                    'dimension': 'team',
+                },
             )
         self.assertEqual(response.status_code, 200, response.text)
         body = response.json()
@@ -456,18 +461,30 @@ class ScoringEndpointsTestCase(support.SharedAppTestCase):
         self.mock_db.execute = mock.AsyncMock(return_value=[])
         response = self.client.get(
             '/scores/monthly-improvement',
-            params={'year': 2026, 'month': 4, 'dimension': 'team'},
+            params={
+                'org': 'acme',
+                'year': 2026,
+                'month': 4,
+                'dimension': 'team',
+            },
         )
         self.assertEqual(response.status_code, 200, response.text)
         self.assertEqual(response.json(), [])
 
     def test_history_by_team_empty_when_no_projects(self) -> None:
         self.mock_db.execute = mock.AsyncMock(return_value=[])
-        response = self.client.get('/scores/history-by-team')
+        response = self.client.get(
+            '/scores/history-by-team', params={'org': 'acme'}
+        )
         self.assertEqual(response.status_code, 200, response.text)
         body = response.json()
         self.assertEqual(body['granularity'], 'day')
         self.assertEqual(body['teams'], [])
+
+    def test_history_by_team_requires_org(self) -> None:
+        self.mock_db.execute = mock.AsyncMock(return_value=[])
+        response = self.client.get('/scores/history-by-team')
+        self.assertEqual(response.status_code, 422, response.text)
 
     def test_history_by_team_returns_aggregated_series(self) -> None:
         self.mock_db.execute = mock.AsyncMock(
@@ -504,7 +521,9 @@ class ScoringEndpointsTestCase(support.SharedAppTestCase):
                 'imbi_common.graph.parse_agtype', side_effect=lambda x: x
             ),
         ):
-            response = self.client.get('/scores/history-by-team')
+            response = self.client.get(
+                '/scores/history-by-team', params={'org': 'acme'}
+            )
         self.assertEqual(response.status_code, 200, response.text)
         body = response.json()
         self.assertEqual(body['granularity'], 'day')
@@ -531,6 +550,7 @@ class ScoringEndpointsTestCase(support.SharedAppTestCase):
             response = self.client.get(
                 '/scores/history-by-team',
                 params={
+                    'org': 'acme',
                     'granularity': 'hour',
                     'from': '2026-01-01T00:00:00',
                     'to': '2026-04-01T00:00:00',
@@ -543,9 +563,16 @@ class ScoringEndpointsTestCase(support.SharedAppTestCase):
 
     def test_history_feed_empty_when_no_projects(self) -> None:
         self.mock_db.execute = mock.AsyncMock(return_value=[])
-        response = self.client.get('/scores/history-feed')
+        response = self.client.get(
+            '/scores/history-feed', params={'org': 'acme'}
+        )
         self.assertEqual(response.status_code, 200, response.text)
         self.assertEqual(response.json(), [])
+
+    def test_history_feed_requires_org(self) -> None:
+        self.mock_db.execute = mock.AsyncMock(return_value=[])
+        response = self.client.get('/scores/history-feed')
+        self.assertEqual(response.status_code, 422, response.text)
 
     def test_history_feed_returns_events(self) -> None:
         self.mock_db.execute = mock.AsyncMock(
@@ -576,7 +603,9 @@ class ScoringEndpointsTestCase(support.SharedAppTestCase):
                 'imbi_common.graph.parse_agtype', side_effect=lambda x: x
             ),
         ):
-            response = self.client.get('/scores/history-feed')
+            response = self.client.get(
+                '/scores/history-feed', params={'org': 'acme'}
+            )
         self.assertEqual(response.status_code, 200, response.text)
         body = response.json()
         self.assertEqual(len(body), 1)
@@ -610,6 +639,7 @@ class ScoringEndpointsTestCase(support.SharedAppTestCase):
             response = self.client.get(
                 '/scores/history-feed',
                 params={
+                    'org': 'acme',
                     'from': '2026-01-01T00:00:00',
                     'to': '2026-04-01T00:00:00',
                     'limit': 50,
@@ -647,7 +677,9 @@ class ScoringEndpointsTestCase(support.SharedAppTestCase):
                 'imbi_common.graph.parse_agtype', side_effect=lambda x: x
             ),
         ):
-            response = self.client.get('/scores/history-feed')
+            response = self.client.get(
+                '/scores/history-feed', params={'org': 'acme'}
+            )
         self.assertEqual(response.status_code, 200, response.text)
         body = response.json()
         self.assertEqual(len(body), 1)


### PR DESCRIPTION
## Summary

Adds the backend for the admin dashboard and fixes a cross-org data leak in the scoring report endpoints.

### New endpoints (gated on new `admin:dashboard:read` permission)
- **`GET /admin/dashboard/status`** — datastore health (PostgreSQL/AGE via `RETURN 1`, ClickHouse via `SELECT 1`/active-parts size, Valkey via `INFO memory`) with latency and on-disk size / resident memory, plus sibling-service health (Assistant/Gateway/MCP/Slackbot via their `/status`, and the API's own version). All probes run concurrently with a 2s per-check timeout; a failed dependency reports `error`/`down` rather than 500ing.
- **`GET /admin/dashboard/metrics`** — 7-day Releases / Events / OpsLog / Pull Request counts with per-day series for the histograms, plus releases-by-environment. The deploy day-series and env rollup come from a single `operations_log FINAL` scan.
- New `InternalServices` settings (`IMBI_INTERNAL_ASSISTANT_URL` etc.) supply sibling URLs for probing.

### Cross-org leak fix
`/scores/history-by-team`, `/scores/history-feed`, `/scores/rollup`, and `/scores/monthly-improvement` previously aggregated across **all** organizations. They now require an `org` query param and filter to that organization via `-[:BELONGS_TO]->(:Organization {slug: org})`.

## Tests
New `tests/endpoints/test_dashboard.py` (status + metrics, incl. permission + empty cases) and updated `test_scoring.py` (org param + `requires_org` 422 cases). `ruff` / `mypy` / `basedpyright` clean.

## Notes
- Dashboard metrics/status are intentionally **instance-wide** (system-health console), unlike the now-org-scoped score reports.
- Pairs with imbi-ui#`feature/admin-dashboard-status` (consumes these endpoints) and imbi-mcp#`feature/admin-dashboard-status` (adds `/status`).