### PR TITLE
Select release-drift base by semver, not tag timestamp

### DIFF
--- a/src/imbi_api/endpoints/project_deployments.py
+++ b/src/imbi_api/endpoints/project_deployments.py
@@ -1720,6 +1720,49 @@ def _release_notes_system() -> str:
     )
 
 
+def _semver_sort_key(name: str) -> tuple[int, int, int] | None:
+    """``(major, minor, patch)`` for version ordering; ``None`` if not semver.
+
+    Pre-release / build metadata is ignored for ordering -- good enough to
+    pick the newest *released* version and to sort the history list.
+    """
+    match = _SEMVER_RE.match(name)
+    if not match:
+        return None
+    major, minor, patch = (int(part) for part in match.groups())
+    return (major, minor, patch)
+
+
+def _release_tag_order_key(
+    name: str, when: typing.Any
+) -> tuple[bool, tuple[int, int, int], str]:
+    """Sort key ranking the latest *release* first.
+
+    Semver-shaped tags outrank non-semver ones; within those, the highest
+    version wins, with the newer timestamp as a tie-break. This deliberately
+    ignores tag/commit *timestamps* for the primary ordering so a backported
+    or late-synced lower version (e.g. ``v4.1.3`` tagged after ``v7.1.0``)
+    can't masquerade as the latest release.
+    """
+    key = _semver_sort_key(name)
+    when_key = when.isoformat() if isinstance(when, datetime.datetime) else ''
+    return (key is not None, key or (0, 0, 0), when_key)
+
+
+def _latest_release_tag(
+    rows: list[dict[str, typing.Any]],
+) -> dict[str, typing.Any] | None:
+    """Pick the latest release tag (highest semver) from ``tags`` rows."""
+    if not rows:
+        return None
+    return max(
+        rows,
+        key=lambda r: _release_tag_order_key(
+            str(r['name']), r.get('tagged_at') or r.get('recorded_at')
+        ),
+    )
+
+
 def _bump_semver(last_tag: str | None, bump: SemverBump) -> str:
     """Bump a semver-shaped tag.  Falls back to ``v0.1.0`` when missing."""
     raw = (last_tag or 'v0.0.0').lstrip('v')
