### PR TITLE
Add team memberships to GET /users/me response

### DIFF
--- a/src/imbi_api/domain/models.py
+++ b/src/imbi_api/domain/models.py
@@ -55,6 +55,7 @@ __all__ = [
     'ServiceApplicationSecrets',
     'Session',
     'TOTPSecret',
+    'TeamMembership',
     'ThirdPartyService',
     'ThirdPartyServiceCreate',
     'ThirdPartyServiceResponse',
@@ -222,6 +223,15 @@ class OrgMembership(pydantic.BaseModel):
     organization_name: str
     organization_slug: str
     role: str
+
+
+class TeamMembership(pydantic.BaseModel):
+    """Team membership for API responses."""
+
+    model_config = pydantic.ConfigDict(extra='ignore')
+    team_name: str
+    team_slug: str
+    organization_slug: str
 
 
 class Role(models.Node):  # type: ignore[misc]
@@ -445,12 +455,14 @@ class CurrentUserResponse(UserResponse):
     """Response model for the authenticated user's own profile.
 
     Extends ``UserResponse`` with the caller's effective permission set
-    so the UI can gate features in a single request. Only exposed via
+    and team memberships so the UI can gate features and offer
+    membership-scoped filters in a single request. Only exposed via
     ``GET /users/me`` — the per-email endpoint deliberately omits
     permissions to avoid disclosing one user's grants to another.
     """
 
     permissions: list[str] = []
+    teams: list[TeamMembership] = []
 
 
 class PasswordChangeRequest(pydantic.BaseModel):

--- a/src/imbi_api/endpoints/users.py
+++ b/src/imbi_api/endpoints/users.py
@@ -41,6 +41,31 @@ async def _load_user_memberships(
     ]
 
 
+async def _load_user_teams(
+    db: graph.Graph, email: str
+) -> list[dict[str, str]]:
+    """Return the user's MEMBER_OF teams as plain dicts."""
+    query = """
+    MATCH (u:User {{email: {email}}})-[:MEMBER_OF]->(t:Team)
+          -[:BELONGS_TO]->(o:Organization)
+    RETURN t.name, t.slug, o.slug
+    ORDER BY o.slug, t.slug
+    """
+    records = await db.execute(
+        query,
+        {'email': email},
+        columns=['team_name', 'team_slug', 'org_slug'],
+    )
+    return [
+        {
+            'team_name': graph.parse_agtype(r['team_name']),
+            'team_slug': graph.parse_agtype(r['team_slug']),
+            'organization_slug': graph.parse_agtype(r['org_slug']),
+        }
+        for r in records
+    ]
+
+
 def _normalize_membership_input(
     value: typing.Any,
 ) -> list[dict[str, str]]:
@@ -444,6 +469,8 @@ async def get_current_user_profile(
 
     memberships = await _load_user_memberships(db, user.email)
     organizations = [models.OrgMembership(**m) for m in memberships]
+    team_records = await _load_user_teams(db, user.email)
+    teams = [models.TeamMembership(**t) for t in team_records]
 
     return models.CurrentUserResponse(
         email=user.email,
@@ -457,6 +484,7 @@ async def get_current_user_profile(
         email_notifications=user.email_notifications,
         organizations=organizations,
         permissions=sorted(auth.permissions),
+        teams=teams,
     )
 
 

--- a/src/imbi_api/models.py
+++ b/src/imbi_api/models.py
@@ -78,6 +78,7 @@ ServiceApplicationResponse = _domain.ServiceApplicationResponse
 ServiceApplicationSecrets = _domain.ServiceApplicationSecrets
 Session = _domain.Session
 TOTPSecret = _domain.TOTPSecret
+TeamMembership = _domain.TeamMembership
 TokenMetadata = _domain.TokenMetadata
 Upload = _domain.Upload
 User = _domain.User
@@ -112,7 +113,7 @@ def parse_scopes(value: typing.Any) -> list[str]:
                 parsed = json.loads(stripped)
                 if isinstance(parsed, list):
                     return [str(v) for v in typing.cast(list[object], parsed)]
-            except (json.JSONDecodeError, ValueError):
+            except json.JSONDecodeError, ValueError:
                 pass
         inner = stripped.strip('{}')
         return inner.split(',') if inner else []

--- a/tests/endpoints/test_users.py
+++ b/tests/endpoints/test_users.py
@@ -50,8 +50,8 @@ class UserEndpointsTestCase(support.SharedAppTestCase):
         )
 
         self.mock_db = mock.AsyncMock(spec=graph.Graph)
-        self.test_app.dependency_overrides[graph._inject_graph] = (
-            lambda: self.mock_db
+        self.test_app.dependency_overrides[graph._inject_graph] = lambda: (
+            self.mock_db
         )
 
         self.client = testclient.TestClient(self.test_app)
@@ -340,12 +340,23 @@ class UserEndpointsTestCase(support.SharedAppTestCase):
         self.test_app.dependency_overrides[permissions.get_current_user] = (
             mock_get_current_user
         )
-        self.mock_db.execute.return_value = [
-            {
-                'org_name': 'Default',
-                'org_slug': 'default',
-                'role': 'developer',
-            },
+        # Two queries fire in order: org memberships, then team
+        # memberships.
+        self.mock_db.execute.side_effect = [
+            [
+                {
+                    'org_name': 'Default',
+                    'org_slug': 'default',
+                    'role': 'developer',
+                },
+            ],
+            [
+                {
+                    'team_name': 'Platform',
+                    'team_slug': 'platform',
+                    'org_slug': 'default',
+                },
+            ],
         ]
 
         with mock.patch(
@@ -364,6 +375,16 @@ class UserEndpointsTestCase(support.SharedAppTestCase):
             ['project:read', 'scoring_policy:rescore'],
         )
         self.assertEqual(len(data['organizations']), 1)
+        self.assertEqual(
+            data['teams'],
+            [
+                {
+                    'team_name': 'Platform',
+                    'team_slug': 'platform',
+                    'organization_slug': 'default',
+                },
+            ],
+        )
 
     def test_get_current_user_profile_rejects_service_account(self) -> None:
         """GET /users/me requires a human user, not a service account."""
@@ -999,8 +1020,8 @@ class OrgMembershipEndpointsTestCase(support.SharedAppTestCase):
         )
 
         self.mock_db = mock.AsyncMock(spec=graph.Graph)
-        self.test_app.dependency_overrides[graph._inject_graph] = (
-            lambda: self.mock_db
+        self.test_app.dependency_overrides[graph._inject_graph] = lambda: (
+            self.mock_db
         )
 
         self.client = testclient.TestClient(self.test_app)
@@ -1455,8 +1476,8 @@ class ServiceAccountGuardRailsTestCase(support.SharedAppTestCase):
         )
 
         self.mock_db = mock.AsyncMock(spec=graph.Graph)
-        self.test_app.dependency_overrides[graph._inject_graph] = (
-            lambda: self.mock_db
+        self.test_app.dependency_overrides[graph._inject_graph] = lambda: (
+            self.mock_db
         )
 
         self.client = testclient.TestClient(self.test_app)


### PR DESCRIPTION
## Summary
Expose the authenticated caller's team memberships on `GET /users/me` so clients can offer membership-scoped features in a single request.

## Problem
`CurrentUserResponse` returned the user's *organization* memberships but not their *team* memberships. The UI's upcoming "My Teams" projects filter needs to know which teams the current user belongs to, and there was no way to get that without one request per team.

## Solution
- Add a `TeamMembership` model (`team_name`, `team_slug`, `organization_slug`).
- Load the user's `MEMBER_OF` teams in `get_current_user_profile` and return them via a new `teams` field — exposed on `/users/me` only, mirroring the existing `organizations` field.
- Re-export `TeamMembership` through `imbi_api.models`.
- Update the `/users/me` test to feed both query result sets and assert the new field.

Pairs with the imbi-ui "My Teams" filter PR, which consumes this field. This change is the prerequisite and should ship first.

Tests: `tests/endpoints/test_users.py` (65 passing); basedpyright clean.