### PR TITLE
Fix 500 on events feed from non-UTF-8 bytes in JSON columns

### DIFF
--- a/src/imbi_api/endpoints/events.py
+++ b/src/imbi_api/endpoints/events.py
@@ -133,7 +133,13 @@ async def _list_impl(
 
     body = {'data': [_row_to_response(r) for r in rows]}
     response = fastapi.responses.JSONResponse(
-        fastapi.encoders.jsonable_encoder(body)
+        # ClickHouse hands back raw bytes for JSON string values that
+        # aren't valid UTF-8 (e.g. cp1252 smart quotes in webhook
+        # payloads); decode leniently so one bad row can't 500 the feed.
+        fastapi.encoders.jsonable_encoder(
+            body,
+            custom_encoder={bytes: lambda o: o.decode(errors='replace')},
+        )
     )
     response.headers['Link'] = build_link_header(request, next_cursor)
     return response

--- a/tests/endpoints/test_events.py
+++ b/tests/endpoints/test_events.py
@@ -175,6 +175,18 @@ class GlobalListTests(_EventsTestBase):
         self.assertIn('Link', response.headers)
         self.assertIn('rel="first"', response.headers['Link'])
 
+    def test_list_tolerates_non_utf8_bytes_in_payload(self) -> None:
+        # ClickHouse returns raw bytes for JSON string values that aren't
+        # valid UTF-8 (e.g. a cp1252 smart quote, 0x91). The endpoint must
+        # decode leniently instead of 500ing on a single bad row.
+        row = _row()
+        row['payload'] = {'title': b'fix \x91thing\x92'}
+        self.mock_query.return_value = [row]
+        response = self.client.get('/events/')
+        self.assertEqual(response.status_code, 200, response.text)
+        body = response.json()
+        self.assertEqual(body['data'][0]['payload']['title'], 'fix �thing�')
+
     def test_list_with_filters(self) -> None:
         self.mock_query.return_value = [_row()]
         response = self.client.get(


### PR DESCRIPTION
## Summary

The project events feed (`GET /api/organizations/{org}/projects/{id}/events/` and the global `/events/`) returns a 500 when any event has a JSON `metadata`/`payload` value containing non-UTF-8 bytes.

## Problem

`events.metadata` and `events.payload` are ClickHouse `JSON` columns. `clickhouse_connect` decodes string values as UTF-8 and, on failure, returns the raw `bytes` rather than raising. A webhook payload carrying cp1252-encoded text — e.g. a smart quote (`0x91`, `'`) in a commit message or PR title — comes back as `bytes` nested inside the parsed `payload` dict.

FastAPI's default bytes encoder is a strict `lambda o: o.decode()`, so a single bad row blows up the whole feed:

```
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x91 in position 2: invalid start byte
  File ".../imbi_api/endpoints/events.py", line 136, in _list_impl
    fastapi.encoders.jsonable_encoder(body)
```

## Solution

Pass a lenient `custom_encoder={bytes: lambda o: o.decode(errors='replace')}` to the single `jsonable_encoder` call in `_list_impl`. This is scoped to the events listings (covers both routers, which share `_list_impl`) rather than globally mutating `fastapi.encoders.ENCODERS_BY_TYPE`. `errors='replace'` is lossy (the smart quote renders as `�`) but is the safe generic choice when the source encoding isn't known at read time.

Adds a regression test that feeds a row with non-UTF-8 bytes in `payload` and asserts a 200.

## Follow-up (not in this PR)

This is a **read-side guard** for rows already written to ClickHouse. The root cause is the **ingestion path** storing non-UTF-8 text into the JSON columns; that should normalize to UTF-8 (or decode cp1252 faithfully) so new bad rows stop appearing. That fix lives in the gateway / webhook ingestion path and is worth a separate ticket.

## Testing

- `just test tests/endpoints/test_events.py` — 23 passed (22 existing + 1 new regression test)
- `ruff format`/`ruff check`/`mypy` clean via pre-commit