### PR TITLE
Make deployment resync depth configurable

### DIFF
--- a/src/imbi_api/endpoints/project_deployments.py
+++ b/src/imbi_api/endpoints/project_deployments.py
@@ -689,16 +689,25 @@ async def resync_for_project(
     project_id: str,
     auth: permissions.AuthContext,
     source: str | None = None,
+    limit: int = 1,
 ) -> ResyncSummary:
     """Resync remote deployments for a single project.
 
     Resolves the project's deployment plugin, asks it for the most
-    recent deployment per environment, upserts ``Release`` nodes for
-    any observed versions that are missing, appends ``DeploymentEvent``
-    rows on the ``DEPLOYED_TO`` edge (dedup'd by ``external_run_id``),
-    and writes a single audit row per environment.  Returns counts +
-    a per-environment error list so the host can surface partial
-    results rather than failing the whole call on one bad env.
+    recent ``limit`` deployments per environment, upserts ``Release``
+    nodes for any observed versions that are missing, appends
+    ``DeploymentEvent`` rows on the ``DEPLOYED_TO`` edge (dedup'd by
+    ``external_run_id``), and writes a single audit row per
+    environment.  Returns counts + a per-environment error list so the
+    host can surface partial results rather than failing the whole call
+    on one bad env.
+
+    ``limit`` controls how many recent deployments per environment the
+    plugin returns.  The default (1) keeps webhook-lapse catch-up cheap;
+    a larger value drives a deeper backfill that both fills in missing
+    historical ``DeploymentEvent`` rows and re-resolves ``performed_by``
+    on already-stored events (dedup'd by ``external_run_id``), which is
+    how stale actor attribution gets corrected.
     """
     summary = ResyncSummary(projects=1)
     resolved, ctx, credentials = await _resolve_and_context(
@@ -723,7 +732,7 @@ async def resync_for_project(
                 c,
                 _resolve_credentials(c, credentials),
                 environments=environments,
-                limit=1,
+                limit=limit,
             )
         )
 
@@ -1080,14 +1089,20 @@ async def resync_project_deployments(
         ),
     ],
     source: str | None = None,
