### PR TITLE
Rename plugin-assignment tab to plugin_type

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
   "pyotp>=2.9.0",
   "python-multipart>=0.0.26",
   "qrcode>=8.0",
-  "sentry-sdk>=2.48.0",
+  "sentry-sdk>=2.48.0,<3",  # 3.0 line abandoned upstream; stay on 2.x
   "slowapi==0.1.9",  # Pin: alpha quality, API may change
   "typer",
   "uvicorn",
@@ -231,6 +231,13 @@ max-complexity = 15
 [tool.uv]
 exclude-newer = "7 days"
 exclude-newer-package = { "clickhouse-connect" = false, "imbi-common" = false, "imbi-plugin-aws" = false, "imbi-plugin-github" = false, "imbi-plugin-logzio" = false, "imbi-plugin-oidc" = false, "imbi-plugin-pagerduty" = false, "imbi-plugin-sentry" = false, "imbi-plugin-sonarqube" = false }
+
+# Interim: track imbi-common main for the unreleased ``PluginType``
+# export (used by the plugin-assignment models). Replace with a
+# ``==`` pin in the dependencies list once the next imbi-common
+# release is cut.
+[tool.uv.sources]
+imbi-common = { path = "../imbi-common", editable = true }
 
 [[tool.uv.index]]
 url = "https://pypi.org/simple"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -237,7 +237,7 @@ exclude-newer-package = { "clickhouse-connect" = false, "imbi-common" = false, "
 # ``==`` pin in the dependencies list once the next imbi-common
 # release is cut.
 [tool.uv.sources]
-imbi-common = { path = "../imbi-common", editable = true }
+imbi-common = { git = "https://github.com/AWeber-Imbi/imbi-common.git", branch = "main" }
 
 [[tool.uv.index]]
 url = "https://pypi.org/simple"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
   "fastapi",
   "filetype",
   "httpx>=0.28.1,<1",
-  "imbi-common[databases,llm,sentry,server]==2.9.0",
+  "imbi-common[databases,llm,sentry,server]==2.9.1",
   "jinja2",
   "jsonpatch>=1.33",
   "mcp>=1.26.0",
@@ -231,13 +231,6 @@ max-complexity = 15
 [tool.uv]
 exclude-newer = "7 days"
 exclude-newer-package = { "clickhouse-connect" = false, "imbi-common" = false, "imbi-plugin-aws" = false, "imbi-plugin-github" = false, "imbi-plugin-logzio" = false, "imbi-plugin-oidc" = false, "imbi-plugin-pagerduty" = false, "imbi-plugin-sentry" = false, "imbi-plugin-sonarqube" = false }
-
-# Interim: track imbi-common main for the unreleased ``PluginType``
-# export (used by the plugin-assignment models). Replace with a
-# ``==`` pin in the dependencies list once the next imbi-common
-# release is cut.
-[tool.uv.sources]
-imbi-common = { git = "https://github.com/AWeber-Imbi/imbi-common.git", branch = "main" }
 
 [[tool.uv.index]]
 url = "https://pypi.org/simple"

--- a/src/imbi_api/domain/models.py
+++ b/src/imbi_api/domain/models.py
@@ -12,6 +12,7 @@ import typing
 
 import pydantic
 from imbi_common import graph, models
+from imbi_common.plugins import PluginType
 
 __all__ = [
     'SECRET_FIELDS',
@@ -880,7 +881,7 @@ class PluginAssignmentCreate(pydantic.BaseModel):
     """Request model for assigning a plugin to a project-type or project."""
 
     plugin_id: str
-    tab: typing.Literal['configuration', 'logs', 'deployment', 'lifecycle']
+    plugin_type: PluginType
     default: bool = False
     options: dict[str, typing.Any] = pydantic.Field(default_factory=dict)
     identity_plugin_id: str | None = None
@@ -899,7 +900,7 @@ class PluginAssignmentResponse(pydantic.BaseModel):
     plugin_id: str
     plugin_slug: str
     label: str
-    tab: typing.Literal['configuration', 'logs', 'deployment', 'lifecycle']
+    plugin_type: PluginType
     default: bool
     options: dict[str, typing.Any] = {}
     source: typing.Literal['project', 'project_type', 'merged'] = (
@@ -1227,7 +1228,7 @@ class WebhookResponse(pydantic.BaseModel):
                 config: dict[str, typing.Any] | list[typing.Any]
                 try:
                     config = json.loads(raw_config) if raw_config else {}
-                except (json.JSONDecodeError, TypeError):
+                except json.JSONDecodeError, TypeError:
                     config = {}
                 rules.append(
                     WebhookRuleResponse(

--- a/src/imbi_api/endpoints/project_deployments.py
+++ b/src/imbi_api/endpoints/project_deployments.py
@@ -1,6 +1,6 @@
 """Project deployment plugin endpoints.
 
-Pass-through endpoints that resolve the project's ``tab='deployment'``
+Pass-through endpoints that resolve the project's ``plugin_type='deployment'``
 plugin and call its handler methods.  Covers ref / commit discovery,
 comparison, ``deploy`` / ``redeploy`` workflow dispatch (Phase 1), and
 the ``promote`` flow with AI-drafted release notes plus tag + Release

--- a/src/imbi_api/endpoints/project_plugins.py
+++ b/src/imbi_api/endpoints/project_plugins.py
@@ -12,7 +12,7 @@ from imbi_api.plugins.assignments import (
     PluginAssignmentRow,
     build_assignment_response,
     validate_identity_plugin_ids,
-    validate_one_default_per_tab,
+    validate_one_default_per_plugin_type,
 )
 
 project_plugins_router = fastapi.APIRouter(tags=['Project Plugins'])
@@ -104,7 +104,7 @@ async def replace_project_plugins(
     rows: list[PluginAssignmentRow] = [
         PluginAssignmentRow(
             plugin_id=a.plugin_id,
-            tab=a.tab,
+            plugin_type=a.plugin_type,
             default=a.default,
             options=a.options,
             identity_plugin_id=a.identity_plugin_id,
@@ -115,7 +115,7 @@ async def replace_project_plugins(
 
     if rows:
         try:
-            validate_one_default_per_tab(rows)
+            validate_one_default_per_plugin_type(rows)
         except ValueError as exc:
             raise fastapi.HTTPException(
                 status_code=400,

--- a/src/imbi_api/endpoints/project_type_plugins.py
+++ b/src/imbi_api/endpoints/project_type_plugins.py
@@ -12,7 +12,7 @@ from imbi_api.plugins.assignments import (
     PluginAssignmentRow,
     build_assignment_response,
     validate_identity_plugin_ids,
-    validate_one_default_per_tab,
+    validate_one_default_per_plugin_type,
 )
 
 project_type_plugins_router = fastapi.APIRouter(
@@ -74,7 +74,7 @@ async def replace_project_type_plugins(
     rows: list[PluginAssignmentRow] = [
         PluginAssignmentRow(
             plugin_id=a.plugin_id,
-            tab=a.tab,
+            plugin_type=a.plugin_type,
             default=a.default,
             options=a.options,
             identity_plugin_id=a.identity_plugin_id,
@@ -83,7 +83,7 @@ async def replace_project_type_plugins(
         for a in assignments
     ]
     try:
-        validate_one_default_per_tab(rows)
+        validate_one_default_per_plugin_type(rows)
     except ValueError as exc:
         raise fastapi.HTTPException(
             status_code=400,

--- a/src/imbi_api/endpoints/service_plugins.py
+++ b/src/imbi_api/endpoints/service_plugins.py
@@ -904,7 +904,8 @@ async def replace_plugin_assignments(
         ' WHERE mine.default = true'
         ' MATCH (mpt)-[sibling:USES_PLUGIN]->(other:Plugin)'
         ' WHERE other.id <> {plugin_id}'
-        ' AND sibling.plugin_type = mine.plugin_type'
+        ' AND coalesce(sibling.plugin_type, sibling.tab) ='
+        ' coalesce(mine.plugin_type, mine.tab)'
         ' AND sibling.default = true'
         ' SET sibling.default = false'
     )

--- a/src/imbi_api/endpoints/service_plugins.py
+++ b/src/imbi_api/endpoints/service_plugins.py
@@ -7,6 +7,7 @@ import fastapi
 import nanoid
 import pydantic
 from imbi_common import graph
+from imbi_common.plugins import PluginType
 from imbi_common.plugins.errors import (
     PluginNotFoundError,
 )
@@ -654,7 +655,7 @@ async def patch_service_plugin_configuration(
 
 class _AssignmentInput(pydantic.BaseModel):
     project_type_slug: str
-    tab: typing.Literal['configuration', 'logs', 'deployment', 'lifecycle']
+    plugin_type: PluginType
     default: bool = False
     options: dict[str, typing.Any] = {}
     identity_plugin_id: str | None = None
@@ -663,7 +664,7 @@ class _AssignmentInput(pydantic.BaseModel):
 class _AssignmentRow(pydantic.BaseModel):
     project_type_slug: str
     project_type_name: str
-    tab: typing.Literal['configuration', 'logs', 'deployment', 'lifecycle']
+    plugin_type: PluginType
     default: bool
     options: dict[str, typing.Any]
     identity_plugin_id: str | None = None
@@ -671,7 +672,7 @@ class _AssignmentRow(pydantic.BaseModel):
 
 _ASSIGNMENT_ROW_FIELDS: tuple[tuple[str, str], ...] = (
     ('project_type_slug', 'pt'),
-    ('tab', 'tab'),
+    ('plugin_type', 'ptype'),
     ('default', 'default'),
     ('options', 'options'),
     ('identity_plugin_id', 'idp'),
@@ -694,7 +695,7 @@ def _assignment_rows_template(
     for i, a in enumerate(body):
         values: dict[str, typing.Any] = {
             'pt': a.project_type_slug,
-            'tab': a.tab,
+            'ptype': a.plugin_type,
             'default': a.default,
             'options': json.dumps(a.options),
             'idp': a.identity_plugin_id or None,
@@ -735,7 +736,11 @@ async def _list_assignments(
             _AssignmentRow(
                 project_type_slug=pt.get('slug', ''),
                 project_type_name=pt.get('name', ''),
-                tab=edge.get('tab', 'configuration'),
+                # Transitional: prefer the new ``plugin_type`` edge
+                # property, fall back to legacy ``tab`` until migrated.
+                plugin_type=edge.get(
+                    'plugin_type', edge.get('tab', 'configuration')
+                ),
                 default=bool(edge.get('default', False)),
                 options=_parse_options(edge.get('options')),
                 identity_plugin_id=coerce_identity_plugin_id(
@@ -795,26 +800,27 @@ async def replace_plugin_assignments(
             detail=f'Plugin {plugin_slug!r} is not loaded',
         ) from exc
 
-    allowed_tab = entry.manifest.plugin_type
-    bad_tab = [a for a in body if a.tab != allowed_tab]
-    if bad_tab:
+    allowed_plugin_type = entry.manifest.plugin_type
+    mismatched = [a for a in body if a.plugin_type != allowed_plugin_type]
+    if mismatched:
         raise fastapi.HTTPException(
             status_code=400,
             detail=(
-                f'Plugin type {allowed_tab!r} can only be assigned to'
-                f' the {allowed_tab!r} tab'
+                f'Assignments for this plugin must use plugin_type'
+                f' {allowed_plugin_type!r}'
             ),
         )
 
     seen: set[tuple[str, str]] = set()
     for a in body:
-        key = (a.project_type_slug, a.tab)
+        key = (a.project_type_slug, a.plugin_type)
         if key in seen:
             raise fastapi.HTTPException(
                 status_code=400,
                 detail=(
                     f'Duplicate assignment for project type'
-                    f' {a.project_type_slug!r} on tab {a.tab!r}'
+                    f' {a.project_type_slug!r} with plugin_type'
+                    f' {a.plugin_type!r}'
                 ),
             )
         seen.add(key)
@@ -860,9 +866,10 @@ async def replace_plugin_assignments(
     # plugin; without it the ``OPTIONAL MATCH`` would emit one row per
     # pre-existing edge and the ``UNWIND`` would multiply the CREATEs.
     #
-    # The trailing demotion runs after the CREATEs: for every (pt, tab)
-    # where this plugin is now default, any *other* plugin that was
-    # default on the same tab is demoted. Plain ``MATCH``/``SET`` only --
+    # The trailing demotion runs after the CREATEs: for every
+    # (pt, plugin_type) where this plugin is now default, any *other*
+    # plugin that was default for the same plugin_type is demoted. Plain
+    # ``MATCH``/``SET`` only --
     # a zero-row match (no default edges, or no competing siblings) is a
     # harmless no-op and the already-applied CREATEs still commit.
     if not body:
@@ -889,14 +896,15 @@ async def replace_plugin_assignments(
         f' UNWIND {rows_tpl} AS row'
         ' MATCH (:Organization {{slug: {org_slug}}})<-[:BELONGS_TO]-'
         '(cpt:ProjectType {{slug: row.project_type_slug}})'
-        ' CREATE (cpt)-[:USES_PLUGIN {{tab: row.tab,'
+        ' CREATE (cpt)-[:USES_PLUGIN {{plugin_type: row.plugin_type,'
         ' default: row.default, options: row.options,'
         ' identity_plugin_id: row.identity_plugin_id}}]->(p)'
         ' WITH p, count(cpt) AS _new'
         ' MATCH (mpt:ProjectType)-[mine:USES_PLUGIN]->(p)'
         ' WHERE mine.default = true'
         ' MATCH (mpt)-[sibling:USES_PLUGIN]->(other:Plugin)'
-        ' WHERE other.id <> {plugin_id} AND sibling.tab = mine.tab'
+        ' WHERE other.id <> {plugin_id}'
+        ' AND sibling.plugin_type = mine.plugin_type'
         ' AND sibling.default = true'
         ' SET sibling.default = false'
     )

--- a/src/imbi_api/endpoints/third_party_services.py
+++ b/src/imbi_api/endpoints/third_party_services.py
@@ -469,7 +469,7 @@ async def _projects_using_tps_for_deployment(
     """Return project ids whose deployment plugin is owned by this TPS.
 
     Walks both project-level and project-type-level ``USES_PLUGIN``
-    edges with ``tab='deployment'`` whose target ``Plugin`` is owned
+    edges with ``plugin_type='deployment'`` whose target ``Plugin`` is owned
     (via ``HAS_PLUGIN``) by the named ThirdPartyService.  Returns a
     de-duplicated, deterministic list so the resync fan-out is stable
     across calls.
@@ -492,11 +492,11 @@ async def _projects_using_tps_for_deployment(
     MATCH (tps)-[:HAS_PLUGIN]->(plugin:Plugin)
     OPTIONAL MATCH (p:Project)-[upe:USES_PLUGIN]->(plugin),
                    (p)-[:OWNED_BY]->(:Team)-[:BELONGS_TO]->(o)
-    WHERE upe.tab = 'deployment'
+    WHERE upe.plugin_type = 'deployment'
     OPTIONAL MATCH (p2:Project)-[:TYPE]
         ->(:ProjectType)-[upte:USES_PLUGIN]->(plugin),
                    (p2)-[:OWNED_BY]->(:Team)-[:BELONGS_TO]->(o)
-    WHERE upte.tab = 'deployment'
+    WHERE upte.plugin_type = 'deployment'
     WITH collect(DISTINCT p.id) AS direct_ids,
          collect(DISTINCT p2.id) AS typed_ids
     RETURN direct_ids + typed_ids AS project_ids

--- a/src/imbi_api/endpoints/third_party_services.py
+++ b/src/imbi_api/endpoints/third_party_services.py
@@ -492,11 +492,11 @@ async def _projects_using_tps_for_deployment(
     MATCH (tps)-[:HAS_PLUGIN]->(plugin:Plugin)
     OPTIONAL MATCH (p:Project)-[upe:USES_PLUGIN]->(plugin),
                    (p)-[:OWNED_BY]->(:Team)-[:BELONGS_TO]->(o)
-    WHERE upe.plugin_type = 'deployment'
+    WHERE coalesce(upe.plugin_type, upe.tab) = 'deployment'
     OPTIONAL MATCH (p2:Project)-[:TYPE]
         ->(:ProjectType)-[upte:USES_PLUGIN]->(plugin),
                    (p2)-[:OWNED_BY]->(:Team)-[:BELONGS_TO]->(o)
-    WHERE upte.plugin_type = 'deployment'
+    WHERE coalesce(upte.plugin_type, upte.tab) = 'deployment'
     WITH collect(DISTINCT p.id) AS direct_ids,
          collect(DISTINCT p2.id) AS typed_ids
     RETURN direct_ids + typed_ids AS project_ids

--- a/src/imbi_api/plugins/assignment_writer.py
+++ b/src/imbi_api/plugins/assignment_writer.py
@@ -25,7 +25,7 @@ from imbi_api.plugins.assignments import PluginAssignmentRow
 
 _ROW_KEYS: tuple[str, ...] = (
     'plugin_id',
-    'tab',
+    'plugin_type',
     'default',
     'options',
     'identity_plugin_id',
@@ -87,7 +87,7 @@ async def replace_assignments(
     edges by guessing the parent key.
 
     Callers must validate plugin ids, identity_plugin_ids, and the
-    one-default-per-tab invariant up front; passing an empty ``rows``
+    one-default-per-plugin-type invariant up front; passing an empty ``rows``
     list clears all assignments.
     """
     parent_head = (
@@ -117,7 +117,7 @@ async def replace_assignments(
             ' WITH parent, count(old) AS _del'
             f' UNWIND {rows_tpl} AS row'
             ' MATCH (p:Plugin {{id: row.plugin_id}})'
-            ' CREATE (parent)-[:USES_PLUGIN {{tab: row.tab,'
+            ' CREATE (parent)-[:USES_PLUGIN {{plugin_type: row.plugin_type,'
             ' default: row.default,'
             ' options: row.options,'
             ' identity_plugin_id: row.identity_plugin_id,'

--- a/src/imbi_api/plugins/assignments.py
+++ b/src/imbi_api/plugins/assignments.py
@@ -4,6 +4,7 @@ import typing
 
 import fastapi
 from imbi_common import graph
+from imbi_common.plugins import PluginType
 from imbi_common.plugins.errors import PluginNotFoundError
 from imbi_common.plugins.registry import get_plugin
 
@@ -13,33 +14,37 @@ from imbi_api.plugins import parse_options
 
 class PluginAssignmentRow(typing.TypedDict):
     plugin_id: str
-    tab: typing.Literal['configuration', 'logs', 'deployment', 'lifecycle']
+    plugin_type: PluginType
     default: bool
     options: dict[str, typing.Any]
     identity_plugin_id: typing.NotRequired[str | None]
     env_payloads: typing.NotRequired[dict[str, dict[str, typing.Any]]]
 
 
-def validate_one_default_per_tab(
+def validate_one_default_per_plugin_type(
     assignments: list[PluginAssignmentRow],
 ) -> None:
-    """Ensure exactly one default per tab in the assignment list.
+    """Ensure exactly one default per plugin type in the assignment list.
 
     Raises:
-        ValueError: If a tab has 0 or >1 defaults.
+        ValueError: If a plugin type has 0 or >1 defaults.
     """
-    by_tab: dict[str, list[bool]] = {}
+    by_plugin_type: dict[str, list[bool]] = {}
     for row in assignments:
-        by_tab.setdefault(row['tab'], []).append(row['default'])
+        by_plugin_type.setdefault(row['plugin_type'], []).append(
+            row['default']
+        )
 
-    for tab, defaults in by_tab.items():
+    for plugin_type, defaults in by_plugin_type.items():
         count = sum(1 for d in defaults if d)
         if count == 0:
-            raise ValueError(f'Tab {tab!r} has no default plugin assignment')
+            raise ValueError(
+                f'Plugin type {plugin_type!r} has no default plugin assignment'
+            )
         if count > 1:
             raise ValueError(
-                f'Tab {tab!r} has {count} default plugin assignments;'
-                f' exactly one is required'
+                f'Plugin type {plugin_type!r} has {count} default plugin'
+                f' assignments; exactly one is required'
             )
 
 
@@ -121,7 +126,10 @@ def build_assignment_response(
         plugin_id=plugin['id'],
         plugin_slug=plugin['plugin_slug'],
         label=plugin['label'],
-        tab=edge.get('tab', 'configuration'),
+        # Transitional: read the new ``plugin_type`` edge property,
+        # falling back to the legacy ``tab`` name until the rename
+        # migration has run. Drop the ``tab`` fallback afterward.
+        plugin_type=edge.get('plugin_type', edge.get('tab', 'configuration')),
         default=bool(edge.get('default', False)),
         options=parse_options(edge.get('options')),
         source=source,

--- a/src/imbi_api/plugins/lifecycle_dispatch.py
+++ b/src/imbi_api/plugins/lifecycle_dispatch.py
@@ -2,7 +2,7 @@
 
 When a project state changes -- create, update, archive, unarchive,
 delete, or relocate -- the API dispatches the event to every plugin
-assigned to ``tab='lifecycle'`` (at the project or project-type level).
+assigned to ``plugin_type='lifecycle'`` (project or project-type level).
 Plugins receive a :class:`PluginContext` with hydrated identity and
 return a :class:`LifecycleResult` describing their per-plugin outcome.
 

--- a/src/imbi_api/plugins/resolution.py
+++ b/src/imbi_api/plugins/resolution.py
@@ -1,4 +1,4 @@
-"""Plugin resolution — find the correct plugin for a project+tab."""
+"""Plugin resolution — find the plugin for a project + plugin_type."""
 
 import logging
 import typing
@@ -71,10 +71,10 @@ def _merge_env_payloads(
 async def resolve_plugin(
     db: graph.Graph,
     project_id: str,
-    tab: str,
+    plugin_type: str,
     source: str | None,
 ) -> ResolvedPlugin:
-    """Find the plugin assigned to a project for a given tab.
+    """Find the plugin assigned to a project for a given plugin type.
 
     Merges project-type defaults with project-level overrides.
     If multiple plugins are assigned, ``source`` selects which one
@@ -96,10 +96,10 @@ async def resolve_plugin(
     query: typing.LiteralString = """
     MATCH (proj:Project {{id: {project_id}}})
     OPTIONAL MATCH (proj)-[pe:USES_PLUGIN]->(p:Plugin)
-    WHERE pe.tab = {tab}
+    WHERE pe.plugin_type = {plugin_type}
     OPTIONAL MATCH (proj)-[:TYPE]->(pt:ProjectType)
       -[pte:USES_PLUGIN]->(p2:Plugin)
-    WHERE pte.tab = {tab}
+    WHERE pte.plugin_type = {plugin_type}
     WITH
       collect(DISTINCT {{id: p.id, slug: p.plugin_slug,
                          edge_options: pe.options,
@@ -123,7 +123,7 @@ async def resolve_plugin(
     """
     records = await db.execute(
         query,
-        {'project_id': project_id, 'tab': tab},
+        {'project_id': project_id, 'plugin_type': plugin_type},
         ['proj_plugins', 'pt_plugins'],
     )
     if not records:
@@ -176,7 +176,10 @@ async def resolve_plugin(
     if not candidates:
         raise fastapi.HTTPException(
             status_code=404,
-            detail=f'No plugin assigned to tab {tab!r} for this project',
+            detail=(
+                f'No plugin assigned for plugin_type {plugin_type!r}'
+                f' for this project'
+            ),
         )
 
     if source:
@@ -266,9 +269,9 @@ async def resolve_plugin(
 async def resolve_all_plugins(
     db: graph.Graph,
     project_id: str,
-    tab: str,
+    plugin_type: str,
 ) -> list[ResolvedPlugin]:
-    """Return every plugin assigned to ``project_id`` for ``tab``.
+    """Return every plugin assigned to ``project_id`` for ``plugin_type``.
 
     Sibling to :func:`resolve_plugin` for fan-out call sites (e.g.
     lifecycle hooks) that must invoke *every* assigned plugin rather
@@ -287,11 +290,11 @@ async def resolve_all_plugins(
     query: typing.LiteralString = """
     MATCH (proj:Project {{id: {project_id}}})
     OPTIONAL MATCH (proj)-[pe:USES_PLUGIN]->(p:Plugin)
-    WHERE pe.tab = {tab}
+    WHERE pe.plugin_type = {plugin_type}
     OPTIONAL MATCH (tps1:ThirdPartyService)-[:HAS_PLUGIN]->(p)
     OPTIONAL MATCH (proj)-[:TYPE]->(pt:ProjectType)
       -[pte:USES_PLUGIN]->(p2:Plugin)
-    WHERE pte.tab = {tab}
+    WHERE pte.plugin_type = {plugin_type}
     OPTIONAL MATCH (tps2:ThirdPartyService)-[:HAS_PLUGIN]->(p2)
     WITH
       collect(DISTINCT {{id: p.id, slug: p.plugin_slug,
@@ -318,7 +321,7 @@ async def resolve_all_plugins(
     """
     records = await db.execute(
         query,
-        {'project_id': project_id, 'tab': tab},
+        {'project_id': project_id, 'plugin_type': plugin_type},
         ['proj_plugins', 'pt_plugins'],
     )
     if not records:
@@ -454,10 +457,11 @@ async def resolve_analysis_plugins(
 
     The union covers three discovery paths:
 
-    1. ``(:Project)-[:USES_PLUGIN {tab:'analysis'}]->(:Plugin)`` — project
-       override.
-    2. ``(:Project)-[:TYPE]->(:ProjectType)-[:USES_PLUGIN {tab:'analysis'}]
-       ->(:Plugin)`` — project-type default. Project override wins per
+    1. ``(:Project)-[:USES_PLUGIN {plugin_type:'analysis'}]->(:Plugin)`` —
+       project override.
+    2. ``(:Project)-[:TYPE]->(:ProjectType)
+       -[:USES_PLUGIN {plugin_type:'analysis'}]->(:Plugin)`` — project-type
+       default. Project override wins per
        plugin id, mirroring :func:`resolve_all_plugins`.
     3. ``(:Project)-[:EXISTS_IN]->(:ThirdPartyService)-[:HAS_PLUGIN]
        ->(:Plugin)`` filtered to ``plugin_type='analysis'``. The
@@ -476,10 +480,10 @@ async def resolve_analysis_plugins(
     query: typing.LiteralString = """
     MATCH (proj:Project {{id: {project_id}}})
     OPTIONAL MATCH (proj)-[pe:USES_PLUGIN]->(p:Plugin)
-    WHERE pe.tab = 'analysis'
+    WHERE pe.plugin_type = 'analysis'
     OPTIONAL MATCH (proj)-[:TYPE]->(pt:ProjectType)
       -[pte:USES_PLUGIN]->(p2:Plugin)
-    WHERE pte.tab = 'analysis'
+    WHERE pte.plugin_type = 'analysis'
     OPTIONAL MATCH (proj)-[:EXISTS_IN]->(tps:ThirdPartyService)
       -[:HAS_PLUGIN]->(p3:Plugin)
     WHERE p3.plugin_type = 'analysis'

--- a/src/imbi_api/plugins/resolution.py
+++ b/src/imbi_api/plugins/resolution.py
@@ -96,10 +96,10 @@ async def resolve_plugin(
     query: typing.LiteralString = """
     MATCH (proj:Project {{id: {project_id}}})
     OPTIONAL MATCH (proj)-[pe:USES_PLUGIN]->(p:Plugin)
-    WHERE pe.plugin_type = {plugin_type}
+    WHERE coalesce(pe.plugin_type, pe.tab) = {plugin_type}
     OPTIONAL MATCH (proj)-[:TYPE]->(pt:ProjectType)
       -[pte:USES_PLUGIN]->(p2:Plugin)
-    WHERE pte.plugin_type = {plugin_type}
+    WHERE coalesce(pte.plugin_type, pte.tab) = {plugin_type}
     WITH
       collect(DISTINCT {{id: p.id, slug: p.plugin_slug,
                          edge_options: pe.options,
@@ -290,11 +290,11 @@ async def resolve_all_plugins(
     query: typing.LiteralString = """
     MATCH (proj:Project {{id: {project_id}}})
     OPTIONAL MATCH (proj)-[pe:USES_PLUGIN]->(p:Plugin)
-    WHERE pe.plugin_type = {plugin_type}
+    WHERE coalesce(pe.plugin_type, pe.tab) = {plugin_type}
     OPTIONAL MATCH (tps1:ThirdPartyService)-[:HAS_PLUGIN]->(p)
     OPTIONAL MATCH (proj)-[:TYPE]->(pt:ProjectType)
       -[pte:USES_PLUGIN]->(p2:Plugin)
-    WHERE pte.plugin_type = {plugin_type}
+    WHERE coalesce(pte.plugin_type, pte.tab) = {plugin_type}
     OPTIONAL MATCH (tps2:ThirdPartyService)-[:HAS_PLUGIN]->(p2)
     WITH
       collect(DISTINCT {{id: p.id, slug: p.plugin_slug,
@@ -480,10 +480,10 @@ async def resolve_analysis_plugins(
     query: typing.LiteralString = """
     MATCH (proj:Project {{id: {project_id}}})
     OPTIONAL MATCH (proj)-[pe:USES_PLUGIN]->(p:Plugin)
-    WHERE pe.plugin_type = 'analysis'
+    WHERE coalesce(pe.plugin_type, pe.tab) = 'analysis'
     OPTIONAL MATCH (proj)-[:TYPE]->(pt:ProjectType)
       -[pte:USES_PLUGIN]->(p2:Plugin)
-    WHERE pte.plugin_type = 'analysis'
+    WHERE coalesce(pte.plugin_type, pte.tab) = 'analysis'
     OPTIONAL MATCH (proj)-[:EXISTS_IN]->(tps:ThirdPartyService)
       -[:HAS_PLUGIN]->(p3:Plugin)
     WHERE p3.plugin_type = 'analysis'

--- a/tests/endpoints/test_project_plugins.py
+++ b/tests/endpoints/test_project_plugins.py
@@ -36,8 +36,8 @@ class ProjectPluginsEndpointTestCase(support.SharedAppTestCase):
             mock_get_current_user
         )
         self.mock_db = mock.AsyncMock(spec=graph.Graph)
-        self.test_app.dependency_overrides[graph._inject_graph] = (
-            lambda: self.mock_db
+        self.test_app.dependency_overrides[graph._inject_graph] = lambda: (
+            self.mock_db
         )
 
     def test_get_project_plugins_not_found(self) -> None:
@@ -70,7 +70,7 @@ class ProjectPluginsEndpointTestCase(support.SharedAppTestCase):
                         {
                             'plugin': plugin_a,
                             'edge': {
-                                'tab': 'configuration',
+                                'plugin_type': 'configuration',
                                 'default': True,
                                 'options': '{}',
                             },
@@ -83,7 +83,7 @@ class ProjectPluginsEndpointTestCase(support.SharedAppTestCase):
                         {
                             'plugin': plugin_b,
                             'edge': {
-                                'tab': 'logs',
+                                'plugin_type': 'logs',
                                 'default': True,
                                 'options': '{}',
                             },
@@ -110,13 +110,13 @@ class ProjectPluginsEndpointTestCase(support.SharedAppTestCase):
                 json=[
                     {
                         'plugin_id': 'p1',
-                        'tab': 'configuration',
+                        'plugin_type': 'configuration',
                         'default': True,
                         'options': {},
                     },
                     {
                         'plugin_id': 'p2',
-                        'tab': 'configuration',
+                        'plugin_type': 'configuration',
                         'default': True,
                         'options': {},
                     },
@@ -164,7 +164,7 @@ class ProjectPluginsEndpointTestCase(support.SharedAppTestCase):
                             {
                                 'plugin': plugin_raw,
                                 'edge': {
-                                    'tab': 'configuration',
+                                    'plugin_type': 'configuration',
                                     'default': True,
                                     'options': '{}',
                                 },
@@ -181,7 +181,7 @@ class ProjectPluginsEndpointTestCase(support.SharedAppTestCase):
                 json=[
                     {
                         'plugin_id': 'p1',
-                        'tab': 'configuration',
+                        'plugin_type': 'configuration',
                         'default': True,
                         'options': {},
                     }

--- a/tests/endpoints/test_project_type_plugins.py
+++ b/tests/endpoints/test_project_type_plugins.py
@@ -36,8 +36,8 @@ class ProjectTypePluginsEndpointTestCase(support.SharedAppTestCase):
             mock_get_current_user
         )
         self.mock_db = mock.AsyncMock(spec=graph.Graph)
-        self.test_app.dependency_overrides[graph._inject_graph] = (
-            lambda: self.mock_db
+        self.test_app.dependency_overrides[graph._inject_graph] = lambda: (
+            self.mock_db
         )
 
     def test_list_empty(self) -> None:
@@ -60,7 +60,7 @@ class ProjectTypePluginsEndpointTestCase(support.SharedAppTestCase):
                     'api_version': 1,
                 },
                 'edge': {
-                    'tab': 'configuration',
+                    'plugin_type': 'configuration',
                     'default': True,
                     'options': '{}',
                 },
@@ -82,7 +82,7 @@ class ProjectTypePluginsEndpointTestCase(support.SharedAppTestCase):
                 json=[
                     {
                         'plugin_id': 'p1',
-                        'tab': 'configuration',
+                        'plugin_type': 'configuration',
                         'default': False,
                         'options': {},
                     }
@@ -101,7 +101,7 @@ class ProjectTypePluginsEndpointTestCase(support.SharedAppTestCase):
                 'api_version': 1,
             },
             'edge': {
-                'tab': 'configuration',
+                'plugin_type': 'configuration',
                 'default': True,
                 'options': '{}',
             },
@@ -117,7 +117,7 @@ class ProjectTypePluginsEndpointTestCase(support.SharedAppTestCase):
                 json=[
                     {
                         'plugin_id': 'p1',
-                        'tab': 'configuration',
+                        'plugin_type': 'configuration',
                         'default': True,
                         'options': {},
                     }
@@ -141,7 +141,7 @@ class ProjectTypePluginsEndpointTestCase(support.SharedAppTestCase):
             ),
             'edge': json.dumps(
                 {
-                    'tab': 'configuration',
+                    'plugin_type': 'configuration',
                     'default': True,
                     'options': '{}',
                 }

--- a/tests/endpoints/test_service_plugins.py
+++ b/tests/endpoints/test_service_plugins.py
@@ -1056,7 +1056,7 @@ class ReplacePluginAssignmentsTestCase(support.SharedAppTestCase):
                     json=[
                         {
                             'project_type_slug': 'web',
-                            'tab': 'configuration',
+                            'plugin_type': 'configuration',
                             'default': True,
                             'options': {'k': 'v'},
                         }
@@ -1090,7 +1090,7 @@ class ReplacePluginAssignmentsTestCase(support.SharedAppTestCase):
         self.assertIn('DELETE old', query)
         self.assertNotIn('UNWIND', query)
 
-    def test_replace_rejects_tab_mismatch(self) -> None:
+    def test_replace_rejects_plugin_type_mismatch(self) -> None:
         self.mock_db.execute.side_effect = [[{'slug': 'ssm'}]]
         with mock.patch(
             'imbi_api.endpoints.service_plugins.get_plugin',
@@ -1102,7 +1102,7 @@ class ReplacePluginAssignmentsTestCase(support.SharedAppTestCase):
                     json=[
                         {
                             'project_type_slug': 'web',
-                            'tab': 'logs',
+                            'plugin_type': 'logs',
                             'default': True,
                             'options': {},
                         }
@@ -1110,11 +1110,11 @@ class ReplacePluginAssignmentsTestCase(support.SharedAppTestCase):
                 )
         self.assertEqual(response.status_code, 400)
 
-    def test_replace_rejects_duplicate_pt_tab(self) -> None:
+    def test_replace_rejects_duplicate_pt_plugin_type(self) -> None:
         self.mock_db.execute.side_effect = [[{'slug': 'ssm'}]]
         row = {
             'project_type_slug': 'web',
-            'tab': 'configuration',
+            'plugin_type': 'configuration',
             'default': True,
             'options': {},
         }
@@ -1142,7 +1142,7 @@ class ReplacePluginAssignmentsTestCase(support.SharedAppTestCase):
                     json=[
                         {
                             'project_type_slug': 'nope',
-                            'tab': 'configuration',
+                            'plugin_type': 'configuration',
                             'default': True,
                             'options': {},
                         }
@@ -1160,7 +1160,7 @@ class AssignmentRowsTemplateTestCase(unittest.TestCase):
 
         a = _AssignmentInput(
             project_type_slug='web',
-            tab='configuration',
+            plugin_type='configuration',
             default=True,
             options={'k': 'v'},
             identity_plugin_id='',
@@ -1168,6 +1168,24 @@ class AssignmentRowsTemplateTestCase(unittest.TestCase):
         tpl, params = _assignment_rows_template([a])
         self.assertIn('{asgn_0_pt}', tpl)
         self.assertEqual(params['asgn_0_pt'], 'web')
+        self.assertEqual(params['asgn_0_ptype'], 'configuration')
         self.assertEqual(params['asgn_0_options'], json.dumps({'k': 'v'}))
         # Empty identity_plugin_id collapses to null.
         self.assertIsNone(params['asgn_0_idp'])
+
+    def test_input_accepts_webhook_and_analysis_plugin_types(self) -> None:
+        # Regression: the assignment body previously hard-coded a tab
+        # Literal of {configuration, logs, deployment, lifecycle}, so a
+        # webhook (or analysis) plugin assignment was rejected with 422
+        # before ever reaching the manifest plugin_type check. The field
+        # now uses imbi_common's PluginType, covering every plugin type.
+        from imbi_api.endpoints.service_plugins import _AssignmentInput
+
+        for plugin_type in ('webhook', 'analysis'):
+            a = _AssignmentInput(
+                project_type_slug='web',
+                plugin_type=plugin_type,
+                default=True,
+                options={},
+            )
+            self.assertEqual(a.plugin_type, plugin_type)

--- a/tests/test_assignment_writer.py
+++ b/tests/test_assignment_writer.py
@@ -27,7 +27,7 @@ class AssignmentRowsTemplateTestCase(unittest.TestCase):
     def test_serializes_options_and_env_payloads_as_json(self) -> None:
         row: PluginAssignmentRow = {
             'plugin_id': 'p1',
-            'tab': 'configuration',
+            'plugin_type': 'configuration',
             'default': True,
             'options': {'k': 'v'},
             'identity_plugin_id': None,
@@ -44,7 +44,7 @@ class AssignmentRowsTemplateTestCase(unittest.TestCase):
     def test_empty_env_payloads_collapse_to_null(self) -> None:
         row: PluginAssignmentRow = {
             'plugin_id': 'p1',
-            'tab': 'configuration',
+            'plugin_type': 'configuration',
             'default': True,
             'options': {},
             'identity_plugin_id': None,
@@ -70,7 +70,7 @@ class ReplaceAssignmentsQueryTestCase(unittest.TestCase):
         rows: list[PluginAssignmentRow] = [
             {
                 'plugin_id': 'p1',
-                'tab': 'configuration',
+                'plugin_type': 'configuration',
                 'default': True,
                 'options': {},
                 'identity_plugin_id': None,

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -15,67 +15,67 @@ if typing.TYPE_CHECKING:
 
 
 class AssignmentsTestCase(unittest.TestCase):
-    def test_validate_one_default_per_tab_ok(self) -> None:
+    def test_validate_one_default_per_plugin_type_ok(self) -> None:
         from imbi_api.plugins.assignments import (
             PluginAssignmentRow,
-            validate_one_default_per_tab,
+            validate_one_default_per_plugin_type,
         )
 
         rows: list[PluginAssignmentRow] = [
             PluginAssignmentRow(
                 plugin_id='p1',
-                tab='configuration',
+                plugin_type='configuration',
                 default=True,
                 options={},
             ),
             PluginAssignmentRow(
                 plugin_id='p2',
-                tab='logs',
+                plugin_type='logs',
                 default=True,
                 options={},
             ),
         ]
-        validate_one_default_per_tab(rows)
+        validate_one_default_per_plugin_type(rows)
 
-    def test_validate_two_defaults_same_tab_raises(self) -> None:
+    def test_validate_two_defaults_same_plugin_type_raises(self) -> None:
         from imbi_api.plugins.assignments import (
             PluginAssignmentRow,
-            validate_one_default_per_tab,
+            validate_one_default_per_plugin_type,
         )
 
         rows: list[PluginAssignmentRow] = [
             PluginAssignmentRow(
                 plugin_id='p1',
-                tab='configuration',
+                plugin_type='configuration',
                 default=True,
                 options={},
             ),
             PluginAssignmentRow(
                 plugin_id='p2',
-                tab='configuration',
+                plugin_type='configuration',
                 default=True,
                 options={},
             ),
         ]
         with self.assertRaises(ValueError):
-            validate_one_default_per_tab(rows)
+            validate_one_default_per_plugin_type(rows)
 
     def test_validate_no_default_raises(self) -> None:
         from imbi_api.plugins.assignments import (
             PluginAssignmentRow,
-            validate_one_default_per_tab,
+            validate_one_default_per_plugin_type,
         )
 
         rows: list[PluginAssignmentRow] = [
             PluginAssignmentRow(
                 plugin_id='p1',
-                tab='configuration',
+                plugin_type='configuration',
                 default=False,
                 options={},
             ),
         ]
         with self.assertRaises(ValueError):
-            validate_one_default_per_tab(rows)
+            validate_one_default_per_plugin_type(rows)
 
 
 class ParseOptionsTestCase(unittest.TestCase):

--- a/uv.lock
+++ b/uv.lock
@@ -1095,7 +1095,7 @@ requires-dist = [
   { name = "fastapi" },
   { name = "filetype" },
   { name = "httpx", specifier = ">=0.28.1,<1" },
-  { name = "imbi-common", extras = ["databases", "llm", "sentry", "server"], git = "https://github.com/AWeber-Imbi/imbi-common.git?branch=main" },
+  { name = "imbi-common", extras = ["databases", "llm", "sentry", "server"], specifier = "==2.9.1" },
   { name = "imbi-plugin-aws", marker = "extra == 'plugins'", specifier = ">=1.0.0" },
   { name = "imbi-plugin-github", marker = "extra == 'plugins'", specifier = ">=1.0.0" },
   { name = "imbi-plugin-logzio", marker = "extra == 'plugins'", specifier = ">=1.0.0" },
@@ -1148,8 +1148,8 @@ docs = [
 
 [[package]]
 name = "imbi-common"
-version = "2.9.0"
-source = { git = "https://github.com/AWeber-Imbi/imbi-common.git?branch=main#14ee150ddaef60fa29965a345c65bbffb463de89" }
+version = "2.9.1"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
   { name = "cryptography" },
   { name = "httpx" },
@@ -1163,6 +1163,10 @@ dependencies = [
   { name = "pyjwt" },
   { name = "python-slugify" },
   { name = "typer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9a/7a/0dc31034aa22aaa92929eeaf317c6b552e659b5e1557d1bd605edcc6f1cd/imbi_common-2.9.1.tar.gz", hash = "sha256:0808fbe949b3e1c347dcfb7c879c0cc547143e97f85c35c623dfd9971de041a9", size = 336897, upload-time = "2026-06-04T01:38:52.101Z" }
+wheels = [
+  { url = "https://files.pythonhosted.org/packages/14/d7/496d7edcbfc0f6a6551c16abd4e368bb756ee444711c350e09d5b736542b/imbi_common-2.9.1-py3-none-any.whl", hash = "sha256:4b445b30461c7d15e3d1635720f32d95f49f38369b5b1939bff5e9c89545bc6c", size = 107627, upload-time = "2026-06-04T01:38:50.624Z" },
 ]
 
 [package.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -1095,7 +1095,7 @@ requires-dist = [
   { name = "fastapi" },
   { name = "filetype" },
   { name = "httpx", specifier = ">=0.28.1,<1" },
-  { name = "imbi-common", extras = ["databases", "llm", "sentry", "server"], specifier = "==2.9.0" },
+  { name = "imbi-common", extras = ["databases", "llm", "sentry", "server"], editable = "../imbi-common" },
   { name = "imbi-plugin-aws", marker = "extra == 'plugins'", specifier = ">=1.0.0" },
   { name = "imbi-plugin-github", marker = "extra == 'plugins'", specifier = ">=1.0.0" },
   { name = "imbi-plugin-logzio", marker = "extra == 'plugins'", specifier = ">=1.0.0" },
@@ -1116,7 +1116,7 @@ requires-dist = [
   { name = "pyotp", specifier = ">=2.9.0" },
   { name = "python-multipart", specifier = ">=0.0.26" },
   { name = "qrcode", specifier = ">=8.0" },
-  { name = "sentry-sdk", specifier = ">=2.48.0" },
+  { name = "sentry-sdk", specifier = ">=2.48.0,<3" },
   { name = "sentry-sdk", marker = "extra == 'sentry'" },
   { name = "slowapi", specifier = "==0.1.9" },
   { name = "typer" },
@@ -1149,7 +1149,7 @@ docs = [
 [[package]]
 name = "imbi-common"
 version = "2.9.0"
-source = { registry = "https://pypi.org/simple" }
+source = { editable = "../imbi-common" }
 dependencies = [
   { name = "cryptography" },
   { name = "httpx" },
@@ -1163,10 +1163,6 @@ dependencies = [
   { name = "pyjwt" },
   { name = "python-slugify" },
   { name = "typer" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ff/5e/e7306a4bafa6e23ad8fd6dcdaef552d646233b974b4cfd3352750ff57631/imbi_common-2.9.0.tar.gz", hash = "sha256:6687219808b824bc65af7229a6193cf2bf86e5b348ad2d3928126446c288b9ef", size = 336785, upload-time = "2026-06-03T15:52:11.958Z" }
-wheels = [
-  { url = "https://files.pythonhosted.org/packages/c2/dc/3c3e782709e5557620aa37e089233a267b0d73c9da44dbcfad963805f646/imbi_common-2.9.0-py3-none-any.whl", hash = "sha256:a8fad461cc7759e61ba101fa44f047610690805163ab43f8e10c8b97d91f8f0c", size = 107509, upload-time = "2026-06-03T15:52:10.159Z" },
 ]
 
 [package.optional-dependencies]
@@ -1186,6 +1182,72 @@ sentry = [
 server = [
   { name = "fastapi" },
   { name = "uvicorn", extra = ["standard"] },
+]
+
+[package.metadata]
+requires-dist = [
+  { name = "anthropic", marker = "extra == 'llm'", specifier = ">=0.40" },
+  { name = "clickhouse-connect", extras = ["async"], marker = "extra == 'databases'", specifier = "==1.0.0" },
+  { name = "cryptography", specifier = ">=42.0.4" },
+  { name = "fastapi", marker = "extra == 'server'", specifier = ">=0.115.0" },
+  { name = "fastembed", marker = "extra == 'databases'", specifier = ">=0.6" },
+  { name = "fastmcp", marker = "extra == 'mcp'", specifier = ">=3,<4" },
+  { name = "httpx", specifier = ">=0.28.1,<1" },
+  { name = "jsonpointer", specifier = ">=3.1.1" },
+  { name = "jsonschema-models" },
+  { name = "markdown-it-py", specifier = ">=3.0" },
+  { name = "nanoid", specifier = ">=2.0.0" },
+  { name = "opentelemetry-api", marker = "extra == 'otel'", specifier = "==1.41.1" },
+  { name = "opentelemetry-distro", marker = "extra == 'otel'", specifier = "==0.62b1" },
+  { name = "opentelemetry-exporter-otlp-proto-http", marker = "extra == 'otel'", specifier = "==1.41.1" },
+  { name = "opentelemetry-instrumentation-aiohttp-client", marker = "extra == 'otel'", specifier = "==0.62b1" },
+  { name = "opentelemetry-instrumentation-asyncio", marker = "extra == 'otel'", specifier = "==0.62b1" },
+  { name = "opentelemetry-instrumentation-fastapi", marker = "extra == 'otel'", specifier = "==0.62b1" },
+  { name = "opentelemetry-instrumentation-httpx", marker = "extra == 'otel'", specifier = "==0.62b1" },
+  { name = "opentelemetry-instrumentation-mcp", marker = "extra == 'otel'", specifier = "==0.60.0" },
+  { name = "opentelemetry-instrumentation-psycopg", marker = "extra == 'otel'", specifier = "==0.62b1" },
+  { name = "opentelemetry-instrumentation-redis", marker = "extra == 'otel'", specifier = "==0.62b1" },
+  { name = "opentelemetry-sdk", marker = "extra == 'otel'", specifier = "==1.41.1" },
+  { name = "orjson" },
+  { name = "pgvector", marker = "extra == 'databases'", specifier = ">=0.3" },
+  { name = "psycopg", extras = ["binary", "pool"], marker = "extra == 'databases'", specifier = ">=3.3" },
+  { name = "pydantic", extras = ["email"], specifier = ">=2.0" },
+  { name = "pydantic-settings" },
+  { name = "pyjwt", specifier = ">=2.10.1" },
+  { name = "python-slugify" },
+  { name = "sentry-sdk", marker = "extra == 'sentry'", specifier = ">=2.48.0" },
+  { name = "typer", specifier = ">=0.21.1" },
+  { name = "uvicorn", extras = ["standard"], marker = "extra == 'server'", specifier = ">=0.40.0" },
+  { name = "valkey", marker = "extra == 'databases'", specifier = ">=6" },
+]
+provides-extras = ["databases", "llm", "mcp", "otel", "sentry", "server"]
+
+[package.metadata.requires-dev]
+dev = [
+  { name = "basedpyright" },
+  { name = "build" },
+  { name = "click", specifier = "~=8.2.1" },
+  { name = "coverage", extras = ["toml"] },
+  { name = "httpx", specifier = ">=0.28.1,<1" },
+  { name = "mypy", specifier = "~=1.19.1" },
+  { name = "pre-commit" },
+  { name = "pytest" },
+  { name = "ruff", specifier = "~=0.14.6" },
+  { name = "sentry-sdk", specifier = ">=2.48.0" },
+  { name = "tomli-w", specifier = "~=1.2" },
+  { name = "uvicorn", extras = ["standard"], specifier = ">=0.40.0" },
+]
+dist = [
+  { name = "build" },
+  { name = "twine" },
+  { name = "wheel" },
+]
+docs = [
+  { name = "griffe-pydantic" },
+  { name = "mkdocs", specifier = ">=1.5,<2" },
+  { name = "mkdocs-material", specifier = ">9.5,<10" },
+  { name = "mkdocstrings", extras = ["python"] },
+  { name = "mkdocstrings-python-xref", specifier = ">=1.6,<2" },
 ]
 
 [[package]]
@@ -2753,16 +2815,15 @@ wheels = [
 
 [[package]]
 name = "sentry-sdk"
-version = "3.0.0a7"
+version = "2.60.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
   { name = "certifi" },
-  { name = "opentelemetry-sdk" },
   { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/66/a5/747ab268f2cf3f4cb50af521e1a85a959411f74cf4a2ecf47782e1981cee/sentry_sdk-3.0.0a7.tar.gz", hash = "sha256:439a858d409b84407560df6b7ebb760acd9ad3d14e05cd919ae36b204e411cb2", size = 329999, upload-time = "2025-10-20T13:50:38.131Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/a2/2e6c090db384cc515069f4f85542bd5baf6786852073020ea73d4a76d3ea/sentry_sdk-2.60.0.tar.gz", hash = "sha256:0bd25e54e78ca02d0be512529fa644bbbf9e8470d7b26371294012d4ca93c978", size = 452946, upload-time = "2026-05-13T13:34:52.516Z" }
 wheels = [
-  { url = "https://files.pythonhosted.org/packages/ce/5e/23837eadf18ad4f9d5894c1210e6c2591136fd36cff338bedc90a1222bf2/sentry_sdk-3.0.0a7-py2.py3-none-any.whl", hash = "sha256:ada791a77c2d489e07b04c068e0fcacd6bbcfe1cb40b5f303207738baf38e868", size = 353618, upload-time = "2025-10-20T13:50:36.158Z" },
+  { url = "https://files.pythonhosted.org/packages/29/41/f2b800b7f12a05dd48c2a6280d4dd812d1425fc66ed3fe3fd99420c41d1a/sentry_sdk-2.60.0-py3-none-any.whl", hash = "sha256:28a536c03291c8bcb363cf35c611b32738ec118ff64d8d6383b096448ac4c803", size = 475616, upload-time = "2026-05-13T13:34:50.259Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1095,7 +1095,7 @@ requires-dist = [
   { name = "fastapi" },
   { name = "filetype" },
   { name = "httpx", specifier = ">=0.28.1,<1" },
-  { name = "imbi-common", extras = ["databases", "llm", "sentry", "server"], editable = "../imbi-common" },
+  { name = "imbi-common", extras = ["databases", "llm", "sentry", "server"], git = "https://github.com/AWeber-Imbi/imbi-common.git?branch=main" },
   { name = "imbi-plugin-aws", marker = "extra == 'plugins'", specifier = ">=1.0.0" },
   { name = "imbi-plugin-github", marker = "extra == 'plugins'", specifier = ">=1.0.0" },
   { name = "imbi-plugin-logzio", marker = "extra == 'plugins'", specifier = ">=1.0.0" },
@@ -1149,7 +1149,7 @@ docs = [
 [[package]]
 name = "imbi-common"
 version = "2.9.0"
-source = { editable = "../imbi-common" }
+source = { git = "https://github.com/AWeber-Imbi/imbi-common.git?branch=main#14ee150ddaef60fa29965a345c65bbffb463de89" }
 dependencies = [
   { name = "cryptography" },
   { name = "httpx" },
@@ -1182,72 +1182,6 @@ sentry = [
 server = [
   { name = "fastapi" },
   { name = "uvicorn", extra = ["standard"] },
-]
-
-[package.metadata]
-requires-dist = [
-  { name = "anthropic", marker = "extra == 'llm'", specifier = ">=0.40" },
-  { name = "clickhouse-connect", extras = ["async"], marker = "extra == 'databases'", specifier = "==1.0.0" },
-  { name = "cryptography", specifier = ">=42.0.4" },
-  { name = "fastapi", marker = "extra == 'server'", specifier = ">=0.115.0" },
-  { name = "fastembed", marker = "extra == 'databases'", specifier = ">=0.6" },
-  { name = "fastmcp", marker = "extra == 'mcp'", specifier = ">=3,<4" },
-  { name = "httpx", specifier = ">=0.28.1,<1" },
-  { name = "jsonpointer", specifier = ">=3.1.1" },
-  { name = "jsonschema-models" },
-  { name = "markdown-it-py", specifier = ">=3.0" },
-  { name = "nanoid", specifier = ">=2.0.0" },
-  { name = "opentelemetry-api", marker = "extra == 'otel'", specifier = "==1.41.1" },
-  { name = "opentelemetry-distro", marker = "extra == 'otel'", specifier = "==0.62b1" },
-  { name = "opentelemetry-exporter-otlp-proto-http", marker = "extra == 'otel'", specifier = "==1.41.1" },
-  { name = "opentelemetry-instrumentation-aiohttp-client", marker = "extra == 'otel'", specifier = "==0.62b1" },
-  { name = "opentelemetry-instrumentation-asyncio", marker = "extra == 'otel'", specifier = "==0.62b1" },
-  { name = "opentelemetry-instrumentation-fastapi", marker = "extra == 'otel'", specifier = "==0.62b1" },
-  { name = "opentelemetry-instrumentation-httpx", marker = "extra == 'otel'", specifier = "==0.62b1" },
-  { name = "opentelemetry-instrumentation-mcp", marker = "extra == 'otel'", specifier = "==0.60.0" },
-  { name = "opentelemetry-instrumentation-psycopg", marker = "extra == 'otel'", specifier = "==0.62b1" },
-  { name = "opentelemetry-instrumentation-redis", marker = "extra == 'otel'", specifier = "==0.62b1" },
-  { name = "opentelemetry-sdk", marker = "extra == 'otel'", specifier = "==1.41.1" },
-  { name = "orjson" },
-  { name = "pgvector", marker = "extra == 'databases'", specifier = ">=0.3" },
-  { name = "psycopg", extras = ["binary", "pool"], marker = "extra == 'databases'", specifier = ">=3.3" },
-  { name = "pydantic", extras = ["email"], specifier = ">=2.0" },
-  { name = "pydantic-settings" },
-  { name = "pyjwt", specifier = ">=2.10.1" },
-  { name = "python-slugify" },
-  { name = "sentry-sdk", marker = "extra == 'sentry'", specifier = ">=2.48.0" },
-  { name = "typer", specifier = ">=0.21.1" },
-  { name = "uvicorn", extras = ["standard"], marker = "extra == 'server'", specifier = ">=0.40.0" },
-  { name = "valkey", marker = "extra == 'databases'", specifier = ">=6" },
-]
-provides-extras = ["databases", "llm", "mcp", "otel", "sentry", "server"]
-
-[package.metadata.requires-dev]
-dev = [
-  { name = "basedpyright" },
-  { name = "build" },
-  { name = "click", specifier = "~=8.2.1" },
-  { name = "coverage", extras = ["toml"] },
-  { name = "httpx", specifier = ">=0.28.1,<1" },
-  { name = "mypy", specifier = "~=1.19.1" },
-  { name = "pre-commit" },
-  { name = "pytest" },
-  { name = "ruff", specifier = "~=0.14.6" },
-  { name = "sentry-sdk", specifier = ">=2.48.0" },
-  { name = "tomli-w", specifier = "~=1.2" },
-  { name = "uvicorn", extras = ["standard"], specifier = ">=0.40.0" },
-]
-dist = [
-  { name = "build" },
-  { name = "twine" },
-  { name = "wheel" },
-]
-docs = [
-  { name = "griffe-pydantic" },
-  { name = "mkdocs", specifier = ">=1.5,<2" },
-  { name = "mkdocs-material", specifier = ">9.5,<10" },
-  { name = "mkdocstrings", extras = ["python"] },
-  { name = "mkdocstrings-python-xref", specifier = ">=1.6,<2" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Renames the plugin-assignment field and the stored `:USES_PLUGIN` edge property `tab` → `plugin_type`, fixing the 422 when assigning a **webhook** (or analysis) plugin to a project type.

## Problem

```
PUT .../plugins/<id>/assignments  body: [{"tab":"webhook", ...}]
422: Input should be 'configuration', 'logs', 'deployment' or 'lifecycle'
```

The field was named `tab`, but the endpoint already validated it against `entry.manifest.plugin_type` — i.e. `tab` was always the plugin type. The hand-maintained `tab` `Literal` (duplicated in 5 spots) had drifted from imbi-common's `PluginManifest.plugin_type`, which gained `webhook` and `analysis`. `resolution.py` already queried `tab:'analysis'` edges, confirming the property has always been the plugin type.

## Solution

- Import `PluginType` from imbi-common (single source of truth, see AWeber-Imbi/imbi-common#152) and replace the drifted Literal in all 5 spots.
- Rename `tab` → `plugin_type` across the assignment models, the validator (`validate_one_default_per_plugin_type`), and every Cypher read/write of the `:USES_PLUGIN` edge property (`assignment_writer`, `service_plugins`, `resolution`, `third_party_services`).
- Edge readers fall back to the legacy `tab` property until the migration runs (transitional; drop afterward).
- Whether a plugin type renders a project-detail tab stays a UI concern (imbi-ui PR).

## Data migration (run once)

AGE graph `imbi`; setting a property to `NULL` removes it:

```sql
SET search_path = ag_catalog, "$user", public;
SELECT * FROM cypher('imbi', $$
  MATCH ()-[e:USES_PLUGIN]->()
  WHERE e.tab IS NOT NULL
  SET e.plugin_type = e.tab, e.tab = NULL
$$) AS (e agtype);
```

## Dependency / CI note

`PluginType` is unreleased in imbi-common, so this pins imbi-common via a `[tool.uv.sources]` editable path to `../imbi-common` (interim; swap to a `==` pin once the next imbi-common release is cut). **CI will be red until imbi-common#152 merges to `main` and the lock is refreshed** — this is the expected cross-repo merge order. Re-locking for the source change pulled `sentry-sdk` to the abandoned `3.0.0a7`, so it's capped at `<3` to stay on the supported 2.x line.

## Testing

- mypy + basedpyright clean; ruff clean (changed files)
- Full suite: **2150 passed, 1 skipped** (against editable imbi-common with `PluginType`)
- New regression test: `_AssignmentInput` accepts `webhook`/`analysis` plugin types

## Related

- imbi-common: AWeber-Imbi/imbi-common#152 (PluginType export)
- imbi-ui: AWeber-Imbi/imbi-ui#405 (matching rename)