### PR TITLE
Fix commit-sync status reads (reserved `by`) and write races

### DIFF
--- a/src/imbi_api/commit_sync/service.py
+++ b/src/imbi_api/commit_sync/service.py
@@ -13,6 +13,7 @@ node so the UI can poll it without a dedicated status store.
 
 from __future__ import annotations
 
+import asyncio
 import datetime
 import logging
 import typing
@@ -33,6 +34,12 @@ _COMMIT_SYNC_SLUG = 'github-commit-sync'
 # Persisted error strings are truncated so a noisy upstream message can't
 # bloat the Project node.
 _MAX_ERROR_LEN = 500
+# Apache AGE aborts a SET with "Entity failed to be updated: <n>"
+# (heap_update -> TM_Updated) when another transaction updates the same
+# Project vertex concurrently. The worker's authoritative status writes
+# retry the transient conflict so they still land under contention.
+_STATUS_WRITE_RETRIES = 3
+_STATUS_RETRY_BACKOFF = 0.05
 
 SyncState = typing.Literal['idle', 'queued', 'running', 'success', 'failed']
 
@@ -210,6 +217,11 @@ def _now_iso() -> str:
     return datetime.datetime.now(datetime.UTC).isoformat()
 
 
+def _is_write_conflict(exc: Exception) -> bool:
+    """True if *exc* is AGE's concurrent-update conflict (TM_Updated)."""
+    return 'failed to be updated' in str(exc)
+
+
 async def set_status(
     db: graph.Graph,
     project_id: str,
@@ -219,8 +231,17 @@ async def set_status(
     commits: int = 0,
     tags: int = 0,
     error: str = '',
+    retry: bool = True,
 ) -> None:
-    """Persist last-sync state on the ``Project`` node (best-effort)."""
+    """Persist last-sync state on the ``Project`` node (best-effort).
+
+    *retry* re-attempts the write when AGE reports a transient concurrent
+    update, so the worker's authoritative transitions (running -> success/
+    failed) still land if a webhook touches the project mid-write. The
+    enqueue endpoint passes ``retry=False`` for its optimistic ``queued``
+    write: dropping that on conflict is correct, since the worker's newer
+    ``running`` write must win rather than be clobbered back to ``queued``.
+    """
     query: typing.LiteralString = """
     MATCH (p:Project {{id: {project_id}}})
     SET p.commit_sync_status = {status},
@@ -231,26 +252,39 @@ async def set_status(
         p.commit_sync_error = {error}
     RETURN p.id AS id
     """
-    try:
-        await db.execute(
-            query,
-            {
-                'project_id': project_id,
-                'status': status,
-                'at': _now_iso(),
-                'by': requested_by,
-                'commits': commits,
-                'tags': tags,
-                'error': error[:_MAX_ERROR_LEN],
-            },
-            ['id'],
-        )
-    except Exception:  # noqa: BLE001
-        LOGGER.warning(
-            'Failed to persist commit-sync status for project %s',
-            project_id,
-            exc_info=True,
-        )
+    params = {
+        'project_id': project_id,
+        'status': status,
+        'at': _now_iso(),
+        'by': requested_by,
+        'commits': commits,
+        'tags': tags,
+        'error': error[:_MAX_ERROR_LEN],
+    }
+    attempts = _STATUS_WRITE_RETRIES if retry else 1
+    for attempt in range(attempts):
+        try:
+            await db.execute(query, params, ['id'])
+            return
+        except Exception as exc:  # noqa: BLE001
+            conflict = _is_write_conflict(exc)
+            if retry and conflict and attempt + 1 < attempts:
+                await asyncio.sleep(_STATUS_RETRY_BACKOFF * (attempt + 1))
+                continue
+            if conflict:
+                LOGGER.debug(
+                    'commit-sync status write for %s lost a concurrent '
+                    'update (status=%s); leaving the newer state in place',
+                    project_id,
+                    status,
+                )
+            else:
+                LOGGER.warning(
+                    'Failed to persist commit-sync status for project %s',
+                    project_id,
+                    exc_info=True,
+                )
+            return
 
 
 def _opt_str(value: object) -> str | None:
@@ -277,7 +311,7 @@ async def read_status(db: graph.Graph, project_id: str) -> CommitSyncStatus:
     MATCH (p:Project {{id: {project_id}}})
     RETURN p.commit_sync_status AS status,
            p.commit_sync_at AS at,
-           p.commit_sync_by AS by,
+           p.commit_sync_by AS requested_by,
            p.commit_sync_commits AS commits,
            p.commit_sync_tags AS tags,
            p.commit_sync_error AS error
@@ -285,7 +319,7 @@ async def read_status(db: graph.Graph, project_id: str) -> CommitSyncStatus:
     records = await db.execute(
         query,
         {'project_id': project_id},
-        ['status', 'at', 'by', 'commits', 'tags', 'error'],
+        ['status', 'at', 'requested_by', 'commits', 'tags', 'error'],
     )
     if not records:
         return CommitSyncStatus()
@@ -307,5 +341,5 @@ async def read_status(db: graph.Graph, project_id: str) -> CommitSyncStatus:
         commits_synced=_opt_int(graph.parse_agtype(row.get('commits'))),
         tags_synced=_opt_int(graph.parse_agtype(row.get('tags'))),
         error=_opt_str(graph.parse_agtype(row.get('error'))),
-        requested_by=_opt_str(graph.parse_agtype(row.get('by'))),
+        requested_by=_opt_str(graph.parse_agtype(row.get('requested_by'))),
     )

