### PR TITLE
Add on-demand commit/tag history sync (background worker)

### DIFF
--- a/src/imbi_api/app.py
+++ b/src/imbi_api/app.py
@@ -25,6 +25,7 @@ def create_app() -> fastapi.FastAPI:
             lifespans.anthropic_hook,
             valkey.valkey_lifespan,
             lifespans.score_worker_hook,
+            lifespans.commit_sync_worker_hook,
             lifespans.identity_refresh_hook,
         ),
         version=version,

--- a/src/imbi_api/commit_sync/__init__.py
+++ b/src/imbi_api/commit_sync/__init__.py
@@ -1,0 +1,28 @@
+"""On-demand commit/tag history sync for imbi-api.
+
+A project-scoped "Sync Commits & Tags" action (Project Doctor) enqueues a
+Valkey-stream job; a background worker resolves the project's
+``github-commit-sync`` webhook plugin, runs a full default-branch +
+all-tags backfill via the plugin's service credential, and records the
+last-sync status on the ``Project`` node for the UI to poll.
+"""
+
+from imbi_api.commit_sync.queue import (
+    consume_commit_sync,
+    enqueue_commit_sync,
+)
+from imbi_api.commit_sync.service import (
+    CommitSyncStatus,
+    CommitSyncUnavailable,
+    read_status,
+    run_sync,
+)
+
+__all__ = [
+    'CommitSyncStatus',
+    'CommitSyncUnavailable',
+    'consume_commit_sync',
+    'enqueue_commit_sync',
+    'read_status',
+    'run_sync',
+]

--- a/src/imbi_api/commit_sync/queue.py
+++ b/src/imbi_api/commit_sync/queue.py
@@ -1,0 +1,242 @@
+"""Commit/tag-sync queue (Valkey Streams).
+
+Mirrors :mod:`imbi_api.scoring.queue`: a single consumer group drains an
+``imbi:commit-sync`` stream, with a per-project debounce, stale-entry
+reclaim, and a dead-letter queue after repeated failures.  Each job runs
+a full commit/tag backfill via :func:`commit_sync.service.run_sync` and
+records the outcome on the ``Project`` node.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import typing
+from collections import abc
+
+from imbi_common import graph
+from valkey import asyncio as valkey
+
+from imbi_api.commit_sync.service import (
+    CommitSyncUnavailable,
+    run_sync,
+    set_status,
+)
+
+STREAM = 'imbi:commit-sync'
+GROUP = 'commit-sync-workers'
+CONSUMER_PREFIX = 'worker'
+DLQ = 'imbi:commit-sync:dlq'
+DEBOUNCE_PREFIX = 'imbi:commit-sync:debounce'
+DEBOUNCE_SECONDS = 10
+MAX_DELIVERIES = 3
+CLAIM_IDLE_MS = 120_000
+
+LOGGER = logging.getLogger(__name__)
+
+
+async def enqueue_commit_sync(
+    client: valkey.Valkey | None,
+    org_slug: str,
+    project_id: str,
+    requested_by: str | None = None,
+) -> bool:
+    """Debounce-then-XADD a commit-sync job. Returns True if enqueued.
+
+    Tolerates *client* being ``None`` (returns False) so the endpoint can
+    surface "queueing unavailable" rather than 500 when Valkey is down.
+    """
+    if client is None:
+        return False
+    try:
+        key = f'{DEBOUNCE_PREFIX}:{project_id}'
+        acquired = await client.set(key, b'1', ex=DEBOUNCE_SECONDS, nx=True)
+        if not acquired:
+            return False
+        await client.xadd(
+            STREAM,
+            {
+                'org_slug': org_slug,
+                'project_id': project_id,
+                'requested_by': requested_by or 'system',
+            },
+        )
+    except Exception:
+        LOGGER.exception('enqueue_commit_sync failed for %s', project_id)
+        return False
+    return True
+
+
+async def ensure_group(client: valkey.Valkey) -> None:
+    try:
+        await client.xgroup_create(STREAM, GROUP, id='$', mkstream=True)
+    except Exception as err:  # noqa: BLE001
+        if 'BUSYGROUP' not in str(err):
+            LOGGER.warning('xgroup_create failed: %s', err)
+
+
+async def _process_message(db: graph.Graph, fields: dict[str, str]) -> None:
+    project_id = fields.get('project_id')
+    org_slug = fields.get('org_slug') or ''
+    requested_by = fields.get('requested_by') or 'system'
+    if not project_id:
+        return
+    await set_status(
+        db, project_id, status='running', requested_by=requested_by
+    )
+    try:
+        commits, tags = await run_sync(db, org_slug, project_id)
+    except CommitSyncUnavailable as exc:
+        # Misconfiguration, not transient: record and don't retry.
+        LOGGER.warning('commit-sync unavailable for %s: %s', project_id, exc)
+        await set_status(
+            db,
+            project_id,
+            status='failed',
+            requested_by=requested_by,
+            error=str(exc),
+        )
+        return
+    except Exception as exc:
+        await set_status(
+            db,
+            project_id,
+            status='failed',
+            requested_by=requested_by,
+            error=f'{type(exc).__name__}: {exc}',
+        )
+        raise
+    LOGGER.info(
+        'commit-sync for %s recorded %d commits, %d tags',
+        project_id,
+        commits,
+        tags,
+    )
+    await set_status(
+        db,
+        project_id,
+        status='success',
+        requested_by=requested_by,
+        commits=commits,
+        tags=tags,
+    )
+
+
+def _decode_fields(
+    raw: abc.Mapping[bytes | str, bytes | str],
+) -> dict[str, str]:
+    return {
+        (k.decode() if isinstance(k, bytes) else k): (
+            v.decode() if isinstance(v, bytes) else v
+        )
+        for k, v in raw.items()
+    }
+
+
+async def _claim_stale(
+    client: valkey.Valkey,
+    consumer: str,
+) -> list[tuple[bytes, abc.Mapping[bytes | str, bytes | str]]]:
+    try:
+        result = await client.xautoclaim(
+            STREAM,
+            GROUP,
+            consumer,
+            min_idle_time=CLAIM_IDLE_MS,
+            start_id='0-0',
+            count=16,
+        )
+    except Exception as err:  # noqa: BLE001
+        LOGGER.debug('xautoclaim failed: %s', err)
+        return []
+    if isinstance(result, (list, tuple)) and len(result) >= 2:  # type: ignore[arg-type]
+        msgs: object = result[1]  # type: ignore[index]
+        if isinstance(msgs, list):
+            return msgs  # type: ignore[return-value]
+    return []
+
+
+async def _maybe_dead_letter(
+    client: valkey.Valkey,
+    msg_id: bytes,
+    fields: dict[str, str],
+) -> bool:
+    try:
+        info = await client.xpending_range(
+            STREAM, GROUP, min=msg_id, max=msg_id, count=1
+        )
+    except Exception:  # noqa: BLE001
+        return False
+    if not info:
+        return False
+    entry: object = info[0]  # type: ignore[index]
+    delivered: int | None = None
+    if isinstance(entry, dict):
+        raw_delivered = entry.get('times_delivered')  # type: ignore[union-attr]
+        if raw_delivered is not None:
+            delivered = int(raw_delivered)  # type: ignore[arg-type]
+    elif isinstance(entry, (list, tuple)) and len(entry) >= 4:  # type: ignore[arg-type]
+        raw_delivered = entry[3]  # type: ignore[index]
+        if raw_delivered is not None:
+            delivered = int(raw_delivered)  # type: ignore[arg-type]
+    if delivered is not None and delivered >= MAX_DELIVERIES:
+        await client.xadd(DLQ, fields)
+        await client.xack(STREAM, GROUP, msg_id)
+        LOGGER.warning(
+            'dead-lettered commit-sync msg %s after %s deliveries',
+            msg_id,
+            delivered,
+        )
+        return True
+    return False
+
+
+async def _handle_entries(
+    client: valkey.Valkey,
+    entries: list[tuple[bytes, abc.Mapping[bytes | str, bytes | str]]],
+    db: graph.Graph,
+    check_dlq: bool = False,
+) -> None:
+    for msg_id, raw_fields in entries:
+        fields = _decode_fields(raw_fields)
+        if check_dlq and await _maybe_dead_letter(client, msg_id, fields):
+            continue
+        try:
+            await _process_message(db, fields)
+        except Exception:
+            LOGGER.exception('commit-sync failed for %s', fields)
+            continue
+        await client.xack(STREAM, GROUP, msg_id)
+
+
+async def consume_commit_sync(
+    client: valkey.Valkey,
+    db: graph.Graph,
+    consumer: str = f'{CONSUMER_PREFIX}-0',
+    stop: asyncio.Event | None = None,
+) -> None:
+    """Run the commit-sync consumer loop until *stop* is set."""
+    await ensure_group(client)
+    LOGGER.info('Commit-sync consumer loop running (consumer=%s)', consumer)
+    while stop is None or not stop.is_set():
+        stale = await _claim_stale(client, consumer)
+        if stale:
+            await _handle_entries(client, stale, db, check_dlq=True)
+        try:
+            response = await client.xreadgroup(
+                GROUP,
+                consumer,
+                {STREAM: '>'},
+                count=16,
+                block=2000,
+            )
+        except Exception:
+            LOGGER.exception('xreadgroup failed')
+            await asyncio.sleep(1)
+            continue
+        if not response:
+            continue
+        for _stream, entries in typing.cast(
+            'list[tuple[object, list[typing.Any]]]', response
+        ):
+            await _handle_entries(client, entries, db)

--- a/src/imbi_api/commit_sync/queue.py
+++ b/src/imbi_api/commit_sync/queue.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
+import socket
 import typing
 from collections import abc
 
@@ -48,8 +50,8 @@ async def enqueue_commit_sync(
     """
     if client is None:
         return False
