### PR TITLE
Search Comments and Components in org-scoped vector search

### DIFF
--- a/src/imbi_api/backfill_embeddings.py
+++ b/src/imbi_api/backfill_embeddings.py
@@ -45,10 +45,13 @@ _NODE_TYPES: list[type[models.Node]] = [
 ]
 
 # GraphModel types that have Embeddable fields but are not Node subclasses.
-# match() still works via model_construct fallback; _auto_embed accepts any
-# GraphModel even though its type annotation says Node.
+# match() still works via model_construct fallback; _auto_embed embeds any
+# GraphModel that declares Embeddable fields.
 _GRAPH_MODEL_TYPES: list[type[models.GraphModel]] = [
     models.Document,
+    models.Release,
+    models.Comment,
+    models.Component,
 ]
 
 _DEFAULT_CONCURRENCY = 4

--- a/src/imbi_api/endpoints/search.py
+++ b/src/imbi_api/endpoints/search.py
@@ -35,7 +35,10 @@ async def _get_org_node_ids(
 
     Covers: the org itself, direct BELONGS_TO children (Team, Environment,
     ProjectType, ThirdPartyService, Tag, DocumentTemplate, LinkDefinition),
-    Projects, Documents, and Releases.
+    Projects, Documents, Releases, Comments, and the Components reachable
+    through the org's release dependency graph. Components are shared,
+    cross-org identities, so they are scoped to those an org actually
+    depends on rather than enumerated globally.
     """
     org_rows = await db.execute(
         'MATCH (o:Organization {{slug: {org_slug}}}) RETURN o.id AS org_id',
@@ -85,6 +88,31 @@ async def _get_org_node_ids(
         'MATCH (:Organization {{slug: {org_slug}}})<-[:BELONGS_TO]-'
         '(:Team)<-[:OWNED_BY]-(:Project)-[:HAS_RELEASE]->(r:Release)'
         ' RETURN r.id AS nid',
+        {'org_slug': org_slug},
+        columns=['nid'],
+    ):
+        nid = graph.parse_agtype(row['nid'])
+        if nid:
+            node_ids.add(nid)
+
+    for row in await db.execute(
+        'MATCH (c:Comment)-[:IN_THREAD]->(:CommentThread)-[:ON_DOCUMENT]->'
+        '(:Document)-[:ATTACHED_TO]->(:Project)-[:OWNED_BY]->(:Team)'
+        '-[:BELONGS_TO]->(:Organization {{slug: {org_slug}}})'
+        ' RETURN c.id AS nid',
+        {'org_slug': org_slug},
+        columns=['nid'],
+    ):
+        nid = graph.parse_agtype(row['nid'])
+        if nid:
+            node_ids.add(nid)
+
+    for row in await db.execute(
+        'MATCH (comp:Component)-[:HAS_RELEASE]->(:ComponentRelease)'
+        '<-[:USES_COMPONENT_RELEASE]-(:Release)<-[:HAS_RELEASE]-(:Project)'
+        '-[:OWNED_BY]->(:Team)-[:BELONGS_TO]->'
+        '(:Organization {{slug: {org_slug}}})'
+        ' RETURN comp.id AS nid',
         {'org_slug': org_slug},
         columns=['nid'],
     ):

--- a/tests/endpoints/test_search.py
+++ b/tests/endpoints/test_search.py
@@ -65,7 +65,7 @@ class SearchEndpointTestCase(support.SharedAppTestCase):
         )
 
     def _setup_org(self, node_ids: list[str] | None = None) -> None:
-        """Configure mock_db.execute for the five org-membership queries.
+        """Configure mock_db.execute for the org-membership queries.
 
         The search handler calls db.execute in this order:
           1. org lookup -> [{org_id: ...}] or []
@@ -73,6 +73,8 @@ class SearchEndpointTestCase(support.SharedAppTestCase):
           3. Project nodes -> [{nid: ...}, ...]
           4. Document nodes -> []
           5. Release nodes -> []
+          6. Comment nodes -> []
+          7. Component nodes -> []
         """
         if node_ids is None:
             node_ids = ['proj-1']
@@ -80,6 +82,8 @@ class SearchEndpointTestCase(support.SharedAppTestCase):
             [{'org_id': '"org-abc"'}],
             [],
             [{'nid': f'"{nid}"'} for nid in node_ids],
+            [],
+            [],
             [],
             [],
         ]
@@ -304,6 +308,8 @@ class SearchEndpointTestCase(support.SharedAppTestCase):
             [{'nid': '"proj-1"'}],  # Project: valid nid included
             [{'nid': '""'}],  # Document: falsy nid skipped
             [{'nid': '""'}],  # Release: falsy nid skipped