+    limit: int = fastapi.Query(default=1, ge=1, le=100),
 ) -> ResyncSummary:
     """Backfill Release nodes + DEPLOYED_TO edges from the remote.
 
-    Asks the project's deployment plugin for the most recent
-    deployment per environment, upserts any missing ``Release`` nodes,
+    Asks the project's deployment plugin for the most recent ``limit``
+    deployments per environment, upserts any missing ``Release`` nodes,
     and dedup-appends ``DeploymentEvent`` rows so the badges advance
     even when the gateway webhook flow has lapsed.  Records one
     audit row per environment with ``action='resync'``.
+
+    ``limit`` defaults to 1 (cheap webhook-lapse catch-up).  Raise it
+    (up to 100, the GitHub per-page ceiling) for a deeper backfill that
+    re-resolves ``performed_by`` on historical events -- e.g. to fix
+    stale deploy attribution after a user links their identity.
 
     Surfaces 400 when the project's deployment plugin does not
     advertise ``supports_deployment_sync`` -- callers should hide the
@@ -1099,6 +1114,7 @@ async def resync_project_deployments(
         project_id=project_id,
         auth=auth,
         source=source,
+        limit=limit,
     )
 
 

--- a/src/imbi_api/endpoints/project_deployments.py
+++ b/src/imbi_api/endpoints/project_deployments.py
@@ -697,10 +697,13 @@ async def resync_for_project(
     recent ``limit`` deployments per environment, upserts ``Release``
     nodes for any observed versions that are missing, appends
     ``DeploymentEvent`` rows on the ``DEPLOYED_TO`` edge (dedup'd by
-    ``external_run_id``), and writes a single audit row per
-    environment.  Returns counts + a per-environment error list so the
-    host can surface partial results rather than failing the whole call
-    on one bad env.
+    ``external_run_id``).  Returns counts + a per-environment error list
+    so the host can surface partial results rather than failing the
+    whole call on one bad env.
+
+    No ``operations_log`` audit row is written: resync backfills
+    historical remote activity, so attributing it to the resync operator
+    would poison ``performed_by`` attribution.
 
     ``limit`` controls how many recent deployments per environment the
     plugin returns.  The default (1) keeps webhook-lapse catch-up cheap;
@@ -1096,8 +1099,9 @@ async def resync_project_deployments(
     Asks the project's deployment plugin for the most recent ``limit``
     deployments per environment, upserts any missing ``Release`` nodes,
     and dedup-appends ``DeploymentEvent`` rows so the badges advance
-    even when the gateway webhook flow has lapsed.  Records one
-    audit row per environment with ``action='resync'``.
+    even when the gateway webhook flow has lapsed.  No ``operations_log``
+    audit row is written -- the ``DEPLOYED_TO`` edge already carries the
+    original creator via ``DeploymentEvent.performed_by``.
 
     ``limit`` defaults to 1 (cheap webhook-lapse catch-up).  Raise it
     (up to 100, the GitHub per-page ceiling) for a deeper backfill that

--- a/tests/endpoints/test_project_deployments.py
+++ b/tests/endpoints/test_project_deployments.py
@@ -110,6 +110,8 @@ class _FakeDeploymentPlugin(DeploymentPlugin):
         self, ctx, credentials, environments, limit=1
     ):
         # Override per-test by setting ``_recent`` on the instance.
+        # Record the limit so tests can assert it was threaded through.
+        self._last_limit = limit  # type: ignore[attr-defined]
         return getattr(self, '_recent', [])
 
 
@@ -1380,6 +1382,47 @@ class ResyncProjectDeploymentsTestCase(ProjectDeploymentsTestCase):
         self.assertEqual(response.status_code, 200, response.text)
         append_call = self.mocks['append_deployment_event'].call_args
         self.assertEqual(append_call.kwargs['performed_by'], 'kevinv')
+
+    def test_resync_defaults_limit_to_one(self) -> None:
+        """Absent ``limit`` keeps the cheap latest-per-env catch-up."""
+        self._arm([self._observed()])
+        with testclient.TestClient(self.test_app) as client:
+            response = client.post(
+                '/organizations/myorg/projects/proj1/deployments/resync'
+            )
+        self.assertEqual(response.status_code, 200, response.text)
+        self.assertEqual(self.mocks['handler'].return_value._last_limit, 1)
+
+    def test_resync_threads_limit_to_plugin(self) -> None:
+        """``?limit=N`` reaches ``list_recent_deployments`` for a deeper
+        backfill that re-resolves historical attribution."""
+        self._arm([self._observed()])
+        with testclient.TestClient(self.test_app) as client:
+            response = client.post(
+                '/organizations/myorg/projects/proj1/deployments/resync'
+                '?limit=50'
+            )
+        self.assertEqual(response.status_code, 200, response.text)
+        self.assertEqual(self.mocks['handler'].return_value._last_limit, 50)
+
+    def test_resync_rejects_out_of_range_limit(self) -> None:
+        """``limit`` is clamped to the 1..100 GitHub per-page window."""
+        self._arm([self._observed()])
+        with testclient.TestClient(self.test_app) as client:
+            self.assertEqual(
+                client.post(
+                    '/organizations/myorg/projects/proj1/deployments/'
+                    'resync?limit=0'
+                ).status_code,
+                422,
+            )
+            self.assertEqual(
+                client.post(
+                    '/organizations/myorg/projects/proj1/deployments/'
+                    'resync?limit=101'
+                ).status_code,
+                422,
+            )
 
     def test_resync_requires_write_permission(self) -> None:
         non_admin = models.User(


### PR DESCRIPTION
## Summary

Adds a bounded `limit` query parameter to the deployment resync endpoint so it can perform a deeper backfill, instead of only ever re-fetching the single latest deployment per environment.

## Problem

`POST /…/projects/{id}/deployments/resync` hard-coded `limit=1` when calling `resync_for_project` → `list_recent_deployments`. That means a resync only ever re-fetches the **latest** deployment per environment. Pre-existing/historical releases are never re-fetched, so:

- Missing historical `DeploymentEvent` rows can't be backfilled.
- Stale actor attribution can't be corrected. A deploy synced **before** a user linked their identity keeps its raw login (e.g. `edl`) as `performed_by` forever, while a later deploy for the same person resolves to their Imbi user — producing inconsistent attribution in the UI.

## Solution

- Expose `limit: int = fastapi.Query(default=1, ge=1, le=100)` on `resync_project_deployments` (100 = the GitHub per-page ceiling the plugin already honors).
- Thread it through `resync_for_project(..., limit=limit)` into `handler.list_recent_deployments(limit=limit)`.
- Default stays **1**, preserving the cheap webhook-lapse catch-up behavior.

A larger `limit` both fills in missing historical `DeploymentEvent` rows and **re-resolves `performed_by`** on already-stored events (dedup'd by `external_run_id`), which is how stale deploy attribution gets corrected — provided the actor now resolves to an Imbi user.

No plugin change required: `list_recent_deployments` already accepts `limit` (capped at 100).

## Tests

- `test_resync_defaults_limit_to_one` — absent param keeps `limit=1`.
- `test_resync_threads_limit_to_plugin` — `?limit=50` reaches the plugin.
- `test_resync_rejects_out_of_range_limit` — `0` and `101` → 422.

## Notes / follow-ups

- This is API-only; the UI resync button still calls `/resync` with no `limit`. A deep resync is currently triggered via `?limit=N`. A UI affordance (or a one-off bulk script across projects) could be a follow-up.
- True full history beyond 100 deployments/env (Option B) would need pagination added inside the plugin's `_list_deployments_for_env`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)