+    key = f'{DEBOUNCE_PREFIX}:{project_id}'
     try:
-        key = f'{DEBOUNCE_PREFIX}:{project_id}'
         acquired = await client.set(key, b'1', ex=DEBOUNCE_SECONDS, nx=True)
         if not acquired:
             return False
@@ -62,6 +64,12 @@ async def enqueue_commit_sync(
             },
         )
     except Exception:
+        # Release the debounce key so a transient Valkey write failure
+        # doesn't block the user's immediate retry for DEBOUNCE_SECONDS.
+        try:
+            await client.delete(key)
+        except Exception:
+            LOGGER.exception('failed to clear debounce key for %s', project_id)
         LOGGER.exception('enqueue_commit_sync failed for %s', project_id)
         return False
     return True
@@ -70,9 +78,10 @@ async def enqueue_commit_sync(
 async def ensure_group(client: valkey.Valkey) -> None:
     try:
         await client.xgroup_create(STREAM, GROUP, id='$', mkstream=True)
-    except Exception as err:  # noqa: BLE001
+    except Exception as err:
         if 'BUSYGROUP' not in str(err):
-            LOGGER.warning('xgroup_create failed: %s', err)
+            LOGGER.exception('xgroup_create failed')
+            raise
 
 
 async def _process_message(db: graph.Graph, fields: dict[str, str]) -> None:
@@ -97,13 +106,16 @@ async def _process_message(db: graph.Graph, fields: dict[str, str]) -> None:
             error=str(exc),
         )
         return
