### PR TITLE
Persist EXISTS_IN edges and surface project services

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
   "fastapi",
   "filetype",
   "httpx>=0.28.1,<1",
-  "imbi-common[databases,llm,sentry,server]==2.8.0",
+  "imbi-common[databases,llm,sentry,server]==2.9.0",
   "jinja2",
   "jsonpatch>=1.33",
   "mcp>=1.26.0",

--- a/src/imbi_api/domain/models.py
+++ b/src/imbi_api/domain/models.py
@@ -1275,8 +1275,11 @@ class ExistsInCreate(pydantic.BaseModel):
     identifier: str = pydantic.Field(min_length=1)
     canonical_url: str | None = None
     #: Optional human dashboard URL; persisted into ``Project.links``
-    #: keyed by the service slug (not stored on the edge).
-    dashboard_url: str | None = None
+    #: keyed by the service slug (not stored on the edge).  Validated as a
+    #: URL at the request boundary so a malformed value can't poison the
+    #: project's ``links`` map (``dict[str, AnyUrl]``), which is
+    #: re-validated on every project read.
+    dashboard_url: pydantic.AnyUrl | None = None
 
 
 class ExistsInResponse(pydantic.BaseModel):

--- a/src/imbi_api/domain/models.py
+++ b/src/imbi_api/domain/models.py
@@ -1273,7 +1273,10 @@ class ExistsInCreate(pydantic.BaseModel):
 
     third_party_service_slug: str
     identifier: str = pydantic.Field(min_length=1)
-    canonical_link: str | None = None
+    canonical_url: str | None = None
+    #: Optional human dashboard URL; persisted into ``Project.links``
+    #: keyed by the service slug (not stored on the edge).
+    dashboard_url: str | None = None
 
 
 class ExistsInResponse(pydantic.BaseModel):
@@ -1282,4 +1285,6 @@ class ExistsInResponse(pydantic.BaseModel):
     third_party_service_slug: str
     third_party_service_name: str
     identifier: str
-    canonical_link: str | None = None
+    canonical_url: str | None = None
+    #: Human dashboard URL read from ``Project.links`` (service slug key).
+    dashboard_url: str | None = None

--- a/src/imbi_api/endpoints/_helpers.py
+++ b/src/imbi_api/endpoints/_helpers.py
@@ -9,7 +9,7 @@ import typing
 import fastapi
 import psycopg
 from imbi_common import graph
-from imbi_common.plugins.base import PluginContext
+from imbi_common.plugins.base import PluginContext, ServiceConnection
 
 from imbi_api import patch as json_patch
 
@@ -280,6 +280,208 @@ async def persist_link_writeback(db: graph.Graph, ctx: PluginContext) -> None:
             writeback.old_owner_repo,
             writeback.new_owner_repo,
         )
