### PR TITLE
Per-environment edge attributes and inline edge editing

### DIFF
--- a/src/imbi_api/endpoints/projects.py
+++ b/src/imbi_api/endpoints/projects.py
@@ -1604,19 +1604,11 @@ async def get_project_schema(
             return None
         props: dict[str, BlueprintSectionProperty] = {}
         for prop_name, prop_schema in schema.properties.items():
-            raw_x_ui = (
-                prop_schema.model_extra.get('x-ui')
-                if prop_schema.model_extra
-                else None
-            )
-            x_ui = dict(raw_x_ui or {})
+            extra = prop_schema.model_extra or {}
+            x_ui = dict(extra.get('x-ui') or {})
             if x_ui.get('editable') is None:
                 x_ui['editable'] = True
-            raw_x_display = (
-                prop_schema.model_extra.get('x-display')
-                if prop_schema.model_extra
-                else None
-            )
+            raw_x_display = extra.get('x-display')
             props[prop_name] = BlueprintSectionProperty(
                 type=getattr(prop_schema, 'type', None),
                 format=getattr(prop_schema, 'format', None),

--- a/src/imbi_api/endpoints/projects.py
+++ b/src/imbi_api/endpoints/projects.py
@@ -1499,6 +1499,14 @@ class BlueprintSectionProperty(pydantic.BaseModel):
         alias='x-ui',
         serialization_alias='x-ui',
     )
+    #: Optional value-display transforms (e.g. ``{'format': 'humanize'}``)
+    #: applied to the rendered value, independent of ``x-ui`` color/icon
+    #: resolution (which keys off the raw value).
+    x_display: dict[str, typing.Any] = pydantic.Field(
+        default_factory=dict,
+        alias='x-display',
+        serialization_alias='x-display',
+    )
 
 
 class BlueprintSection(pydantic.BaseModel):
@@ -1507,6 +1515,11 @@ class BlueprintSection(pydantic.BaseModel):
     name: str
     slug: str
     description: str | None = None
+    #: ``project`` for node blueprints (project-level attributes);
+    #: ``environment`` for relationship blueprints on the
+    #: ``Project -[:DEPLOYED_IN]-> Environment`` edge (per-environment
+    #: edge attributes rendered in the Environments card).
+    scope: typing.Literal['project', 'environment'] = 'project'
     properties: dict[str, BlueprintSectionProperty]
 
 
@@ -1568,30 +1581,27 @@ async def get_project_schema(
         graph.parse_agtype(records[0]['env_slugs']) or []
     )
 
-    # Fetch all enabled node blueprints for Project
-    all_blueprints = await db.match(
-        models.Blueprint,
-        {'type': 'Project', 'enabled': True},
-        order_by='priority',
-    )
+    def _build_section(
+        bp: models.Blueprint,
+        scope: typing.Literal['project', 'environment'],
+    ) -> BlueprintSection | None:
+        """Build a schema section from a blueprint, or ``None`` to skip.
 
-    # Match blueprints whose filters intersect the project's own
-    # types/envs. A blueprint with no filter matches everything.
-    # A blueprint with a project_type filter matches if any of
-    # the project's types appear in that list (same for environment).
-    sections: list[BlueprintSection] = []
-    for bp in all_blueprints:
+        A blueprint is skipped when its filter doesn't intersect the
+        project's own types/envs, or when it declares no properties. A
+        blueprint with no filter matches everything; a ``project_type``
+        filter matches if any of the project's types appear in it (same
+        for ``environment``).
+        """
         f = bp.filter
         if f is not None:
             if f.project_type and not type_slugs.intersection(f.project_type):
-                continue
+                return None
             if f.environment and not env_slugs.intersection(f.environment):
-                continue
-
+                return None
         schema = bp.json_schema
         if not schema.properties:
-            continue
-
+            return None
         props: dict[str, BlueprintSectionProperty] = {}
         for prop_name, prop_schema in schema.properties.items():
             raw_x_ui = (
@@ -1602,6 +1612,11 @@ async def get_project_schema(
             x_ui = dict(raw_x_ui or {})
             if x_ui.get('editable') is None:
                 x_ui['editable'] = True
+            raw_x_display = (
+                prop_schema.model_extra.get('x-display')
+                if prop_schema.model_extra
+                else None
+            )
             props[prop_name] = BlueprintSectionProperty(
                 type=getattr(prop_schema, 'type', None),
                 format=getattr(prop_schema, 'format', None),
@@ -1611,19 +1626,136 @@ async def get_project_schema(
                 default=getattr(prop_schema, 'default', None),
                 minimum=getattr(prop_schema, 'minimum', None),
                 maximum=getattr(prop_schema, 'maximum', None),
-                **{'x-ui': x_ui},
+                **{'x-ui': x_ui, 'x-display': dict(raw_x_display or {})},
             )
-
-        sections.append(
-            BlueprintSection(
-                name=bp.name,
-                slug=bp.slug or '',
-                description=bp.description,
-                properties=props,
-            )
+        return BlueprintSection(
+            name=bp.name,
+            slug=bp.slug or '',
+            description=bp.description,
+            scope=scope,
+            properties=props,
         )
 
+    # Node blueprints (project-level attributes) ...
+    node_blueprints = await db.match(
+        models.Blueprint,
+        {'type': 'Project', 'enabled': True},
+        order_by='priority',
+    )
+    # ... and relationship blueprints on the
+    # ``Project -[:DEPLOYED_IN]-> Environment`` edge (per-environment edge
+    # attributes), which carry the same JSON-Schema + ``x-ui`` metadata so
+    # the UI renders them with the shared attribute-display logic.
+    rel_blueprints = await db.match(
+        models.Blueprint,
+        {'kind': 'relationship', 'enabled': True},
+        order_by='priority',
+    )
+
+    sections: list[BlueprintSection] = []
+    for bp in node_blueprints:
+        section = _build_section(bp, 'project')
+        if section is not None:
+            sections.append(section)
+    for bp in rel_blueprints:
+        if (
+            bp.source != 'Project'
+            or bp.target != 'Environment'
+            or bp.edge != 'DEPLOYED_IN'
+        ):
+            continue
+        section = _build_section(bp, 'environment')
+        if section is not None:
+            sections.append(section)
+
     return ProjectSchemaResponse(sections=sections)
+
+
+class EnvironmentEdgeUpdate(pydantic.BaseModel):
+    """Edge-property updates for a project's ``DEPLOYED_IN`` edge.
+
+    Keys are blueprint-defined edge attributes (accepted via
+    ``extra='allow'``). A non-null value sets the property; a ``null``
+    value removes it.
+    """
+
+    model_config = pydantic.ConfigDict(extra='allow')
+
+
+@projects_router.patch('/{project_id}/environments/{env_slug}')
+async def patch_project_environment(
+    org_slug: str,
+    project_id: str,
+    env_slug: str,
+    updates: EnvironmentEdgeUpdate,
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(permissions.require_permission('project:write')),
+    ],
+) -> dict[str, typing.Any]:
+    """Update ``DEPLOYED_IN`` edge properties for a single environment.
+
+    Performs targeted per-key ``SET`` / ``REMOVE`` on the one
+    ``(project)-[:DEPLOYED_IN]->(environment)`` edge, so it neither
+    rewrites the other environments' edges nor relies on edge deletion
+    (both of which behave unreliably on some Apache AGE builds). Protected
+    structural keys are rejected. Returns the updated edge properties.
+    """
+    props = {
+        k: v
+        for k, v in (updates.model_extra or {}).items()
+        if k not in _PROTECTED_ENV_KEYS
+    }
+    if not props:
+        raise fastapi.HTTPException(
+            status_code=400,
+            detail='No editable edge properties provided',
+        )
+
+    params: dict[str, typing.Any] = {
+        'project_id': project_id,
+        'org_slug': org_slug,
+        'env_slug': env_slug,
+    }
+    set_parts: list[str] = []
+    remove_parts: list[str] = []
+    for i, (key, value) in enumerate(props.items()):
+        if value is None:
+            remove_parts.append(f'r.{escape_prop(key)}')
+        else:
+            param = f'edge_{i}'
+            set_parts.append(f'r.{escape_prop(key)} = {{{param}}}')
+            params[param] = value
+
+    mutations = ''
+    if set_parts:
+        mutations += ' SET ' + ', '.join(set_parts)
+    if remove_parts:
+        mutations += ' REMOVE ' + ', '.join(remove_parts)
+
+    query: str = (
+        'MATCH (p:Project {{id: {project_id}}})'
+        '-[:OWNED_BY]->(:Team)'
+        '-[:BELONGS_TO]->(o:Organization {{slug: {org_slug}}})'
+        ' MATCH (p)-[r:DEPLOYED_IN]->'
+        '(e:Environment {{slug: {env_slug}}})-[:BELONGS_TO]->(o)'
+        + mutations
+        + ' RETURN properties(r) AS props'
+    )
+    records = await db.execute(query, params, ['props'])
+    if not records:
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail=(
+                f'Project {project_id!r} is not deployed in '
+                f'environment {env_slug!r}'
+            ),
+        )
+    edge_props = graph.parse_agtype(records[0]['props']) or {}
+    return {
+        k: v for k, v in edge_props.items() if k not in _PROTECTED_ENV_KEYS
+    }
 
 
 @projects_router.get('/{project_id}', name='get_project')
@@ -2035,9 +2167,16 @@ def _build_update_clauses(
     new_edge_props_tpl = _edge_props_map(new_env_entries)
 
     if data.environments is not None:
-        # MERGE (not CREATE) so the retry loop in
-        # _execute_project_update cannot accumulate duplicate edges
-        # if AGE rolls back the SET phase but not the edge write.
+        # Replace the project's DEPLOYED_IN edges wholesale: delete the
+        # existing ones, then re-create them with inline edge properties
+        # (mirroring ``create_project``). We deliberately avoid
+        # ``MERGE (p)-[r]->(e) SET r = {map}``: some Apache AGE builds
+        # silently no-op a full-property ``SET r = {map}`` on a
+        # relationship, dropping every edge attribute, whereas inline
+        # ``CREATE ... {props}`` persists reliably. The DELETE and CREATE
+        # run in the same transaction as one ``execute`` call, so a
+        # retried attempt (see _execute_project_update) rolls back wholly
+        # and cannot accumulate duplicate edges.
         rel_clauses += (
             ' WITH DISTINCT p, o'
             ' OPTIONAL MATCH'
@@ -2045,15 +2184,12 @@ def _build_update_clauses(
             ' DELETE old_env'
         )
         if new_env_entries:
-            merge_set = (
-                ' SET r =' + new_edge_props_tpl if new_edge_props_tpl else ''
-            )
             rel_clauses += (
                 ' WITH DISTINCT p, o'
                 f' UNWIND {new_env_tpl} AS entry'
                 ' MATCH (e:Environment'
                 ' {{slug: entry.slug}})-[:BELONGS_TO]->(o)'
-                ' MERGE (p)-[r:DEPLOYED_IN]->(e)' + merge_set
+                ' CREATE (p)-[:DEPLOYED_IN' + new_edge_props_tpl + ']->(e)'
             )
 
     return rel_clauses, new_env_params

--- a/src/imbi_api/endpoints/projects.py
+++ b/src/imbi_api/endpoints/projects.py
@@ -603,7 +603,7 @@ def _latest_deployment_event(
     return latest_ts, latest_by
 
 
-async def _lookup_ops_log_performed_by(
+async def lookup_ops_log_performed_by(
     targets: list[tuple[str, str, str]],
 ) -> dict[tuple[str, str, str], str]:
     """Map ``(project_id, environment_slug, version)`` → ``performed_by``.
@@ -737,7 +737,7 @@ async def _fetch_current_releases(
         ) in latest.items()
         if performed_by is None and (tag or committish)
     ]
-    performed_by_by_key = await _lookup_ops_log_performed_by(enrich_targets)
+    performed_by_by_key = await lookup_ops_log_performed_by(enrich_targets)
     if performed_by_by_key:
         for key, (tag, committish, ts, performed_by) in list(latest.items()):
             if performed_by is not None:
@@ -1694,11 +1694,17 @@ async def patch_project_environment(
     (both of which behave unreliably on some Apache AGE builds). Protected
     structural keys are rejected. Returns the updated edge properties.
     """
-    props = {
-        k: v
-        for k, v in (updates.model_extra or {}).items()
-        if k not in _PROTECTED_ENV_KEYS
-    }
+    extra = updates.model_extra or {}
+    protected_keys = sorted(k for k in extra if k in _PROTECTED_ENV_KEYS)
+    if protected_keys:
+        raise fastapi.HTTPException(
+            status_code=400,
+            detail=(
+                'Protected environment fields are not editable via this '
+                f'endpoint: {protected_keys!r}'
+            ),
+        )
+    props = dict(extra)
     if not props:
         raise fastapi.HTTPException(
             status_code=400,
@@ -1744,7 +1750,9 @@ async def patch_project_environment(
                 f'environment {env_slug!r}'
             ),
         )
-    edge_props = graph.parse_agtype(records[0]['props']) or {}
+    edge_props: dict[str, typing.Any] = (
+        graph.parse_agtype(records[0]['props']) or {}
+    )
     return {
         k: v for k, v in edge_props.items() if k not in _PROTECTED_ENV_KEYS
     }

--- a/src/imbi_api/endpoints/releases.py
+++ b/src/imbi_api/endpoints/releases.py
@@ -165,6 +165,10 @@ class CurrentReleaseEnvironment(pydantic.BaseModel):
     last_event_at: datetime.datetime | None = None
     external_run_url: str | None = None
     ci_status: CheckStatus | None = None
+    #: Deployer of the latest event when observed from a remote (e.g. the
+    #: GitHub ``deployment.creator.login``). ``None`` for in-product deploys,
+    #: where the operator is captured in the operations log instead.
+    performed_by: str | None = None
 
 
 # -- Helpers ------------------------------------------------------------
@@ -729,6 +733,7 @@ async def list_current_releases(
             last_event_at=event.timestamp if event else None,
             external_run_url=event.external_run_url if event else None,
             ci_status=ci_status_by_slug.get(env['slug']),
+            performed_by=event.performed_by if event else None,
         )
         sortable.append((env.get('sort_order') or 0, env['name'], item))
 

--- a/src/imbi_api/endpoints/releases.py
+++ b/src/imbi_api/endpoints/releases.py
@@ -27,6 +27,7 @@ from imbi_api import sbom
 from imbi_api.auth import permissions
 from imbi_api.endpoints._helpers import fetch_or_404
 from imbi_api.endpoints.operations_log import complete_opslog_entry
+from imbi_api.endpoints.projects import lookup_ops_log_performed_by
 from imbi_api.plugins import call_with_timeout
 from imbi_api.scoring import OptionalValkeyClient
 from imbi_api.scoring import queue as score_queue
@@ -717,6 +718,22 @@ async def list_current_releases(
         db, org_slug, project_id, auth, by_env
     )
 
+    # Backfill performed_by from operations_log for events whose AGE edge
+    # left it null (in-product deploy/promote path), mirroring the
+    # project-detail current-releases view so both agree.
+    enrich_targets: list[tuple[str, str, str]] = []
+    for env, release_raw, event in by_env.values():
+        if event is None or event.performed_by is not None:
+            continue
+        if release_raw is None:
+            continue
+        version = str(
+            release_raw.get('tag') or release_raw.get('committish') or ''
+        )
+        if version:
+            enrich_targets.append((project_id, env['slug'], version))
+    performed_by_by_key = await lookup_ops_log_performed_by(enrich_targets)
+
     sortable: list[tuple[int, str, CurrentReleaseEnvironment]] = []
     for env, release_raw, event in by_env.values():
         release_resp = (
@@ -724,6 +741,18 @@ async def list_current_releases(
             if release_raw is not None
             else None
         )
+        performed_by = event.performed_by if event else None
+        if (
+            performed_by is None
+            and event is not None
+            and release_raw is not None
+        ):
+            version = str(
+                release_raw.get('tag') or release_raw.get('committish') or ''
+            )
+            performed_by = performed_by_by_key.get(
+                (project_id, env['slug'], version)
+            )
         item = CurrentReleaseEnvironment(
             environment=ReleaseEnvironmentRef(
                 slug=env['slug'], name=env['name']
@@ -733,7 +762,7 @@ async def list_current_releases(
             last_event_at=event.timestamp if event else None,
             external_run_url=event.external_run_url if event else None,
             ci_status=ci_status_by_slug.get(env['slug']),
-            performed_by=event.performed_by if event else None,
+            performed_by=performed_by,
         )
         sortable.append((env.get('sort_order') or 0, env['name'], item))
 

--- a/tests/endpoints/test_projects.py
+++ b/tests/endpoints/test_projects.py
@@ -675,8 +675,15 @@ class ProjectEndpointsTestCase(support.SharedAppTestCase):
 
         self.assertEqual(response.status_code, 200)
 
-    def test_patch_project_environments_uses_merge(self) -> None:
-        """Env edges use MERGE so retries cannot duplicate them."""
+    def test_patch_project_environments_uses_inline_create(self) -> None:
+        """Env edges are re-created with inline props (not SET r = {map}).
+
+        Some Apache AGE builds silently no-op a full-property
+        ``SET r = {map}`` on a relationship, dropping every edge
+        attribute. The update path deletes the old DEPLOYED_IN edges
+        and re-creates them with inline properties, matching the
+        create path, so edge attributes persist reliably.
+        """
         existing = self._project_data(
             environments=[
                 {
@@ -719,8 +726,9 @@ class ProjectEndpointsTestCase(support.SharedAppTestCase):
             for call in self.mock_db.execute.call_args_list
             if 'old_env:DEPLOYED_IN' in call.args[0]
         )
-        self.assertIn('MERGE (p)-[r:DEPLOYED_IN]->(e)', update_query)
-        self.assertNotIn('CREATE (p)-[:DEPLOYED_IN', update_query)
+        self.assertIn('CREATE (p)-[:DEPLOYED_IN', update_query)
+        self.assertNotIn('MERGE (p)-[r:DEPLOYED_IN]->(e)', update_query)
+        self.assertNotIn('SET r =', update_query)
 
     def test_patch_project_team_change(self) -> None:
         """Patch a project to change its team."""

--- a/tests/endpoints/test_projects_helpers.py
+++ b/tests/endpoints/test_projects_helpers.py
@@ -2,7 +2,7 @@
 
 Covers the private helpers added in the release-committish work:
 ``_fetch_pr_counts``, ``_resolve_display_names``,
-``_fetch_current_releases`` and ``_lookup_ops_log_performed_by``.
+``_fetch_current_releases`` and ``lookup_ops_log_performed_by``.
 """
 
 import datetime
@@ -298,13 +298,13 @@ class FetchCurrentReleasesTestCase(unittest.IsolatedAsyncioTestCase):
 
 
 class LookupOpsLogPerformedByTestCase(unittest.IsolatedAsyncioTestCase):
-    """Coverage for ``_lookup_ops_log_performed_by``."""
+    """Coverage for ``lookup_ops_log_performed_by``."""
 
     async def test_empty_targets_short_circuits(self) -> None:
         with mock.patch(
             'imbi_api.endpoints.projects.ch_client.Clickhouse.get_instance'
         ) as gi:
-            result = await projects._lookup_ops_log_performed_by([])
+            result = await projects.lookup_ops_log_performed_by([])
         self.assertEqual(result, {})
         gi.assert_not_called()
 
@@ -331,7 +331,7 @@ class LookupOpsLogPerformedByTestCase(unittest.IsolatedAsyncioTestCase):
             'imbi_api.endpoints.projects.ch_client.Clickhouse.get_instance',
             return_value=ch,
         ):
-            result = await projects._lookup_ops_log_performed_by(
+            result = await projects.lookup_ops_log_performed_by(
                 [('p1', 'prod', '1.0.0')]
             )
         self.assertEqual(
@@ -345,7 +345,7 @@ class LookupOpsLogPerformedByTestCase(unittest.IsolatedAsyncioTestCase):
             'imbi_api.endpoints.projects.ch_client.Clickhouse.get_instance',
             return_value=ch,
         ):
-            result = await projects._lookup_ops_log_performed_by(
+            result = await projects.lookup_ops_log_performed_by(
                 [('p1', 'prod', '1.0.0')]
             )
         self.assertEqual(result, {})


### PR DESCRIPTION
## Summary

Backend support for the redesigned project **Environments** card (paired UI PR: AWeber-Imbi/imbi-ui#414).

- **Schema** — `get_project_schema` now also returns relationship-blueprint sections with `scope="environment"` for the `Project -[:DEPLOYED_IN]-> Environment` edge, carrying the same JSON-Schema + `x-ui`/`x-display` metadata as node blueprints so the UI renders edge attributes with the shared attribute-display logic. Adds `BlueprintSection.scope` and `BlueprintSectionProperty.x_display`.
- **Inline edge edit** — new `PATCH /{project_id}/environments/{env_slug}` (`project:write`) performs targeted per-key `SET`/`REMOVE` on the single `DEPLOYED_IN` edge. `null` clears a property; protected structural keys are rejected.
- **Edge-write reliability** — the wholesale environment-update path switches from `MERGE (p)-[r]->(e) SET r = {map}` to `DELETE`+`CREATE` with inline edge properties, because some Apache AGE builds silently no-op a full-property `SET r = {map}` on a relationship (dropping every edge attribute). The `DELETE` and `CREATE` run in one transaction, so a retried attempt rolls back wholly and cannot accumulate duplicate edges.
- **Deployer** — surface `performed_by` (remote deployer, e.g. GitHub `deployment.creator.login`) on current-release environments.

## Review note

Please give extra scrutiny to the `_build_update_clauses` `MERGE+SET → DELETE+CREATE` change. During okteto testing an earlier variant of the wholesale-replace path was observed to under-delete parallel edges on AGE; the inline per-key PATCH endpoint above is the primary path the new UI uses, but this wholesale path is still reachable via `replace /environments`.

## Testing

`tests/endpoints/test_projects.py` updated (`test_patch_project_environments_uses_inline_create`) to assert the inline `CREATE` (not `MERGE`/`SET r =`). Affected endpoint tests pass locally (mock-DB).

> Note: `pyproject.toml`/`uv.lock` are intentionally **not** in this PR — those local changes are the okteto editable `imbi-common` path rewrite, not part of this feature.