@@ -2206,15 +2249,19 @@ async def get_release_drift(
     the commits authored after the tag's commit.  With no prior tag the
     drift is the full (capped) history and the suggestion is ``v0.1.0``.
     """
+    # Fetch all tags and pick the latest *release* by semver (not by
+    # timestamp): a late-synced or backported lower version must not be
+    # treated as the base, or the "commits since the last tag" delta below
+    # is computed from the wrong tag.
     tag_rows = await clickhouse.query(
-        'SELECT name, sha, tagged_at FROM tags FINAL '
-        'WHERE project_id = {project_id:String} '
-        'ORDER BY coalesce(tagged_at, recorded_at) DESC LIMIT 1',
+        'SELECT name, sha, tagged_at, recorded_at FROM tags FINAL '
+        'WHERE project_id = {project_id:String}',
         {'project_id': project_id},
     )
-    latest_tag = str(tag_rows[0]['name']) if tag_rows else None
-    latest_tag_sha = str(tag_rows[0]['sha']) if tag_rows else None
-    latest_tag_at = tag_rows[0].get('tagged_at') if tag_rows else None
+    latest = _latest_release_tag(tag_rows)
+    latest_tag = str(latest['name']) if latest else None
+    latest_tag_sha = str(latest['sha']) if latest else None
+    latest_tag_at = latest.get('tagged_at') if latest else None
 
     head_rows = await clickhouse.query(
         'SELECT sha FROM commits FINAL '
@@ -2332,6 +2379,13 @@ async def get_release_history(
                 package_url=None,
             )
         )
+    # Order by released version (highest semver first) so the head of the
+    # list is the current release -- consistent with the drift base, which
+    # is also chosen by semver rather than timestamp.
+    entries.sort(
+        key=lambda e: _release_tag_order_key(e.tag, e.published_at),
+        reverse=True,
+    )
     return entries
 
 

--- a/src/imbi_api/endpoints/project_deployments.py
+++ b/src/imbi_api/endpoints/project_deployments.py
@@ -2261,7 +2261,11 @@ async def get_release_drift(
     latest = _latest_release_tag(tag_rows)
     latest_tag = str(latest['name']) if latest else None
     latest_tag_sha = str(latest['sha']) if latest else None
-    latest_tag_at = latest.get('tagged_at') if latest else None
+    latest_tag_at = (
+        (latest.get('tagged_at') or latest.get('recorded_at'))
+        if latest
+        else None
+    )
 
     head_rows = await clickhouse.query(
         'SELECT sha FROM commits FINAL '
@@ -2347,11 +2351,14 @@ async def get_release_history(
 ) -> list[ReleaseHistoryEntry]:
     """Release history: ClickHouse tags joined to their ``Release`` nodes."""
     capped = max(1, min(limit, 100))
+    # Fetch all tags (not a timestamp-limited window) so the semver sort
+    # below ranks the full candidate set: a high-semver tag with an old or
+    # late-synced timestamp must still be able to reach the head of the list,
+    # consistent with the drift base selection.
     tag_rows = await clickhouse.query(
         'SELECT name, sha, tagged_at, tagger_name, url, recorded_at '
-        'FROM tags FINAL WHERE project_id = {project_id:String} '
-        'ORDER BY coalesce(tagged_at, recorded_at) DESC LIMIT {limit:UInt32}',
-        {'project_id': project_id, 'limit': capped},
+        'FROM tags FINAL WHERE project_id = {project_id:String}',
+        {'project_id': project_id},
     )
     nodes = await _release_nodes_by_tag(db, org_slug, project_id)
     ci_by_sha = await _ci_status_by_sha(
@@ -2386,7 +2393,7 @@ async def get_release_history(
         key=lambda e: _release_tag_order_key(e.tag, e.published_at),
         reverse=True,
     )
-    return entries
+    return entries[:capped]
 
 
 @project_deployments_router.post('/releases/cut', status_code=201)

--- a/tests/endpoints/test_project_deployments.py
+++ b/tests/endpoints/test_project_deployments.py
@@ -1802,6 +1802,37 @@ class ReleasesTabEndpointsTestCase(ProjectDeploymentsTestCase):
         # A feat commit bumps the minor off v7.1.0, not off v4.1.3.
         self.assertEqual(data['suggested_tag'], 'v7.2.0')
 
+    def test_release_drift_latest_tag_at_falls_back_to_recorded_at(
+        self,
+    ) -> None:
+        """``latest_tag_at`` uses ``recorded_at`` when ``tagged_at`` null."""
+        recorded = datetime.datetime(2026, 3, 2, tzinfo=datetime.UTC)
+        self._patch_query(
+            [
+                [
+                    {
+                        'name': 'v1.0.0',
+                        'sha': 'tagsha',
+                        'tagged_at': None,
+                        'recorded_at': recorded,
+                    }
+                ],
+                [{'sha': 'headsha'}],
+                [{'authored_at': recorded}],
+                [self._commit_row('feat1', message='feat: new thing')],
+                [{'c': 1}],
+            ]
+        )
+        with testclient.TestClient(self.test_app) as client:
+            response = client.get(f'{self._BASE}/release-drift')
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertIsNotNone(data['latest_tag_at'])
+        self.assertEqual(
+            datetime.datetime.fromisoformat(data['latest_tag_at']),
+            recorded,
+        )
+
     def test_release_history_joins_tags_and_nodes(self) -> None:
         when = datetime.datetime(2026, 1, 1, tzinfo=datetime.UTC)
         self._patch_query(
@@ -1866,6 +1897,73 @@ class ReleasesTabEndpointsTestCase(ProjectDeploymentsTestCase):
         # Tag with no matching Release node -> null metadata, unknown CI.
         self.assertIsNone(data[1]['notes_markdown'])
         self.assertEqual(data[1]['ci_status'], 'unknown')
+
+    def test_release_history_head_is_highest_semver_not_newest(self) -> None:
+        """The head of history is the highest semver, ignoring timestamps.
+
+        A late-synced lower version (newer timestamp) must not out-rank the
+        highest semver tag, mirroring the drift base selection.  This guards
+        against re-introducing a timestamp-limited candidate window that could
+        drop the highest version before the semver sort runs.
+        """
+        older = datetime.datetime(2026, 1, 1, tzinfo=datetime.UTC)
+        newer = datetime.datetime(2026, 6, 1, tzinfo=datetime.UTC)
+        self._patch_query(
+            [
+                [
+                    {
+                        'name': 'v4.1.3',
+                        'sha': 'sha413',
+                        'tagged_at': newer,
+                        'tagger_name': 'Rel Bot',
+                        'url': '',
+                        'recorded_at': newer,
+                    },
+                    {
+                        'name': 'v7.1.0',
+                        'sha': 'sha710',
+                        'tagged_at': older,
+                        'tagger_name': 'Rel Bot',
+                        'url': '',
+                        'recorded_at': older,
+                    },
+                ],
+                # ci_status lookup
+                [],
+            ]
+        )
+        self.mock_db.execute = mock.AsyncMock(return_value=[])
+        with testclient.TestClient(self.test_app) as client:
+            response = client.get(f'{self._BASE}/release-history')
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual([e['tag'] for e in data], ['v7.1.0', 'v4.1.3'])
+
+    def test_release_history_limit_applies_after_semver_sort(self) -> None:
+        """``limit`` slices the semver-sorted list, keeping top versions."""
+        when = datetime.datetime(2026, 1, 1, tzinfo=datetime.UTC)
+        self._patch_query(
+            [
+                [
+                    {
+                        'name': f'v{major}.0.0',
+                        'sha': f'sha{major}',
+                        'tagged_at': when,
+                        'tagger_name': 'Rel Bot',
+                        'url': '',
+                        'recorded_at': when,
+                    }
+                    for major in (1, 5, 3, 2, 4)
+                ],
+                [],
+            ]
+        )
+        self.mock_db.execute = mock.AsyncMock(return_value=[])
+        with testclient.TestClient(self.test_app) as client:
+            response = client.get(f'{self._BASE}/release-history?limit=2')
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual([e['tag'] for e in data], ['v5.0.0', 'v4.0.0'])
 
     def test_cut_release_creates_tag_and_release_no_deploy(self) -> None:
         triggered: dict[str, bool] = {'called': False}

--- a/tests/endpoints/test_project_deployments.py
+++ b/tests/endpoints/test_project_deployments.py
@@ -1765,6 +1765,43 @@ class ReleasesTabEndpointsTestCase(ProjectDeploymentsTestCase):
         self.assertEqual(data['commits'], [])
         self.assertEqual(data['suggested_tag'], 'v2.0.1')
 
+    def test_release_drift_picks_highest_semver_not_newest(self) -> None:
+        """A late-synced lower version must not out-rank the latest release."""
+        older = datetime.datetime(2026, 1, 1, tzinfo=datetime.UTC)
+        newer = datetime.datetime(2026, 6, 1, tzinfo=datetime.UTC)
+        self._patch_query(
+            [
+                [
+                    # v4.1.3 (a backport) was tagged most recently, but
+                    # v7.1.0 is the highest version -> the real base.
+                    {
+                        'name': 'v4.1.3',
+                        'sha': 'sha413',
+                        'tagged_at': newer,
+                        'recorded_at': newer,
+                    },
+                    {
+                        'name': 'v7.1.0',
+                        'sha': 'sha710',
+                        'tagged_at': older,
+                        'recorded_at': older,
+                    },
+                ],
+                [{'sha': 'headsha'}],
+                [{'authored_at': older}],
+                [self._commit_row('feat1', message='feat: new thing')],
+                [{'c': 2}],
+            ]
+        )
+        with testclient.TestClient(self.test_app) as client:
+            response = client.get(f'{self._BASE}/release-drift')
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data['latest_tag'], 'v7.1.0')
+        self.assertEqual(data['latest_tag_sha'], 'sha710')
+        # A feat commit bumps the minor off v7.1.0, not off v4.1.3.
+        self.assertEqual(data['suggested_tag'], 'v7.2.0')
+
     def test_release_history_joins_tags_and_nodes(self) -> None:
         when = datetime.datetime(2026, 1, 1, tzinfo=datetime.UTC)
         self._patch_query(


### PR DESCRIPTION
## Problem
`release-drift` and `release-history` ranked tags by `coalesce(tagged_at, recorded_at) DESC`. A backported or late-synced lower version (e.g. `v4.1.3` tagged after `v7.1.0`) then out-ranks the true latest release — so the drift base, and the "commits since the last tag" delta computed from it, came from the wrong tag (the bogus 100+ commit count), while the "Currently Released" card showed a different, higher version.

## Fix
- Add `_semver_sort_key` / `_latest_release_tag`: pick the latest release by **highest semver** (timestamp only as a tie-break; non-semver tags fall back to newest-recorded).
- `release-drift` fetches all tags and chooses the base by version → the commit list is genuinely "commits since the latest release".
- `release-history` entries are sorted by semver desc, so its head (the "Currently Released" entry) agrees with the drift base.

## Testing
- New `test_release_drift_picks_highest_semver_not_newest` (a newer-timestamped `v4.1.3` must not beat `v7.1.0`).
- `ReleasesTabEndpointsTestCase` — 44 passed; ruff + basedpyright + mypy clean.

Pairs with imbi-ui `fix/release-tab-drift-and-layout` (UI consistency for the same flow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)