### PR TITLE
Bump to 2.9.2; log API-key owner in access log

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "imbi-api"
-version = "2.9.1"
+version = "2.9.2"
 description = "Imbi is a DevOps Service Management Platform designed to provide an efficient way to manage a large environment that contains many services and applications."
 readme = "README.md"
 requires-python = ">=3.14"
@@ -28,7 +28,7 @@ dependencies = [
   "fastapi",
   "filetype",
   "httpx>=0.28.1,<1",
-  "imbi-common[databases,llm,sentry,server]==2.9.1",
+  "imbi-common[databases,llm,sentry,server]==2.9.2",
   "jinja2",
   "jsonpatch>=1.33",
   "mcp>=1.26.0",

--- a/src/imbi_api/auth/permissions.py
+++ b/src/imbi_api/auth/permissions.py
@@ -13,7 +13,7 @@ import fastapi
 import jwt
 import pydantic
 from fastapi import security
-from imbi_common import graph
+from imbi_common import access_log, graph
 from imbi_common.auth import core
 
 from imbi_api import models, settings
@@ -658,7 +658,14 @@ async def _authenticate_token(
     treats the token as a JWT.
     """
     if token.startswith('ik_'):
-        return await authenticate_api_key(db, token, auth_settings)
+        ctx = await authenticate_api_key(db, token, auth_settings)
+        # Cache the key's owner so imbi-common's access log renders the
+        # person (email / service-account slug) instead of the opaque
+        # ``ik_<id>`` it parses from the Authorization header.
+        access_log.remember_api_key_principal(
+            ctx.session_id or '', ctx.principal_name
+        )
+        return ctx
     return await authenticate_jwt(db, token, auth_settings)
 
 

--- a/tests/auth/test_permissions.py
+++ b/tests/auth/test_permissions.py
@@ -368,3 +368,55 @@ class ServiceAccountPermissionTestCase(
         self.assertEqual(ctx.service_account.slug, 'deploy-bot')
         self.assertEqual(ctx.auth_method, 'client_credentials')
         self.assertIn('project:read', ctx.permissions)
+
+
+class ApiKeyAccessLogPrincipalTestCase(unittest.IsolatedAsyncioTestCase):
+    """`_authenticate_token` registers the API-key owner for the log."""
+
+    def _ctx(self) -> permissions.AuthContext:
+        return permissions.AuthContext(
+            user=models.User(
+                email='dev@example.com',
+                display_name='Dev',
+                is_active=True,
+                is_admin=False,
+                password_hash='x',
+                created_at=datetime.datetime.now(datetime.UTC),
+            ),
+            session_id='ik_abc123',
+            auth_method='api_key',
+        )
+
+    async def test_api_key_registers_owner(self) -> None:
+        ctx = self._ctx()
+        with (
+            mock.patch.object(
+                permissions,
+                'authenticate_api_key',
+                mock.AsyncMock(return_value=ctx),
+            ),
+            mock.patch.object(
+                permissions.access_log, 'remember_api_key_principal'
+            ) as remember,
+        ):
+            result = await permissions._authenticate_token(
+                mock.AsyncMock(), 'ik_abc123_secret', mock.Mock()
+            )
+        self.assertIs(result, ctx)
+        remember.assert_called_once_with('ik_abc123', 'dev@example.com')
+
+    async def test_jwt_does_not_register(self) -> None:
+        with (
+            mock.patch.object(
+                permissions,
+                'authenticate_jwt',
+                mock.AsyncMock(return_value=self._ctx()),
+            ),
+            mock.patch.object(
+                permissions.access_log, 'remember_api_key_principal'
+            ) as remember,
+        ):
+            await permissions._authenticate_token(
+                mock.AsyncMock(), 'jwt.token.here', mock.Mock()
+            )
+        remember.assert_not_called()

--- a/uv.lock
+++ b/uv.lock
@@ -1016,7 +1016,7 @@ wheels = [
 
 [[package]]
 name = "imbi-api"
-version = "2.9.1"
+version = "2.9.2"
 source = { editable = "." }
 dependencies = [
   { name = "aioboto3" },
@@ -1095,7 +1095,7 @@ requires-dist = [
   { name = "fastapi" },
   { name = "filetype" },
   { name = "httpx", specifier = ">=0.28.1,<1" },
-  { name = "imbi-common", extras = ["databases", "llm", "sentry", "server"], specifier = "==2.9.1" },
+  { name = "imbi-common", extras = ["databases", "llm", "sentry", "server"], specifier = "==2.9.2" },
   { name = "imbi-plugin-aws", marker = "extra == 'plugins'", specifier = ">=1.0.0" },
   { name = "imbi-plugin-github", marker = "extra == 'plugins'", specifier = ">=1.0.0" },
   { name = "imbi-plugin-logzio", marker = "extra == 'plugins'", specifier = ">=1.0.0" },
@@ -1148,7 +1148,7 @@ docs = [
 
 [[package]]
 name = "imbi-common"
-version = "2.9.1"
+version = "2.9.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
   { name = "cryptography" },
@@ -1164,9 +1164,9 @@ dependencies = [
   { name = "python-slugify" },
   { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9a/7a/0dc31034aa22aaa92929eeaf317c6b552e659b5e1557d1bd605edcc6f1cd/imbi_common-2.9.1.tar.gz", hash = "sha256:0808fbe949b3e1c347dcfb7c879c0cc547143e97f85c35c623dfd9971de041a9", size = 336897, upload-time = "2026-06-04T01:38:52.101Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/0d/39325e67d4fa8de59ee2962339cc5c7dcd0891298c034b23950b003d120e/imbi_common-2.9.2.tar.gz", hash = "sha256:236b0a7baee0125c4af9449c1a99326d49813466e7b0732b4ebbcb618a7f8cf6", size = 338283, upload-time = "2026-06-04T17:42:41.652Z" }
 wheels = [
-  { url = "https://files.pythonhosted.org/packages/14/d7/496d7edcbfc0f6a6551c16abd4e368bb756ee444711c350e09d5b736542b/imbi_common-2.9.1-py3-none-any.whl", hash = "sha256:4b445b30461c7d15e3d1635720f32d95f49f38369b5b1939bff5e9c89545bc6c", size = 107627, upload-time = "2026-06-04T01:38:50.624Z" },
+  { url = "https://files.pythonhosted.org/packages/ec/86/88ff71441a35836c791fbd7565e1a2359bddf60b91376eb132fd0d2d3dce/imbi_common-2.9.2-py3-none-any.whl", hash = "sha256:f72db0695a0e7406e99e2a7c4497883f76f3025af82e904e3bfd2d2c013d52de", size = 108246, upload-time = "2026-06-04T17:42:40.216Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary
Renders the **API-key owner** in the access log instead of the opaque `ik_<id>`, and bumps to the 2.9.2 lockstep release.

## Details
- Bump version → 2.9.2, pin `imbi-common==2.9.2`, re-lock.
- Register the resolved API-key owner with imbi-common's access log via `access_log.remember_api_key_principal` at the `_authenticate_token` chokepoint — so log lines show the user email / service-account slug instead of `ik_<id>`. One call site covers the cache-hit fast path and both fresh (User / ServiceAccount) auth paths.

Consumes the `remember_api_key_principal` hook released in **imbi-common 2.9.2** (#153).

Before:
```
... - ik_1f84d89dd2901fcf567f72620c511dfd "GET /api/.../deployments/promotion-options" 200
```
After:
```
... - gavinr@aweber.com "GET /api/.../deployments/promotion-options" 200
```

## Tests
2 unit tests on `_authenticate_token` (api-key registers owner; JWT does not). ruff + basedpyright + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)