+
+
+async def merge_project_links(
+    db: graph.Graph,
+    project_id: str,
+    *,
+    add: dict[str, str] | None = None,
+    remove: collections.abc.Iterable[str] | None = None,
+) -> bool:
+    """Apply additions and removals to the project's external link map.
+
+    Reads the current links once, applies ``add`` (set/overwrite) and
+    ``remove`` (drop keys), and writes the map back as the JSON-encoded
+    string ``p.links`` is stored as on the AGE node. Returns ``True``
+    when the map changed. Companion to :func:`update_project_link` for
+    the multi-key / removal case driven by a service writeback.
+    """
+    links = await lookup_project_links(db, project_id)
+    updated = dict(links)
+    for key, url in (add or {}).items():
+        if url:
+            updated[key] = url
+    for key in remove or ():
+        updated.pop(key, None)
+    if updated == links:
+        return False
+    query: typing.LiteralString = (
+        'MATCH (p:Project {{id: {project_id}}}) '
+        'SET p.links = {links} RETURN p.id AS id'
+    )
+    await db.execute(
+        query,
+        {'project_id': project_id, 'links': json.dumps(updated)},
+        ['id'],
+    )
+    return True
+
+
+async def lookup_project_exists_in(
+    db: graph.Graph,
+    project_id: str,
+) -> list[ServiceConnection]:
+    """Return the project's ``EXISTS_IN`` connections.
+
+    One :class:`ServiceConnection` per
+    ``(:Project)-[:EXISTS_IN]->(:ThirdPartyService)`` edge, carrying the
+    service slug, the edge ``identifier``, and the canonical API URL.
+    Returns ``[]`` on lookup failure or when the project exists in no
+    services. Populated onto :attr:`PluginContext.service_connections`
+    so plugins can read the relationship without re-querying the graph.
+    """
+    query: typing.LiteralString = (
+        'MATCH (p:Project {{id: {project_id}}}) '
+        '-[ei:EXISTS_IN]->(tps:ThirdPartyService) '
+        'RETURN tps.slug AS service_slug, '
+        'ei.identifier AS identifier, '
+        'ei.canonical_url AS canonical_url'
+    )
+    try:
+        records = await db.execute(
+            query,
+            {'project_id': project_id},
+            ['service_slug', 'identifier', 'canonical_url'],
+        )
+    except Exception:  # noqa: BLE001
+        LOGGER.debug('Project EXISTS_IN lookup failed', exc_info=True)
+        return []
+    connections: list[ServiceConnection] = []
+    for r in records:
+        slug = graph.parse_agtype(r.get('service_slug'))
+        if not slug:
+            continue
+        identifier = graph.parse_agtype(r.get('identifier'))
+        canonical_url = graph.parse_agtype(r.get('canonical_url'))
+        connections.append(
+            ServiceConnection(
+                service_slug=str(slug),
+                identifier='' if identifier is None else str(identifier),
+                canonical_url=(
+                    None if canonical_url is None else str(canonical_url)
+                ),
+            )
+        )
+    return connections
+
+
+async def persist_service_writeback(
+    db: graph.Graph, ctx: PluginContext
+) -> None:
+    """Persist a project's service relationship a plugin reported on ``ctx``.
+
+    A lifecycle plugin sets ``ctx.service_writeback`` when a call
+    created, moved, or tore down the project's relationship with the
+    service it is bound to (``ctx.third_party_service_slug``). Upsert the
+    ``EXISTS_IN`` edge (identifier + canonical API URL) and merge any
+    dashboard links into ``Project.links`` -- or, when ``remove`` is set,
+    delete the edge and drop those link keys. Best-effort: a write
+    failure is logged and swallowed so persistence never fails the
+    user-facing request whose result we already have.
+    """
+    writeback = ctx.service_writeback
+    if writeback is None:
+        return
+    slug = ctx.third_party_service_slug
+    if not slug:
+        LOGGER.warning(
+            'Service writeback for project %s has no bound '
+            'third_party_service_slug; skipping',
+            ctx.project_id,
+        )
+        return
+    try:
+        if writeback.remove:
+            await _delete_exists_in(db, ctx.org_slug, ctx.project_id, slug)
+            await merge_project_links(
+                db, ctx.project_id, remove=writeback.dashboard_links.keys()
+            )
+        else:
+            await _merge_exists_in(
+                db,
+                ctx.org_slug,
+                ctx.project_id,
+                slug,
+                writeback.identifier,
+                writeback.canonical_url,
+            )
+            await merge_project_links(
+                db, ctx.project_id, add=writeback.dashboard_links
+            )
+    except Exception:  # noqa: BLE001
+        LOGGER.warning(
+            'Failed to persist service writeback for project %s (%s)',
+            ctx.project_id,
+            slug,
+            exc_info=True,
+        )
+        return
+    LOGGER.info(
+        'Persisted EXISTS_IN edge for project %s -> %s (%s)',
+        ctx.project_id,
+        slug,
+        'removed' if writeback.remove else writeback.identifier,
+    )
+
+
+async def _merge_exists_in(
+    db: graph.Graph,
+    org_slug: str,
+    project_id: str,
+    tps_slug: str,
+    identifier: str,
+    canonical_url: str,
+) -> None:
+    """Upsert the ``EXISTS_IN`` edge for ``(project, service)``."""
+    query: typing.LiteralString = """
+    MATCH (p:Project {{id: {project_id}}})
+          -[:OWNED_BY]->(:Team)
+          -[:BELONGS_TO]->(o:Organization {{slug: {org_slug}}})
+    MATCH (tps:ThirdPartyService {{slug: {tps_slug}}})
+          -[:BELONGS_TO]->(o)
+    MERGE (p)-[ei:EXISTS_IN]->(tps)
+    SET ei.identifier = {identifier},
+        ei.canonical_url = {canonical_url}
+    RETURN ei.identifier AS identifier
+    """
+    await db.execute(
+        query,
+        {
+            'org_slug': org_slug,
+            'project_id': project_id,
+            'tps_slug': tps_slug,
+            'identifier': identifier,
+            'canonical_url': canonical_url,
+        },
+        ['identifier'],
+    )
+
+
+async def _delete_exists_in(
+    db: graph.Graph,
+    org_slug: str,
+    project_id: str,
+    tps_slug: str,
+) -> None:
+    """Remove the ``EXISTS_IN`` edge for ``(project, service)``. Idempotent."""
+    query: typing.LiteralString = """
+    MATCH (p:Project {{id: {project_id}}})
+          -[:OWNED_BY]->(:Team)
+          -[:BELONGS_TO]->(:Organization {{slug: {org_slug}}})
+    OPTIONAL MATCH (p)-[ei:EXISTS_IN]->
+          (tps:ThirdPartyService {{slug: {tps_slug}}})
+    DELETE ei
+    """
+    await db.execute(
+        query,
+        {
+            'org_slug': org_slug,
+            'project_id': project_id,
+            'tps_slug': tps_slug,
+        },
+        [],
+    )
 
 
 async def lookup_project_type_slugs(

--- a/src/imbi_api/endpoints/project_analysis.py
+++ b/src/imbi_api/endpoints/project_analysis.py
@@ -30,6 +30,7 @@ from imbi_common.plugins.errors import PluginCredentialsMissing
 
 from imbi_api.auth import permissions
 from imbi_api.endpoints._helpers import (
+    lookup_project_exists_in,
     lookup_project_links,
     lookup_project_slugs,
     lookup_project_type_slugs,
@@ -89,6 +90,7 @@ async def _build_context(
     project_slug, team_slug = await lookup_project_slugs(db, project_id)
     project_links = await lookup_project_links(db, project_id)
     project_type_slugs = await lookup_project_type_slugs(db, project_id)
+    service_connections = await lookup_project_exists_in(db, project_id)
     return PluginContext(
         project_id=project_id,
         project_slug=project_slug,
@@ -97,6 +99,8 @@ async def _build_context(
         assignment_options=resolved.options,
         project_links=project_links,
         project_type_slugs=project_type_slugs,
+        third_party_service_slug=resolved.third_party_service_slug,
+        service_connections=service_connections,
     )
 
 

--- a/src/imbi_api/endpoints/projects.py
+++ b/src/imbi_api/endpoints/projects.py
@@ -28,6 +28,7 @@ from imbi_api import blueprint_attributes
 from imbi_api import patch as json_patch
 from imbi_api.auth import permissions
 from imbi_api.domain import scoring as scoring_models
+from imbi_api.domain.models import ExistsInResponse
 from imbi_api.endpoints._helpers import conflict_on_unique_violation
 from imbi_api.endpoints._json_fields import (
     JSONFields,
@@ -230,6 +231,12 @@ class ProjectResponse(pydantic.BaseModel):
     environments: list[EnvironmentRef] = []
     links: dict[str, pydantic.AnyUrl] = {}
     identifiers: dict[str, int | str] = {}
+    # The project's EXISTS_IN connections, one entry per
+    # ``(:Project)-[:EXISTS_IN]->(:ThirdPartyService)`` edge.  Read-only
+    # structured surface (identifier + canonical API URL + the dashboard
+    # URL from ``links``); maintained through the project-services
+    # endpoints, not by editing ``identifiers``.
+    services: list[ExistsInResponse] = []
     score: float | None = None
     breakdown: scoring_models.ScoreBreakdown | None = None
     relationships: ProjectRelationships | None = None
@@ -255,6 +262,52 @@ class ProjectResponse(pydantic.BaseModel):
         if isinstance(value, str):
             return json.loads(value)
         return value
+
+    @pydantic.model_validator(mode='before')
+    @classmethod
+    def _build_services(cls, data: typing.Any) -> typing.Any:
+        """Build the ``services`` list from the EXISTS_IN edges.
+
+        The read fragment returns a ``service_edges`` list of
+        ``{slug, name, identifier, canonical_url}`` from each
+        ``(:Project)-[:EXISTS_IN]->(:ThirdPartyService)`` edge.  Pair each
+        with the matching ``Project.links[slug]`` dashboard URL and expose
+        the result as the read-only ``services`` field.  ``identifiers``
+        is intentionally left as the node property -- edge identifiers are
+        *not* merged into it, so the editable identifier map and the
+        service relationship never collide.
+        """
+        if not isinstance(data, dict):
+            return data
+        values = typing.cast('dict[str, typing.Any]', data)
+        raw_edges = values.pop('service_edges', None)
+        if not raw_edges or not isinstance(raw_edges, list):
+            return values
+        edges = typing.cast('list[dict[str, typing.Any]]', raw_edges)
+        raw_links: typing.Any = values.get('links') or {}
+        if isinstance(raw_links, str):
+            raw_links = json.loads(raw_links) or {}
+        links = typing.cast('dict[str, typing.Any]', raw_links)
+        services: list[dict[str, typing.Any]] = []
+        for edge in edges:
+            slug = edge.get('slug')
+            if not slug or not isinstance(slug, str):
+                continue
+            identifier = edge.get('identifier')
+            dashboard = links.get(slug)
+            services.append(
+                {
+                    'third_party_service_slug': slug,
+                    'third_party_service_name': edge.get('name') or slug,
+                    'identifier': ''
+                    if identifier is None
+                    else str(identifier),
+                    'canonical_url': edge.get('canonical_url'),
+                    'dashboard_url': str(dashboard) if dashboard else None,
+                }
+            )
+        values['services'] = services
+        return values
 
 
 class ProjectMutationResponse(ProjectResponse):
@@ -864,10 +917,19 @@ _RETURN_FRAGMENT: typing.LiteralString = """
     OPTIONAL MATCH (p)<-[:DEPENDS_ON]-(in_:Project)
     WITH p, o, t, pts, envs, outbound_count,
          count(in_) AS inbound_count
+    OPTIONAL MATCH (p)-[ei:EXISTS_IN]->(tps:ThirdPartyService)
+    WITH p, o, t, pts, envs, outbound_count, inbound_count,
+         collect(CASE WHEN tps IS NOT NULL
+                 THEN {{slug: tps.slug,
+                        name: tps.name,
+                        identifier: ei.identifier,
+                        canonical_url: ei.canonical_url}}
+                 END) AS service_edges
     RETURN p{{.*,
         team: t{{.*, organization: o{{.*}}}},
         project_types: pts,
-        environments: envs
+        environments: envs,
+        service_edges: service_edges
     }} AS project,
     outbound_count,
     inbound_count

--- a/src/imbi_api/endpoints/webhooks.py
+++ b/src/imbi_api/endpoints/webhooks.py
@@ -829,12 +829,14 @@ async def create_project_service(
 
     # The dashboard URL is a human link, not edge state: persist it into
     # ``Project.links`` keyed by the service slug so the edge and its
-    # links entry stay a single coherent row.
-    if data.dashboard_url:
+    # links entry stay a single coherent row.  ``dashboard_url`` is an
+    # ``AnyUrl`` (validated at the boundary); store its string form.
+    dashboard_url = str(data.dashboard_url) if data.dashboard_url else None
+    if dashboard_url:
         await merge_project_links(
             db,
             project_id,
-            add={data.third_party_service_slug: data.dashboard_url},
+            add={data.third_party_service_slug: dashboard_url},
         )
 
     r = records[0]
@@ -849,7 +851,7 @@ async def create_project_service(
         canonical_url=graph.parse_agtype(
             r.get('canonical_url'),
         ),
-        dashboard_url=data.dashboard_url,
+        dashboard_url=dashboard_url,
     )
 
 

--- a/src/imbi_api/endpoints/webhooks.py
+++ b/src/imbi_api/endpoints/webhooks.py
@@ -14,7 +14,11 @@ from imbi_common.auth import encryption
 from imbi_api import patch as json_patch
 from imbi_api.auth import permissions
 from imbi_api.domain import models
-from imbi_api.endpoints._helpers import conflict_on_unique_violation
+from imbi_api.endpoints._helpers import (
+    conflict_on_unique_violation,
+    lookup_project_links,
+    merge_project_links,
+)
 from imbi_api.graph_sql import props_template, set_clause
 
 LOGGER = logging.getLogger(__name__)
@@ -734,7 +738,7 @@ async def list_project_services(
     RETURN tps.slug AS service_slug,
            tps.name AS service_name,
            ei.identifier AS identifier,
-           ei.canonical_link AS canonical_link
+           ei.canonical_url AS canonical_url
     ORDER BY tps.name
     """
     records = await db.execute(
@@ -744,25 +748,28 @@ async def list_project_services(
             'service_slug',
             'service_name',
             'identifier',
-            'canonical_link',
+            'canonical_url',
         ],
     )
 
-    return [
-        models.ExistsInResponse(
-            third_party_service_slug=graph.parse_agtype(
-                r['service_slug'],
-            ),
-            third_party_service_name=graph.parse_agtype(
-                r['service_name'],
-            ),
-            identifier=graph.parse_agtype(r['identifier']),
-            canonical_link=graph.parse_agtype(
-                r.get('canonical_link'),
-            ),
+    links = await lookup_project_links(db, project_id)
+    responses: list[models.ExistsInResponse] = []
+    for r in records:
+        slug = graph.parse_agtype(r['service_slug'])
+        responses.append(
+            models.ExistsInResponse(
+                third_party_service_slug=slug,
+                third_party_service_name=graph.parse_agtype(
+                    r['service_name'],
+                ),
+                identifier=graph.parse_agtype(r['identifier']),
+                canonical_url=graph.parse_agtype(
+                    r.get('canonical_url'),
+                ),
+                dashboard_url=links.get(slug),
+            )
         )
-        for r in records
-    ]
+    return responses
 
 
 @project_services_router.post('/', status_code=201)
@@ -787,11 +794,11 @@ async def create_project_service(
           -[:BELONGS_TO]->(o)
     MERGE (p)-[ei:EXISTS_IN]->(tps)
     SET ei.identifier = {identifier},
-        ei.canonical_link = {canonical_link}
+        ei.canonical_url = {canonical_url}
     RETURN tps.slug AS service_slug,
            tps.name AS service_name,
            ei.identifier AS identifier,
-           ei.canonical_link AS canonical_link
+           ei.canonical_url AS canonical_url
     """
     records = await db.execute(
         query,
@@ -800,13 +807,13 @@ async def create_project_service(
             'project_id': project_id,
             'tps_slug': data.third_party_service_slug,
             'identifier': data.identifier,
-            'canonical_link': data.canonical_link,
+            'canonical_url': data.canonical_url,
         },
         [
             'service_slug',
             'service_name',
             'identifier',
-            'canonical_link',
+            'canonical_url',
         ],
     )
 
@@ -820,6 +827,16 @@ async def create_project_service(
             ),
         )
 
+    # The dashboard URL is a human link, not edge state: persist it into
+    # ``Project.links`` keyed by the service slug so the edge and its
+    # links entry stay a single coherent row.
+    if data.dashboard_url:
+        await merge_project_links(
+            db,
+            project_id,
+            add={data.third_party_service_slug: data.dashboard_url},
+        )
+
     r = records[0]
     return models.ExistsInResponse(
         third_party_service_slug=graph.parse_agtype(
@@ -829,9 +846,10 @@ async def create_project_service(
             r['service_name'],
         ),
         identifier=graph.parse_agtype(r['identifier']),
-        canonical_link=graph.parse_agtype(
-            r.get('canonical_link'),
+        canonical_url=graph.parse_agtype(
+            r.get('canonical_url'),
         ),
+        dashboard_url=data.dashboard_url,
     )
 
 
@@ -881,3 +899,7 @@ async def delete_project_service(
                 f'{service_slug!r} not found'
             ),
         )
+
+    # Drop the matching dashboard link so the edge and its ``links``
+    # entry are removed together.
+    await merge_project_links(db, project_id, remove=[service_slug])

--- a/src/imbi_api/plugins/lifecycle_dispatch.py
+++ b/src/imbi_api/plugins/lifecycle_dispatch.py
@@ -30,6 +30,8 @@ from imbi_common.plugins.base import (
     LifecycleResult,
     LinkWriteback,
     PluginContext,
+    ServiceConnection,
+    ServiceWriteback,
 )
 from imbi_common.plugins.errors import PluginCredentialsMissing
 
@@ -88,6 +90,9 @@ class LifecycleContextBundle:
     team_slug: str | None
     project_links: dict[str, str]
     project_type_slugs: list[str]
+    service_connections: list[ServiceConnection] = dataclasses.field(
+        default_factory=list
+    )
 
 
 async def build_lifecycle_context_bundle(
@@ -99,27 +104,31 @@ async def build_lifecycle_context_bundle(
     write, and pass it as ``bundle=`` to :func:`dispatch_lifecycle`.
     """
     from imbi_api.endpoints._helpers import (
+        lookup_project_exists_in,
         lookup_project_links,
         lookup_project_slugs,
         lookup_project_type_slugs,
     )
 
-    # Three independent DB lookups; gather them concurrently so each
-    # lifecycle dispatch pays one round-trip latency rather than three.
+    # Independent DB lookups; gather them concurrently so each lifecycle
+    # dispatch pays one round-trip latency rather than several.
     (
         (project_slug, team_slug),
         project_links,
         project_type_slugs,
+        service_connections,
     ) = await asyncio.gather(
         lookup_project_slugs(db, project_id),
         lookup_project_links(db, project_id),
         lookup_project_type_slugs(db, project_id),
+        lookup_project_exists_in(db, project_id),
     )
     return LifecycleContextBundle(
         project_slug=project_slug,
         team_slug=team_slug,
         project_links=project_links,
         project_type_slugs=project_type_slugs,
+        service_connections=service_connections,
     )
 
 
@@ -182,6 +191,8 @@ async def dispatch_lifecycle(
             project_name=project_name,
             project_description=project_description,
             project_ui_url=project_ui_url,
+            third_party_service_slug=resolved.third_party_service_slug,
+            service_connections=bundle.service_connections,
         )
         invocation = await _invoke_one(db, ctx, resolved, event, auth)
         results.append(invocation)
@@ -243,6 +254,7 @@ async def _invoke_one(
     # writeback it reports through the closure so we can persist the
     # link after the call regardless of which context instance was used.
     captured_writeback: list[LinkWriteback] = []
+    captured_service_writeback: list[ServiceWriteback] = []
 
     async def _call(c: PluginContext) -> LifecycleResult:
         credentials = await _resolve_credentials(db, c, resolved)
@@ -250,6 +262,8 @@ async def _invoke_one(
         res: LifecycleResult = await call_with_timeout(method(c, credentials))
         if c.link_writeback is not None:
             captured_writeback.append(c.link_writeback)
+        if c.service_writeback is not None:
+            captured_service_writeback.append(c.service_writeback)
         return res
 
     try:
@@ -285,13 +299,20 @@ async def _invoke_one(
             message=f'{type(exc).__name__}: {exc}',
         )
 
-    if captured_writeback:
+    if captured_writeback or captured_service_writeback:
         # Lazy import to avoid the endpoints/_helpers <-> this-module
         # cycle described above.
-        from imbi_api.endpoints._helpers import persist_link_writeback
+        from imbi_api.endpoints._helpers import (
+            persist_link_writeback,
+            persist_service_writeback,
+        )
 
-        ctx.link_writeback = captured_writeback[-1]
-        await persist_link_writeback(db, ctx)
+        if captured_writeback:
+            ctx.link_writeback = captured_writeback[-1]
+            await persist_link_writeback(db, ctx)
+        if captured_service_writeback:
+            ctx.service_writeback = captured_service_writeback[-1]
+            await persist_service_writeback(db, ctx)
 
     return LifecycleInvocation(
         plugin_id=resolved.plugin_id,

--- a/src/imbi_api/plugins/resolution.py
+++ b/src/imbi_api/plugins/resolution.py
@@ -33,6 +33,13 @@ class ResolvedPlugin(typing.NamedTuple):
     # per-env payloads" by call sites; the default is None rather than
     # {} so the NamedTuple does not carry a shared mutable default.
     env_payloads: dict[str, dict[str, typing.Any]] | None = None
+    # Slug of the ThirdPartyService this plugin instance is attached to
+    # via ``(:ThirdPartyService)-[:HAS_PLUGIN]->(:Plugin)``, or ``None``
+    # when the plugin is not bound to a service.  The host injects it
+    # into ``PluginContext.third_party_service_slug`` so the plugin knows
+    # which service its ``service_writeback`` / ``EXISTS_IN`` edge
+    # targets.
+    third_party_service_slug: str | None = None
 
 
 def _merge_env_payloads(
@@ -281,9 +288,11 @@ async def resolve_all_plugins(
     MATCH (proj:Project {{id: {project_id}}})
     OPTIONAL MATCH (proj)-[pe:USES_PLUGIN]->(p:Plugin)
     WHERE pe.tab = {tab}
+    OPTIONAL MATCH (tps1:ThirdPartyService)-[:HAS_PLUGIN]->(p)
     OPTIONAL MATCH (proj)-[:TYPE]->(pt:ProjectType)
       -[pte:USES_PLUGIN]->(p2:Plugin)
     WHERE pte.tab = {tab}
+    OPTIONAL MATCH (tps2:ThirdPartyService)-[:HAS_PLUGIN]->(p2)
     WITH
       collect(DISTINCT {{id: p.id, slug: p.plugin_slug,
                          edge_options: pe.options,
@@ -291,6 +300,7 @@ async def resolve_all_plugins(
                          plugin_options: p.options,
                          identity_plugin_id: pe.identity_plugin_id,
                          plugin_identity_plugin_id: p.identity_plugin_id,
+                         tps_slug: tps1.slug,
                          default: pe.default,
                          src: 'project'}})
        AS proj_plugins,
@@ -300,6 +310,7 @@ async def resolve_all_plugins(
                          plugin_options: p2.options,
                          identity_plugin_id: pte.identity_plugin_id,
                          plugin_identity_plugin_id: p2.identity_plugin_id,
+                         tps_slug: tps2.slug,
                          default: pte.default,
                          src: 'project_type'}})
        AS pt_plugins
@@ -384,6 +395,7 @@ async def resolve_all_plugins(
                 plugin_id,
             )
             continue
+        tps_slug = chosen.get('tps_slug')
         resolved.append(
             ResolvedPlugin(
                 plugin_id=plugin_id,
@@ -394,6 +406,11 @@ async def resolve_all_plugins(
                 env_payloads=_merge_env_payloads(
                     chosen.get('pt_edge_env_payloads'),
                     chosen.get('edge_env_payloads'),
+                ),
+                third_party_service_slug=(
+                    tps_slug
+                    if isinstance(tps_slug, str) and tps_slug
+                    else None
                 ),
             )
         )
@@ -481,6 +498,7 @@ async def resolve_analysis_plugins(
        AS pt_plugins,
       collect(DISTINCT {{id: p3.id, slug: p3.plugin_slug,
                          plugin_options: p3.options,
+                         tps_slug: tps.slug,
                          src: 'third_party_service'}})
        AS tps_plugins
     RETURN proj_plugins, pt_plugins, tps_plugins
@@ -575,12 +593,18 @@ async def resolve_analysis_plugins(
                 plugin_id,
             )
             continue
+        tps_slug = chosen.get('tps_slug')
         resolved.append(
             ResolvedPlugin(
                 plugin_id=plugin_id,
                 plugin_slug=plugin_slug,
                 entry=entry,
                 options=options,
+                third_party_service_slug=(
+                    tps_slug
+                    if isinstance(tps_slug, str) and tps_slug
+                    else None
+                ),
             )
         )
     return resolved

--- a/tests/endpoints/test_project_response_surfacing.py
+++ b/tests/endpoints/test_project_response_surfacing.py
@@ -1,0 +1,100 @@
+"""Tests for EXISTS_IN surfacing on :class:`ProjectResponse`.
+
+Exercises the ``_build_services`` model validator that turns the read
+fragment's ``service_edges`` (+ the dashboard URL from ``links``) into
+the read-only ``services`` list, leaving ``identifiers`` untouched.
+"""
+
+import unittest
+
+from imbi_api.endpoints.projects import ProjectResponse
+
+
+class BuildServicesTestCase(unittest.TestCase):
+    def _build(self, data: dict[str, object]) -> dict[str, object]:
+        return ProjectResponse._build_services(data)
+
+    def test_no_edges_is_passthrough(self) -> None:
+        data = {'identifiers': {'a': 1}}
+        self.assertEqual(self._build(dict(data)), data)
+
+    def test_builds_services_with_dashboard_from_links(self) -> None:
+        out = self._build(
+            {
+                'identifiers': {},
+                'links': {'github': 'https://aweber.ghe.com/o/r'},
+                'service_edges': [
+                    {
+                        'slug': 'github',
+                        'name': 'GitHub',
+                        'identifier': 134741,
+                        'canonical_url': (
+                            'https://api.aweber.ghe.com/repositories/134741'
+                        ),
+                    }
+                ],
+            }
+        )
+        services = out['services']
+        assert isinstance(services, list)
+        self.assertEqual(len(services), 1)
+        svc = services[0]
+        self.assertEqual(svc['third_party_service_slug'], 'github')
+        self.assertEqual(svc['third_party_service_name'], 'GitHub')
+        # numeric identifier is stringified
+        self.assertEqual(svc['identifier'], '134741')
+        self.assertEqual(
+            svc['canonical_url'],
+            'https://api.aweber.ghe.com/repositories/134741',
+        )
+        self.assertEqual(svc['dashboard_url'], 'https://aweber.ghe.com/o/r')
+        # service_edges is consumed
+        self.assertNotIn('service_edges', out)
+
+    def test_identifiers_are_not_touched(self) -> None:
+        # The edge identifier must NOT be merged into identifiers — the
+        # node map is the editable source of truth.
+        out = self._build(
+            {
+                'identifiers': {'github': '999'},
+                'links': {},
+                'service_edges': [
+                    {'slug': 'github', 'name': 'GitHub', 'identifier': 134741}
+                ],
+            }
+        )
+        self.assertEqual(out['identifiers'], {'github': '999'})
+        self.assertEqual(out['services'][0]['identifier'], '134741')  # type: ignore[index]
+
+    def test_links_json_string_is_parsed(self) -> None:
+        out = self._build(
+            {
+                'links': '{"github": "https://dash/x"}',
+                'service_edges': [
+                    {'slug': 'github', 'name': 'GitHub', 'identifier': '1'}
+                ],
+            }
+        )
+        self.assertEqual(out['services'][0]['dashboard_url'], 'https://dash/x')  # type: ignore[index]
+
+    def test_missing_dashboard_is_none(self) -> None:
+        out = self._build(
+            {
+                'links': {},
+                'service_edges': [
+                    {
+                        'slug': 'sonarqube',
+                        'name': 'SonarQube',
+                        'identifier': 'cc:webform',
+                        'canonical_url': None,
+                    }
+                ],
+            }
+        )
+        svc = out['services'][0]  # type: ignore[index]
+        self.assertIsNone(svc['dashboard_url'])
+        self.assertIsNone(svc['canonical_url'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/endpoints/test_service_writeback.py
+++ b/tests/endpoints/test_service_writeback.py
@@ -40,9 +40,7 @@ class LookupProjectExistsInTestCase(unittest.TestCase):
                 'canonical_url': None,
             },
         ]
-        result = asyncio.run(
-            _helpers.lookup_project_exists_in(db, 'proj-1')
-        )
+        result = asyncio.run(_helpers.lookup_project_exists_in(db, 'proj-1'))
         self.assertEqual(len(result), 2)
         self.assertEqual(result[0].service_slug, 'github-enterprise-cloud')
         # numeric-looking identifiers round-trip back to a string
@@ -57,9 +55,7 @@ class LookupProjectExistsInTestCase(unittest.TestCase):
     def test_empty_on_lookup_failure(self) -> None:
         db = mock.AsyncMock()
         db.execute.side_effect = RuntimeError('boom')
-        result = asyncio.run(
-            _helpers.lookup_project_exists_in(db, 'proj-1')
-        )
+        result = asyncio.run(_helpers.lookup_project_exists_in(db, 'proj-1'))
         self.assertEqual(result, [])
 
     def test_skips_rows_without_slug(self) -> None:
@@ -67,9 +63,7 @@ class LookupProjectExistsInTestCase(unittest.TestCase):
         db.execute.return_value = [
             {'service_slug': None, 'identifier': 'x', 'canonical_url': None}
         ]
-        result = asyncio.run(
-            _helpers.lookup_project_exists_in(db, 'proj-1')
-        )
+        result = asyncio.run(_helpers.lookup_project_exists_in(db, 'proj-1'))
         self.assertEqual(result, [])
 
 

--- a/tests/endpoints/test_service_writeback.py
+++ b/tests/endpoints/test_service_writeback.py
@@ -1,0 +1,211 @@
+"""Tests for the service-writeback / EXISTS_IN helpers.
+
+Covers :func:`lookup_project_exists_in`, :func:`merge_project_links`,
+and :func:`persist_service_writeback` in
+:mod:`imbi_api.endpoints._helpers`.
+"""
+
+import asyncio
+import json
+import unittest
+import unittest.mock as mock
+
+from imbi_common.plugins.base import PluginContext, ServiceWriteback
+
+from imbi_api.endpoints import _helpers
+
+
+def _ctx(**kwargs: object) -> PluginContext:
+    base: dict[str, object] = {
+        'project_id': 'proj-1',
+        'project_slug': 'proj',
+        'org_slug': 'org-1',
+    }
+    base.update(kwargs)
+    return PluginContext(**base)  # type: ignore[arg-type]
+
+
+class LookupProjectExistsInTestCase(unittest.TestCase):
+    def test_returns_connections(self) -> None:
+        db = mock.AsyncMock()
+        db.execute.return_value = [
+            {
+                'service_slug': 'github-enterprise-cloud',
+                'identifier': '134741',
+                'canonical_url': 'https://api.x.ghe.com/repositories/134741',
+            },
+            {
+                'service_slug': 'sonarqube',
+                'identifier': 'conv:account',
+                'canonical_url': None,
+            },
+        ]
+        result = asyncio.run(
+            _helpers.lookup_project_exists_in(db, 'proj-1')
+        )
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0].service_slug, 'github-enterprise-cloud')
+        # numeric-looking identifiers round-trip back to a string
+        self.assertEqual(result[0].identifier, '134741')
+        self.assertEqual(
+            result[0].canonical_url,
+            'https://api.x.ghe.com/repositories/134741',
+        )
+        self.assertEqual(result[1].service_slug, 'sonarqube')
+        self.assertIsNone(result[1].canonical_url)
+
+    def test_empty_on_lookup_failure(self) -> None:
+        db = mock.AsyncMock()
+        db.execute.side_effect = RuntimeError('boom')
+        result = asyncio.run(
+            _helpers.lookup_project_exists_in(db, 'proj-1')
+        )
+        self.assertEqual(result, [])
+
+    def test_skips_rows_without_slug(self) -> None:
+        db = mock.AsyncMock()
+        db.execute.return_value = [
+            {'service_slug': None, 'identifier': 'x', 'canonical_url': None}
+        ]
+        result = asyncio.run(
+            _helpers.lookup_project_exists_in(db, 'proj-1')
+        )
+        self.assertEqual(result, [])
+
+
+class MergeProjectLinksTestCase(unittest.TestCase):
+    def test_add_and_remove(self) -> None:
+        db = mock.AsyncMock()
+        with mock.patch.object(
+            _helpers,
+            'lookup_project_links',
+            new=mock.AsyncMock(return_value={'old': 'https://old', 'k': 'v'}),
+        ):
+            changed = asyncio.run(
+                _helpers.merge_project_links(
+                    db,
+                    'proj-1',
+                    add={'github': 'https://gh'},
+                    remove=['old'],
+                )
+            )
+        self.assertTrue(changed)
+        db.execute.assert_awaited_once()
+        params = db.execute.await_args.args[1]
+        written = json.loads(params['links'])
+        self.assertEqual(written, {'k': 'v', 'github': 'https://gh'})
+
+    def test_no_op_returns_false(self) -> None:
+        db = mock.AsyncMock()
+        with mock.patch.object(
+            _helpers,
+            'lookup_project_links',
+            new=mock.AsyncMock(return_value={'k': 'v'}),
+        ):
+            changed = asyncio.run(
+                _helpers.merge_project_links(db, 'proj-1', add={'k': 'v'})
+            )
+        self.assertFalse(changed)
+        db.execute.assert_not_awaited()
+
+
+class PersistServiceWritebackTestCase(unittest.TestCase):
+    def test_noop_when_no_writeback(self) -> None:
+        db = mock.AsyncMock()
+        asyncio.run(_helpers.persist_service_writeback(db, _ctx()))
+        db.execute.assert_not_awaited()
+
+    def test_skips_without_bound_slug(self) -> None:
+        db = mock.AsyncMock()
+        ctx = _ctx(
+            service_writeback=ServiceWriteback(
+                identifier='1', canonical_url='https://api/1'
+            )
+        )
+        asyncio.run(_helpers.persist_service_writeback(db, ctx))
+        db.execute.assert_not_awaited()
+
+    def test_upsert_path(self) -> None:
+        db = mock.AsyncMock()
+        ctx = _ctx(
+            third_party_service_slug='github-enterprise-cloud',
+            service_writeback=ServiceWriteback(
+                identifier='134741',
+                canonical_url='https://api.x.ghe.com/repositories/134741',
+                dashboard_links={'github-enterprise-cloud': 'https://x/o/r'},
+            ),
+        )
+        with (
+            mock.patch.object(
+                _helpers, '_merge_exists_in', new=mock.AsyncMock()
+            ) as merge_edge,
+            mock.patch.object(
+                _helpers,
+                'merge_project_links',
+                new=mock.AsyncMock(return_value=True),
+            ) as merge_links,
+        ):
+            asyncio.run(_helpers.persist_service_writeback(db, ctx))
+        merge_edge.assert_awaited_once_with(
+            db,
+            'org-1',
+            'proj-1',
+            'github-enterprise-cloud',
+            '134741',
+            'https://api.x.ghe.com/repositories/134741',
+        )
+        merge_links.assert_awaited_once()
+        self.assertEqual(
+            merge_links.await_args.kwargs['add'],
+            {'github-enterprise-cloud': 'https://x/o/r'},
+        )
+
+    def test_remove_path(self) -> None:
+        db = mock.AsyncMock()
+        ctx = _ctx(
+            third_party_service_slug='github-enterprise-cloud',
+            service_writeback=ServiceWriteback(
+                identifier='1',
+                canonical_url='https://api/1',
+                dashboard_links={'github-enterprise-cloud': 'https://x/o/r'},
+                remove=True,
+            ),
+        )
+        with (
+            mock.patch.object(
+                _helpers, '_delete_exists_in', new=mock.AsyncMock()
+            ) as delete_edge,
+            mock.patch.object(
+                _helpers,
+                'merge_project_links',
+                new=mock.AsyncMock(return_value=True),
+            ) as merge_links,
+        ):
+            asyncio.run(_helpers.persist_service_writeback(db, ctx))
+        delete_edge.assert_awaited_once_with(
+            db, 'org-1', 'proj-1', 'github-enterprise-cloud'
+        )
+        self.assertEqual(
+            list(merge_links.await_args.kwargs['remove']),
+            ['github-enterprise-cloud'],
+        )
+
+    def test_write_failure_is_swallowed(self) -> None:
+        db = mock.AsyncMock()
+        ctx = _ctx(
+            third_party_service_slug='github',
+            service_writeback=ServiceWriteback(
+                identifier='1', canonical_url='https://api/1'
+            ),
+        )
+        with mock.patch.object(
+            _helpers,
+            '_merge_exists_in',
+            new=mock.AsyncMock(side_effect=RuntimeError('db down')),
+        ):
+            # must not raise
+            asyncio.run(_helpers.persist_service_writeback(db, ctx))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/endpoints/test_webhooks.py
+++ b/tests/endpoints/test_webhooks.py
@@ -1412,7 +1412,7 @@ class ProjectServicesEndpointsTestCase(support.SharedAppTestCase):
             'service_slug': 'github',
             'service_name': 'GitHub',
             'identifier': 'org/repo',
-            'canonical_link': 'https://github.com/org/repo',
+            'canonical_url': 'https://github.com/org/repo',
         }
 
     # -- List --
@@ -1452,9 +1452,9 @@ class ProjectServicesEndpointsTestCase(support.SharedAppTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), [])
 
-    def test_list_without_canonical_link(self) -> None:
+    def test_list_without_canonical_url(self) -> None:
         record = copy.deepcopy(self.service_record)
-        record['canonical_link'] = None
+        record['canonical_url'] = None
 
         self.mock_db.execute.return_value = [record]
         with mock.patch(
@@ -1467,7 +1467,7 @@ class ProjectServicesEndpointsTestCase(support.SharedAppTestCase):
 
         self.assertEqual(response.status_code, 200)
         data = response.json()
-        self.assertIsNone(data[0]['canonical_link'])
+        self.assertIsNone(data[0]['canonical_url'])
 
     # -- Create --
 
@@ -1484,7 +1484,7 @@ class ProjectServicesEndpointsTestCase(support.SharedAppTestCase):
                 json={
                     'third_party_service_slug': 'github',
                     'identifier': 'org/repo',
-                    'canonical_link': ('https://github.com/org/repo'),
+                    'canonical_url': ('https://github.com/org/repo'),
                 },
             )
 
@@ -1551,3 +1551,76 @@ class ProjectServicesEndpointsTestCase(support.SharedAppTestCase):
 
         self.assertEqual(response.status_code, 404)
         self.assertIn('not found', response.json()['detail'])
+
+    # -- Dashboard URL folding --
+
+    def test_list_includes_dashboard_url_from_links(self) -> None:
+        self.mock_db.execute.return_value = [self.service_record]
+        with (
+            mock.patch(
+                'imbi_common.graph.parse_agtype',
+                side_effect=lambda x: x,
+            ),
+            mock.patch(
+                'imbi_api.endpoints.webhooks.lookup_project_links',
+                new=mock.AsyncMock(
+                    return_value={'github': 'https://aweber.ghe.com/o/r'}
+                ),
+            ),
+        ):
+            response = self.client.get(
+                '/organizations/engineering/projects/my-project/services/',
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json()[0]['dashboard_url'],
+            'https://aweber.ghe.com/o/r',
+        )
+
+    def test_create_with_dashboard_url_writes_link(self) -> None:
+        self.mock_db.execute.return_value = [self.service_record]
+        with (
+            mock.patch(
+                'imbi_common.graph.parse_agtype',
+                side_effect=lambda x: x,
+            ),
+            mock.patch(
+                'imbi_api.endpoints.webhooks.merge_project_links',
+                new=mock.AsyncMock(return_value=True),
+            ) as merge_links,
+        ):
+            response = self.client.post(
+                '/organizations/engineering/projects/my-project/services/',
+                json={
+                    'third_party_service_slug': 'github',
+                    'identifier': 'org/repo',
+                    'canonical_url': 'https://api.github.com/repositories/1',
+                    'dashboard_url': 'https://github.com/org/repo',
+                },
+            )
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(
+            response.json()['dashboard_url'],
+            'https://github.com/org/repo',
+        )
+        merge_links.assert_awaited_once()
+        self.assertEqual(
+            merge_links.await_args.kwargs['add'],
+            {'github': 'https://github.com/org/repo'},
+        )
+
+    def test_delete_clears_dashboard_link(self) -> None:
+        self.mock_db.execute.return_value = [{'deleted': 1}]
+        with mock.patch(
+            'imbi_api.endpoints.webhooks.merge_project_links',
+            new=mock.AsyncMock(return_value=True),
+        ) as merge_links:
+            response = self.client.delete(
+                '/organizations/engineering/projects/my-project/services/github',
+            )
+        self.assertEqual(response.status_code, 204)
+        merge_links.assert_awaited_once()
+        self.assertEqual(
+            list(merge_links.await_args.kwargs['remove']),
+            ['github'],
+        )

--- a/tests/test_lifecycle_dispatch.py
+++ b/tests/test_lifecycle_dispatch.py
@@ -18,6 +18,7 @@ from imbi_common.plugins.base import (
     LinkWriteback,
     PluginContext,
     PluginManifest,
+    ServiceWriteback,
 )
 from imbi_common.plugins.registry import RegistryEntry
 
@@ -196,6 +197,119 @@ class DispatchLifecycleTestCase(unittest.TestCase):
         args = update_link.await_args.args
         self.assertEqual(args[2], 'github-repository')
         self.assertEqual(args[3], 'https://github.com/octo/renamed')
+
+    def test_archive_persists_service_writeback(self) -> None:
+        # A lifecycle plugin that reports a service writeback on ctx
+        # triggers an EXISTS_IN upsert + dashboard-link merge against the
+        # plugin's bound third-party service.
+        class _Svc(LifecyclePlugin):
+            manifest = PluginManifest(
+                slug='gh', name='gh', plugin_type='lifecycle'
+            )
+
+            async def on_project_archived(self, ctx, credentials):  # type: ignore[override]
+                ctx.service_writeback = ServiceWriteback(
+                    identifier='134741',
+                    canonical_url='https://api.x.ghe.com/repositories/134741',
+                    dashboard_links={
+                        'github-enterprise-cloud': 'https://x.ghe.com/o/r'
+                    },
+                )
+                return LifecycleResult(status='ok', message='done')
+
+            async def on_project_unarchived(self, ctx, credentials):  # type: ignore[override]
+                raise NotImplementedError
+
+        entry = RegistryEntry(
+            handler_cls=_Svc,
+            manifest=_Svc.manifest,
+            package_name='imbi-plugin-gh',
+            package_version='1.0.0',
+        )
+        resolved = ResolvedPlugin(
+            plugin_id='p1',
+            plugin_slug='gh',
+            entry=entry,
+            options={},
+            third_party_service_slug='github-enterprise-cloud',
+        )
+        with (
+            mock.patch(
+                'imbi_api.endpoints._helpers._merge_exists_in',
+                new=mock.AsyncMock(),
+            ) as merge_edge,
+            mock.patch(
+                'imbi_api.endpoints._helpers.merge_project_links',
+                new=mock.AsyncMock(return_value=True),
+            ) as merge_links,
+        ):
+            results, _ = self._run([resolved])
+        self.assertEqual(results[0].status, 'ok')
+        merge_edge.assert_awaited_once()
+        # _merge_exists_in(db, org, project, slug, identifier, canonical_url)
+        args = merge_edge.await_args.args
+        self.assertEqual(args[1], 'org-1')
+        self.assertEqual(args[2], 'proj-1')
+        self.assertEqual(args[3], 'github-enterprise-cloud')
+        self.assertEqual(args[4], '134741')
+        self.assertEqual(args[5], 'https://api.x.ghe.com/repositories/134741')
+        merge_links.assert_awaited_once()
+        self.assertEqual(
+            merge_links.await_args.kwargs['add'],
+            {'github-enterprise-cloud': 'https://x.ghe.com/o/r'},
+        )
+
+    def test_service_writeback_remove_deletes_edge(self) -> None:
+        class _Svc(LifecyclePlugin):
+            manifest = PluginManifest(
+                slug='gh', name='gh', plugin_type='lifecycle'
+            )
+
+            async def on_project_archived(self, ctx, credentials):  # type: ignore[override]
+                ctx.service_writeback = ServiceWriteback(
+                    identifier='1',
+                    canonical_url='https://api.x/1',
+                    dashboard_links={
+                        'github-enterprise-cloud': 'https://x/o/r'
+                    },
+                    remove=True,
+                )
+                return LifecycleResult(status='ok')
+
+            async def on_project_unarchived(self, ctx, credentials):  # type: ignore[override]
+                raise NotImplementedError
+
+        entry = RegistryEntry(
+            handler_cls=_Svc,
+            manifest=_Svc.manifest,
+            package_name='imbi-plugin-gh',
+            package_version='1.0.0',
+        )
+        resolved = ResolvedPlugin(
+            plugin_id='p1',
+            plugin_slug='gh',
+            entry=entry,
+            options={},
+            third_party_service_slug='github-enterprise-cloud',
+        )
+        with (
+            mock.patch(
+                'imbi_api.endpoints._helpers._delete_exists_in',
+                new=mock.AsyncMock(),
+            ) as delete_edge,
+            mock.patch(
+                'imbi_api.endpoints._helpers.merge_project_links',
+                new=mock.AsyncMock(return_value=True),
+            ) as merge_links,
+        ):
+            results, _ = self._run([resolved])
+        self.assertEqual(results[0].status, 'ok')
+        delete_edge.assert_awaited_once()
+        self.assertEqual(
+            delete_edge.await_args.args[3], 'github-enterprise-cloud'
+        )
+        # remove path drops the dashboard keys, not adds them
+        self.assertIn('remove', merge_links.await_args.kwargs)
 
     def test_emits_one_clickhouse_call_for_multiple_plugins(self) -> None:
         """H17: N plugins → 1 ClickHouse insert (rows batched)."""

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -527,18 +527,18 @@ class ExistsInModelTestCase(unittest.TestCase):
                 'identifier': 'org/repo',
             }
         )
-        self.assertIsNone(obj.canonical_link)
+        self.assertIsNone(obj.canonical_url)
 
     def test_exists_in_create_with_link(self) -> None:
         obj = domain_models.ExistsInCreate.model_validate(
             {
                 'third_party_service_slug': 'github',
                 'identifier': 'org/repo',
-                'canonical_link': 'https://github.com/org/repo',
+                'canonical_url': 'https://github.com/org/repo',
             }
         )
         self.assertEqual(
-            obj.canonical_link,
+            obj.canonical_url,
             'https://github.com/org/repo',
         )
 
@@ -560,7 +560,7 @@ class ExistsInModelTestCase(unittest.TestCase):
             }
         )
         self.assertEqual(obj.third_party_service_name, 'GitHub')
-        self.assertIsNone(obj.canonical_link)
+        self.assertIsNone(obj.canonical_url)
 
 
 class WebhookResponseFromGraphRecordTestCase(unittest.TestCase):

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -882,6 +882,85 @@ class ResolveAllPluginsTestCase(unittest.TestCase):
         slugs = {r.plugin_slug for r in result}
         self.assertEqual(slugs, {'github-lifecycle', 'aws-lifecycle'})
 
+    def test_surfaces_third_party_service_slug(self) -> None:
+        from imbi_api.plugins.resolution import resolve_all_plugins
+
+        mock_db = mock.AsyncMock()
+        mock_db.execute.return_value = [
+            {
+                'pt_plugins': '[]',
+                'proj_plugins': json.dumps(
+                    [
+                        {
+                            'id': 'p1',
+                            'slug': 'github-lifecycle',
+                            'edge_options': '{}',
+                            'plugin_options': '{}',
+                            'tps_slug': 'github-enterprise-cloud',
+                            'default': True,
+                            'src': 'project',
+                        }
+                    ]
+                ),
+            }
+        ]
+        entry = _make_registry_entry('github-lifecycle')
+        with (
+            mock.patch(
+                'imbi_api.plugins.resolution.get_plugin',
+                side_effect=lambda slug: entry,
+            ),
+            mock.patch(
+                'imbi_api.plugins.lifecycle.get_enabled_map',
+                new=mock.AsyncMock(return_value={'github-lifecycle': True}),
+            ),
+        ):
+            result = asyncio.run(
+                resolve_all_plugins(mock_db, 'proj1', 'lifecycle')
+            )
+        self.assertEqual(len(result), 1)
+        self.assertEqual(
+            result[0].third_party_service_slug, 'github-enterprise-cloud'
+        )
+
+    def test_third_party_service_slug_none_when_unbound(self) -> None:
+        from imbi_api.plugins.resolution import resolve_all_plugins
+
+        mock_db = mock.AsyncMock()
+        mock_db.execute.return_value = [
+            {
+                'pt_plugins': '[]',
+                'proj_plugins': json.dumps(
+                    [
+                        {
+                            'id': 'p1',
+                            'slug': 'github-lifecycle',
+                            'edge_options': '{}',
+                            'plugin_options': '{}',
+                            'tps_slug': None,
+                            'default': True,
+                            'src': 'project',
+                        }
+                    ]
+                ),
+            }
+        ]
+        entry = _make_registry_entry('github-lifecycle')
+        with (
+            mock.patch(
+                'imbi_api.plugins.resolution.get_plugin',
+                side_effect=lambda slug: entry,
+            ),
+            mock.patch(
+                'imbi_api.plugins.lifecycle.get_enabled_map',
+                new=mock.AsyncMock(return_value={'github-lifecycle': True}),
+            ),
+        ):
+            result = asyncio.run(
+                resolve_all_plugins(mock_db, 'proj1', 'lifecycle')
+            )
+        self.assertIsNone(result[0].third_party_service_slug)
+
     def test_skips_unregistered_plugin(self) -> None:
         from imbi_common.plugins.errors import PluginNotFoundError
 

--- a/uv.lock
+++ b/uv.lock
@@ -7,7 +7,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "0001-01-01T00:00:00Z"  # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer = "2026-05-27T15:59:52.237516Z"
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
@@ -1095,7 +1095,7 @@ requires-dist = [
   { name = "fastapi" },
   { name = "filetype" },
   { name = "httpx", specifier = ">=0.28.1,<1" },
-  { name = "imbi-common", extras = ["databases", "llm", "sentry", "server"], specifier = "==2.8.0" },
+  { name = "imbi-common", extras = ["databases", "llm", "sentry", "server"], specifier = "==2.9.0" },
   { name = "imbi-plugin-aws", marker = "extra == 'plugins'", specifier = ">=1.0.0" },
   { name = "imbi-plugin-github", marker = "extra == 'plugins'", specifier = ">=1.0.0" },
   { name = "imbi-plugin-logzio", marker = "extra == 'plugins'", specifier = ">=1.0.0" },
@@ -1148,7 +1148,7 @@ docs = [
 
 [[package]]
 name = "imbi-common"
-version = "2.8.0"
+version = "2.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
   { name = "cryptography" },
@@ -1164,9 +1164,9 @@ dependencies = [
   { name = "python-slugify" },
   { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/97/bc/d530fb11a6cc77b6fb9205824f90ffd61a9e177e5521547e8f56d625cb67/imbi_common-2.8.0.tar.gz", hash = "sha256:064407290a832f73e6ae2830f6802268f41a4ce65a68fb5f51c18cc45e966c70", size = 329556, upload-time = "2026-05-29T23:58:54.186Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ff/5e/e7306a4bafa6e23ad8fd6dcdaef552d646233b974b4cfd3352750ff57631/imbi_common-2.9.0.tar.gz", hash = "sha256:6687219808b824bc65af7229a6193cf2bf86e5b348ad2d3928126446c288b9ef", size = 336785, upload-time = "2026-06-03T15:52:11.958Z" }
 wheels = [
-  { url = "https://files.pythonhosted.org/packages/7f/3f/eb691a100829dff13f58c56a38bcd8c48ec83dd4a8270aca97da63b5a604/imbi_common-2.8.0-py3-none-any.whl", hash = "sha256:30cdb1aa1666f39a36eee9cc2285891650eb2340fcf184c26ed34c115695608d", size = 105139, upload-time = "2026-05-29T23:58:52.578Z" },
+  { url = "https://files.pythonhosted.org/packages/c2/dc/3c3e782709e5557620aa37e089233a267b0d73c9da44dbcfad963805f646/imbi_common-2.9.0-py3-none-any.whl", hash = "sha256:a8fad461cc7759e61ba101fa44f047610690805163ab43f8e10c8b97d91f8f0c", size = 107509, upload-time = "2026-06-03T15:52:10.159Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
> **Draft** — depends on AWeber-Imbi/imbi-common#150 (`ServiceWriteback`
> / `ServiceConnection`). CI will fail to resolve those symbols until
> imbi-common releases and the `imbi-common` pin here is bumped.

## Summary

Makes the host persist plugin-maintained `EXISTS_IN` edges and surface a
project's third-party-service connections on the project response.

## Problem

`EXISTS_IN` edges were hand-entered only; lifecycle plugins had no way
to record the canonical relationship they provision, and the project
response didn't expose the edge data at all.

## Solution

- `lookup_project_exists_in` + `persist_service_writeback` (`_helpers`):
  upsert / tear down the edge and merge the dashboard URL into
  `Project.links`.
- Surface the bound third-party-service slug in plugin resolution;
  inject `third_party_service_slug` + `service_connections` into the
  lifecycle and analysis contexts; capture/persist `ServiceWriteback`
  in lifecycle dispatch.
- Rename the edge property `canonical_link` → `canonical_url`; fold
  `dashboard_url` into the `/services` endpoints (create writes the
  link, delete clears it).
- `ProjectResponse` gains a read-only `services` list (identifier +
  canonical API URL + dashboard URL); `identifiers` stays node-only
  (the earlier edge-merge was reverted — it shadowed node edits).

## Companion PRs

Part of `exists-in-edge-management` (plan:
`imbi-orchestration/plans/exists-in-edge-management.md`).
- AWeber-Imbi/imbi-common#150 (prerequisite)
- imbi-plugin-github (draft)
- imbi-ui (draft)