-    except Exception as exc:
+    except Exception:
+        # Persist a generic, user-safe message; the polling endpoint
+        # exposes this status, so keep raw exception detail in logs only.
+        LOGGER.exception('commit-sync run failed for %s', project_id)
         await set_status(
             db,
             project_id,
             status='failed',
             requested_by=requested_by,
-            error=f'{type(exc).__name__}: {exc}',
+            error='Commit sync failed. See server logs for details.',
         )
         raise
     LOGGER.info(
@@ -212,16 +224,26 @@ async def _handle_entries(
 async def consume_commit_sync(
     client: valkey.Valkey,
     db: graph.Graph,
-    consumer: str = f'{CONSUMER_PREFIX}-0',
+    consumer: str | None = None,
     stop: asyncio.Event | None = None,
 ) -> None:
     """Run the commit-sync consumer loop until *stop* is set."""
+    # Derive a per-process consumer name so concurrent workers don't share
+    # a Pending Entries List and stale-claim each other's in-flight jobs.
+    consumer = (
+        consumer or f'{CONSUMER_PREFIX}-{socket.gethostname()}-{os.getpid()}'
+    )
     await ensure_group(client)
     LOGGER.info('Commit-sync consumer loop running (consumer=%s)', consumer)
     while stop is None or not stop.is_set():
         stale = await _claim_stale(client, consumer)
         if stale:
-            await _handle_entries(client, stale, db, check_dlq=True)
+            try:
+                await _handle_entries(client, stale, db, check_dlq=True)
+            except Exception:
+                LOGGER.exception('commit-sync stale-entry handling failed')
+                await asyncio.sleep(1)
+                continue
         try:
             response = await client.xreadgroup(
                 GROUP,
@@ -239,4 +261,9 @@ async def consume_commit_sync(
         for _stream, entries in typing.cast(
             'list[tuple[object, list[typing.Any]]]', response
         ):
-            await _handle_entries(client, entries, db)
+            try:
+                await _handle_entries(client, entries, db)
+            except Exception:
+                LOGGER.exception('commit-sync entry handling failed')
+                await asyncio.sleep(1)
+                break

--- a/src/imbi_api/commit_sync/service.py
+++ b/src/imbi_api/commit_sync/service.py
@@ -1,0 +1,311 @@
+"""Resolve + invoke the commit-sync plugin and track its status.
+
+The on-demand sync acts with the ``github-commit-sync`` plugin's
+*service* credential (PAT or GitHub App), so there is no acting user: the
+worker resolves the plugin attached to a ``ThirdPartyService`` the project
+``EXISTS_IN``, builds the :class:`PluginContext` it needs (project links +
+the connected ``service_plugins`` for host resolution), decrypts the
+credential, and awaits the plugin's ``sync_all_history`` method.
+
+Last-sync state is persisted as a handful of properties on the ``Project``
+node so the UI can poll it without a dedicated status store.
+"""
+
+from __future__ import annotations
+
+import datetime
+import logging
+import typing
+from collections import abc
+
+import pydantic
+from imbi_common import graph
+from imbi_common.plugins.base import PluginContext, ServicePlugin
+from imbi_common.plugins.errors import PluginNotFoundError
+from imbi_common.plugins.registry import RegistryEntry, get_plugin
+
+from imbi_api.plugins import parse_options
+from imbi_api.plugins.credentials import get_plugin_credentials
+
+LOGGER = logging.getLogger(__name__)
+
+_COMMIT_SYNC_SLUG = 'github-commit-sync'
+# Persisted error strings are truncated so a noisy upstream message can't
+# bloat the Project node.
+_MAX_ERROR_LEN = 500
+
+SyncState = typing.Literal['idle', 'queued', 'running', 'success', 'failed']
+
+
+class CommitSyncUnavailable(Exception):
+    """No ``github-commit-sync`` plugin is reachable for the project."""
+
+
+class CommitSyncStatus(pydantic.BaseModel):
+    """Last-sync state for a project's commit/tag history."""
+
+    status: SyncState = 'idle'
+    last_synced_at: datetime.datetime | None = None
+    commits_synced: int | None = None
+    tags_synced: int | None = None
+    error: str | None = None
+    requested_by: str | None = None
+
+
+class _ResolvedCommitSync(typing.NamedTuple):
+    plugin_id: str
+    entry: RegistryEntry
+    tps_slug: str
+    service_endpoint: str | None
+    service_plugins: list[ServicePlugin]
+
+
+async def _resolve_plugin(
+    db: graph.Graph, project_id: str
+) -> _ResolvedCommitSync:
+    """Find the ``github-commit-sync`` plugin attached to a service the
+    project ``EXISTS_IN`` and gather the sibling plugins on that service.
+
+    Raises :class:`CommitSyncUnavailable` when no such plugin is
+    configured (or its registry entry is missing).
+    """
+    query: typing.LiteralString = """
+    MATCH (proj:Project {{id: {project_id}}})
+      -[:EXISTS_IN]->(tps:ThirdPartyService)
+      -[:HAS_PLUGIN]->(csp:Plugin {{plugin_slug: {slug}}})
+    OPTIONAL MATCH (tps)-[:HAS_PLUGIN]->(sib:Plugin)
+    WITH tps, csp,
+      collect(DISTINCT {{slug: sib.plugin_slug, options: sib.options}})
+        AS siblings
+    RETURN csp.id AS plugin_id,
+           tps.slug AS tps_slug,
+           tps.api_endpoint AS api_endpoint,
+           siblings AS siblings
+    LIMIT 1
+    """
+    records = await db.execute(
+        query,
+        {'project_id': project_id, 'slug': _COMMIT_SYNC_SLUG},
+        ['plugin_id', 'tps_slug', 'api_endpoint', 'siblings'],
+    )
+    if not records:
+        raise CommitSyncUnavailable(
+            'No github-commit-sync plugin is connected to a service this '
+            'project belongs to; configure it on the GitHub service.'
+        )
+    record = records[0]
+    plugin_id = graph.parse_agtype(record.get('plugin_id'))
+    if not plugin_id:
+        raise CommitSyncUnavailable(
+            'github-commit-sync plugin row is missing an id'
+        )
+    try:
+        entry = get_plugin(_COMMIT_SYNC_SLUG)
+    except PluginNotFoundError as exc:
+        raise CommitSyncUnavailable(
+            'github-commit-sync plugin is not loaded in the registry'
+        ) from exc
+    tps_slug = graph.parse_agtype(record.get('tps_slug'))
+    api_endpoint = graph.parse_agtype(record.get('api_endpoint'))
+    siblings = typing.cast(
+        'list[dict[str, typing.Any]]',
+        graph.parse_agtype(record.get('siblings')) or [],
+    )
+    service_plugins: list[ServicePlugin] = []
+    for sib in siblings:
+        slug = sib.get('slug')
+        if not slug:
+            continue
+        service_plugins.append(
+            ServicePlugin(
+                slug=str(slug), options=parse_options(sib.get('options'))
+            )
+        )
+    return _ResolvedCommitSync(
+        plugin_id=str(plugin_id),
+        entry=entry,
+        tps_slug=str(tps_slug) if tps_slug else '',
+        service_endpoint=str(api_endpoint) if api_endpoint else None,
+        service_plugins=service_plugins,
+    )
+
+
+async def _build_context(
+    db: graph.Graph,
+    org_slug: str,
+    project_id: str,
+    resolved: _ResolvedCommitSync,
+) -> PluginContext:
+    """Assemble the :class:`PluginContext` the plugin needs (no actor)."""
+    # Imported here (not at module load) so the worker/service module
+    # never pulls the endpoints package at import time.
+    from imbi_api.endpoints import _helpers
+
+    project_slug, team_slug = await _helpers.lookup_project_slugs(
+        db, project_id
+    )
+    project_links = await _helpers.lookup_project_links(db, project_id)
+    project_type_slugs = await _helpers.lookup_project_type_slugs(
+        db, project_id
+    )
+    service_connections = await _helpers.lookup_project_exists_in(
+        db, project_id
+    )
+    assignment_options: dict[str, typing.Any] = {
+        'service_slug': resolved.tps_slug,
+    }
+    if resolved.service_endpoint:
+        assignment_options['service_endpoint'] = resolved.service_endpoint
+    return PluginContext(
+        project_id=project_id,
+        project_slug=project_slug,
+        org_slug=org_slug,
+        team_slug=team_slug,
+        assignment_options=assignment_options,
+        service_plugins=resolved.service_plugins,
+        project_links=project_links,
+        project_type_slugs=project_type_slugs,
+        third_party_service_slug=resolved.tps_slug or None,
+        service_connections=service_connections,
+    )
+
+
+async def check_available(db: graph.Graph, project_id: str) -> None:
+    """Raise :class:`CommitSyncUnavailable` if the project can't be synced.
+
+    Used by the enqueue endpoint to fail fast (400) rather than queueing a
+    job that the worker can only mark failed.
+    """
+    await _resolve_plugin(db, project_id)
+
+
+async def run_sync(
+    db: graph.Graph, org_slug: str, project_id: str
+) -> tuple[int, int]:
+    """Resolve the commit-sync plugin and run a full history backfill.
+
+    Returns ``(commits_recorded, tags_recorded)``.  Raises
+    :class:`CommitSyncUnavailable` when no plugin/credential is
+    configured; other failures propagate so the caller can record them.
+    """
+    resolved = await _resolve_plugin(db, project_id)
+    ctx = await _build_context(db, org_slug, project_id, resolved)
+    credentials = await get_plugin_credentials(
+        db, resolved.plugin_id, resolved.entry
+    )
+    handler = resolved.entry.handler_cls()
+    sync = getattr(handler, 'sync_all_history', None)
+    if sync is None:
+        raise CommitSyncUnavailable(
+            'github-commit-sync plugin does not implement sync_all_history; '
+            'upgrade imbi-plugin-github'
+        )
+    sync_fn = typing.cast(
+        'abc.Callable[..., abc.Awaitable[tuple[int, int]]]', sync
+    )
+    return await sync_fn(ctx=ctx, credentials=credentials)
+
+
+def _now_iso() -> str:
+    return datetime.datetime.now(datetime.UTC).isoformat()
+
+
+async def set_status(
+    db: graph.Graph,
+    project_id: str,
+    *,
+    status: SyncState,
+    requested_by: str = '',
+    commits: int = 0,
+    tags: int = 0,
+    error: str = '',
+) -> None:
+    """Persist last-sync state on the ``Project`` node (best-effort)."""
+    query: typing.LiteralString = """
+    MATCH (p:Project {{id: {project_id}}})
+    SET p.commit_sync_status = {status},
+        p.commit_sync_at = {at},
+        p.commit_sync_by = {by},
+        p.commit_sync_commits = {commits},
+        p.commit_sync_tags = {tags},
+        p.commit_sync_error = {error}
+    RETURN p.id AS id
+    """
+    try:
+        await db.execute(
+            query,
+            {
+                'project_id': project_id,
+                'status': status,
+                'at': _now_iso(),
+                'by': requested_by,
+                'commits': commits,
+                'tags': tags,
+                'error': error[:_MAX_ERROR_LEN],
+            },
+            ['id'],
+        )
+    except Exception:  # noqa: BLE001
+        LOGGER.warning(
+            'Failed to persist commit-sync status for project %s',
+            project_id,
+            exc_info=True,
+        )
+
+
+def _opt_str(value: object) -> str | None:
+    text = str(value) if value is not None else ''
+    return text or None
+
+
+def _opt_int(value: object) -> int | None:
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        try:
+            return int(value)
+        except ValueError:
+            return None
+    return None
+
+
+async def read_status(db: graph.Graph, project_id: str) -> CommitSyncStatus:
+    """Read last-sync state from the ``Project`` node (``idle`` default)."""
+    query: typing.LiteralString = """
+    MATCH (p:Project {{id: {project_id}}})
+    RETURN p.commit_sync_status AS status,
+           p.commit_sync_at AS at,
+           p.commit_sync_by AS by,
+           p.commit_sync_commits AS commits,
+           p.commit_sync_tags AS tags,
+           p.commit_sync_error AS error
+    """
+    records = await db.execute(
+        query,
+        {'project_id': project_id},
+        ['status', 'at', 'by', 'commits', 'tags', 'error'],
+    )
+    if not records:
+        return CommitSyncStatus()
+    row = records[0]
+    status_raw = graph.parse_agtype(row.get('status'))
+    status: SyncState = 'idle'
+    if status_raw in ('queued', 'running', 'success', 'failed', 'idle'):
+        status = status_raw
+    at_raw = _opt_str(graph.parse_agtype(row.get('at')))
+    last_synced_at: datetime.datetime | None = None
+    if at_raw:
+        try:
+            last_synced_at = datetime.datetime.fromisoformat(at_raw)
+        except ValueError:
+            last_synced_at = None
+    return CommitSyncStatus(
+        status=status,
+        last_synced_at=last_synced_at,
+        commits_synced=_opt_int(graph.parse_agtype(row.get('commits'))),
+        tags_synced=_opt_int(graph.parse_agtype(row.get('tags'))),
+        error=_opt_str(graph.parse_agtype(row.get('error'))),
+        requested_by=_opt_str(graph.parse_agtype(row.get('by'))),
+    )

--- a/src/imbi_api/endpoints/organizations.py
+++ b/src/imbi_api/endpoints/organizations.py
@@ -22,6 +22,7 @@ from .identity_plugins import identity_plugins_router
 from .link_definitions import link_definitions_router
 from .operations_log import operations_log_project_router
 from .project_analysis import project_analysis_router
+from .project_commit_sync import project_commit_sync_router
 from .project_configuration import project_configuration_router
 from .project_deployments import project_deployments_router
 from .project_logs import project_logs_router
@@ -141,6 +142,10 @@ organizations_router.include_router(
 organizations_router.include_router(
     project_analysis_router,
     prefix='/{org_slug}/projects/{project_id}/analysis',
+)
+organizations_router.include_router(
+    project_commit_sync_router,
+    prefix='/{org_slug}/projects/{project_id}/commits',
 )
 organizations_router.include_router(
     pull_requests_project_router,

--- a/src/imbi_api/endpoints/project_commit_sync.py
+++ b/src/imbi_api/endpoints/project_commit_sync.py
@@ -1,0 +1,83 @@
+"""On-demand commit/tag history sync endpoints (Project Doctor).
+
+``POST /sync`` enqueues a background backfill of the project's full
+default-branch commit history and tag list; ``GET /sync-status`` returns
+the last-run state for the UI to poll.  The work runs as a Valkey-stream
+job (no request-scoped user) using the ``github-commit-sync`` plugin's
+service credential, so the endpoint only validates eligibility and
+enqueues.
+"""
+
+import typing
+
+import fastapi
+import pydantic
+from imbi_common import graph
+
+from imbi_api.auth import permissions
+from imbi_api.commit_sync import service
+from imbi_api.commit_sync.queue import enqueue_commit_sync
+from imbi_api.plugins.resolution import resolve_plugin
+from imbi_api.scoring import OptionalValkeyClient
+
+project_commit_sync_router = fastapi.APIRouter(tags=['Project: Commits'])
+
+
+class CommitSyncEnqueueResponse(pydantic.BaseModel):
+    """Result of enqueueing a commit/tag sync."""
+
+    enqueued: bool
+
+
+@project_commit_sync_router.post('/sync', status_code=202)
+async def sync_commits_and_tags(
+    org_slug: str,
+    project_id: str,
+    db: graph.Pool,
+    valkey_client: OptionalValkeyClient,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('project:deployment:write'),
+        ),
+    ],
+) -> CommitSyncEnqueueResponse:
+    """Enqueue a full commit + tag history backfill for the project.
+
+    Requires the project to have a GitHub deployment plugin (the same
+    gate as deployment resync) and a connected ``github-commit-sync``
+    plugin to provide the service credential.  Returns ``enqueued=False``
+    when the job was debounced or Valkey is unavailable.
+    """
+    # Eligibility gate: a deployment plugin must resolve (404 otherwise).
+    await resolve_plugin(db, project_id, 'deployment', None)
+    try:
+        await service.check_available(db, project_id)
+    except service.CommitSyncUnavailable as exc:
+        raise fastapi.HTTPException(status_code=400, detail=str(exc)) from exc
+    requested_by = auth.principal_name
+    enqueued = await enqueue_commit_sync(
+        valkey_client, org_slug, project_id, requested_by
+    )
+    if enqueued:
+        await service.set_status(
+            db, project_id, status='queued', requested_by=requested_by
+        )
+    return CommitSyncEnqueueResponse(enqueued=enqueued)
+
+
+@project_commit_sync_router.get('/sync-status')
+async def get_commit_sync_status(
+    org_slug: str,
+    project_id: str,
+    db: graph.Pool,
+    _auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('project:deployment:read'),
+        ),
+    ],
+) -> service.CommitSyncStatus:
+    """Return the project's last commit/tag sync state."""
+    del org_slug
+    return await service.read_status(db, project_id)

--- a/src/imbi_api/lifespans.py
+++ b/src/imbi_api/lifespans.py
@@ -14,6 +14,7 @@ from imbi_common import clickhouse, graph, valkey
 from imbi_common.llm import AnthropicClient
 
 from imbi_api import openapi
+from imbi_api.commit_sync import queue as commit_sync_queue
 from imbi_api.email.client import EmailClient
 from imbi_api.email.templates import TemplateManager
 from imbi_api.identity import sweeper as identity_sweeper
@@ -129,6 +130,39 @@ async def identity_refresh_hook() -> abc.AsyncGenerator[None]:
             pass
         except Exception:  # noqa: BLE001
             LOGGER.warning('Identity sweeper exited with error', exc_info=True)
+
+
+@contextlib.asynccontextmanager
+async def commit_sync_worker_hook() -> abc.AsyncGenerator[None]:
+    """Run the on-demand commit/tag-sync consumer loop."""
+    try:
+        client = valkey.get_client()
+    except RuntimeError:
+        LOGGER.warning('Valkey unavailable; commit-sync worker not started')
+        yield None
+        return
+    if _graph is None:
+        LOGGER.warning('Graph not ready; commit-sync worker not started')
+        yield None
+        return
+    stop = asyncio.Event()
+    LOGGER.info('Commit-sync worker starting')
+    consumer_task = asyncio.create_task(
+        commit_sync_queue.consume_commit_sync(client, _graph, stop=stop)
+    )
+    try:
+        yield None
+    finally:
+        stop.set()
+        consumer_task.cancel()
+        try:
+            await consumer_task
+        except asyncio.CancelledError:
+            pass
+        except Exception:  # noqa: BLE001
+            LOGGER.warning(
+                'Commit-sync worker task exited with error', exc_info=True
+            )
 
 
 @contextlib.asynccontextmanager

--- a/tests/endpoints/test_project_commit_sync.py
+++ b/tests/endpoints/test_project_commit_sync.py
@@ -1,0 +1,131 @@
+"""Tests for the on-demand commit/tag-sync endpoints."""
+
+import datetime
+from unittest import mock
+
+import fastapi
+from fastapi import testclient
+from imbi_common import graph
+
+from imbi_api import models
+from imbi_api.auth import password, permissions
+from imbi_api.commit_sync import service
+from imbi_api.endpoints import project_commit_sync
+from tests import support
+
+_BASE = '/organizations/octo/projects/p1/commits'
+
+
+class CommitSyncEndpointTestCase(support.SharedAppTestCase):
+    def setUp(self) -> None:
+        self.user = models.User(
+            email='dev@example.com',
+            display_name='Dev',
+            is_active=True,
+            is_admin=False,
+            password_hash=password.hash_password('testpassword123'),
+            created_at=datetime.datetime.now(datetime.UTC),
+        )
+        self.auth = permissions.AuthContext(
+            user=self.user,
+            session_id='s',
+            auth_method='jwt',
+            permissions={
+                'project:deployment:read',
+                'project:deployment:write',
+            },
+        )
+
+        async def _user() -> permissions.AuthContext:
+            return self.auth
+
+        self.test_app.dependency_overrides[permissions.get_current_user] = (
+            _user
+        )
+        self.mock_db = mock.AsyncMock(spec=graph.Graph)
+        self.test_app.dependency_overrides[graph._inject_graph] = lambda: (
+            self.mock_db
+        )
+        from imbi_api import scoring
+
+        self.test_app.dependency_overrides[scoring._inject_optional_client] = (
+            lambda: mock.AsyncMock()
+        )
+        # No ``with``: instantiating the client without the context
+        # manager skips app lifespan startup (no DB/Valkey connections),
+        # matching the rest of the endpoint suite.
+        self.client = testclient.TestClient(self.test_app)
+
+    def test_sync_enqueues(self) -> None:
+        with (
+            mock.patch.object(
+                project_commit_sync, 'resolve_plugin', mock.AsyncMock()
+            ),
+            mock.patch.object(service, 'check_available', mock.AsyncMock()),
+            mock.patch.object(
+                project_commit_sync,
+                'enqueue_commit_sync',
+                mock.AsyncMock(return_value=True),
+            ),
+            mock.patch.object(service, 'set_status', mock.AsyncMock()) as ss,
+        ):
+            response = self.client.post(f'{_BASE}/sync')
+        self.assertEqual(202, response.status_code)
+        self.assertTrue(response.json()['enqueued'])
+        self.assertEqual('queued', ss.await_args.kwargs['status'])
+
+    def test_sync_debounced_skips_status(self) -> None:
+        with (
+            mock.patch.object(
+                project_commit_sync, 'resolve_plugin', mock.AsyncMock()
+            ),
+            mock.patch.object(service, 'check_available', mock.AsyncMock()),
+            mock.patch.object(
+                project_commit_sync,
+                'enqueue_commit_sync',
+                mock.AsyncMock(return_value=False),
+            ),
+            mock.patch.object(service, 'set_status', mock.AsyncMock()) as ss,
+        ):
+            response = self.client.post(f'{_BASE}/sync')
+        self.assertEqual(202, response.status_code)
+        self.assertFalse(response.json()['enqueued'])
+        ss.assert_not_awaited()
+
+    def test_sync_no_commit_sync_plugin_returns_400(self) -> None:
+        with (
+            mock.patch.object(
+                project_commit_sync, 'resolve_plugin', mock.AsyncMock()
+            ),
+            mock.patch.object(
+                service,
+                'check_available',
+                mock.AsyncMock(
+                    side_effect=service.CommitSyncUnavailable('nope')
+                ),
+            ),
+        ):
+            response = self.client.post(f'{_BASE}/sync')
+        self.assertEqual(400, response.status_code)
+
+    def test_sync_no_deployment_plugin_returns_404(self) -> None:
+        with mock.patch.object(
+            project_commit_sync,
+            'resolve_plugin',
+            mock.AsyncMock(side_effect=fastapi.HTTPException(status_code=404)),
+        ):
+            response = self.client.post(f'{_BASE}/sync')
+        self.assertEqual(404, response.status_code)
+
+    def test_get_status(self) -> None:
+        status = service.CommitSyncStatus(
+            status='success', commits_synced=10, tags_synced=2
+        )
+        with mock.patch.object(
+            service, 'read_status', mock.AsyncMock(return_value=status)
+        ):
+            response = self.client.get(f'{_BASE}/sync-status')
+        self.assertEqual(200, response.status_code)
+        data = response.json()
+        self.assertEqual('success', data['status'])
+        self.assertEqual(10, data['commits_synced'])

--- a/tests/test_commit_sync_queue.py
+++ b/tests/test_commit_sync_queue.py
@@ -1,0 +1,122 @@
+"""Tests for the commit/tag-sync queue."""
+
+from __future__ import annotations
+
+import unittest
+from unittest import mock
+
+from imbi_api.commit_sync import queue
+from imbi_api.commit_sync.service import CommitSyncUnavailable
+
+
+class EnqueueTests(unittest.IsolatedAsyncioTestCase):
+    async def test_enqueue_xadds_when_debounce_acquired(self) -> None:
+        client = mock.AsyncMock()
+        client.set = mock.AsyncMock(return_value=True)
+        client.xadd = mock.AsyncMock()
+        result = await queue.enqueue_commit_sync(client, 'octo', 'p1', 'alice')
+        self.assertTrue(result)
+        client.xadd.assert_awaited_once()
+        args, _ = client.xadd.await_args
+        self.assertEqual(args[0], queue.STREAM)
+        self.assertEqual(args[1]['project_id'], 'p1')
+        self.assertEqual(args[1]['org_slug'], 'octo')
+        self.assertEqual(args[1]['requested_by'], 'alice')
+
+    async def test_enqueue_skips_when_debounced(self) -> None:
+        client = mock.AsyncMock()
+        client.set = mock.AsyncMock(return_value=None)
+        client.xadd = mock.AsyncMock()
+        result = await queue.enqueue_commit_sync(client, 'octo', 'p1')
+        self.assertFalse(result)
+        client.xadd.assert_not_called()
+
+    async def test_enqueue_none_client_returns_false(self) -> None:
+        self.assertFalse(await queue.enqueue_commit_sync(None, 'octo', 'p1'))
+
+
+class ProcessMessageTests(unittest.IsolatedAsyncioTestCase):
+    async def test_success_sets_running_then_success(self) -> None:
+        db = mock.AsyncMock()
+        with (
+            mock.patch.object(
+                queue, 'run_sync', mock.AsyncMock(return_value=(3, 2))
+            ),
+            mock.patch.object(queue, 'set_status', mock.AsyncMock()) as ss,
+        ):
+            await queue._process_message(
+                db,
+                {'project_id': 'p1', 'org_slug': 'octo', 'requested_by': 'a'},
+            )
+        statuses = [c.kwargs['status'] for c in ss.await_args_list]
+        self.assertEqual(['running', 'success'], statuses)
+        success = ss.await_args_list[-1].kwargs
+        self.assertEqual(3, success['commits'])
+        self.assertEqual(2, success['tags'])
+
+    async def test_unavailable_marks_failed_without_raising(self) -> None:
+        db = mock.AsyncMock()
+        with (
+            mock.patch.object(
+                queue,
+                'run_sync',
+                mock.AsyncMock(side_effect=CommitSyncUnavailable('nope')),
+            ),
+            mock.patch.object(queue, 'set_status', mock.AsyncMock()) as ss,
+        ):
+            await queue._process_message(db, {'project_id': 'p1'})
+        self.assertEqual('failed', ss.await_args_list[-1].kwargs['status'])
+
+    async def test_other_error_marks_failed_and_raises(self) -> None:
+        db = mock.AsyncMock()
+        with (
+            mock.patch.object(
+                queue,
+                'run_sync',
+                mock.AsyncMock(side_effect=RuntimeError('boom')),
+            ),
+            mock.patch.object(queue, 'set_status', mock.AsyncMock()) as ss,
+        ):
+            with self.assertRaises(RuntimeError):
+                await queue._process_message(db, {'project_id': 'p1'})
+        self.assertEqual('failed', ss.await_args_list[-1].kwargs['status'])
+
+    async def test_missing_project_id_is_noop(self) -> None:
+        db = mock.AsyncMock()
+        with mock.patch.object(queue, 'set_status', mock.AsyncMock()) as ss:
+            await queue._process_message(db, {})
+        ss.assert_not_awaited()
+
+
+class ConsumerTests(unittest.IsolatedAsyncioTestCase):
+    async def test_xack_on_success(self) -> None:
+        client = mock.AsyncMock()
+        with mock.patch.object(queue, '_process_message', mock.AsyncMock()):
+            await queue._handle_entries(
+                client, [(b'1-0', {b'project_id': b'p1'})], mock.AsyncMock()
+            )
+        client.xack.assert_awaited_once()
+
+    async def test_no_xack_on_exception(self) -> None:
+        client = mock.AsyncMock()
+        with mock.patch.object(
+            queue,
+            '_process_message',
+            mock.AsyncMock(side_effect=RuntimeError('boom')),
+        ):
+            await queue._handle_entries(
+                client, [(b'1-0', {b'project_id': b'p1'})], mock.AsyncMock()
+            )
+        client.xack.assert_not_called()
+
+    async def test_dlq_after_max_deliveries(self) -> None:
+        client = mock.AsyncMock()
+        client.xpending_range = mock.AsyncMock(
+            return_value=[{'times_delivered': queue.MAX_DELIVERIES}]
+        )
+        result = await queue._maybe_dead_letter(
+            client, b'1-0', {'project_id': 'p1'}
+        )
+        self.assertTrue(result)
+        client.xadd.assert_awaited_once()
+        client.xack.assert_awaited_once()

--- a/tests/test_commit_sync_service.py
+++ b/tests/test_commit_sync_service.py
@@ -1,0 +1,168 @@
+"""Tests for the commit-sync service (resolution, status, run)."""
+
+from __future__ import annotations
+
+import unittest
+from unittest import mock
+
+from imbi_common.plugins.base import ServicePlugin
+
+from imbi_api.commit_sync import service
+
+
+def _resolve_rows() -> list[dict[str, object]]:
+    return [
+        {
+            'plugin_id': '"plg-1"',
+            'tps_slug': '"github"',
+            'api_endpoint': '"https://api.github.com"',
+            'siblings': (
+                '[{"slug": "github-commit-sync", "options": {}}, '
+                '{"slug": "github-deployment", "options": {}}]'
+            ),
+        }
+    ]
+
+
+class ResolvePluginTests(unittest.IsolatedAsyncioTestCase):
+    async def test_resolves_plugin_and_siblings(self) -> None:
+        db = mock.AsyncMock()
+        db.execute.return_value = _resolve_rows()
+        with mock.patch.object(
+            service, 'get_plugin', return_value=mock.Mock()
+        ):
+            resolved = await service._resolve_plugin(db, 'p1')
+        self.assertEqual('plg-1', resolved.plugin_id)
+        self.assertEqual('github', resolved.tps_slug)
+        self.assertEqual('https://api.github.com', resolved.service_endpoint)
+        slugs = {sp.slug for sp in resolved.service_plugins}
+        self.assertEqual({'github-commit-sync', 'github-deployment'}, slugs)
+
+    async def test_no_plugin_raises_unavailable(self) -> None:
+        db = mock.AsyncMock()
+        db.execute.return_value = []
+        with self.assertRaises(service.CommitSyncUnavailable):
+            await service._resolve_plugin(db, 'p1')
+
+
+class RunSyncTests(unittest.IsolatedAsyncioTestCase):
+    async def test_invokes_handler_sync_all_history(self) -> None:
+        db = mock.AsyncMock()
+        handler = mock.Mock()
+        handler.sync_all_history = mock.AsyncMock(return_value=(5, 1))
+        entry = mock.Mock()
+        entry.handler_cls.return_value = handler
+        resolved = service._ResolvedCommitSync(
+            plugin_id='plg-1',
+            entry=entry,
+            tps_slug='github',
+            service_endpoint='https://api.github.com',
+            service_plugins=[ServicePlugin(slug='github')],
+        )
+        with (
+            mock.patch.object(
+                service,
+                '_resolve_plugin',
+                mock.AsyncMock(return_value=resolved),
+            ),
+            mock.patch.object(
+                service,
+                '_build_context',
+                mock.AsyncMock(return_value=mock.Mock()),
+            ),
+            mock.patch.object(
+                service,
+                'get_plugin_credentials',
+                mock.AsyncMock(return_value={'access_token': 'x'}),
+            ),
+        ):
+            result = await service.run_sync(db, 'octo', 'p1')
+        self.assertEqual((5, 1), result)
+        handler.sync_all_history.assert_awaited_once()
+
+    async def test_missing_method_raises_unavailable(self) -> None:
+        db = mock.AsyncMock()
+        handler = object()  # no sync_all_history
+        entry = mock.Mock()
+        entry.handler_cls.return_value = handler
+        resolved = service._ResolvedCommitSync(
+            plugin_id='plg-1',
+            entry=entry,
+            tps_slug='github',
+            service_endpoint=None,
+            service_plugins=[],
+        )
+        with (
+            mock.patch.object(
+                service,
+                '_resolve_plugin',
+                mock.AsyncMock(return_value=resolved),
+            ),
+            mock.patch.object(
+                service,
+                '_build_context',
+                mock.AsyncMock(return_value=mock.Mock()),
+            ),
+            mock.patch.object(
+                service,
+                'get_plugin_credentials',
+                mock.AsyncMock(return_value={}),
+            ),
+        ):
+            with self.assertRaises(service.CommitSyncUnavailable):
+                await service.run_sync(db, 'octo', 'p1')
+
+
+class StatusTests(unittest.IsolatedAsyncioTestCase):
+    async def test_set_status_writes_all_fields(self) -> None:
+        db = mock.AsyncMock()
+        await service.set_status(
+            db,
+            'p1',
+            status='success',
+            requested_by='alice',
+            commits=7,
+            tags=3,
+        )
+        db.execute.assert_awaited_once()
+        params = db.execute.await_args.args[1]
+        self.assertEqual('success', params['status'])
+        self.assertEqual(7, params['commits'])
+        self.assertEqual('alice', params['by'])
+
+    async def test_read_status_idle_when_unset(self) -> None:
+        db = mock.AsyncMock()
+        db.execute.return_value = [
+            {
+                'status': None,
+                'at': None,
+                'by': None,
+                'commits': None,
+                'tags': None,
+                'error': None,
+            }
+        ]
+        status = await service.read_status(db, 'p1')
+        self.assertEqual('idle', status.status)
+        self.assertIsNone(status.last_synced_at)
+        self.assertIsNone(status.commits_synced)
+
+    async def test_read_status_parses_success(self) -> None:
+        db = mock.AsyncMock()
+        db.execute.return_value = [
+            {
+                'status': '"success"',
+                'at': '"2026-06-04T12:00:00+00:00"',
+                'by': '"alice"',
+                'commits': 12,
+                'tags': 4,
+                'error': '""',
+            }
+        ]
+        status = await service.read_status(db, 'p1')
+        self.assertEqual('success', status.status)
+        self.assertEqual(12, status.commits_synced)
+        self.assertEqual(4, status.tags_synced)
+        self.assertEqual('alice', status.requested_by)
+        self.assertIsNotNone(status.last_synced_at)
+        self.assertIsNone(status.error)


### PR DESCRIPTION
## Summary
Backend for a "Sync Commits & Tags" Project Doctor action: a Valkey-stream background job that backfills a project's full default-branch commit history and tag list into ClickHouse, mirroring the score-recompute queue.

## Problem
Commit/tag history is only populated by GitHub push webhooks. There's no way to backfill a project that connected late or missed deliveries, and the work is too large to run synchronously in a request.

## Solution
- `commit_sync/queue.py`: `imbi:commit-sync` stream + consumer group, per-project debounce, stale-entry reclaim, DLQ after repeated failures (a trimmed twin of `scoring/queue.py`).
- `commit_sync/service.py`: resolves the `github-commit-sync` webhook plugin attached to a `ThirdPartyService` the project `EXISTS_IN`, builds the `PluginContext` (project links + sibling `service_plugins` for host resolution), decrypts the plugin's **service** credential, and invokes the plugin's `sync_all_history`. Persists last-sync state (status / counts / error / requester) on the `Project` node; degrades gracefully when the plugin predates `sync_all_history`.
- `POST .../projects/{id}/commits/sync` enqueues (202), gated on a resolvable deployment plugin (eligibility) + a configured commit-sync plugin (400 otherwise); `GET .../commits/sync-status` returns state for the UI to poll. Permission: `project:deployment:{write,read}`.
- `commit_sync_worker_hook` wired into the app lifespan after the scorer.

## Notes
- Acts with the plugin's service credential (PAT or GitHub App), so no acting user is needed.
- Depends on imbi-plugin-github #27 (`sync_all_history`) at runtime — degrades to a clear error until that ships. Release held for the coordinated bump.
- 22 tests; ruff/basedpyright/mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)