### PR TITLE
Fix: tighten events table test assertions

### DIFF
--- a/tests/endpoints/test_events.py
+++ b/tests/endpoints/test_events.py
@@ -265,7 +265,7 @@ class GlobalListTests(_EventsTestBase):
         response = self.client.get('/events/')
         self.assertEqual(response.status_code, 200)
         sql = self.mock_query.await_args.args[0]
-        self.assertIn('FROM events', sql)
+        self.assertIn('FROM events WHERE', sql)
 
     def test_list_with_since_until(self) -> None:
         self.mock_query.return_value = []
@@ -368,7 +368,7 @@ class GetEventByIdTests(_EventsTestBase):
         response = self.client.get('/events/evt-1')
         self.assertEqual(response.status_code, 200)
         sql = self.mock_query.await_args.args[0]
-        self.assertIn('FROM events', sql)
+        self.assertIn('FROM events ', sql)
         params = self.mock_query.await_args.args[1]
         self.assertEqual(params['event_id'], 'evt-1')
 


### PR DESCRIPTION
## Summary

- Tighten `FROM events` assertions to `FROM events WHERE` (list) and `FROM events ` with trailing space (get-by-id)

## Problem

CodeRabbit flagged on #448 that `assertIn('FROM events', sql)` is too loose — the string `'FROM events'` is a substring of `'FROM events_latest'`, so the test would pass even if the query regressed to using the view.

## Solution

Use more specific substrings that cannot match `events_latest`:
- List endpoint: `'FROM events WHERE'`  
- Get-by-id endpoint: `'FROM events '` (trailing space before `WHERE`)