### PR TITLE
Expose parent third-party service on plugin assignments

### DIFF
--- a/src/imbi_api/domain/models.py
+++ b/src/imbi_api/domain/models.py
@@ -936,6 +936,10 @@ class PluginAssignmentResponse(pydantic.BaseModel):
     # settings page (and the admin TPS page), which push current Imbi
     # state to the remote on demand.
     supports_lifecycle_sync: bool = False
+    # Parent third-party service (``ThirdPartyService -[:HAS_PLUGIN]->
+    # Plugin``) so the UI can show which service powers the tab.
+    service_name: str | None = None
+    service_icon: str | None = None
 
 
 class LifecycleSyncError(pydantic.BaseModel):

--- a/src/imbi_api/endpoints/project_plugins.py
+++ b/src/imbi_api/endpoints/project_plugins.py
@@ -37,10 +37,14 @@ async def get_project_plugins(
           (o:Organization {{slug: {org_slug}}})
     OPTIONAL MATCH (proj)-[:TYPE]->(pt:ProjectType)
                    -[pte:USES_PLUGIN]->(p2:Plugin)
+    OPTIONAL MATCH (s2:ThirdPartyService)-[:HAS_PLUGIN]->(p2)
     WITH proj, collect({{plugin: p2{{.*}}, edge: pte{{.*}},
+                         service: s2{{.*}},
                          src: 'project_type'}}) AS pt_rows
     OPTIONAL MATCH (proj)-[pe:USES_PLUGIN]->(p:Plugin)
+    OPTIONAL MATCH (s:ThirdPartyService)-[:HAS_PLUGIN]->(p)
     WITH pt_rows, collect({{plugin: p{{.*}}, edge: pe{{.*}},
+                            service: s{{.*}},
                             src: 'project'}}) AS proj_rows
     RETURN pt_rows, proj_rows
     """
@@ -69,6 +73,7 @@ async def get_project_plugins(
             merged[plugin['id']] = {
                 'plugin': plugin,
                 'edge': graph.parse_agtype(row.get('edge')) or {},
+                'service': graph.parse_agtype(row.get('service')),
                 'source': 'project_type',
             }
     for row in proj_rows:
@@ -77,11 +82,14 @@ async def get_project_plugins(
             merged[plugin['id']] = {
                 'plugin': plugin,
                 'edge': graph.parse_agtype(row.get('edge')) or {},
+                'service': graph.parse_agtype(row.get('service')),
                 'source': 'project',
             }
 
     return [
-        build_assignment_response(v['plugin'], v['edge'], v['source'])
+        build_assignment_response(
+            v['plugin'], v['edge'], v['source'], v['service']
+        )
         for v in merged.values()
         if v['plugin'].get('id')
     ]

--- a/src/imbi_api/plugins/assignments.py
+++ b/src/imbi_api/plugins/assignments.py
@@ -110,6 +110,7 @@ def build_assignment_response(
     plugin: dict[str, typing.Any],
     edge: dict[str, typing.Any],
     source: typing.Literal['project', 'project_type', 'merged'],
+    service: dict[str, typing.Any] | None = None,
 ) -> models.PluginAssignmentResponse:
     """Build a PluginAssignmentResponse from parsed plugin/edge dicts."""
     supports_histogram = False
@@ -144,6 +145,8 @@ def build_assignment_response(
         supports_histogram=supports_histogram,
         supports_deployment_sync=supports_deployment_sync,
         supports_lifecycle_sync=supports_lifecycle_sync,
+        service_name=(service or {}).get('name'),
+        service_icon=(service or {}).get('icon'),
     )
 
 


### PR DESCRIPTION
## Summary
Surfaces the integrated third-party service behind a plugin assignment so the UI can render *which* service powers a plugin-driven feature instead of hardcoding provider names.

## Problem
The project-detail Deployments tab (and similar plugin-driven UI) needs to show the service backing the active plugin — e.g. the GitHub service icon/name for a deployment plugin. The API exposed the plugin assignment but not its parent `ThirdPartyService`, forcing the UI toward hardcoded, provider-specific assumptions.

## Solution
- Add `service_name` and `service_icon` to `PluginAssignmentResponse` (both optional).
- `build_assignment_response` accepts and threads the parent service.
- The project-plugins query collects the `ThirdPartyService -[:HAS_PLUGIN]-> Plugin` edge (both the project-type and project phases).

## Impact
Additive, optional response fields — existing clients are unaffected. No imbi-common dependency, so this can merge independently of the deployment-attribution work.

## Testing
ruff + mypy clean (pre-commit); existing project-plugins endpoint tests pass.