+            [{'nid': '""'}],  # Comment: falsy nid skipped
+            [{'nid': '""'}],  # Component: falsy nid skipped
         ]
         self.mock_db.search.return_value = [
             self._make_result(node_id='proj-1'),
@@ -322,6 +328,8 @@ class SearchEndpointTestCase(support.SharedAppTestCase):
             [],  # Projects
             [],  # Documents
             [],  # Releases
+            [],  # Comments
+            [],  # Components
         ]
         self.mock_db.search.return_value = [
             self._make_result(node_id='team-1', node_label='Team'),
@@ -340,6 +348,8 @@ class SearchEndpointTestCase(support.SharedAppTestCase):
             [],  # Projects
             [{'nid': '"doc-1"'}],  # Documents
             [],  # Releases
+            [],  # Comments
+            [],  # Components
         ]
         self.mock_db.search.return_value = [
             self._make_result(node_id='doc-1', node_label='Document'),
@@ -358,6 +368,8 @@ class SearchEndpointTestCase(support.SharedAppTestCase):
             [],  # Projects
             [],  # Documents
             [{'nid': '"rel-1"'}],  # Releases
+            [],  # Comments
+            [],  # Components
         ]
         self.mock_db.search.return_value = [
             self._make_result(node_id='rel-1', node_label='Release'),
@@ -367,6 +379,50 @@ class SearchEndpointTestCase(support.SharedAppTestCase):
         data = response.json()
         self.assertEqual(len(data), 1)
         self.assertEqual(data[0]['node_id'], 'rel-1')
+
+    def test_comment_node_ids_included(self) -> None:
+        """Comment IN_THREAD query nodes are included in org scope."""
+        self.mock_db.execute.side_effect = [
+            [{'org_id': '"org-abc"'}],
+            [],  # BELONGS_TO
+            [],  # Projects
+            [],  # Documents
+            [],  # Releases
+            [{'nid': '"comment-1"'}],  # Comments
+            [],  # Components
+        ]
+        self.mock_db.search.return_value = [
+            self._make_result(
+                node_id='comment-1',
+                node_label='Comment',
+                attribute='body',
+            ),
+        ]
+        response = self.client.get(f'{_BASE_URL}?q=test')
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]['node_id'], 'comment-1')
+
+    def test_component_node_ids_included(self) -> None:
+        """Component dependency-graph query nodes are in org scope."""
+        self.mock_db.execute.side_effect = [
+            [{'org_id': '"org-abc"'}],
+            [],  # BELONGS_TO
+            [],  # Projects
+            [],  # Documents
+            [],  # Releases
+            [],  # Comments
+            [{'nid': '"comp-1"'}],  # Components
+        ]
+        self.mock_db.search.return_value = [
+            self._make_result(node_id='comp-1', node_label='Component'),
+        ]
+        response = self.client.get(f'{_BASE_URL}?q=test')
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]['node_id'], 'comp-1')
 
     def test_limit_reached_mid_batch_stops_inner_loop(self) -> None:
         """Inner loop breaks early when limit is reached mid-batch."""
@@ -421,6 +477,8 @@ class SearchEndpointTestCase(support.SharedAppTestCase):
             [{'nid': '""'}],  # Project: falsy nid skipped
             [],  # Documents
             [],  # Releases
+            [],  # Comments
+            [],  # Components
         ]
         self.mock_db.search.return_value = []
         response = self.client.get(f'{_BASE_URL}?q=test')

--- a/uv.lock
+++ b/uv.lock
@@ -1149,7 +1149,7 @@ docs = [
 [[package]]
 name = "imbi-common"
 version = "2.10.0"
-source = { git = "https://github.com/AWeber-Imbi/imbi-common.git?branch=main#fda46230d4e45020102b99ae0ed804b2c2b9104a" }
+source = { git = "https://github.com/AWeber-Imbi/imbi-common.git?branch=main#4e0b514a34460dcdd2d4baa3bf7c4c1073001492" }
 dependencies = [
     { name = "cryptography" },
     { name = "httpx" },


### PR DESCRIPTION
## Summary

The org-scoped vector search endpoint enumerated Projects, Documents, and Releases but **not** Comments or Components, so those node types never appeared in results even once they carry embeddings.

## Problem

`_get_org_node_ids()` built the org scope from Org → BELONGS_TO children → Projects → Documents → Releases. Comments and Components were absent, so their ids were never passed to `db.search()`'s `node_id = ANY(...)` filter.

## Solution

- Enumerate **Comments** via `IN_THREAD → ON_DOCUMENT → ATTACHED_TO → OWNED_BY → BELONGS_TO`.
- Enumerate **Components** through the org's release dependency graph (`Component → ComponentRelease ← USES_COMPONENT_RELEASE ← Release ← HAS_RELEASE ← Project → …`). Components are shared, cross-org identities with no direct org edge, so they're scoped to those an org actually depends on.
- `backfill_embeddings`: add `Release`, `Comment`, and `Component` to the embeddable `GraphModel` types so existing rows can be populated.

## Dependency

Depends on **AWeber-Imbi/imbi-common#166**, which embeds these `GraphModel` types. These node types will not be searchable until that ships and `uv run python -m imbi_api.backfill_embeddings` is run against existing data. Lockstep release.

## Testing

- `tests/endpoints/test_search.py` + `tests/test_backfill_embeddings.py` pass (added `test_comment_node_ids_included`, `test_component_node_ids_included`).
- ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)