### PR TITLE
Exclude archived projects from org-scoped search

### DIFF
--- a/src/imbi_api/endpoints/search.py
+++ b/src/imbi_api/endpoints/search.py
@@ -49,6 +49,10 @@ async def _get_org_node_ids(
     through the org's release dependency graph. Components are shared,
     cross-org identities, so they are scoped to those an org actually
     depends on rather than enumerated globally.
+
+    Archived projects are excluded, along with the Documents, Releases,
+    Comments, and Components reached through them, so search never
+    surfaces content from an archived project.
     """
     org_rows = await db.execute(
         'MATCH (o:Organization {{slug: {org_slug}}}) RETURN o.id AS org_id',
@@ -75,7 +79,9 @@ async def _get_org_node_ids(
 
     for row in await db.execute(
         'MATCH (p:Project)-[:OWNED_BY]->(:Team)-[:BELONGS_TO]->'
-        '(:Organization {{slug: {org_slug}}}) RETURN p.id AS nid',
+        '(:Organization {{slug: {org_slug}}})'
+        ' WHERE coalesce(p.archived, false) = false'
+        ' RETURN p.id AS nid',
         {'org_slug': org_slug},
         columns=['nid'],
     ):
@@ -84,8 +90,9 @@ async def _get_org_node_ids(
             node_ids.add(nid)
 
     for row in await db.execute(
-        'MATCH (d:Document)-[:ATTACHED_TO]->(:Project)-[:OWNED_BY]->'
+        'MATCH (d:Document)-[:ATTACHED_TO]->(p:Project)-[:OWNED_BY]->'
         '(:Team)-[:BELONGS_TO]->(:Organization {{slug: {org_slug}}})'
+        ' WHERE coalesce(p.archived, false) = false'
         ' RETURN d.id AS nid',
         {'org_slug': org_slug},
         columns=['nid'],
@@ -96,7 +103,8 @@ async def _get_org_node_ids(
 
     for row in await db.execute(
         'MATCH (:Organization {{slug: {org_slug}}})<-[:BELONGS_TO]-'
-        '(:Team)<-[:OWNED_BY]-(:Project)-[:HAS_RELEASE]->(r:Release)'
+        '(:Team)<-[:OWNED_BY]-(p:Project)-[:HAS_RELEASE]->(r:Release)'
+        ' WHERE coalesce(p.archived, false) = false'
         ' RETURN r.id AS nid',
         {'org_slug': org_slug},
         columns=['nid'],
@@ -107,8 +115,9 @@ async def _get_org_node_ids(
 
     for row in await db.execute(
         'MATCH (c:Comment)-[:IN_THREAD]->(:CommentThread)-[:ON_DOCUMENT]->'
-        '(:Document)-[:ATTACHED_TO]->(:Project)-[:OWNED_BY]->(:Team)'
+        '(:Document)-[:ATTACHED_TO]->(p:Project)-[:OWNED_BY]->(:Team)'
         '-[:BELONGS_TO]->(:Organization {{slug: {org_slug}}})'
+        ' WHERE coalesce(p.archived, false) = false'
         ' RETURN c.id AS nid',
         {'org_slug': org_slug},
         columns=['nid'],
@@ -119,9 +128,10 @@ async def _get_org_node_ids(
 
     for row in await db.execute(
         'MATCH (comp:Component)-[:HAS_RELEASE]->(:ComponentRelease)'
-        '<-[:USES_COMPONENT_RELEASE]-(:Release)<-[:HAS_RELEASE]-(:Project)'
+        '<-[:USES_COMPONENT_RELEASE]-(:Release)<-[:HAS_RELEASE]-(p:Project)'
         '-[:OWNED_BY]->(:Team)-[:BELONGS_TO]->'
         '(:Organization {{slug: {org_slug}}})'
+        ' WHERE coalesce(p.archived, false) = false'
         ' RETURN comp.id AS nid',
         {'org_slug': org_slug},
         columns=['nid'],

--- a/tests/endpoints/test_search.py
+++ b/tests/endpoints/test_search.py
@@ -129,10 +129,13 @@ class SearchEndpointTestCase(support.SharedAppTestCase):
         self.client.get(f'{_BASE_URL}?q=test')
         queries = [c.args[0] for c in self.mock_db.execute.call_args_list]
         archived_clause = 'coalesce(p.archived, false) = false'
-        filtered = [q for q in queries if archived_clause in q]
-        self.assertEqual(len(filtered), 5)
-        # The org lookup (first call) never filters by project.
+        # The org lookup and the direct BELONGS_TO query do not traverse a
+        # Project, so they must not carry the filter.
         self.assertNotIn(archived_clause, queries[0])
+        self.assertNotIn(archived_clause, queries[1])
+        # Every subsequent project-traversing query must carry the filter.
+        for query in queries[2:]:
+            self.assertIn(archived_clause, query)
 
     def test_org_not_found_returns_404(self) -> None:
         self._setup_org_not_found()

--- a/tests/endpoints/test_search.py
+++ b/tests/endpoints/test_search.py
@@ -117,6 +117,23 @@ class SearchEndpointTestCase(support.SharedAppTestCase):
         # The handler enriches results for UI routing before returning.
         self.mock_enrich.assert_awaited_once()
 
+    def test_archived_projects_excluded_from_scope(self) -> None:
+        """Each project-traversing scope query filters out archived projects.
+
+        The org lookup and the direct BELONGS_TO query do not traverse a
+        Project, so they must not carry the filter; the Project, Document,
+        Release, Comment, and Component queries must.
+        """
+        self._setup_org()
+        self.mock_db.search.return_value = []
+        self.client.get(f'{_BASE_URL}?q=test')
+        queries = [c.args[0] for c in self.mock_db.execute.call_args_list]
+        archived_clause = 'coalesce(p.archived, false) = false'
+        filtered = [q for q in queries if archived_clause in q]
+        self.assertEqual(len(filtered), 5)
+        # The org lookup (first call) never filters by project.
+        self.assertNotIn(archived_clause, queries[0])
+
     def test_org_not_found_returns_404(self) -> None:
         self._setup_org_not_found()
         response = self.client.get(f'{_BASE_URL}?q=foo')


### PR DESCRIPTION
## Summary

The org-scoped search enumerated every project regardless of archived state, so archived projects — and the documents, releases, comments, and dependency components reached through them — showed up in results.

## Changes

- Add `WHERE coalesce(p.archived, false) = false` to each `_get_org_node_ids` scope query that traverses a `Project` (Project, Document, Release, Comment, Component), so archived projects and their nested content are dropped from the searchable node set.

This mirrors the projects list endpoint, which already excludes archived by default (`coalesce(p.archived, false) = false`).

## Scope note

This excludes **both** archived projects and content nested under them (a doc/release from an archived project would otherwise leak through while the project itself is hidden). If you'd prefer to hide only the Project nodes and keep their docs/releases searchable, that's a one-line narrowing — say the word.

There's no per-request `include_archived` toggle yet; easy to add later if needed.

## Testing

- New `test_archived_projects_excluded_from_scope` asserts the filter is present on exactly the five project-traversing queries and absent from the org lookup.
- Full search endpoint suite passes (39); ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)