### PR TITLE
Add /events filters and by-id endpoint for webhook history

### DIFF
--- a/src/imbi_api/endpoints/events.py
+++ b/src/imbi_api/endpoints/events.py
@@ -59,7 +59,7 @@ class EventsPage(pydantic.BaseModel):
 _SELECT_COLUMNS: str = (
     'id, project_id, recorded_at, type, third_party_service, '
     'attributed_to, toJSONString(metadata) AS metadata, '
-    'toJSONString(payload) AS payload, version'
+    'toJSONString(payload) AS payload'
 )
 
 

--- a/src/imbi_api/endpoints/events.py
+++ b/src/imbi_api/endpoints/events.py
@@ -10,6 +10,7 @@ The global router lives at /events; the project-scoped router is mounted at
 from __future__ import annotations
 
 import datetime
+import json
 import typing
 
 import fastapi
@@ -48,13 +49,71 @@ class EventsPage(pydantic.BaseModel):
     data: list[EventRecord]
 
 
+#: Columns to return on every read. ``metadata`` and ``payload`` are
+#: ClickHouse ``JSON`` columns; clickhouse-connect returns nested
+#: array-of-tuple paths in their internal binary form (Python
+#: ``bytes``) that fastapi's encoder can't serialize. Wrapping them
+#: in :func:`toJSONString` forces ClickHouse to serialize each value
+#: as JSON text we then ``json.loads`` server-side, so the response
+#: encoder only sees ``dict`` / ``list`` / scalar trees.
+_SELECT_COLUMNS: str = (
+    'id, project_id, recorded_at, type, third_party_service, '
+    'attributed_to, toJSONString(metadata) AS metadata, '
+    'toJSONString(payload) AS payload, version'
+)
+
+
+def _parse_json_column(value: object, column_name: str) -> object:
+    """Parse a ``toJSONString``-serialized JSON column into Python.
+
+    Defensive: a malformed value gets returned as a marker dict so a
+    single bad row doesn't sink the whole list response.
+    """
+    if isinstance(value, dict | list):
+        # clickhouse-connect can hand back an already-parsed structure
+        # (with non-UTF-8 ``bytes`` buried in string values); pass it
+        # through so the response encoder decodes those bytes leniently.
+        return typing.cast(object, value)
+    if isinstance(value, bytes):
+        value = value.decode('utf-8', errors='replace')
+    if not isinstance(value, str):
+        return {}
+    try:
+        return json.loads(value)
+    except json.JSONDecodeError:
+        return {
+            '__raw__': value,
+            '__error__': f'invalid JSON in {column_name}',
+        }
+
+
 def _row_to_response(row: dict[str, typing.Any]) -> dict[str, typing.Any]:
     out: dict[str, typing.Any] = {}
     for k, v in row.items():
         if isinstance(v, datetime.datetime) and v.tzinfo is None:
-            v = v.replace(tzinfo=datetime.UTC)
-        out[k] = v
+            out[k] = v.replace(tzinfo=datetime.UTC)
+        elif k in ('metadata', 'payload'):
+            out[k] = _parse_json_column(v, k)
+        else:
+            out[k] = v
     return out
