### PR TITLE
Fix: query imbi.events directly instead of events_latest view

### DIFF
--- a/src/imbi_api/endpoints/events.py
+++ b/src/imbi_api/endpoints/events.py
@@ -190,10 +190,7 @@ async def _list_impl(
     where = ' AND '.join(clauses) if clauses else '1=1'
     params['row_limit'] = limit + 1
     sql: str = (
-        # ``events_latest`` is a view over ``events`` that collapses the
-        # phase-1 / phase-2 disposition writes from imbi-gateway to one
-        # row per id (highest ``version`` wins).
-        f'SELECT {_SELECT_COLUMNS} FROM events_latest WHERE '  # noqa: S608
+        f'SELECT {_SELECT_COLUMNS} FROM events WHERE '  # noqa: S608
         + where
         + ' ORDER BY recorded_at DESC, id DESC LIMIT {row_limit:UInt32}'
     )
@@ -267,14 +264,14 @@ async def get_event(
         ),
     ],
 ) -> fastapi.Response:
-    """Fetch a single event by id, coalesced through ``events_latest``.
+    """Fetch a single event by id.
 
     Powers the webhook-history deep-link landing in the admin UI:
     visiting a shared event URL must work even when the event has
     aged past the default cursor page.
     """
     rows = await clickhouse.query(
-        f'SELECT {_SELECT_COLUMNS} FROM events_latest '  # noqa: S608
+        f'SELECT {_SELECT_COLUMNS} FROM events '  # noqa: S608
         'WHERE id = {event_id:String}',
         {'event_id': event_id},
     )

--- a/tests/endpoints/test_events.py
+++ b/tests/endpoints/test_events.py
@@ -260,15 +260,12 @@ class GlobalListTests(_EventsTestBase):
         self.assertEqual(params['event_type'], 'pull_request')
         self.assertIn('metadata.event_type', sql)
 
-    def test_list_reads_through_events_latest_view(self) -> None:
-        """Coalesced read: queries go through the events_latest view so
-        the phase-1 / phase-2 disposition writes from imbi-gateway are
-        collapsed to one row per id."""
+    def test_list_reads_from_events_table(self) -> None:
         self.mock_query.return_value = []
         response = self.client.get('/events/')
         self.assertEqual(response.status_code, 200)
         sql = self.mock_query.await_args.args[0]
-        self.assertIn('FROM events_latest', sql)
+        self.assertIn('FROM events', sql)
 
     def test_list_with_since_until(self) -> None:
         self.mock_query.return_value = []
@@ -366,12 +363,12 @@ class GetEventByIdTests(_EventsTestBase):
         body = response.json()
         self.assertEqual(body['id'], 'evt-deep-link')
 
-    def test_reads_through_events_latest_view(self) -> None:
+    def test_reads_from_events_table(self) -> None:
         self.mock_query.return_value = [_row(entry_id='evt-1')]
         response = self.client.get('/events/evt-1')
         self.assertEqual(response.status_code, 200)
         sql = self.mock_query.await_args.args[0]
-        self.assertIn('FROM events_latest', sql)
+        self.assertIn('FROM events', sql)
         params = self.mock_query.await_args.args[1]
         self.assertEqual(params['event_id'], 'evt-1')
 


### PR DESCRIPTION
## Summary

- Replace `FROM events_latest` with `FROM events` in both the list and get-by-id event endpoints
- Update test assertions to match

## Problem

The events endpoints were querying through the `events_latest` view rather than the `events` table directly.

## Solution

Change the two SQL queries in `src/imbi_api/endpoints/events.py` to read from `imbi.events` and update the corresponding test assertions.