--- a/src/imbi_api/endpoints/project_commit_sync.py
+++ b/src/imbi_api/endpoints/project_commit_sync.py
@@ -60,8 +60,15 @@ async def sync_commits_and_tags(
         valkey_client, org_slug, project_id, requested_by
     )
     if enqueued:
+        # Optimistic, best-effort: if the worker has already flipped the
+        # project to ``running``, that newer write must win -- so this one
+        # does not retry the concurrent-update conflict.
         await service.set_status(
-            db, project_id, status='queued', requested_by=requested_by
+            db,
+            project_id,
+            status='queued',
+            requested_by=requested_by,
+            retry=False,
         )
     return CommitSyncEnqueueResponse(enqueued=enqueued)
 

--- a/tests/test_commit_sync_service.py
+++ b/tests/test_commit_sync_service.py
@@ -130,13 +130,35 @@ class StatusTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(7, params['commits'])
         self.assertEqual('alice', params['by'])
 
+    async def test_set_status_retries_on_write_conflict(self) -> None:
+        db = mock.AsyncMock()
+        db.execute.side_effect = [
+            Exception('Entity failed to be updated: 3'),
+            [{'id': '"p1"'}],
+        ]
+        with mock.patch.object(service.asyncio, 'sleep'):
+            await service.set_status(db, 'p1', status='running')
+        self.assertEqual(2, db.execute.await_count)
+
+    async def test_set_status_no_retry_drops_conflict(self) -> None:
+        db = mock.AsyncMock()
+        db.execute.side_effect = Exception('Entity failed to be updated: 3')
+        await service.set_status(db, 'p1', status='queued', retry=False)
+        db.execute.assert_awaited_once()
+
+    async def test_set_status_swallows_unrelated_error(self) -> None:
+        db = mock.AsyncMock()
+        db.execute.side_effect = Exception('boom')
+        await service.set_status(db, 'p1', status='running')
+        db.execute.assert_awaited_once()
+
     async def test_read_status_idle_when_unset(self) -> None:
         db = mock.AsyncMock()
         db.execute.return_value = [
             {
                 'status': None,
                 'at': None,
-                'by': None,
+                'requested_by': None,
                 'commits': None,
                 'tags': None,
                 'error': None,
@@ -153,7 +175,7 @@ class StatusTests(unittest.IsolatedAsyncioTestCase):
             {
                 'status': '"success"',
                 'at': '"2026-06-04T12:00:00+00:00"',
-                'by': '"alice"',
+                'requested_by': '"alice"',
                 'commits': 12,
                 'tags': 4,
                 'error': '""',


### PR DESCRIPTION
## Summary

Two fixes in the on-demand commit-sync status path (shipped in 2.9.2).

### `GET /commits/sync-status` 500 (reserved word `by`)
`read_status` aliased `p.commit_sync_by AS by`, but `by` is a reserved word: AGE's query expansion produced `syntax error at or near "by"`, so the polling endpoint returned 500. Renamed the Cypher alias and result column to `requested_by`.

### `set_status` lost writes to concurrent-update conflicts
`set_status` could lose its write to AGE's `Entity failed to be updated: 3` (`TM_Updated`) when a webhook touched the same `Project` mid-write. Dropping a worker's terminal transition left status stuck at `running`. `set_status` now retries the transient conflict so authoritative writes land; the enqueue endpoint's optimistic `queued` write passes `retry=False` so it can't clobber a newer `running`.

## Test plan
- `pytest tests/test_commit_sync_service.py tests/endpoints/test_project_commit_sync.py` — 15 passed
- Added tests: retry-on-conflict, no-retry-drops-conflict, swallow-unrelated-error; updated `read_status` mocks to `requested_by`
- ruff, basedpyright, mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)