+
+
+def _events_response(body: object) -> fastapi.responses.JSONResponse:
+    """Serialize an events response body to JSON.
+
+    Both read paths (the list feed and the by-id lookup) route through
+    here so they share one decode policy: ClickHouse can hand back raw
+    ``bytes`` for JSON string values that aren't valid UTF-8 (e.g.
+    cp1252 smart quotes in webhook payloads); decode them leniently so
+    one bad row can't 500 the response.
+    """
+    return fastapi.responses.JSONResponse(
+        fastapi.encoders.jsonable_encoder(
+            body,
+            custom_encoder={bytes: lambda o: o.decode(errors='replace')},
+        )
+    )
 
 
 _FILTER_FIELDS: tuple[str, ...] = (
@@ -72,6 +131,7 @@ async def _list_impl(
     cursor: str | None = None,
     forced_filters: dict[str, str] | None = None,
     query_filters: dict[str, str | None] | None = None,
+    event_type: str | None = None,
     since: str | None = None,
     until: str | None = None,
 ) -> fastapi.Response:
@@ -94,6 +154,17 @@ async def _list_impl(
         if value is not None:
             clauses.append(f'{field} = {{{field}:String}}')
             params[field] = value
+
+    if event_type is not None:
+        # ``metadata.event_type`` carries the resolved per-source
+        # event-type label written by the gateway (e.g. 'pull_request',
+        # 'push'). The top-level ``type`` column is the event
+        # *category* — clients filter ``type='webhook'`` for the
+        # webhook-history view and use this field to narrow further.
+        clauses.append(
+            "CAST(metadata.event_type, 'String') = {event_type:String}"
+        )
+        params['event_type'] = event_type
 
     if since is not None:
         params['since'] = parse_iso(since, 'since')
@@ -119,7 +190,10 @@ async def _list_impl(
     where = ' AND '.join(clauses) if clauses else '1=1'
     params['row_limit'] = limit + 1
     sql: str = (
-        'SELECT * FROM events WHERE '  # noqa: S608
+        # ``events_latest`` is a view over ``events`` that collapses the
+        # phase-1 / phase-2 disposition writes from imbi-gateway to one
+        # row per id (highest ``version`` wins).
+        f'SELECT {_SELECT_COLUMNS} FROM events_latest WHERE '  # noqa: S608
         + where
         + ' ORDER BY recorded_at DESC, id DESC LIMIT {row_limit:UInt32}'
     )
@@ -132,15 +206,7 @@ async def _list_impl(
         next_cursor = encode_cursor(last['recorded_at'], last['id'])
 
     body = {'data': [_row_to_response(r) for r in rows]}
-    response = fastapi.responses.JSONResponse(
-        # ClickHouse hands back raw bytes for JSON string values that
-        # aren't valid UTF-8 (e.g. cp1252 smart quotes in webhook
-        # payloads); decode leniently so one bad row can't 500 the feed.
-        fastapi.encoders.jsonable_encoder(
-            body,
-            custom_encoder={bytes: lambda o: o.decode(errors='replace')},
-        )
-    )
+    response = _events_response(body)
     response.headers['Link'] = build_link_header(request, next_cursor)
     return response
 
@@ -158,11 +224,17 @@ async def list_events(
     cursor: str | None = None,
     project_id: str | None = None,
     type: str | None = None,
+    event_type: str | None = None,
     attributed_to: str | None = None,
+    third_party_service: str | None = None,
     since: str | None = None,
     until: str | None = None,
 ) -> fastapi.Response:
     """List events across every organization (admin / audit feed).
+
+    ``type`` is the event *category* (e.g. 'webhook'); ``event_type``
+    narrows further by the per-source label in
+    ``metadata.event_type`` (e.g. 'pull_request', 'push').
 
     Per-project event access lives on the org-scoped router; this
     endpoint is gated on ``admin:events:read`` because the unscoped
@@ -177,10 +249,38 @@ async def list_events(
             'project_id': project_id,
             'type': type,
             'attributed_to': attributed_to,
+            'third_party_service': third_party_service,
         },
+        event_type=event_type,
         since=since,
         until=until,
     )
+
+
+@events_router.get('/{event_id}', response_model=EventRecord)
+async def get_event(
+    event_id: str,
+    _auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('admin:events:read'),
+        ),
+    ],
+) -> fastapi.Response:
+    """Fetch a single event by id, coalesced through ``events_latest``.
+
+    Powers the webhook-history deep-link landing in the admin UI:
+    visiting a shared event URL must work even when the event has
+    aged past the default cursor page.
+    """
+    rows = await clickhouse.query(
+        f'SELECT {_SELECT_COLUMNS} FROM events_latest '  # noqa: S608
+        'WHERE id = {event_id:String}',
+        {'event_id': event_id},
+    )
+    if not rows:
+        raise fastapi.HTTPException(status_code=404, detail='Event not found')
+    return _events_response(_row_to_response(rows[0]))
 
 
 @events_project_router.get('/', response_model=EventsPage)
@@ -197,6 +297,7 @@ async def list_project_events(
     limit: int = DEFAULT_LIMIT,
     cursor: str | None = None,
     type: str | None = None,
+    event_type: str | None = None,
     attributed_to: str | None = None,
     since: str | None = None,
     until: str | None = None,
@@ -212,6 +313,7 @@ async def list_project_events(
             'type': type,
             'attributed_to': attributed_to,
         },
+        event_type=event_type,
         since=since,
         until=until,
     )

--- a/tests/endpoints/test_events.py
+++ b/tests/endpoints/test_events.py
@@ -22,6 +22,10 @@ def _row(
     entry_id: str = 'evt-1',
     project_id: str = 'p1',
 ) -> dict[str, typing.Any]:
+    # ``metadata`` and ``payload`` come back from ClickHouse as
+    # ``toJSONString``-serialized text (see ``_SELECT_COLUMNS`` in
+    # the events endpoint module); the helper handles the JSON
+    # parse.
     return {
         'id': entry_id,
         'project_id': project_id,
@@ -30,8 +34,8 @@ def _row(
         'type': 'project-change',
         'third_party_service': 'internal',
         'attributed_to': 'alice@example.com',
-        'metadata': {},
-        'payload': {'field': 'name', 'old': 'A', 'new': 'B'},
+        'metadata': '{}',
+        'payload': '{"field":"name","old":"A","new":"B"}',
     }
 
 
@@ -163,6 +167,36 @@ class RowToResponseTests(unittest.TestCase):
         assert isinstance(recorded, datetime.datetime)
         self.assertEqual(recorded.tzinfo, datetime.UTC)
 
+    def test_metadata_parsed_from_json_text(self) -> None:
+        """``toJSONString`` returns JSON text; the helper parses it
+        back to a Python dict for serialization."""
+        out = events._row_to_response(
+            {
+                'id': 'a',
+                'metadata': '{"webhook_id":"w-1","handlers":[]}',
+                'payload': '{"ref":"main"}',
+            }
+        )
+        self.assertEqual('w-1', out['metadata']['webhook_id'])
+        self.assertEqual([], out['metadata']['handlers'])
+        self.assertEqual('main', out['payload']['ref'])
+
+    def test_bytes_metadata_decoded_then_parsed(self) -> None:
+        """If clickhouse-connect hands back the JSON text as bytes
+        (e.g. with a Latin-1 byte inside a string value), decode
+        with replacement before parsing."""
+        out = events._row_to_response(
+            {'id': 'a', 'metadata': b'{"foo":"AB\x80C"}'}
+        )
+        self.assertEqual('AB�C', out['metadata']['foo'])
+
+    def test_malformed_json_in_metadata_does_not_500(self) -> None:
+        out = events._row_to_response(
+            {'id': 'a', 'metadata': 'not actually json'}
+        )
+        self.assertEqual('not actually json', out['metadata']['__raw__'])
+        self.assertIn('invalid JSON', out['metadata']['__error__'])
+
 
 class GlobalListTests(_EventsTestBase):
     def test_list_returns_200(self) -> None:
@@ -195,6 +229,7 @@ class GlobalListTests(_EventsTestBase):
                 'project_id': 'p1',
                 'type': 'project-change',
                 'attributed_to': 'alice@example.com',
+                'third_party_service': 'github-enterprise-cloud',
             },
         )
         self.assertEqual(response.status_code, 200)
@@ -203,6 +238,37 @@ class GlobalListTests(_EventsTestBase):
         self.assertEqual(params['project_id'], 'p1')
         self.assertEqual(params['type'], 'project-change')
         self.assertEqual(params['attributed_to'], 'alice@example.com')
+        self.assertEqual(
+            params['third_party_service'], 'github-enterprise-cloud'
+        )
+        sql = call.args[0]
+        self.assertIn('third_party_service =', sql)
+
+    def test_list_filters_by_event_type_through_metadata(self) -> None:
+        """``event_type`` filters on ``metadata.event_type`` so the
+        webhook-history view can narrow within ``type=webhook``."""
+        self.mock_query.return_value = [_row()]
+        response = self.client.get(
+            '/events/',
+            params={'type': 'webhook', 'event_type': 'pull_request'},
+        )
+        self.assertEqual(response.status_code, 200)
+        call = self.mock_query.await_args
+        sql = call.args[0]
+        params = call.args[1]
+        self.assertEqual(params['type'], 'webhook')
+        self.assertEqual(params['event_type'], 'pull_request')
+        self.assertIn('metadata.event_type', sql)
+
+    def test_list_reads_through_events_latest_view(self) -> None:
+        """Coalesced read: queries go through the events_latest view so
+        the phase-1 / phase-2 disposition writes from imbi-gateway are
+        collapsed to one row per id."""
+        self.mock_query.return_value = []
+        response = self.client.get('/events/')
+        self.assertEqual(response.status_code, 200)
+        sql = self.mock_query.await_args.args[0]
+        self.assertIn('FROM events_latest', sql)
 
     def test_list_with_since_until(self) -> None:
         self.mock_query.return_value = []
@@ -288,6 +354,60 @@ class GlobalListTests(_EventsTestBase):
         self.assertIn('cursor_ts', params)
         self.assertEqual(params['cursor_id'], 'evt-x')
         self.assertIn('(recorded_at, id) <', sql)
+
+
+class GetEventByIdTests(_EventsTestBase):
+    """Tests for the GET /events/{event_id} deep-link endpoint."""
+
+    def test_returns_event_when_found(self) -> None:
+        self.mock_query.return_value = [_row(entry_id='evt-deep-link')]
+        response = self.client.get('/events/evt-deep-link')
+        self.assertEqual(response.status_code, 200, response.text)
+        body = response.json()
+        self.assertEqual(body['id'], 'evt-deep-link')
+
+    def test_reads_through_events_latest_view(self) -> None:
+        self.mock_query.return_value = [_row(entry_id='evt-1')]
+        response = self.client.get('/events/evt-1')
+        self.assertEqual(response.status_code, 200)
+        sql = self.mock_query.await_args.args[0]
+        self.assertIn('FROM events_latest', sql)
+        params = self.mock_query.await_args.args[1]
+        self.assertEqual(params['event_id'], 'evt-1')
+
+    def test_returns_404_when_not_found(self) -> None:
+        self.mock_query.return_value = []
+        response = self.client.get('/events/nope')
+        self.assertEqual(response.status_code, 404)
+
+    def test_tolerates_non_utf8_bytes_in_payload(self) -> None:
+        # The by-id lookup must share the list feed's lenient decode
+        # policy: a non-UTF-8 byte in a payload string can't 500 it.
+        row = _row(entry_id='evt-1')
+        row['payload'] = {'title': b'fix \x91thing\x92'}
+        self.mock_query.return_value = [row]
+        response = self.client.get('/events/evt-1')
+        self.assertEqual(response.status_code, 200, response.text)
+        body = response.json()
+        self.assertEqual(body['payload']['title'], 'fix �thing�')
+
+    def test_non_admin_denied(self) -> None:
+        non_admin = api_models.User(
+            email='basic@example.com',
+            display_name='Basic',
+            is_active=True,
+            is_admin=False,
+            is_service_account=False,
+            created_at=datetime.datetime.now(datetime.UTC),
+        )
+        self.auth = api_permissions.AuthContext(
+            user=non_admin,
+            session_id='s',
+            auth_method='jwt',
+            permissions={'project:read'},
+        )
+        response = self.client.get('/events/evt-1')
+        self.assertEqual(response.status_code, 403)
 
 
 class ProjectScopedListTests(_EventsTestBase):


### PR DESCRIPTION
## Summary

Adds the `/events` query surface that backs the Webhook History admin
view: source/event-type filters, view-based reads, and a by-id
endpoint for deep links.

## Problem

The webhook-history UI needs to list recorded webhook deliveries with
their handler outcomes and to deep-link a single event. The existing
`/events` listing reads the raw table (so it can show half-written
phase-1 rows), exposes no filters for narrowing by source or event
type, and has no single-event endpoint.

## Solution

- `_list_impl` reads from the `events_latest` view so phase-1 and
  phase-2 disposition writes coalesce per id. `SELECT *` is replaced
  with an explicit column list that wraps the `JSON` columns in
  `toJSONString` — clickhouse-connect's default representation of the
  new typed JSON returns nested `Array(Tuple(...))` paths as raw
  bytes that fastapi's encoder can't serialize.
- `_row_to_response` parses the `toJSONString`-serialized `metadata`
  and `payload` back into dicts via `_parse_json_column`; defensively
  decodes bytes with replacement and substitutes a `__raw__` /
  `__error__` marker on malformed values so a single bad row does not
  500 the list.
- `list_events` gains `third_party_service` and `event_type` query
  parameters. `type` is the event *category* (`'webhook'` for inbound
  webhook deliveries); `event_type` filters on `metadata.event_type`
  (the per-source label like `'pull_request'`). `list_project_events`
  gains the same `event_type` parameter.
- New `GET /events/{event_id}` returning one `EventRecord`, also
  through the `events_latest` view. Gated on `admin:events:read`; 404
  on miss. Backs the webhook-history deep-link landing in imbi-ui.
- Tests cover the new filters, view-based read, by-id 404 +
  permission, JSON-text parsing, and bytes / malformed-JSON fallback
  paths.

Depends on the `events_latest` view and `version` column from the
companion imbi-common PR.

---

**Companion PRs** (merge in order):
1. imbi-common https://github.com/AWeber-Imbi/imbi-common/pull/159 — schema (`events.version` + `events_latest` view)
2. imbi-api https://github.com/AWeber-Imbi/imbi-api/pull/437 — `/events` filters + by-id endpoint
3. imbi-ui https://github.com/AWeber-Imbi/imbi-ui/pull/415 — Webhook History admin view
