### PR TITLE
Pin sentry-sdk to 2.x to drop stale 3.0.0a7 alpha

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
   "pyotp>=2.9.0",
   "python-multipart>=0.0.26",
   "qrcode>=8.0",
-  "sentry-sdk>=2.48.0",
+  "sentry-sdk>=2.48.0,<3",  # 3.0 line abandoned upstream; stay on 2.x
   "slowapi==0.1.9",  # Pin: alpha quality, API may change
   "typer",
   "uvicorn",
@@ -64,7 +64,7 @@ plugins = [
   "imbi-plugin-oidc>=1.0.0",
   "imbi-plugin-sonarqube>=0.0.0",
 ]
-sentry = ["sentry-sdk"]
+sentry = ["sentry-sdk>=2.48.0,<3"]
 
 [dependency-groups]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -1116,8 +1116,8 @@ requires-dist = [
   { name = "pyotp", specifier = ">=2.9.0" },
   { name = "python-multipart", specifier = ">=0.0.26" },
   { name = "qrcode", specifier = ">=8.0" },
-  { name = "sentry-sdk", specifier = ">=2.48.0" },
-  { name = "sentry-sdk", marker = "extra == 'sentry'" },
+  { name = "sentry-sdk", specifier = ">=2.48.0,<3" },
+  { name = "sentry-sdk", marker = "extra == 'sentry'", specifier = ">=2.48.0,<3" },
   { name = "slowapi", specifier = "==0.1.9" },
   { name = "typer" },
   { name = "uvicorn" },
@@ -2753,16 +2753,15 @@ wheels = [
 
 [[package]]
 name = "sentry-sdk"
-version = "3.0.0a7"
+version = "2.60.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
   { name = "certifi" },
-  { name = "opentelemetry-sdk" },
   { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/66/a5/747ab268f2cf3f4cb50af521e1a85a959411f74cf4a2ecf47782e1981cee/sentry_sdk-3.0.0a7.tar.gz", hash = "sha256:439a858d409b84407560df6b7ebb760acd9ad3d14e05cd919ae36b204e411cb2", size = 329999, upload-time = "2025-10-20T13:50:38.131Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/a2/2e6c090db384cc515069f4f85542bd5baf6786852073020ea73d4a76d3ea/sentry_sdk-2.60.0.tar.gz", hash = "sha256:0bd25e54e78ca02d0be512529fa644bbbf9e8470d7b26371294012d4ca93c978", size = 452946, upload-time = "2026-05-13T13:34:52.516Z" }
 wheels = [
-  { url = "https://files.pythonhosted.org/packages/ce/5e/23837eadf18ad4f9d5894c1210e6c2591136fd36cff338bedc90a1222bf2/sentry_sdk-3.0.0a7-py2.py3-none-any.whl", hash = "sha256:ada791a77c2d489e07b04c068e0fcacd6bbcfe1cb40b5f303207738baf38e868", size = 353618, upload-time = "2025-10-20T13:50:36.158Z" },
+  { url = "https://files.pythonhosted.org/packages/29/41/f2b800b7f12a05dd48c2a6280d4dd812d1425fc66ed3fe3fd99420c41d1a/sentry_sdk-2.60.0-py3-none-any.whl", hash = "sha256:28a536c03291c8bcb363cf35c611b32738ec118ff64d8d6383b096448ac4c803", size = 475616, upload-time = "2026-05-13T13:34:50.259Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

The deployed `imbi-api` container shipped with **`sentry-sdk 3.0.0a7`**, an abandoned upstream alpha. Sentry gave up on the 3.0 rewrite and now emits a `UserWarning` on every `sentry_sdk.init()`:

> We won't be continuing development on SDK 3.0. Please use the last stable version of the SDK… https://github.com/getsentry/sentry-python/discussions/4955

This surfaced from `imbi_common/sentry.py:82` (where `init()` is called) at startup.

## Problem

`uv.lock` had `sentry-sdk == 3.0.0a7` baked in. Both relevant constraints — the main `sentry-sdk>=2.48.0` and the redundant, unbounded `sentry = ["sentry-sdk"]` extra — were satisfied by the alpha (`3.0.0a7 > 2.48.0`), so uv's minimal-change locking preserved it across every re-lock, including the 2.9.0 version bump. imbi-api was the only one of the five Python services on the alpha; the other four resolve to the stable `2.60.0`.

A forced fresh resolve (`uv lock --upgrade-package sentry-sdk`) cleanly picks `2.60.0` with no config change, confirming the alpha was a stale-lock artifact rather than a current constraint.

## Solution

- Add an explicit `<3` upper bound on both the main dependency and the `sentry` extra so a future 3.x alpha can't drift back in (the 3.0 line is dead upstream).
- Re-lock: `sentry-sdk 3.0.0a7 → 2.60.0`, dropping the unused `opentelemetry-sdk` transitive dep the alpha pulled in.

The lock change is applied surgically to keep the diff reviewable (the file's existing 2-space formatting predates uv's indentation change; a full `uv lock` would reformat all ~2800 lines). `uv lock --locked` passes against the edited lock.

After merge, rebuild/redeploy the container and the startup warning is gone.