### PR TITLE
Support attaching documents to users and project types

### DIFF
--- a/src/imbi_api/endpoints/comments.py
+++ b/src/imbi_api/endpoints/comments.py
@@ -1,6 +1,6 @@
-"""Page-level threaded comments on project documents.
+"""Page-level threaded comments on documents.
 
-Comments hang off a project ``Document`` via a ``CommentThread`` vertex
+Comments hang off a ``Document`` via a ``CommentThread`` vertex
 (``ON_DOCUMENT`` edge) containing one or more ``Comment`` vertices
 (``IN_THREAD`` edge). The root comment is the oldest comment in a thread;
 replies follow in ``created_at`` order.
@@ -39,7 +39,7 @@ _COMMENT_EVENT_TYPE: typing.LiteralString = 'document-comment'
 
 async def _emit_comment_event(
     *,
-    project_id: str,
+    project_id: str | None,
     document_id: str,
     thread_id: str,
     comment_id: str,
@@ -59,7 +59,7 @@ async def _emit_comment_event(
             [
                 [
                     nanoid.generate(),
-                    project_id,
+                    project_id or '',
                     datetime.datetime.now(datetime.UTC),
                     _COMMENT_EVENT_TYPE,
                     'internal',
@@ -265,22 +265,40 @@ _COMMENTS_TAIL: typing.LiteralString = """
     RETURN t, d, comments
 """
 
-# Document-ownership join used by every query to scope to project -> org.
+# Document-ownership join used by every query to scope the document to
+# the organization through whichever vertex it is attached to (project,
+# project type, or user). When ``{project_id}`` is non-null the document
+# must additionally be attached to that project — this keeps the
+# project-scoped comment routes from resolving another project's
+# document.
 _DOC_JOIN: typing.LiteralString = """
     MATCH (d:Document {{id: {document_id}}})
-          -[:ATTACHED_TO]->(:Project {{id: {project_id}}})
+    OPTIONAL MATCH (d)-[:ATTACHED_TO]->(p:Project)
           -[:OWNED_BY]->(:Team)
           -[:BELONGS_TO]->(:Organization {{slug: {org_slug}}})
+    OPTIONAL MATCH (d)-[:ATTACHED_TO]->(pt:ProjectType)
+          -[:BELONGS_TO]->(:Organization {{slug: {org_slug}}})
+    OPTIONAL MATCH (d)-[:ATTACHED_TO]->(u:User)
+          -[:MEMBER_OF]->(:Organization {{slug: {org_slug}}})
+    WITH d, p, pt, u
+    WHERE ({project_id} IS NULL
+           AND (p IS NOT NULL OR pt IS NOT NULL OR u IS NOT NULL))
+       OR (p IS NOT NULL AND p.id = {project_id})
+    WITH DISTINCT d
 """
 
 
 async def _verify_document(
     db: graph.Pool,
     org_slug: str,
-    project_id: str,
+    project_id: str | None,
     document_id: str,
 ) -> None:
-    """Raise 404 unless the document belongs to the project -> org."""
+    """Raise 404 unless the document belongs to the org.
+
+    When ``project_id`` is provided the document must be attached to
+    that project.
+    """
     query: str = _DOC_JOIN + 'RETURN d.id AS id'
     records = await db.execute(
         query,
@@ -301,7 +319,7 @@ async def _verify_document(
 async def _fetch_thread(
     db: graph.Pool,
     org_slug: str,
-    project_id: str,
+    project_id: str | None,
     document_id: str,
     thread_id: str,
 ) -> dict[str, typing.Any] | None:
@@ -332,7 +350,7 @@ async def _fetch_thread(
 async def _fetch_comment(
     db: graph.Pool,
     org_slug: str,
-    project_id: str,
+    project_id: str | None,
     document_id: str,
     thread_id: str,
     comment_id: str,
@@ -366,13 +384,13 @@ async def _fetch_comment(
 @comments_router.get('', response_model=CommentThreadListResponse)
 async def list_comment_threads(
     org_slug: str,
-    project_id: str,
     document_id: str,
     db: graph.Pool,
     _auth: typing.Annotated[
         permissions.AuthContext,
         fastapi.Depends(permissions.require_permission('document:read')),
     ],
+    project_id: str | None = None,
 ) -> dict[str, typing.Any]:
     """List every comment thread on a document, comments oldest-first."""
     await _verify_document(db, org_slug, project_id, document_id)
@@ -402,7 +420,6 @@ async def list_comment_threads(
 )
 async def create_comment_thread(
     org_slug: str,
-    project_id: str,
     document_id: str,
     data: CommentThreadCreate,
     db: graph.Pool,
@@ -410,6 +427,7 @@ async def create_comment_thread(
         permissions.AuthContext,
         fastapi.Depends(permissions.require_permission('comment:create')),
     ],
+    project_id: str | None = None,
 ) -> dict[str, typing.Any]:
     """Create a thread, its ``ON_DOCUMENT`` edge, and the root comment."""
     await _verify_document(db, org_slug, project_id, document_id)
@@ -511,7 +529,6 @@ async def create_comment_thread(
 )
 async def create_reply(
     org_slug: str,
-    project_id: str,
     document_id: str,
     thread_id: str,
     data: CommentBodyCreate,
@@ -520,6 +537,7 @@ async def create_reply(
         permissions.AuthContext,
         fastapi.Depends(permissions.require_permission('comment:create')),
     ],
+    project_id: str | None = None,
 ) -> dict[str, typing.Any]:
     """Add a reply comment to an existing thread."""
     now = datetime.datetime.now(datetime.UTC)
@@ -582,7 +600,6 @@ async def create_reply(
 @comments_router.patch('/{thread_id}', response_model=CommentThreadResponse)
 async def patch_comment_thread(
     org_slug: str,
-    project_id: str,
     document_id: str,
     thread_id: str,
     operations: list[json_patch.PatchOperation],
@@ -591,6 +608,7 @@ async def patch_comment_thread(
         permissions.AuthContext,
         fastapi.Depends(permissions.require_permission('comment:write')),
     ],
+    project_id: str | None = None,
 ) -> dict[str, typing.Any]:
     """Resolve or reopen a thread via JSON Patch (only ``/resolved``)."""
     existing = await _fetch_thread(
@@ -659,7 +677,6 @@ async def patch_comment_thread(
 )
 async def patch_comment(
     org_slug: str,
-    project_id: str,
     document_id: str,
     thread_id: str,
     comment_id: str,
@@ -669,6 +686,7 @@ async def patch_comment(
         permissions.AuthContext,
         fastapi.Depends(permissions.require_permission('comment:write')),
     ],
+    project_id: str | None = None,
 ) -> dict[str, typing.Any]:
     """Edit a comment via JSON Patch (only ``/body`` and ``/mentions``).
 
@@ -747,7 +765,6 @@ async def patch_comment(
 )
 async def acknowledge_comment(
     org_slug: str,
-    project_id: str,
     document_id: str,
     thread_id: str,
     comment_id: str,
@@ -756,6 +773,7 @@ async def acknowledge_comment(
         permissions.AuthContext,
         fastapi.Depends(permissions.require_permission('comment:write')),
     ],
+    project_id: str | None = None,
 ) -> dict[str, typing.Any]:
     """Toggle the principal in the comment's ``acknowledged_by`` array."""
     existing = await _fetch_comment(
@@ -807,7 +825,6 @@ async def acknowledge_comment(
 @comments_router.delete('/{thread_id}/comments/{comment_id}', status_code=204)
 async def delete_comment(
     org_slug: str,
-    project_id: str,
     document_id: str,
     thread_id: str,
     comment_id: str,
@@ -816,6 +833,7 @@ async def delete_comment(
         permissions.AuthContext,
         fastapi.Depends(permissions.require_permission('comment:delete')),
     ],
+    project_id: str | None = None,
 ) -> None:
     """Delete a comment. Author-only. Deletes the thread if it was the
     root and no other comments remain.

--- a/src/imbi_api/endpoints/document_templates.py
+++ b/src/imbi_api/endpoints/document_templates.py
@@ -43,6 +43,11 @@ class OrganizationRef(pydantic.BaseModel):
     slug: str
 
 
+DocumentTemplateType = typing.Literal[
+    'project', 'global', 'user', 'project_type'
+]
+
+
 class DocumentTemplateBase(pydantic.BaseModel):
     name: str = pydantic.Field(min_length=1)
     slug: str = pydantic.Field(min_length=1)
@@ -50,6 +55,13 @@ class DocumentTemplateBase(pydantic.BaseModel):
     icon: pydantic.HttpUrl | str | None = None
     title: str | None = None
     content: str = ''
+    type: DocumentTemplateType = pydantic.Field(
+        default='project',
+        description=(
+            'Which attachment contexts may use this template: project, '
+            'user, or project_type documents; global applies everywhere.'
+        ),
+    )
     tags: list[str] = pydantic.Field(
         default=[],
         description='Tag slugs to attach. Must already exist in the org.',
@@ -69,6 +81,7 @@ class DocumentTemplateUpdate(pydantic.BaseModel):
     icon: pydantic.HttpUrl | str | None = None
     title: str | None = None
     content: str | None = None
+    type: DocumentTemplateType | None = None
     tags: list[str] | None = None
     project_type_slugs: list[str] | None = None
     sort_order: int | None = None
@@ -82,6 +95,7 @@ class DocumentTemplateResponse(pydantic.BaseModel):
     icon: pydantic.HttpUrl | str | None = None
     title: str | None = None
     content: str = ''
+    type: DocumentTemplateType = 'project'
     tags: list[TagRef] = []
     project_type_slugs: list[str] = []
     sort_order: int = 0
@@ -124,6 +138,10 @@ def _parse_template_row(
     template['tags'] = tags
     template.setdefault('project_type_slugs', [])
     template.setdefault('sort_order', 0)
+    # Rows written before the ``type`` column landed are project
+    # templates — that was the only attachment context at the time.
+    if not template.get('type'):
+        template['type'] = 'project'
     return template
 
 
@@ -267,6 +285,7 @@ async def create_document_template(
         'icon': str(data.icon) if data.icon else None,
         'title': data.title,
         'content': data.content,
+        'type': data.type,
         'project_type_slugs': data.project_type_slugs,
         'sort_order': data.sort_order,
         'created_at': now.isoformat(),
@@ -313,12 +332,17 @@ async def list_document_templates(
         ),
     ],
     project_type: str | None = None,
+    context: typing.Literal['project', 'user', 'project_type'] | None = None,
 ) -> list[dict[str, typing.Any]]:
     """List document templates for an organization.
 
     ``project_type`` (optional): when provided, only templates that
     apply to the given project-type slug are returned. Templates with
     an empty ``project_type_slugs`` apply to every project type.
+
+    ``context`` (optional): when provided, only templates whose
+    ``type`` matches the attachment context (or is ``'global'``) are
+    returned.
     """
     query: str = (
         """
@@ -343,6 +367,11 @@ async def list_document_templates(
         )
         slugs: list[str] = [str(s) for s in (raw_slugs or [])]
         if project_type is not None and slugs and project_type not in slugs:
+            continue
+        if context is not None and template['type'] not in (
+            context,
+            'global',
+        ):
             continue
         results.append(template)
     return results
@@ -478,6 +507,7 @@ async def update_document_template(
         'icon': existing.get('icon'),
         'title': existing.get('title'),
         'content': existing.get('content', ''),
+        'type': existing.get('type', 'project'),
         'project_type_slugs': existing.get('project_type_slugs', []),
         'sort_order': existing.get('sort_order', 0),
     }
@@ -524,6 +554,7 @@ async def patch_document_template(
         'icon': existing.get('icon'),
         'title': existing.get('title'),
         'content': existing.get('content', ''),
+        'type': existing.get('type', 'project'),
         'tags': [t['slug'] for t in existing.get('tags', [])],
         'project_type_slugs': existing.get('project_type_slugs', []),
         'sort_order': existing.get('sort_order', 0),

--- a/src/imbi_api/endpoints/documents.py
+++ b/src/imbi_api/endpoints/documents.py
@@ -464,6 +464,17 @@ async def _list_documents_impl(
             detail=f'limit must be 1..{MAX_LIMIT}',
         )
 
+    attachment_filters = sum(
+        value is not None
+        for value in (project_id, project_type_slug, user_email)
+    )
+    if attachment_filters > 1:
+        raise fastapi.HTTPException(
+            status_code=400,
+            detail='Only one attachment filter (project, project_type, '
+            'user) may be specified at a time',
+        )
+
     params: dict[str, typing.Any] = {
         'org_slug': org_slug,
         'row_limit': limit + 1,

--- a/src/imbi_api/endpoints/documents.py
+++ b/src/imbi_api/endpoints/documents.py
@@ -1,10 +1,16 @@
-"""Project documents with tag support.
+"""Documents with tag support, attachable to multiple vertex kinds.
 
-Documents are project-scoped via a required ``ATTACHED_TO`` edge and may
-optionally be tagged with org-scoped ``Tag`` nodes via ``TAGGED_WITH``.
-The top-level ``documents_router`` supports cross-project search filtered
-by tag; ``documents_project_router`` handles CRUD scoped to a single
-project.
+A document is attached to exactly one owning vertex via an
+``ATTACHED_TO`` edge — a ``Project``, a ``ProjectType``, or a ``User``
+— and may optionally be tagged with org-scoped ``Tag`` nodes via
+``TAGGED_WITH``.
+
+The top-level ``documents_router`` supports the org-wide index
+(filterable by tag, project, project type, or user) plus generic
+single-document read/write/delete that works regardless of where the
+document is attached. ``documents_project_router``,
+``documents_project_type_router``, and ``documents_user_router``
+handle list + create scoped to a single attachment target.
 """
 
 import datetime
@@ -30,6 +36,8 @@ LOGGER = logging.getLogger(__name__)
 
 documents_router = fastapi.APIRouter(tags=['Documents'])
 documents_project_router = fastapi.APIRouter(tags=['Documents'])
+documents_project_type_router = fastapi.APIRouter(tags=['Documents'])
+documents_user_router = fastapi.APIRouter(tags=['Documents'])
 
 DEFAULT_LIMIT: int = 50
 MAX_LIMIT: int = 500
@@ -38,7 +46,10 @@ _DOCUMENT_READONLY_PATHS: frozenset[str] = frozenset(
     [
         '/id',
         '/project_id',
+        '/attached_to',
+        '/comment_count',
         '/created_by',
+        '/created_by_name',
         '/created_at',
         '/updated_by',
         '/updated_at',
@@ -51,16 +62,34 @@ class TagRef(pydantic.BaseModel):
     slug: str
 
 
+class AttachmentRef(pydantic.BaseModel):
+    """The vertex a document hangs off of.
+
+    ``id`` is the project id, the project-type slug, or the user
+    email depending on ``kind``. ``team`` and ``project_types`` are
+    only populated for ``kind='project'``.
+    """
+
+    kind: typing.Literal['project', 'project_type', 'user']
+    id: str
+    name: str
+    team: str | None = None
+    project_types: list[str] = []
+
+
 class DocumentResponse(pydantic.BaseModel):
     id: str
     title: str = ''
     content: str
     created_by: str
+    created_by_name: str | None = None
     created_at: datetime.datetime
     updated_by: str | None = None
     updated_at: datetime.datetime | None = None
-    project_id: str
+    project_id: str | None = None
+    attached_to: AttachmentRef | None = None
     is_pinned: bool = False
+    comment_count: int = 0
     tags: list[TagRef] = []
 
 
@@ -77,11 +106,25 @@ class DocumentListResponse(pydantic.BaseModel):
     data: list[DocumentResponse]
 
 
+def _str_list(value: typing.Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    items = typing.cast('list[object]', value)
+    return [str(v) for v in items]
+
+
 def _parse_document_row(
     record: dict[str, typing.Any],
 ) -> dict[str, typing.Any]:
     document: dict[str, typing.Any] = graph.parse_agtype(record['n'])
-    project: dict[str, typing.Any] = graph.parse_agtype(record['p'])
+    project: dict[str, typing.Any] | None = graph.parse_agtype(record['p'])
+    team: dict[str, typing.Any] | None = graph.parse_agtype(record['team'])
+    project_type: dict[str, typing.Any] | None = graph.parse_agtype(
+        record['pt']
+    )
+    user: dict[str, typing.Any] | None = graph.parse_agtype(record['u'])
+    ptype_names = _str_list(graph.parse_agtype(record['ptype_names']))
+    author: dict[str, typing.Any] | None = graph.parse_agtype(record['author'])
     raw_tags: list[typing.Any] = graph.parse_agtype(record['tags']) or []
     tags: list[dict[str, str]] = []
     for t in raw_tags:
@@ -94,24 +137,94 @@ def _parse_document_row(
         tags.append(
             {'name': str(entry.get('name', '')), 'slug': str(slug)},
         )
-    document['project_id'] = project.get('id', '')
+
+    attached: dict[str, typing.Any] | None = None
+    if project:
+        attached = {
+            'kind': 'project',
+            'id': str(project.get('id', '')),
+            'name': str(project.get('name', '')),
+            'team': str(team.get('name', '')) if team else None,
+            'project_types': ptype_names,
+        }
+    elif project_type:
+        attached = {
+            'kind': 'project_type',
+            'id': str(project_type.get('slug', '')),
+            'name': str(project_type.get('name', '')),
+        }
+    elif user:
+        attached = {
+            'kind': 'user',
+            'id': str(user.get('email', '')),
+            'name': str(user.get('display_name', '')),
+        }
+
+    document['project_id'] = project.get('id', '') if project else None
+    document['attached_to'] = attached
     document['tags'] = tags
+    document['comment_count'] = int(
+        graph.parse_agtype(record['comment_count']) or 0
+    )
+    document['created_by_name'] = (
+        str(author.get('display_name', '')) or None if author else None
+    )
     # Defaults for rows written before these columns landed.
     document['is_pinned'] = bool(document.get('is_pinned', False))
     document['title'] = str(document.get('title') or '')
     return document
 
 
-# Tail fragment used by every query that returns a document. Always
-# runs on ``n, p`` already in scope and emits ``n, p, tags`` columns.
-_TAGS_TAIL: typing.LiteralString = """
-    OPTIONAL MATCH (n)-[:TAGGED_WITH]->(tag:Tag)
-    WITH n, p, collect(CASE WHEN tag IS NOT NULL
-                            THEN tag{{.name, .slug}}
-                            END) AS raw_tags
-    WITH n, p, [t IN raw_tags WHERE t IS NOT NULL] AS tags
-    RETURN n, p, tags
+# Resolves the document's attachment target. Requires ``o`` (the org)
+# and ``n`` (the document) in scope; emits ``n, o, p, team, pt, u``
+# with the org-membership guarantee enforced. Filter fragments are
+# appended to the WHERE clause by callers.
+_ATTACHMENT_MATCH: typing.LiteralString = """
+    OPTIONAL MATCH (n)-[:ATTACHED_TO]->(p:Project)
+          -[:OWNED_BY]->(team:Team)-[:BELONGS_TO]->(o)
+    OPTIONAL MATCH (n)-[:ATTACHED_TO]->(pt:ProjectType)-[:BELONGS_TO]->(o)
+    OPTIONAL MATCH (n)-[:ATTACHED_TO]->(u:User)-[:MEMBER_OF]->(o)
+    WITH n, o, p, team, pt, u
+    WHERE (p IS NOT NULL OR pt IS NOT NULL OR u IS NOT NULL)
 """
+
+# Enrichment tail used by every query that returns a document. Runs
+# with ``n, p, team, pt, u`` in scope and emits the full column set.
+# Aggregates run stepwise so each OPTIONAL MATCH cannot multiply the
+# rows of the next.
+_ENRICH_TAIL: typing.LiteralString = """
+    OPTIONAL MATCH (p)-[:TYPE]->(ptype:ProjectType)
+    WITH n, p, team, pt, u,
+         collect(CASE WHEN ptype IS NOT NULL
+                      THEN ptype.name END) AS raw_ptype_names
+    WITH n, p, team, pt, u,
+         [x IN raw_ptype_names WHERE x IS NOT NULL] AS ptype_names
+    OPTIONAL MATCH (n)-[:TAGGED_WITH]->(tag:Tag)
+    WITH n, p, team, pt, u, ptype_names,
+         collect(CASE WHEN tag IS NOT NULL
+                      THEN tag{{.name, .slug}}
+                      END) AS raw_tags
+    WITH n, p, team, pt, u, ptype_names,
+         [t IN raw_tags WHERE t IS NOT NULL] AS tags
+    OPTIONAL MATCH (c:Comment)-[:IN_THREAD]->(:CommentThread)
+          -[:ON_DOCUMENT]->(n)
+    WITH n, p, team, pt, u, ptype_names, tags,
+         count(c) AS comment_count
+    OPTIONAL MATCH (author:User {{email: n.created_by}})
+    RETURN n, p, team, pt, u, ptype_names, tags, comment_count, author
+"""
+
+_DOCUMENT_COLUMNS: list[str] = [
+    'n',
+    'p',
+    'team',
+    'pt',
+    'u',
+    'ptype_names',
+    'tags',
+    'comment_count',
+    'author',
+]
 
 
 async def _attach_tags(
@@ -187,6 +300,64 @@ async def _validate_tag_slugs(
         )
 
 
+_DOCUMENT_CREATE_FRAGMENT: typing.LiteralString = """
+    CREATE (n:Document {{
+        id: {id},
+        title: {title},
+        content: {content},
+        created_by: {created_by},
+        created_at: {created_at},
+        is_pinned: {is_pinned}
+    }})
+    CREATE (n)-[:ATTACHED_TO]->(target)
+    RETURN n.id AS id
+"""
+
+
+async def _create_document_impl(
+    db: graph.Pool,
+    auth: permissions.AuthContext,
+    org_slug: str,
+    data: DocumentCreate,
+    anchor_match: typing.LiteralString,
+    anchor_params: dict[str, typing.Any],
+    not_found_detail: str,
+) -> dict[str, typing.Any]:
+    """Create a document attached to the vertex bound as ``target``."""
+    tag_slugs = list(dict.fromkeys(data.tags))
+    await _validate_tag_slugs(db, org_slug, tag_slugs)
+
+    now = datetime.datetime.now(datetime.UTC)
+    document_id = nanoid.generate()
+    records = await db.execute(
+        anchor_match + _DOCUMENT_CREATE_FRAGMENT,
+        {
+            **anchor_params,
+            'org_slug': org_slug,
+            'id': document_id,
+            'title': data.title,
+            'content': data.content,
+            'created_by': auth.principal_name,
+            'created_at': now.isoformat(),
+            'is_pinned': False,
+        },
+        columns=['id'],
+    )
+    if not records:
+        raise fastapi.HTTPException(status_code=404, detail=not_found_detail)
+
+    if tag_slugs:
+        await _attach_tags(db, org_slug, document_id, tag_slugs)
+
+    document = await _fetch_document(db, org_slug, document_id)
+    if document is None:
+        raise fastapi.HTTPException(
+            status_code=500,
+            detail='Document created but could not be read back',
+        )
+    return document
+
+
 @documents_project_router.post(
     '/', status_code=201, response_model=DocumentResponse
 )
@@ -201,56 +372,78 @@ async def create_document(
     ],
 ) -> dict[str, typing.Any]:
     """Create a document attached to a project, optionally with tags."""
-    tag_slugs = list(dict.fromkeys(data.tags))
-    await _validate_tag_slugs(db, org_slug, tag_slugs)
-
-    now = datetime.datetime.now(datetime.UTC)
-    document_id = nanoid.generate()
-    create_query: typing.LiteralString = """
-    MATCH (p:Project {{id: {project_id}}})
+    anchor: typing.LiteralString = """
+    MATCH (target:Project {{id: {project_id}}})
           -[:OWNED_BY]->(:Team)
           -[:BELONGS_TO]->(:Organization {{slug: {org_slug}}})
-    CREATE (n:Document {{
-        id: {id},
-        title: {title},
-        content: {content},
-        created_by: {created_by},
-        created_at: {created_at},
-        is_pinned: {is_pinned}
-    }})
-    CREATE (n)-[:ATTACHED_TO]->(p)
-    RETURN n.id AS id
     """
-    records = await db.execute(
-        create_query,
-        {
-            'org_slug': org_slug,
-            'project_id': project_id,
-            'id': document_id,
-            'title': data.title,
-            'content': data.content,
-            'created_by': auth.principal_name,
-            'created_at': now.isoformat(),
-            'is_pinned': False,
-        },
-        columns=['id'],
+    return await _create_document_impl(
+        db,
+        auth,
+        org_slug,
+        data,
+        anchor,
+        {'project_id': project_id},
+        f'Project {project_id!r} not found',
     )
-    if not records:
-        raise fastapi.HTTPException(
-            status_code=404,
-            detail=f'Project {project_id!r} not found',
-        )
 
-    if tag_slugs:
-        await _attach_tags(db, org_slug, document_id, tag_slugs)
 
-    document = await _fetch_document(db, org_slug, project_id, document_id)
-    if document is None:
-        raise fastapi.HTTPException(
-            status_code=500,
-            detail='Document created but could not be read back',
-        )
-    return document
+@documents_project_type_router.post(
+    '/', status_code=201, response_model=DocumentResponse
+)
+async def create_project_type_document(
+    org_slug: str,
+    type_slug: str,
+    data: DocumentCreate,
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(permissions.require_permission('document:create')),
+    ],
+) -> dict[str, typing.Any]:
+    """Create a document attached to a project type."""
+    anchor: typing.LiteralString = """
+    MATCH (target:ProjectType {{slug: {type_slug}}})
+          -[:BELONGS_TO]->(:Organization {{slug: {org_slug}}})
+    """
+    return await _create_document_impl(
+        db,
+        auth,
+        org_slug,
+        data,
+        anchor,
+        {'type_slug': type_slug},
+        f'Project type {type_slug!r} not found',
+    )
+
+
+@documents_user_router.post(
+    '/', status_code=201, response_model=DocumentResponse
+)
+async def create_user_document(
+    org_slug: str,
+    email: str,
+    data: DocumentCreate,
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(permissions.require_permission('document:create')),
+    ],
+) -> dict[str, typing.Any]:
+    """Create a document attached to a user (org member)."""
+    anchor: typing.LiteralString = """
+    MATCH (target:User {{email: {email}}})
+          -[:MEMBER_OF]->(:Organization {{slug: {org_slug}}})
+    """
+    return await _create_document_impl(
+        db,
+        auth,
+        org_slug,
+        data,
+        anchor,
+        {'email': email},
+        f'User {email!r} not found',
+    )
 
 
 async def _list_documents_impl(
@@ -258,8 +451,10 @@ async def _list_documents_impl(
     request: fastapi.Request,
     db: graph.Pool,
     org_slug: str,
-    project_id: str | None,
-    tag_slug: str | None,
+    project_id: str | None = None,
+    project_type_slug: str | None = None,
+    user_email: str | None = None,
+    tag_slug: str | None = None,
     limit: int,
     cursor: str | None,
 ) -> fastapi.Response:
@@ -273,10 +468,16 @@ async def _list_documents_impl(
         'org_slug': org_slug,
         'row_limit': limit + 1,
     }
-    project_predicate = ''
+    filters = ''
     if project_id is not None:
-        project_predicate = ' AND p.id = {project_id}'
+        filters += ' AND p.id = {project_id}'
         params['project_id'] = project_id
+    if project_type_slug is not None:
+        filters += ' AND pt.slug = {project_type_slug}'
+        params['project_type_slug'] = project_type_slug
+    if user_email is not None:
+        filters += ' AND u.email = {user_email}'
+        params['user_email'] = user_email
 
     tag_match = ''
     if tag_slug is not None:
@@ -295,8 +496,8 @@ async def _list_documents_impl(
             )
         cursor_ts, cursor_id = decoded
         cursor_clause = (
-            ' WHERE n.created_at < {cursor_ts}'
-            ' OR (n.created_at = {cursor_ts} AND n.id < {cursor_id})'
+            ' AND (n.created_at < {cursor_ts}'
+            ' OR (n.created_at = {cursor_ts} AND n.id < {cursor_id}))'
         )
         params['cursor_ts'] = cursor_ts.isoformat()
         params['cursor_id'] = cursor_id
@@ -304,21 +505,21 @@ async def _list_documents_impl(
     query: str = (
         """
     MATCH (o:Organization {{slug: {org_slug}}})
-    MATCH (n:Document)-[:ATTACHED_TO]->(p:Project)
-          -[:OWNED_BY]->(:Team)-[:BELONGS_TO]->(o)
-    WHERE 1 = 1"""
-        + project_predicate
+    MATCH (n:Document)"""
         + tag_match
+        + _ATTACHMENT_MATCH
+        + filters
         + cursor_clause
         + """
-    WITH DISTINCT n, p, n.created_at AS sort_ts, n.id AS sort_id
+    WITH DISTINCT n, p, team, pt, u,
+         n.created_at AS sort_ts, n.id AS sort_id
     ORDER BY sort_ts DESC, sort_id DESC
     LIMIT {row_limit}
     """
-        + _TAGS_TAIL
+        + _ENRICH_TAIL
     )
 
-    records = await db.execute(query, params, columns=['n', 'p', 'tags'])
+    records = await db.execute(query, params, columns=_DOCUMENT_COLUMNS)
     next_cursor: str | None = None
     parsed = [_parse_document_row(r) for r in records]
     if len(parsed) > limit:
@@ -355,13 +556,21 @@ async def list_documents(
     cursor: str | None = None,
     tag: str | None = None,
     project_id: str | None = None,
+    project_type: str | None = None,
+    user: str | None = None,
 ) -> fastapi.Response:
-    """Cross-project document search. Filter by tag slug and/or project id."""
+    """Org-wide document index.
+
+    Filter by tag slug, project id, project-type slug, and/or user
+    email.
+    """
     return await _list_documents_impl(
         request=request,
         db=db,
         org_slug=org_slug,
         project_id=project_id,
+        project_type_slug=project_type,
+        user_email=user,
         tag_slug=tag,
         limit=limit,
         cursor=cursor,
@@ -394,34 +603,117 @@ async def list_project_documents(
     )
 
 
+@documents_project_type_router.get('/', response_model=DocumentListResponse)
+async def list_project_type_documents(
+    request: fastapi.Request,
+    org_slug: str,
+    type_slug: str,
+    db: graph.Pool,
+    _auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(permissions.require_permission('document:read')),
+    ],
+    limit: int = DEFAULT_LIMIT,
+    cursor: str | None = None,
+    tag: str | None = None,
+) -> fastapi.Response:
+    """List documents attached to a specific project type."""
+    return await _list_documents_impl(
+        request=request,
+        db=db,
+        org_slug=org_slug,
+        project_type_slug=type_slug,
+        tag_slug=tag,
+        limit=limit,
+        cursor=cursor,
+    )
+
+
+@documents_user_router.get('/', response_model=DocumentListResponse)
+async def list_user_documents(
+    request: fastapi.Request,
+    org_slug: str,
+    email: str,
+    db: graph.Pool,
+    _auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(permissions.require_permission('document:read')),
+    ],
+    limit: int = DEFAULT_LIMIT,
+    cursor: str | None = None,
+    tag: str | None = None,
+) -> fastapi.Response:
+    """List documents attached to a specific user."""
+    return await _list_documents_impl(
+        request=request,
+        db=db,
+        org_slug=org_slug,
+        user_email=email,
+        tag_slug=tag,
+        limit=limit,
+        cursor=cursor,
+    )
+
+
+def _scope_filter(
+    project_id: str | None,
+) -> tuple[typing.LiteralString, dict[str, typing.Any]]:
+    """Optional project constraint for the generic document queries."""
+    if project_id is None:
+        return '', {}
+    return ' AND p.id = {project_id}', {'project_id': project_id}
+
+
 async def _fetch_document(
     db: graph.Pool,
     org_slug: str,
-    project_id: str,
     document_id: str,
+    project_id: str | None = None,
 ) -> dict[str, typing.Any] | None:
+    scope, scope_params = _scope_filter(project_id)
     query: str = (
         """
-    MATCH (n:Document {{id: {document_id}}})
-          -[:ATTACHED_TO]->(p:Project {{id: {project_id}}})
-          -[:OWNED_BY]->(:Team)
-          -[:BELONGS_TO]->(:Organization {{slug: {org_slug}}})
-    WITH DISTINCT n, p
+    MATCH (o:Organization {{slug: {org_slug}}})
+    MATCH (n:Document {{id: {document_id}}})"""
+        + _ATTACHMENT_MATCH
+        + scope
+        + """
+    WITH DISTINCT n, p, team, pt, u
     """
-        + _TAGS_TAIL
+        + _ENRICH_TAIL
     )
     records = await db.execute(
         query,
         {
             'document_id': document_id,
-            'project_id': project_id,
             'org_slug': org_slug,
+            **scope_params,
         },
-        columns=['n', 'p', 'tags'],
+        columns=_DOCUMENT_COLUMNS,
     )
     if not records:
         return None
     return _parse_document_row(records[0])
+
+
+@documents_router.get('/{document_id}', response_model=DocumentResponse)
+async def get_org_document(
+    org_slug: str,
+    document_id: str,
+    db: graph.Pool,
+    _auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(permissions.require_permission('document:read')),
+    ],
+) -> dict[str, typing.Any]:
+    """Retrieve a single document regardless of attachment kind."""
+    return await fetch_or_404(
+        _fetch_document,
+        db,
+        org_slug,
+        document_id,
+        detail=f'Document {document_id!r} not found',
+    )
 
 
 @documents_project_router.get(
@@ -437,13 +729,13 @@ async def get_document(
         fastapi.Depends(permissions.require_permission('document:read')),
     ],
 ) -> dict[str, typing.Any]:
-    """Retrieve a single document."""
+    """Retrieve a single project document."""
     return await fetch_or_404(
         _fetch_document,
         db,
         org_slug,
-        project_id,
         document_id,
+        project_id,
         detail=f'Document {document_id!r} not found',
     )
 
@@ -479,22 +771,15 @@ def _resolve_patched_field(
     return fallback
 
 
-@documents_project_router.patch(
-    '/{document_id}', response_model=DocumentResponse
-)
-async def patch_document(
+async def _patch_document_impl(
+    db: graph.Pool,
+    auth: permissions.AuthContext,
     org_slug: str,
-    project_id: str,
     document_id: str,
     operations: list[json_patch.PatchOperation],
-    db: graph.Pool,
-    auth: typing.Annotated[
-        permissions.AuthContext,
-        fastapi.Depends(permissions.require_permission('document:write')),
-    ],
+    project_id: str | None = None,
 ) -> dict[str, typing.Any]:
-    """Update document content and/or tag attachments via JSON Patch."""
-    existing = await _fetch_document(db, org_slug, project_id, document_id)
+    existing = await _fetch_document(db, org_slug, document_id, project_id)
     if existing is None:
         raise fastapi.HTTPException(
             status_code=404, detail=f'Document {document_id!r} not found'
@@ -555,12 +840,15 @@ async def patch_document(
         bool(existing.get('is_pinned', False)),
     )
 
+    scope, scope_params = _scope_filter(project_id)
     now = datetime.datetime.now(datetime.UTC)
-    set_query: typing.LiteralString = """
-    MATCH (n:Document {{id: {document_id}}})
-          -[:ATTACHED_TO]->(:Project {{id: {project_id}}})
-          -[:OWNED_BY]->(:Team)
-          -[:BELONGS_TO]->(:Organization {{slug: {org_slug}}})
+    set_query: str = (
+        """
+    MATCH (o:Organization {{slug: {org_slug}}})
+    MATCH (n:Document {{id: {document_id}}})"""
+        + _ATTACHMENT_MATCH
+        + scope
+        + """
     SET n.title = {title},
         n.content = {content},
         n.updated_by = {updated_by},
@@ -568,17 +856,18 @@ async def patch_document(
         n.is_pinned = {is_pinned}
     RETURN n.id AS id
     """
+    )
     records = await db.execute(
         set_query,
         {
             'org_slug': org_slug,
-            'project_id': project_id,
             'document_id': document_id,
             'title': new_title,
             'content': new_content,
             'updated_by': auth.principal_name,
             'updated_at': now.isoformat(),
             'is_pinned': new_is_pinned,
+            **scope_params,
         },
         columns=['id'],
     )
@@ -591,12 +880,95 @@ async def patch_document(
         await _detach_all_tags(db, document_id)
         await _attach_tags(db, org_slug, document_id, new_tags)
 
-    document = await _fetch_document(db, org_slug, project_id, document_id)
+    document = await _fetch_document(db, org_slug, document_id, project_id)
     if document is None:
         raise fastapi.HTTPException(
             status_code=404, detail=f'Document {document_id!r} not found'
         )
     return document
+
+
+@documents_router.patch('/{document_id}', response_model=DocumentResponse)
+async def patch_org_document(
+    org_slug: str,
+    document_id: str,
+    operations: list[json_patch.PatchOperation],
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(permissions.require_permission('document:write')),
+    ],
+) -> dict[str, typing.Any]:
+    """Update a document via JSON Patch regardless of attachment kind."""
+    return await _patch_document_impl(
+        db, auth, org_slug, document_id, operations
+    )
+
+
+@documents_project_router.patch(
+    '/{document_id}', response_model=DocumentResponse
+)
+async def patch_document(
+    org_slug: str,
+    project_id: str,
+    document_id: str,
+    operations: list[json_patch.PatchOperation],
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(permissions.require_permission('document:write')),
+    ],
+) -> dict[str, typing.Any]:
+    """Update document content and/or tag attachments via JSON Patch."""
+    return await _patch_document_impl(
+        db, auth, org_slug, document_id, operations, project_id
+    )
+
+
+async def _delete_document_impl(
+    db: graph.Pool,
+    org_slug: str,
+    document_id: str,
+    project_id: str | None = None,
+) -> None:
+    scope, scope_params = _scope_filter(project_id)
+    query: str = (
+        """
+    MATCH (o:Organization {{slug: {org_slug}}})
+    MATCH (n:Document {{id: {document_id}}})"""
+        + _ATTACHMENT_MATCH
+        + scope
+        + """
+    DETACH DELETE n
+    RETURN 1 AS deleted
+    """
+    )
+    records = await db.execute(
+        query,
+        {
+            'document_id': document_id,
+            'org_slug': org_slug,
+            **scope_params,
+        },
+    )
+    if not records:
+        raise fastapi.HTTPException(
+            status_code=404, detail=f'Document {document_id!r} not found'
+        )
+
+
+@documents_router.delete('/{document_id}', status_code=204)
+async def delete_org_document(
+    org_slug: str,
+    document_id: str,
+    db: graph.Pool,
+    _auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(permissions.require_permission('document:delete')),
+    ],
+) -> None:
+    """Delete a document regardless of attachment kind."""
+    await _delete_document_impl(db, org_slug, document_id)
 
 
 @documents_project_router.delete('/{document_id}', status_code=204)
@@ -610,24 +982,5 @@ async def delete_document(
         fastapi.Depends(permissions.require_permission('document:delete')),
     ],
 ) -> None:
-    """Delete a document."""
-    query: typing.LiteralString = """
-    MATCH (n:Document {{id: {document_id}}})
-          -[:ATTACHED_TO]->(p:Project {{id: {project_id}}})
-          -[:OWNED_BY]->(:Team)
-          -[:BELONGS_TO]->(:Organization {{slug: {org_slug}}})
-    DETACH DELETE n
-    RETURN n
-    """
-    records = await db.execute(
-        query,
-        {
-            'document_id': document_id,
-            'project_id': project_id,
-            'org_slug': org_slug,
-        },
-    )
-    if not records:
-        raise fastapi.HTTPException(
-            status_code=404, detail=f'Document {document_id!r} not found'
-        )
+    """Delete a project document."""
+    await _delete_document_impl(db, org_slug, document_id, project_id)

--- a/src/imbi_api/endpoints/organizations.py
+++ b/src/imbi_api/endpoints/organizations.py
@@ -15,7 +15,12 @@ from imbi_api.relationships import RelationshipSpec, build_relationships
 
 from .comments import comments_router
 from .document_templates import document_templates_router
-from .documents import documents_project_router, documents_router
+from .documents import (
+    documents_project_router,
+    documents_project_type_router,
+    documents_router,
+    documents_user_router,
+)
 from .environments import environments_router
 from .events import events_project_router
 from .identity_plugins import identity_plugins_router
@@ -104,10 +109,24 @@ organizations_router.include_router(
     prefix='/{org_slug}/projects/{project_id}/documents',
 )
 organizations_router.include_router(
+    documents_project_type_router,
+    prefix='/{org_slug}/project-types/{type_slug}/documents',
+)
+organizations_router.include_router(
+    documents_user_router,
+    prefix='/{org_slug}/users/{email}/documents',
+)
+organizations_router.include_router(
     comments_router,
     prefix=(
         '/{org_slug}/projects/{project_id}/documents/{document_id}/comments'
     ),
+)
+# Attachment-agnostic comment routes — the same handlers resolve the
+# document through whichever vertex it is attached to.
+organizations_router.include_router(
+    comments_router,
+    prefix='/{org_slug}/documents/{document_id}/comments',
 )
 organizations_router.include_router(
     document_templates_router,

--- a/tests/endpoints/test_document_templates.py
+++ b/tests/endpoints/test_document_templates.py
@@ -104,6 +104,88 @@ class DocumentTemplateEndpointsTestCase(support.SharedAppTestCase):
         self.assertEqual(body['slug'], 'adr')
         self.assertEqual(body['organization']['slug'], 'engineering')
         self.assertEqual(body['tags'], [])
+        # Rows without a stored type surface as project templates and
+        # the create defaults to 'project'.
+        self.assertEqual(body['type'], 'project')
+        create_call = self.mock_db.execute.await_args_list[1]
+        self.assertEqual(create_call.args[1]['type'], 'project')
+
+    def test_create_with_type(self) -> None:
+        self.mock_db.execute.side_effect = [
+            [],
+            [
+                {
+                    'nt': self._template_row(type='user')['nt'],
+                    'o': self._template_row()['o'],
+                }
+            ],
+            [self._template_row(type='user')],
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.post(
+                '/organizations/engineering/document-templates/',
+                json={
+                    'name': 'ADR',
+                    'slug': 'adr',
+                    'content': '# Context',
+                    'type': 'user',
+                },
+            )
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.json()['type'], 'user')
+        create_call = self.mock_db.execute.await_args_list[1]
+        self.assertEqual(create_call.args[1]['type'], 'user')
+
+    def test_create_invalid_type_rejected(self) -> None:
+        response = self.client.post(
+            '/organizations/engineering/document-templates/',
+            json={
+                'name': 'ADR',
+                'slug': 'adr',
+                'content': '# Context',
+                'type': 'team',
+            },
+        )
+        self.assertEqual(response.status_code, 422)
+
+    def test_list_filter_by_context(self) -> None:
+        """``context=`` keeps matching-type and global templates."""
+        self.mock_db.execute.return_value = [
+            {
+                'nt': self._template_row(slug='proj', type='project')['nt'],
+                'o': self._template_row()['o'],
+                'tags': [],
+            },
+            {
+                'nt': self._template_row(slug='everywhere', type='global')[
+                    'nt'
+                ],
+                'o': self._template_row()['o'],
+                'tags': [],
+            },
+            {
+                'nt': self._template_row(slug='personal', type='user')['nt'],
+                'o': self._template_row()['o'],
+                'tags': [],
+            },
+            # Legacy row without a type behaves as a project template.
+            {
+                'nt': self._template_row(slug='legacy')['nt'],
+                'o': self._template_row()['o'],
+                'tags': [],
+            },
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.get(
+                '/organizations/engineering/document-templates/?context=user'
+            )
+        self.assertEqual(response.status_code, 200)
+        slugs = [t['slug'] for t in response.json()]
+        self.assertEqual(slugs, ['everywhere', 'personal'])
 
     def test_create_with_tags(self) -> None:
         # Calls: validate_tags, dup check, create, attach_tags, fetch

--- a/tests/endpoints/test_documents.py
+++ b/tests/endpoints/test_documents.py
@@ -13,7 +13,7 @@ from tests import support
 
 
 class DocumentEndpointsTestCase(support.SharedAppTestCase):
-    """Test cases for documents CRUD + cross-project search."""
+    """Test cases for documents CRUD + the org-wide index."""
 
     def setUp(self) -> None:
         from imbi_api.auth import permissions
@@ -70,15 +70,47 @@ class DocumentEndpointsTestCase(support.SharedAppTestCase):
         data: dict[str, typing.Any] = {
             'id': 'proj-abc',
             'slug': 'billing-api',
+            'name': 'Billing API',
         }
         data.update(overrides)
         return data
 
+    def _row(
+        self,
+        n: dict | None = None,
+        p: dict | None = None,
+        team: dict | None = None,
+        pt: dict | None = None,
+        u: dict | None = None,
+        ptype_names: list[str] | None = None,
+        tags: list[dict] | None = None,
+        comment_count: int = 0,
+        author: dict | None = None,
+    ) -> dict[str, typing.Any]:
+        """A full document row as returned by the enriched queries."""
+        return {
+            'n': n if n is not None else self._document_data(),
+            'p': p,
+            'team': team,
+            'pt': pt,
+            'u': u,
+            'ptype_names': ptype_names or [],
+            'tags': tags or [],
+            'comment_count': comment_count,
+            'author': author,
+        }
+
+    def _project_row(self, n: dict | None = None, **kwargs) -> dict:
+        kwargs.setdefault('p', self._project())
+        kwargs.setdefault('team', {'name': 'Platform', 'slug': 'platform'})
+        return self._row(n=n, **kwargs)
+
     # -- Create --------------------------------------------------------
 
     def test_create_success_no_tags(self) -> None:
-        self.mock_db.execute.return_value = [
-            {'n': self._document_data(), 'p': self._project(), 'tags': []}
+        self.mock_db.execute.side_effect = [
+            [{'id': 'document-1'}],
+            [self._project_row()],
         ]
         with mock.patch(
             'imbi_common.graph.parse_agtype', side_effect=lambda x: x
@@ -94,6 +126,11 @@ class DocumentEndpointsTestCase(support.SharedAppTestCase):
         self.assertEqual(response.json()['project_id'], 'proj-abc')
         self.assertEqual(response.json()['title'], 'DB lock runbook')
         self.assertEqual(response.json()['tags'], [])
+        attached = response.json()['attached_to']
+        self.assertEqual(attached['kind'], 'project')
+        self.assertEqual(attached['id'], 'proj-abc')
+        self.assertEqual(attached['name'], 'Billing API')
+        self.assertEqual(attached['team'], 'Platform')
 
     def test_create_with_tags(self) -> None:
         # Calls: validate_tags, create_document, attach_tags, fetch_document
@@ -105,14 +142,12 @@ class DocumentEndpointsTestCase(support.SharedAppTestCase):
             [{'id': 'document-1'}],
             [{'attached': 2}],
             [
-                {
-                    'n': self._document_data(),
-                    'p': self._project(),
-                    'tags': [
+                self._project_row(
+                    tags=[
                         {'name': 'Runbook', 'slug': 'runbook'},
                         {'name': 'Alert', 'slug': 'alert'},
                     ],
-                }
+                )
             ],
         ]
         with mock.patch(
@@ -185,20 +220,81 @@ class DocumentEndpointsTestCase(support.SharedAppTestCase):
         )
         self.assertEqual(response.status_code, 422)
 
+    def test_create_user_document(self) -> None:
+        self.mock_db.execute.side_effect = [
+            [{'id': 'document-1'}],
+            [
+                self._row(
+                    u={
+                        'email': 'gavinr@example.com',
+                        'display_name': 'Gavin M. Roy',
+                    },
+                )
+            ],
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.post(
+                '/organizations/engineering/users/gavinr@example.com'
+                '/documents/',
+                json={'title': 't', 'content': 'x'},
+            )
+        self.assertEqual(response.status_code, 201)
+        body = response.json()
+        self.assertIsNone(body['project_id'])
+        self.assertEqual(body['attached_to']['kind'], 'user')
+        self.assertEqual(body['attached_to']['id'], 'gavinr@example.com')
+        self.assertEqual(body['attached_to']['name'], 'Gavin M. Roy')
+        create_call = self.mock_db.execute.await_args_list[0]
+        self.assertEqual(create_call.args[1]['email'], 'gavinr@example.com')
+
+    def test_create_user_document_user_not_found(self) -> None:
+        self.mock_db.execute.return_value = []
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.post(
+                '/organizations/engineering/users/ghost@example.com'
+                '/documents/',
+                json={'title': 't', 'content': 'x'},
+            )
+        self.assertEqual(response.status_code, 404)
+
+    def test_create_project_type_document(self) -> None:
+        self.mock_db.execute.side_effect = [
+            [{'id': 'document-1'}],
+            [
+                self._row(
+                    pt={'slug': 'http-api', 'name': 'HTTP API'},
+                )
+            ],
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.post(
+                '/organizations/engineering/project-types/http-api/documents/',
+                json={'title': 't', 'content': 'x'},
+            )
+        self.assertEqual(response.status_code, 201)
+        body = response.json()
+        self.assertIsNone(body['project_id'])
+        self.assertEqual(body['attached_to']['kind'], 'project_type')
+        self.assertEqual(body['attached_to']['id'], 'http-api')
+        self.assertEqual(body['attached_to']['name'], 'HTTP API')
+        create_call = self.mock_db.execute.await_args_list[0]
+        self.assertEqual(create_call.args[1]['type_slug'], 'http-api')
+
     # -- List ----------------------------------------------------------
 
     def test_list_project_documents(self) -> None:
         self.mock_db.execute.return_value = [
-            {
-                'n': self._document_data(id='n1'),
-                'p': self._project(),
-                'tags': [],
-            },
-            {
-                'n': self._document_data(id='n2'),
-                'p': self._project(),
-                'tags': [{'name': 'Runbook', 'slug': 'runbook'}],
-            },
+            self._project_row(n=self._document_data(id='n1')),
+            self._project_row(
+                n=self._document_data(id='n2'),
+                tags=[{'name': 'Runbook', 'slug': 'runbook'}],
+            ),
         ]
         with mock.patch(
             'imbi_common.graph.parse_agtype', side_effect=lambda x: x
@@ -211,16 +307,16 @@ class DocumentEndpointsTestCase(support.SharedAppTestCase):
 
     def test_list_cross_project_by_tag(self) -> None:
         self.mock_db.execute.return_value = [
-            {
-                'n': self._document_data(id='n1'),
-                'p': self._project(id='proj-a', slug='a'),
-                'tags': [{'name': 'Runbook', 'slug': 'runbook'}],
-            },
-            {
-                'n': self._document_data(id='n2'),
-                'p': self._project(id='proj-b', slug='b'),
-                'tags': [{'name': 'Runbook', 'slug': 'runbook'}],
-            },
+            self._project_row(
+                n=self._document_data(id='n1'),
+                p=self._project(id='proj-a', slug='a'),
+                tags=[{'name': 'Runbook', 'slug': 'runbook'}],
+            ),
+            self._project_row(
+                n=self._document_data(id='n2'),
+                p=self._project(id='proj-b', slug='b'),
+                tags=[{'name': 'Runbook', 'slug': 'runbook'}],
+            ),
         ]
         with mock.patch(
             'imbi_common.graph.parse_agtype', side_effect=lambda x: x
@@ -231,6 +327,82 @@ class DocumentEndpointsTestCase(support.SharedAppTestCase):
         self.assertEqual(response.status_code, 200)
         projects = {n['project_id'] for n in response.json()['data']}
         self.assertEqual(projects, {'proj-a', 'proj-b'})
+
+    def test_list_mixed_attachments(self) -> None:
+        """The org index returns project, project-type, and user docs."""
+        self.mock_db.execute.return_value = [
+            self._project_row(
+                n=self._document_data(id='n1'),
+                ptype_names=['API', 'Consumer'],
+                comment_count=3,
+                author={
+                    'email': 'admin@example.com',
+                    'display_name': 'Admin User',
+                },
+            ),
+            self._row(
+                n=self._document_data(id='n2'),
+                pt={'slug': 'http-api', 'name': 'HTTP API'},
+            ),
+            self._row(
+                n=self._document_data(id='n3'),
+                u={
+                    'email': 'gavinr@example.com',
+                    'display_name': 'Gavin M. Roy',
+                },
+            ),
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.get('/organizations/engineering/documents/')
+        self.assertEqual(response.status_code, 200)
+        data = response.json()['data']
+        self.assertEqual(len(data), 3)
+        self.assertEqual(data[0]['attached_to']['kind'], 'project')
+        self.assertEqual(
+            data[0]['attached_to']['project_types'], ['API', 'Consumer']
+        )
+        self.assertEqual(data[0]['comment_count'], 3)
+        self.assertEqual(data[0]['created_by_name'], 'Admin User')
+        self.assertEqual(data[1]['attached_to']['kind'], 'project_type')
+        self.assertEqual(data[2]['attached_to']['kind'], 'user')
+
+    def test_list_user_documents(self) -> None:
+        self.mock_db.execute.return_value = [
+            self._row(
+                u={
+                    'email': 'gavinr@example.com',
+                    'display_name': 'Gavin M. Roy',
+                },
+            )
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.get(
+                '/organizations/engineering/users/gavinr@example.com'
+                '/documents/'
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.json()['data']), 1)
+        call = self.mock_db.execute.await_args_list[0]
+        self.assertEqual(call.args[1]['user_email'], 'gavinr@example.com')
+
+    def test_list_project_type_documents(self) -> None:
+        self.mock_db.execute.return_value = [
+            self._row(pt={'slug': 'http-api', 'name': 'HTTP API'})
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.get(
+                '/organizations/engineering/project-types/http-api/documents/'
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.json()['data']), 1)
+        call = self.mock_db.execute.await_args_list[0]
+        self.assertEqual(call.args[1]['project_type_slug'], 'http-api')
 
     def test_list_invalid_limit(self) -> None:
         response = self.client.get(
@@ -248,13 +420,7 @@ class DocumentEndpointsTestCase(support.SharedAppTestCase):
     # -- Get -----------------------------------------------------------
 
     def test_get_single(self) -> None:
-        self.mock_db.execute.return_value = [
-            {
-                'n': self._document_data(),
-                'p': self._project(),
-                'tags': [],
-            }
-        ]
+        self.mock_db.execute.return_value = [self._project_row()]
         with mock.patch(
             'imbi_common.graph.parse_agtype', side_effect=lambda x: x
         ):
@@ -271,27 +437,41 @@ class DocumentEndpointsTestCase(support.SharedAppTestCase):
         )
         self.assertEqual(response.status_code, 404)
 
+    def test_get_org_document(self) -> None:
+        """The generic route resolves a user-attached document."""
+        self.mock_db.execute.return_value = [
+            self._row(
+                u={
+                    'email': 'gavinr@example.com',
+                    'display_name': 'Gavin M. Roy',
+                },
+            )
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.get(
+                '/organizations/engineering/documents/document-1'
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()['attached_to']['kind'], 'user')
+
+    def test_get_org_document_not_found(self) -> None:
+        self.mock_db.execute.return_value = []
+        response = self.client.get(
+            '/organizations/engineering/documents/ghost'
+        )
+        self.assertEqual(response.status_code, 404)
+
     # -- Patch ---------------------------------------------------------
 
     def test_patch_content(self) -> None:
         # 1: _fetch_document (existing), 2: SET query,
         # 3: _fetch_document (final)
         self.mock_db.execute.side_effect = [
-            [
-                {
-                    'n': self._document_data(),
-                    'p': self._project(),
-                    'tags': [],
-                }
-            ],
+            [self._project_row()],
             [{'id': 'document-1'}],
-            [
-                {
-                    'n': self._document_data(content='Updated text'),
-                    'p': self._project(),
-                    'tags': [],
-                }
-            ],
+            [self._project_row(n=self._document_data(content='Updated text'))],
         ]
         with mock.patch(
             'imbi_common.graph.parse_agtype', side_effect=lambda x: x
@@ -309,26 +489,51 @@ class DocumentEndpointsTestCase(support.SharedAppTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()['content'], 'Updated text')
 
+    def test_patch_org_document(self) -> None:
+        """The generic route patches a user-attached document."""
+        user = {
+            'email': 'gavinr@example.com',
+            'display_name': 'Gavin M. Roy',
+        }
+        self.mock_db.execute.side_effect = [
+            [self._row(u=user)],
+            [{'id': 'document-1'}],
+            [
+                self._row(
+                    n=self._document_data(content='Updated text'),
+                    u=user,
+                )
+            ],
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.patch(
+                '/organizations/engineering/documents/document-1',
+                json=[
+                    {
+                        'op': 'replace',
+                        'path': '/content',
+                        'value': 'Updated text',
+                    }
+                ],
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()['content'], 'Updated text')
+
     def test_patch_replace_tags(self) -> None:
         # fetch-existing, validate, SET, detach, attach, fetch-final
         self.mock_db.execute.side_effect = [
-            [
-                {
-                    'n': self._document_data(),
-                    'p': self._project(),
-                    'tags': [],
-                }
-            ],
+            [self._project_row()],
             [{'tag_slug': 'runbook', 'found': True}],
             [{'id': 'document-1'}],
             [{'removed': 0}],
             [{'attached': 1}],
             [
-                {
-                    'n': self._document_data(updated_by='admin@example.com'),
-                    'p': self._project(),
-                    'tags': [{'name': 'Runbook', 'slug': 'runbook'}],
-                }
+                self._project_row(
+                    n=self._document_data(updated_by='admin@example.com'),
+                    tags=[{'name': 'Runbook', 'slug': 'runbook'}],
+                )
             ],
         ]
         with mock.patch(
@@ -350,8 +555,9 @@ class DocumentEndpointsTestCase(support.SharedAppTestCase):
         )
 
     def test_create_defaults_is_pinned_false(self) -> None:
-        self.mock_db.execute.return_value = [
-            {'n': self._document_data(), 'p': self._project(), 'tags': []}
+        self.mock_db.execute.side_effect = [
+            [{'id': 'document-1'}],
+            [self._project_row()],
         ]
         with mock.patch(
             'imbi_common.graph.parse_agtype', side_effect=lambda x: x
@@ -370,21 +576,9 @@ class DocumentEndpointsTestCase(support.SharedAppTestCase):
 
     def test_patch_title(self) -> None:
         self.mock_db.execute.side_effect = [
-            [
-                {
-                    'n': self._document_data(),
-                    'p': self._project(),
-                    'tags': [],
-                }
-            ],
+            [self._project_row()],
             [{'id': 'document-1'}],
-            [
-                {
-                    'n': self._document_data(title='New title'),
-                    'p': self._project(),
-                    'tags': [],
-                }
-            ],
+            [self._project_row(n=self._document_data(title='New title'))],
         ]
         with mock.patch(
             'imbi_common.graph.parse_agtype', side_effect=lambda x: x
@@ -407,21 +601,9 @@ class DocumentEndpointsTestCase(support.SharedAppTestCase):
 
     def test_patch_is_pinned(self) -> None:
         self.mock_db.execute.side_effect = [
-            [
-                {
-                    'n': self._document_data(),
-                    'p': self._project(),
-                    'tags': [],
-                }
-            ],
+            [self._project_row()],
             [{'id': 'document-1'}],
-            [
-                {
-                    'n': self._document_data(is_pinned=True),
-                    'p': self._project(),
-                    'tags': [],
-                }
-            ],
+            [self._project_row(n=self._document_data(is_pinned=True))],
         ]
         with mock.patch(
             'imbi_common.graph.parse_agtype', side_effect=lambda x: x
@@ -444,13 +626,7 @@ class DocumentEndpointsTestCase(support.SharedAppTestCase):
 
     def test_patch_title_null_rejected(self) -> None:
         """Explicit ``replace /title -> null`` must 400, not silently no-op."""
-        self.mock_db.execute.return_value = [
-            {
-                'n': self._document_data(),
-                'p': self._project(),
-                'tags': [],
-            }
-        ]
+        self.mock_db.execute.return_value = [self._project_row()]
         with mock.patch(
             'imbi_common.graph.parse_agtype', side_effect=lambda x: x
         ):
@@ -462,13 +638,7 @@ class DocumentEndpointsTestCase(support.SharedAppTestCase):
 
     def test_patch_is_pinned_null_rejected(self) -> None:
         """Explicit ``replace /is_pinned -> null`` must 400."""
-        self.mock_db.execute.return_value = [
-            {
-                'n': self._document_data(),
-                'p': self._project(),
-                'tags': [],
-            }
-        ]
+        self.mock_db.execute.return_value = [self._project_row()]
         with mock.patch(
             'imbi_common.graph.parse_agtype', side_effect=lambda x: x
         ):
@@ -480,13 +650,7 @@ class DocumentEndpointsTestCase(support.SharedAppTestCase):
 
     def test_patch_content_null_rejected(self) -> None:
         """Explicit ``replace /content -> null`` must 400."""
-        self.mock_db.execute.return_value = [
-            {
-                'n': self._document_data(),
-                'p': self._project(),
-                'tags': [],
-            }
-        ]
+        self.mock_db.execute.return_value = [self._project_row()]
         with mock.patch(
             'imbi_common.graph.parse_agtype', side_effect=lambda x: x
         ):
@@ -497,13 +661,7 @@ class DocumentEndpointsTestCase(support.SharedAppTestCase):
         self.assertEqual(response.status_code, 400)
 
     def test_patch_readonly_path_rejected(self) -> None:
-        self.mock_db.execute.return_value = [
-            {
-                'n': self._document_data(),
-                'p': self._project(),
-                'tags': [],
-            }
-        ]
+        self.mock_db.execute.return_value = [self._project_row()]
         with mock.patch(
             'imbi_common.graph.parse_agtype', side_effect=lambda x: x
         ):
@@ -514,6 +672,24 @@ class DocumentEndpointsTestCase(support.SharedAppTestCase):
                         'op': 'replace',
                         'path': '/created_by',
                         'value': 'attacker',
+                    }
+                ],
+            )
+        self.assertEqual(response.status_code, 400)
+
+    def test_patch_attached_to_rejected(self) -> None:
+        """The attachment is immutable over the PATCH API."""
+        self.mock_db.execute.return_value = [self._project_row()]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.patch(
+                '/organizations/engineering/documents/document-1',
+                json=[
+                    {
+                        'op': 'replace',
+                        'path': '/attached_to',
+                        'value': {'kind': 'user', 'id': 'x'},
                     }
                 ],
             )
@@ -530,7 +706,7 @@ class DocumentEndpointsTestCase(support.SharedAppTestCase):
     # -- Delete --------------------------------------------------------
 
     def test_delete_success(self) -> None:
-        self.mock_db.execute.return_value = [{'n': True}]
+        self.mock_db.execute.return_value = [{'deleted': 1}]
         response = self.client.delete(
             '/organizations/engineering/projects/proj-abc/documents/document-1'
         )
@@ -543,19 +719,24 @@ class DocumentEndpointsTestCase(support.SharedAppTestCase):
         )
         self.assertEqual(response.status_code, 404)
 
+    def test_delete_org_document(self) -> None:
+        self.mock_db.execute.return_value = [{'deleted': 1}]
+        response = self.client.delete(
+            '/organizations/engineering/documents/document-1'
+        )
+        self.assertEqual(response.status_code, 204)
+
     # -- Pagination + cursor edge cases --------------------------------
 
     def test_list_pagination_emits_next_cursor(self) -> None:
         """Returning limit+1 rows emits a Link header with rel=next."""
         rows = [
-            {
-                'n': self._document_data(
+            self._project_row(
+                n=self._document_data(
                     id=f'n{i}',
                     created_at=f'2026-03-1{i % 10}T12:00:00Z',
                 ),
-                'p': self._project(),
-                'tags': [],
-            }
+            )
             for i in range(3)
         ]
         self.mock_db.execute.return_value = rows
@@ -579,11 +760,7 @@ class DocumentEndpointsTestCase(support.SharedAppTestCase):
             .decode()
         )
         self.mock_db.execute.return_value = [
-            {
-                'n': self._document_data(id='n-next'),
-                'p': self._project(),
-                'tags': [],
-            }
+            self._project_row(n=self._document_data(id='n-next'))
         ]
         with mock.patch(
             'imbi_common.graph.parse_agtype', side_effect=lambda x: x
@@ -595,13 +772,7 @@ class DocumentEndpointsTestCase(support.SharedAppTestCase):
 
     def test_patch_validation_error(self) -> None:
         """Patching /content to an empty string returns 400."""
-        self.mock_db.execute.return_value = [
-            {
-                'n': self._document_data(),
-                'p': self._project(),
-                'tags': [],
-            }
-        ]
+        self.mock_db.execute.return_value = [self._project_row()]
         with mock.patch(
             'imbi_common.graph.parse_agtype', side_effect=lambda x: x
         ):
@@ -614,13 +785,7 @@ class DocumentEndpointsTestCase(support.SharedAppTestCase):
     def test_patch_concurrent_delete_returns_404(self) -> None:
         """Update query returning no rows after fetch yields 404."""
         self.mock_db.execute.side_effect = [
-            [
-                {
-                    'n': self._document_data(),
-                    'p': self._project(),
-                    'tags': [],
-                }
-            ],
+            [self._project_row()],
             [],
         ]
         with mock.patch(

--- a/tests/endpoints/test_documents.py
+++ b/tests/endpoints/test_documents.py
@@ -410,6 +410,14 @@ class DocumentEndpointsTestCase(support.SharedAppTestCase):
         )
         self.assertEqual(response.status_code, 400)
 
+    def test_list_mutually_exclusive_filters(self) -> None:
+        response = self.client.get(
+            '/organizations/engineering/documents/'
+            '?project_id=proj-abc&project_type=http-api'
+        )
+        self.assertEqual(response.status_code, 400)
+        self.mock_db.execute.assert_not_called()
+
     def test_list_invalid_cursor(self) -> None:
         response = self.client.get(
             '/organizations/engineering/documents/?cursor=!!not-base64!!'


### PR DESCRIPTION
## Summary

Documents previously required a Project attachment. A document now attaches to exactly one of Project, ProjectType, or User via the existing `ATTACHED_TO` edge.

- **New scoped routers:** list + create under `/{org}/users/{email}/documents` and `/{org}/project-types/{type_slug}/documents`.
- **Attachment-agnostic document routes** under `/{org}/documents/{document_id}` (GET/PATCH/DELETE) that resolve the document through whichever vertex it is attached to.
- **Enriched org index** (`GET /{org}/documents`) for the Documents index/feed UI: `attached_to` (kind, id, name, owning team + project-type names for projects), `comment_count`, and the author's display name. New `project_type` and `user` filters.
- **Comments generalized:** the document-ownership join resolves any attachment kind, with the project-scoped routes still enforcing project membership; the comments router is additionally mounted at `/{org}/documents/{document_id}/comments`.
- **`DocumentTemplate.type`** (`'project'|'global'|'user'|'project_type'`, default `'project'`; legacy rows surface as `'project'`) plus a `context=` list filter that keeps matching-type and `global` templates.

## Part of a 3-PR stack

1. imbi-common `feature/document-attachment-types` — model + template type
2. **imbi-api** (this PR) — depends on the imbi-common branch's model, but **does not require a new imbi-common release** to run: all document/template/comment endpoints use raw Cypher with local Pydantic response models.
3. imbi-ui `feature/documents-index` — consumes these endpoints

## Testing

2,284 tests pass; lint/mypy/basedpyright clean. All new and modified Cypher was additionally **validated against a live Apache AGE instance** — attachment resolution, the enrichment tail, filters, the project-scope leak guard (a user-attached document cannot be resolved through a project-scoped comment route), `SET`, and `DETACH DELETE`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
