### PR TITLE
Add PR sync module, endpoints, blueprint compliance, and Valkey worker

### DIFF
--- a/src/imbi_api/app.py
+++ b/src/imbi_api/app.py
@@ -26,6 +26,7 @@ def create_app() -> fastapi.FastAPI:
             valkey.valkey_lifespan,
             lifespans.score_worker_hook,
             lifespans.commit_sync_worker_hook,
+            lifespans.pr_sync_worker_hook,
             lifespans.identity_refresh_hook,
         ),
         version=version,

--- a/src/imbi_api/blueprint_compliance.py
+++ b/src/imbi_api/blueprint_compliance.py
@@ -128,12 +128,42 @@ def _check_property(
                 description=(
                     f'`{prop_name}` has no value. '
                     f'The blueprint default is `{default!r}`. '
-                    f'Use **Apply Blueprint Defaults** to set it.'
+                    f'Use **Apply Blueprint Fixes** to set it.'
                 ),
                 status='warn',
             )
 
     return None
+
+
+def _stale_blueprint_properties(
+    all_blueprints: list[models.Blueprint],
+    applicable: list[models.Blueprint],
+    current_props: dict[str, typing.Any],
+) -> list[str]:
+    """Return property names set on the project with no applicable blueprint.
+
+    A property is "stale" when it was set by a blueprint that no longer
+    applies to this project's type(s). Only considers properties defined in
+    *some* blueprint (so core model fields like ``id`` or ``name`` are never
+    flagged).
+    """
+    all_bp_props: set[str] = set()
+    for bp in all_blueprints:
+        if bp.kind != 'node':
+            continue
+        for prop_name in bp.json_schema.properties or {}:
+            all_bp_props.add(prop_name)
+
+    applicable_props: set[str] = set()
+    for bp in applicable:
+        for prop_name in bp.json_schema.properties or {}:
+            applicable_props.add(prop_name)
+
+    stale = all_bp_props - applicable_props
+    return [
+        p for p in stale if not _is_missing(current_props.get(p, _SENTINEL))
+    ]
 
 
 def _applicable_blueprints(
@@ -185,17 +215,6 @@ async def check_blueprint_compliance(
 
     type_slug_set = set(type_slugs)
     applicable = _applicable_blueprints(all_blueprints, type_slug_set)
-    if not applicable:
-        return [
-            AnalysisResultItem(
-                slug=f'{_BLUEPRINT_PLUGIN_SLUG}:no-applicable',
-                title='No blueprints apply to this project type',
-                description=(
-                    "No enabled blueprints match this project's type(s)."
-                ),
-                status='pass',
-            )
-        ]
 
     props = await _fetch_project_props(db, project_id)
     findings: list[AnalysisResultItem] = []
@@ -217,7 +236,35 @@ async def check_blueprint_compliance(
             if finding is not None:
                 findings.append(finding)
 
+    # Detect blueprint-managed properties no longer in any applicable
+    # blueprint.
+    stale = _stale_blueprint_properties(all_blueprints, applicable, props)
+    for prop_name in sorted(stale):
+        findings.append(
+            AnalysisResultItem(
+                slug=f'{_BLUEPRINT_PLUGIN_SLUG}:stale:{prop_name}',
+                title=f'Property not in any applicable blueprint: {prop_name}',
+                description=(
+                    f'`{prop_name}` is set on this project but is not defined '
+                    f'in any currently applicable blueprint. '
+                    f'Use **Apply Blueprint Fixes** to remove it.'
+                ),
+                status='warn',
+            )
+        )
+
     if not findings:
+        if not applicable:
+            return [
+                AnalysisResultItem(
+                    slug=f'{_BLUEPRINT_PLUGIN_SLUG}:no-applicable',
+                    title='No blueprints apply to this project type',
+                    description=(
+                        "No enabled blueprints match this project's type(s)."
+                    ),
+                    status='pass',
+                )
+            ]
         return [
             AnalysisResultItem(
                 slug=f'{_BLUEPRINT_PLUGIN_SLUG}:all-pass',
@@ -297,3 +344,50 @@ async def apply_blueprint_defaults(
         list(defaults.keys()),
     )
     return len(defaults)
+
+
+async def remove_stale_blueprint_properties(
+    db: graph.Graph,
+    project_id: str,
+    type_slugs: list[str],
+) -> int:
+    """Remove blueprint-managed properties no longer in any applicable
+    blueprint.
+
+    Only removes properties defined in *some* blueprint, so core model
+    fields (``id``, ``name``, etc.) are never touched. Stale properties are
+    removed by setting them to ``null`` in a single Cypher ``SET`` clause.
+
+    Returns the number of properties removed.
+    """
+    all_blueprints = await project_blueprints(db)
+    if not all_blueprints:
+        return 0
+
+    type_slug_set = set(type_slugs)
+    applicable = _applicable_blueprints(all_blueprints, type_slug_set)
+    props = await _fetch_project_props(db, project_id)
+
+    stale = [
+        p
+        for p in _stale_blueprint_properties(all_blueprints, applicable, props)
+        if _SAFE_PROP_RE.match(p)
+    ]
+    if not stale:
+        return 0
+
+    # Setting a property to null removes it from the AGE node.
+    set_parts = [f'p.{k} = null' for k in stale]
+    cypher = (
+        'MATCH (p:Project {{id: {project_id}}}) SET '
+        + ', '.join(set_parts)
+        + ' RETURN p.id AS id'
+    )
+    await db.execute(cypher, {'project_id': project_id}, ['id'])
+    LOGGER.info(
+        'Removed %d stale blueprint property/ies from project %s: %s',
+        len(stale),
+        project_id,
+        stale,
+    )
+    return len(stale)

--- a/src/imbi_api/blueprint_compliance.py
+++ b/src/imbi_api/blueprint_compliance.py
@@ -24,8 +24,8 @@ from imbi_api.blueprint_attributes import project_blueprints
 
 LOGGER = logging.getLogger(__name__)
 
-_BLUEPRINT_PLUGIN_SLUG = 'blueprint-compliance'
-_BLUEPRINT_PLUGIN_ID = 'built-in'
+BLUEPRINT_PLUGIN_SLUG = 'blueprint-compliance'
+BLUEPRINT_PLUGIN_ID = 'built-in'
 
 _SENTINEL = object()  # distinguishes "not present" from explicit None
 
@@ -70,7 +70,7 @@ def _check_property(
 
     if required and missing:
         return AnalysisResultItem(
-            slug=f'{_BLUEPRINT_PLUGIN_SLUG}:{section_slug}:{prop_name}:missing',
+            slug=f'{BLUEPRINT_PLUGIN_SLUG}:{section_slug}:{prop_name}:missing',
             title=f'Required property not set: {display}',
             description=(
                 f'`{prop_name}` is required by the **{section_slug}** '
@@ -84,7 +84,7 @@ def _check_property(
         if enum is not None and current_value not in enum:
             choices = ', '.join(f'`{v}`' for v in enum)
             return AnalysisResultItem(
-                slug=f'{_BLUEPRINT_PLUGIN_SLUG}:{section_slug}:{prop_name}:invalid-enum',
+                slug=f'{BLUEPRINT_PLUGIN_SLUG}:{section_slug}:{prop_name}:invalid-enum',
                 title=f'Property value not in allowed set: {display}',
                 description=(
                     f'`{prop_name}` is `{current_value!r}` but the '
@@ -99,7 +99,7 @@ def _check_property(
         if isinstance(current_value, (int, float)):
             if minimum is not None and current_value < minimum:
                 return AnalysisResultItem(
-                    slug=f'{_BLUEPRINT_PLUGIN_SLUG}:{section_slug}:{prop_name}:below-minimum',
+                    slug=f'{BLUEPRINT_PLUGIN_SLUG}:{section_slug}:{prop_name}:below-minimum',
                     title=f'Property below minimum: {display}',
                     description=(
                         f'`{prop_name}` is `{current_value}` but '
@@ -109,7 +109,7 @@ def _check_property(
                 )
             if maximum is not None and current_value > maximum:
                 return AnalysisResultItem(
-                    slug=f'{_BLUEPRINT_PLUGIN_SLUG}:{section_slug}:{prop_name}:above-maximum',
+                    slug=f'{BLUEPRINT_PLUGIN_SLUG}:{section_slug}:{prop_name}:above-maximum',
                     title=f'Property above maximum: {display}',
                     description=(
                         f'`{prop_name}` is `{current_value}` but '
@@ -123,7 +123,7 @@ def _check_property(
         default = getattr(prop_schema, 'default', None)
         if default is not None:
             return AnalysisResultItem(
-                slug=f'{_BLUEPRINT_PLUGIN_SLUG}:{section_slug}:{prop_name}:use-default',
+                slug=f'{BLUEPRINT_PLUGIN_SLUG}:{section_slug}:{prop_name}:use-default',
                 title=f'Property not set — default available: {display}',
                 description=(
                     f'`{prop_name}` has no value. '
@@ -203,7 +203,7 @@ async def check_blueprint_compliance(
     if not all_blueprints:
         return [
             AnalysisResultItem(
-                slug=f'{_BLUEPRINT_PLUGIN_SLUG}:no-blueprints',
+                slug=f'{BLUEPRINT_PLUGIN_SLUG}:no-blueprints',
                 title='No Project blueprints configured',
                 description=(
                     'No enabled Project blueprints are defined. '
@@ -242,7 +242,7 @@ async def check_blueprint_compliance(
     for prop_name in sorted(stale):
         findings.append(
             AnalysisResultItem(
-                slug=f'{_BLUEPRINT_PLUGIN_SLUG}:stale:{prop_name}',
+                slug=f'{BLUEPRINT_PLUGIN_SLUG}:stale:{prop_name}',
                 title=f'Property not in any applicable blueprint: {prop_name}',
                 description=(
                     f'`{prop_name}` is set on this project but is not defined '
@@ -257,7 +257,7 @@ async def check_blueprint_compliance(
         if not applicable:
             return [
                 AnalysisResultItem(
-                    slug=f'{_BLUEPRINT_PLUGIN_SLUG}:no-applicable',
+                    slug=f'{BLUEPRINT_PLUGIN_SLUG}:no-applicable',
                     title='No blueprints apply to this project type',
                     description=(
                         "No enabled blueprints match this project's type(s)."
@@ -267,7 +267,7 @@ async def check_blueprint_compliance(
             ]
         return [
             AnalysisResultItem(
-                slug=f'{_BLUEPRINT_PLUGIN_SLUG}:all-pass',
+                slug=f'{BLUEPRINT_PLUGIN_SLUG}:all-pass',
                 title='All blueprint properties are correctly set',
                 description=(
                     'Every required and recommended blueprint property '

--- a/src/imbi_api/blueprint_compliance.py
+++ b/src/imbi_api/blueprint_compliance.py
@@ -1,0 +1,299 @@
+"""Blueprint property compliance check for Project Doctor.
+
+Compares a project's current AGE node properties against every
+applicable Project blueprint's JSON Schema and emits an
+:class:`~imbi_common.plugins.base.AnalysisResultItem` for each
+non-conformant property.
+
+This is a *built-in* check — no external plugin or credentials are
+required; it queries the graph directly.  The caller is responsible
+for wrapping the returned items into :class:`AnalysisResult` objects
+(adding ``plugin_slug`` and ``plugin_id``).
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import typing
+
+from imbi_common import graph, models
+from imbi_common.plugins.base import AnalysisResultItem
+
+from imbi_api.blueprint_attributes import project_blueprints
+
+LOGGER = logging.getLogger(__name__)
+
+_BLUEPRINT_PLUGIN_SLUG = 'blueprint-compliance'
+_BLUEPRINT_PLUGIN_ID = 'built-in'
+
+_SENTINEL = object()  # distinguishes "not present" from explicit None
+
+# Blueprint property names must be safe to embed in Cypher SET clauses.
+# Only allow names that look like identifiers.
+_SAFE_PROP_RE = re.compile(r'^[A-Za-z_][A-Za-z0-9_]*$')
+
+_FETCH_PROPS_QUERY = """
+MATCH (p:Project {{id: {project_id}}})
+RETURN p{{.*}} AS props
+"""
+
+
+async def _fetch_project_props(
+    db: graph.Graph, project_id: str
+) -> dict[str, typing.Any]:
+    rows = await db.execute(
+        _FETCH_PROPS_QUERY, {'project_id': project_id}, ['props']
+    )
+    if not rows:
+        return {}
+    raw = graph.parse_agtype(rows[0]['props'])
+    if not isinstance(raw, dict):
+        return {}
+    return typing.cast('dict[str, typing.Any]', raw)
+
+
+def _is_missing(value: typing.Any) -> bool:
+    return value is _SENTINEL or value is None or value == ''
+
+
+def _check_property(
+    section_slug: str,
+    prop_name: str,
+    prop_schema: models.Schema,
+    required: bool,
+    current_value: typing.Any,
+) -> AnalysisResultItem | None:
+    """Return a finding for a non-conformant property, or ``None``."""
+    display = getattr(prop_schema, 'title', None) or prop_name
+    missing = _is_missing(current_value)
+
+    if required and missing:
+        return AnalysisResultItem(
+            slug=f'{_BLUEPRINT_PLUGIN_SLUG}:{section_slug}:{prop_name}:missing',
+            title=f'Required property not set: {display}',
+            description=(
+                f'`{prop_name}` is required by the **{section_slug}** '
+                f'blueprint but has no value. Edit the project to set it.'
+            ),
+            status='fail',
+        )
+
+    if not missing:
+        enum = getattr(prop_schema, 'enum', None)
+        if enum is not None and current_value not in enum:
+            choices = ', '.join(f'`{v}`' for v in enum)
+            return AnalysisResultItem(
+                slug=f'{_BLUEPRINT_PLUGIN_SLUG}:{section_slug}:{prop_name}:invalid-enum',
+                title=f'Property value not in allowed set: {display}',
+                description=(
+                    f'`{prop_name}` is `{current_value!r}` but the '
+                    f'allowed values are: {choices}. '
+                    f'Edit the project to correct it.'
+                ),
+                status='fail',
+            )
+
+        minimum = getattr(prop_schema, 'minimum', None)
+        maximum = getattr(prop_schema, 'maximum', None)
+        if isinstance(current_value, (int, float)):
+            if minimum is not None and current_value < minimum:
+                return AnalysisResultItem(
+                    slug=f'{_BLUEPRINT_PLUGIN_SLUG}:{section_slug}:{prop_name}:below-minimum',
+                    title=f'Property below minimum: {display}',
+                    description=(
+                        f'`{prop_name}` is `{current_value}` but '
+                        f'the minimum is `{minimum}`.'
+                    ),
+                    status='warn',
+                )
+            if maximum is not None and current_value > maximum:
+                return AnalysisResultItem(
+                    slug=f'{_BLUEPRINT_PLUGIN_SLUG}:{section_slug}:{prop_name}:above-maximum',
+                    title=f'Property above maximum: {display}',
+                    description=(
+                        f'`{prop_name}` is `{current_value}` but '
+                        f'the maximum is `{maximum}`.'
+                    ),
+                    status='warn',
+                )
+
+    # Missing but not required — warn when a default is available
+    if missing:
+        default = getattr(prop_schema, 'default', None)
+        if default is not None:
+            return AnalysisResultItem(
+                slug=f'{_BLUEPRINT_PLUGIN_SLUG}:{section_slug}:{prop_name}:use-default',
+                title=f'Property not set — default available: {display}',
+                description=(
+                    f'`{prop_name}` has no value. '
+                    f'The blueprint default is `{default!r}`. '
+                    f'Use **Apply Blueprint Defaults** to set it.'
+                ),
+                status='warn',
+            )
+
+    return None
+
+
+def _applicable_blueprints(
+    blueprints: list[models.Blueprint],
+    type_slug_set: set[str],
+) -> list[models.Blueprint]:
+    out: list[models.Blueprint] = []
+    for bp in blueprints:
+        if bp.kind != 'node':
+            continue
+        f = bp.filter
+        if (
+            f is not None
+            and f.project_type
+            and not type_slug_set.intersection(f.project_type)
+        ):
+            continue
+        if bp.json_schema.properties:
+            out.append(bp)
+    return out
+
+
+async def check_blueprint_compliance(
+    db: graph.Graph,
+    project_id: str,
+    type_slugs: list[str],
+) -> list[AnalysisResultItem]:
+    """Return blueprint compliance findings for a project.
+
+    Loads every enabled Project blueprint, filters to those that apply
+    to the project's types, and checks each property against the
+    project's current AGE node properties.  Returns a single ``pass``
+    item when everything is compliant so the Doctor card always shows
+    something for this check.
+    """
+    all_blueprints = await project_blueprints(db)
+    if not all_blueprints:
+        return [
+            AnalysisResultItem(
+                slug=f'{_BLUEPRINT_PLUGIN_SLUG}:no-blueprints',
+                title='No Project blueprints configured',
+                description=(
+                    'No enabled Project blueprints are defined. '
+                    'Add blueprints to track property compliance.'
+                ),
+                status='pass',
+            )
+        ]
+
+    type_slug_set = set(type_slugs)
+    applicable = _applicable_blueprints(all_blueprints, type_slug_set)
+    if not applicable:
+        return [
+            AnalysisResultItem(
+                slug=f'{_BLUEPRINT_PLUGIN_SLUG}:no-applicable',
+                title='No blueprints apply to this project type',
+                description=(
+                    "No enabled blueprints match this project's type(s)."
+                ),
+                status='pass',
+            )
+        ]
+
+    props = await _fetch_project_props(db, project_id)
+    findings: list[AnalysisResultItem] = []
+
+    for bp in applicable:
+        schema = bp.json_schema
+        required_names: set[str] = set(schema.required or [])
+        section_slug = bp.slug or ''
+        for prop_name, prop_schema in (schema.properties or {}).items():
+            extra = prop_schema.model_extra or {}
+            x_ui = dict(extra.get('x-ui') or {})
+            required = (
+                prop_name in required_names or x_ui.get('required') is True
+            )
+            current_value = props.get(prop_name, _SENTINEL)
+            finding = _check_property(
+                section_slug, prop_name, prop_schema, required, current_value
+            )
+            if finding is not None:
+                findings.append(finding)
+
+    if not findings:
+        return [
+            AnalysisResultItem(
+                slug=f'{_BLUEPRINT_PLUGIN_SLUG}:all-pass',
+                title='All blueprint properties are correctly set',
+                description=(
+                    'Every required and recommended blueprint property '
+                    'has a valid value.'
+                ),
+                status='pass',
+            )
+        ]
+    return findings
+
+
+async def apply_blueprint_defaults(
+    db: graph.Graph,
+    project_id: str,
+    type_slugs: list[str],
+) -> int:
+    """Set blueprint default values on project properties that are unset.
+
+    Only touches properties that are currently ``None`` / absent AND
+    have a ``default`` in the blueprint schema. Does not overwrite
+    existing values.
+
+    Returns the number of properties updated.
+    """
+    all_blueprints = await project_blueprints(db)
+    if not all_blueprints:
+        return 0
+
+    type_slug_set = set(type_slugs)
+    applicable = _applicable_blueprints(all_blueprints, type_slug_set)
+    if not applicable:
+        return 0
+
+    props = await _fetch_project_props(db, project_id)
+
+    # Collect prop_name → default for every unset property with a default.
+    # Use an ordered dict so later (higher-priority) blueprints win.
+    defaults: dict[str, typing.Any] = {}
+    for bp in applicable:
+        for prop_name, prop_schema in (
+            bp.json_schema.properties or {}
+        ).items():
+            if not _SAFE_PROP_RE.match(prop_name):
+                LOGGER.warning(
+                    'Skipping unsafe blueprint property name %r', prop_name
+                )
+                continue
+            if not _is_missing(props.get(prop_name)):
+                continue
+            default = getattr(prop_schema, 'default', None)
+            if default is not None:
+                defaults[prop_name] = default
+
+    if not defaults:
+        return 0
+
+    # Build a single SET clause; parameter names are indexed to avoid
+    # collisions with the property names themselves.
+    set_parts = [f'p.{k} = {{v{i}}}' for i, k in enumerate(defaults)]
+    cypher = (
+        'MATCH (p:Project {{id: {project_id}}}) SET '
+        + ', '.join(set_parts)
+        + ' RETURN p.id AS id'
+    )
+    params: dict[str, typing.Any] = {'project_id': project_id}
+    for i, (_, v) in enumerate(defaults.items()):
+        params[f'v{i}'] = v
+
+    await db.execute(cypher, params, ['id'])
+    LOGGER.info(
+        'Applied %d blueprint default(s) to project %s: %s',
+        len(defaults),
+        project_id,
+        list(defaults.keys()),
+    )
+    return len(defaults)

--- a/src/imbi_api/endpoints/organizations.py
+++ b/src/imbi_api/endpoints/organizations.py
@@ -34,6 +34,7 @@ from .project_incidents import project_incidents_router
 from .project_lifecycle import project_lifecycle_router
 from .project_logs import project_logs_router
 from .project_plugins import project_plugins_router
+from .project_pr_sync import project_pr_sync_router
 from .project_type_plugins import project_type_plugins_router
 from .project_types import project_types_router
 from .projects import projects_router
@@ -175,6 +176,10 @@ organizations_router.include_router(
 organizations_router.include_router(
     project_commit_sync_router,
     prefix='/{org_slug}/projects/{project_id}/commits',
+)
+organizations_router.include_router(
+    project_pr_sync_router,
+    prefix='/{org_slug}/projects/{project_id}/pull-requests',
 )
 organizations_router.include_router(
     pull_requests_project_router,

--- a/src/imbi_api/endpoints/project_analysis.py
+++ b/src/imbi_api/endpoints/project_analysis.py
@@ -29,6 +29,12 @@ from imbi_common.plugins.base import (
 from imbi_common.plugins.errors import PluginCredentialsMissing
 
 from imbi_api.auth import permissions
+from imbi_api.blueprint_compliance import (
+    _BLUEPRINT_PLUGIN_ID,
+    _BLUEPRINT_PLUGIN_SLUG,
+    apply_blueprint_defaults,
+    check_blueprint_compliance,
+)
 from imbi_api.endpoints._helpers import (
     lookup_project_exists_in,
     lookup_project_links,
@@ -381,6 +387,12 @@ async def get_project_analysis(
     return report
 
 
+class ApplyDefaultsResponse(pydantic.BaseModel):
+    """Result of applying blueprint defaults to a project."""
+
+    properties_updated: int
+
+
 @project_analysis_router.post('/run', response_model=AnalysisReport)
 async def run_project_analysis(
     org_slug: str,
@@ -391,20 +403,27 @@ async def run_project_analysis(
         fastapi.Depends(permissions.require_permission('project:write')),
     ],
 ) -> AnalysisReport:
-    plugins = await resolve_analysis_plugins(db, project_id)
-    if not plugins:
-        report = await _persist_report(
-            db,
-            project_id=project_id,
-            overall_status='pass',
-            triggered_by_user_id=(auth.user.id if auth.user else None),
-            results=[],
+    type_slugs = await lookup_project_type_slugs(db, project_id)
+    compliance_items = await check_blueprint_compliance(
+        db, project_id, type_slugs
+    )
+    compliance_results = [
+        AnalysisResult(
+            slug=item.slug,
+            title=item.title,
+            description=item.description,
+            status=item.status,
+            plugin_slug=_BLUEPRINT_PLUGIN_SLUG,
+            plugin_id=_BLUEPRINT_PLUGIN_ID,
         )
-        return report
+        for item in compliance_items
+    ]
+
+    plugins = await resolve_analysis_plugins(db, project_id)
     per_plugin = await asyncio.gather(
         *(_run_one(db, org_slug, project_id, rp) for rp in plugins)
     )
-    results: list[AnalysisResult] = []
+    results: list[AnalysisResult] = list(compliance_results)
     for batch in per_plugin:
         results.extend(batch)
     results.sort(key=lambda r: (-_STATUS_RANK.get(r.status, 0), r.title))
@@ -417,3 +436,35 @@ async def run_project_analysis(
         triggered_by_user_id=triggered,
         results=results,
     )
+
+
+@project_analysis_router.post(
+    '/apply-blueprint-defaults',
+    response_model=ApplyDefaultsResponse,
+)
+async def apply_project_blueprint_defaults(
+    org_slug: str,
+    project_id: str,
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(permissions.require_permission('project:write')),
+    ],
+) -> ApplyDefaultsResponse:
+    """Apply blueprint default values to any unset project properties.
+
+    Only sets properties that are currently absent or ``null`` and that
+    have a ``default`` defined in the applicable blueprint schema.
+    Existing values are never overwritten.
+    """
+    del org_slug
+    type_slugs = await lookup_project_type_slugs(db, project_id)
+    count = await apply_blueprint_defaults(db, project_id, type_slugs)
+    if auth.user:
+        LOGGER.info(
+            'User %s applied %d blueprint default(s) to project %s',
+            auth.user.id,
+            count,
+            project_id,
+        )
+    return ApplyDefaultsResponse(properties_updated=count)

--- a/src/imbi_api/endpoints/project_analysis.py
+++ b/src/imbi_api/endpoints/project_analysis.py
@@ -30,8 +30,8 @@ from imbi_common.plugins.errors import PluginCredentialsMissing
 
 from imbi_api.auth import permissions
 from imbi_api.blueprint_compliance import (
-    _BLUEPRINT_PLUGIN_ID,
-    _BLUEPRINT_PLUGIN_SLUG,
+    BLUEPRINT_PLUGIN_ID,
+    BLUEPRINT_PLUGIN_SLUG,
     apply_blueprint_defaults,
     check_blueprint_compliance,
     remove_stale_blueprint_properties,
@@ -415,8 +415,8 @@ async def run_project_analysis(
             title=item.title,
             description=item.description,
             status=item.status,
-            plugin_slug=_BLUEPRINT_PLUGIN_SLUG,
-            plugin_id=_BLUEPRINT_PLUGIN_ID,
+            plugin_slug=BLUEPRINT_PLUGIN_SLUG,
+            plugin_id=BLUEPRINT_PLUGIN_ID,
         )
         for item in compliance_items
     ]

--- a/src/imbi_api/endpoints/project_analysis.py
+++ b/src/imbi_api/endpoints/project_analysis.py
@@ -34,6 +34,7 @@ from imbi_api.blueprint_compliance import (
     _BLUEPRINT_PLUGIN_SLUG,
     apply_blueprint_defaults,
     check_blueprint_compliance,
+    remove_stale_blueprint_properties,
 )
 from imbi_api.endpoints._helpers import (
     lookup_project_exists_in,
@@ -388,9 +389,10 @@ async def get_project_analysis(
 
 
 class ApplyDefaultsResponse(pydantic.BaseModel):
-    """Result of applying blueprint defaults to a project."""
+    """Result of syncing blueprint properties on a project."""
 
     properties_updated: int
+    properties_removed: int = 0
 
 
 @project_analysis_router.post('/run', response_model=AnalysisReport)
@@ -460,11 +462,17 @@ async def apply_project_blueprint_defaults(
     del org_slug
     type_slugs = await lookup_project_type_slugs(db, project_id)
     count = await apply_blueprint_defaults(db, project_id, type_slugs)
+    removed = await remove_stale_blueprint_properties(
+        db, project_id, type_slugs
+    )
     if auth.user:
         LOGGER.info(
-            'User %s applied %d blueprint default(s) to project %s',
+            'User %s applied %d default(s), removed %d stale on project %s',
             auth.user.id,
             count,
+            removed,
             project_id,
         )
-    return ApplyDefaultsResponse(properties_updated=count)
+    return ApplyDefaultsResponse(
+        properties_updated=count, properties_removed=removed
+    )

--- a/src/imbi_api/endpoints/project_pr_sync.py
+++ b/src/imbi_api/endpoints/project_pr_sync.py
@@ -1,0 +1,85 @@
+"""On-demand PR history sync endpoints (Project Doctor).
+
+``POST /pull-requests/sync`` enqueues a background backfill of the
+project's full pull-request history; ``GET /pull-requests/sync-status``
+returns the last-run state for the UI to poll.  The work runs as a
+Valkey-stream job using the ``github-pr-sync`` plugin's service
+credential, so the endpoint only validates eligibility and enqueues.
+"""
+
+import typing
+
+import fastapi
+import pydantic
+from imbi_common import graph
+
+from imbi_api.auth import permissions
+from imbi_api.plugins.resolution import resolve_plugin
+from imbi_api.pr_sync import service
+from imbi_api.pr_sync.queue import enqueue_pr_sync
+from imbi_api.scoring import OptionalValkeyClient
+
+project_pr_sync_router = fastapi.APIRouter(tags=['Project: Pull Requests'])
+
+
+class PRSyncEnqueueResponse(pydantic.BaseModel):
+    """Result of enqueueing a PR history sync."""
+
+    enqueued: bool
+
+
+@project_pr_sync_router.post('/sync', status_code=202)
+async def sync_pull_requests(
+    org_slug: str,
+    project_id: str,
+    db: graph.Pool,
+    valkey_client: OptionalValkeyClient,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('project:deployment:write'),
+        ),
+    ],
+) -> PRSyncEnqueueResponse:
+    """Enqueue a full pull-request history backfill for the project.
+
+    Requires the project to have a GitHub deployment plugin (the same
+    gate as deployment resync) and a connected ``github-pr-sync`` plugin
+    to provide the service credential.  Returns ``enqueued=False`` when
+    the job was debounced or Valkey is unavailable.
+    """
+    await resolve_plugin(db, project_id, 'deployment', None)
+    try:
+        await service.check_available(db, project_id)
+    except service.PRSyncUnavailable as exc:
+        raise fastapi.HTTPException(status_code=400, detail=str(exc)) from exc
+    requested_by = auth.principal_name
+    enqueued = await enqueue_pr_sync(
+        valkey_client, org_slug, project_id, requested_by
+    )
+    if enqueued:
+        await service.set_status(
+            db,
+            project_id,
+            status='queued',
+            requested_by=requested_by,
+            retry=False,
+        )
+    return PRSyncEnqueueResponse(enqueued=enqueued)
+
+
+@project_pr_sync_router.get('/sync-status')
+async def get_pr_sync_status(
+    org_slug: str,
+    project_id: str,
+    db: graph.Pool,
+    _auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('project:deployment:read'),
+        ),
+    ],
+) -> service.PRSyncStatus:
+    """Return the project's last PR sync state."""
+    del org_slug
+    return await service.read_status(db, project_id)

--- a/src/imbi_api/lifespans.py
+++ b/src/imbi_api/lifespans.py
@@ -19,6 +19,7 @@ from imbi_api.email.client import EmailClient
 from imbi_api.email.templates import TemplateManager
 from imbi_api.identity import sweeper as identity_sweeper
 from imbi_api.plugins import lifecycle as plugin_lifecycle
+from imbi_api.pr_sync import queue as pr_sync_queue
 from imbi_api.scoring import queue as score_queue
 from imbi_api.storage.client import StorageClient
 
@@ -162,6 +163,39 @@ async def commit_sync_worker_hook() -> abc.AsyncGenerator[None]:
         except Exception:  # noqa: BLE001
             LOGGER.warning(
                 'Commit-sync worker task exited with error', exc_info=True
+            )
+
+
+@contextlib.asynccontextmanager
+async def pr_sync_worker_hook() -> abc.AsyncGenerator[None]:
+    """Run the on-demand PR-sync consumer loop."""
+    try:
+        client = valkey.get_client()
+    except RuntimeError:
+        LOGGER.warning('Valkey unavailable; pr-sync worker not started')
+        yield None
+        return
+    if _graph is None:
+        LOGGER.warning('Graph not ready; pr-sync worker not started')
+        yield None
+        return
+    stop = asyncio.Event()
+    LOGGER.info('PR-sync worker starting')
+    consumer_task = asyncio.create_task(
+        pr_sync_queue.consume_pr_sync(client, _graph, stop=stop)
+    )
+    try:
+        yield None
+    finally:
+        stop.set()
+        consumer_task.cancel()
+        try:
+            await consumer_task
+        except asyncio.CancelledError:
+            pass
+        except Exception:  # noqa: BLE001
+            LOGGER.warning(
+                'PR-sync worker task exited with error', exc_info=True
             )
 
 

--- a/src/imbi_api/pr_sync/__init__.py
+++ b/src/imbi_api/pr_sync/__init__.py
@@ -1,0 +1,28 @@
+"""On-demand pull-request history sync for imbi-api.
+
+A project-scoped "Sync Pull Requests" action enqueues a Valkey-stream
+job; a background worker resolves the project's ``github-pr-sync``
+webhook plugin, runs a full PR backfill via the plugin's service
+credential, and records the last-sync status on the ``Project`` node for
+the UI to poll.
+"""
+
+from imbi_api.pr_sync.queue import (
+    consume_pr_sync,
+    enqueue_pr_sync,
+)
+from imbi_api.pr_sync.service import (
+    PRSyncStatus,
+    PRSyncUnavailable,
+    read_status,
+    run_sync,
+)
+
+__all__ = [
+    'PRSyncStatus',
+    'PRSyncUnavailable',
+    'consume_pr_sync',
+    'enqueue_pr_sync',
+    'read_status',
+    'run_sync',
+]

--- a/src/imbi_api/pr_sync/queue.py
+++ b/src/imbi_api/pr_sync/queue.py
@@ -1,0 +1,308 @@
+"""PR-sync queue (Valkey Streams).
+
+Mirrors :mod:`imbi_api.commit_sync.queue`: a single consumer group
+drains an ``imbi:pr-sync`` stream, with a per-project debounce,
+stale-entry reclaim, and a dead-letter queue after repeated failures.
+Each job runs a full PR backfill via
+:func:`pr_sync.service.run_sync` and records the outcome on the
+``Project`` node.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import socket
+import time
+import typing
+from collections import abc
+
+from imbi_common import graph
+from imbi_common.plugins.errors import PluginRateLimited
+from valkey import asyncio as valkey
+
+from imbi_api.pr_sync.service import (
+    PRSyncUnavailable,
+    run_sync,
+    set_status,
+)
+
+STREAM = 'imbi:pr-sync'
+GROUP = 'pr-sync-workers'
+CONSUMER_PREFIX = 'worker'
+DLQ = 'imbi:pr-sync:dlq'
+DEBOUNCE_PREFIX = 'imbi:pr-sync:debounce'
+DEBOUNCE_SECONDS = 10
+MAX_DELIVERIES = 3
+CLAIM_IDLE_MS = 120_000
+PAUSE_KEY = 'imbi:pr-sync:paused-until'
+PAUSE_POLL_CAP_SECONDS = 30
+PAUSE_KEY_BUFFER_SECONDS = 5
+
+LOGGER = logging.getLogger(__name__)
+
+
+async def enqueue_pr_sync(
+    client: valkey.Valkey | None,
+    org_slug: str,
+    project_id: str,
+    requested_by: str | None = None,
+) -> bool:
+    """Debounce-then-XADD a PR-sync job. Returns True if enqueued."""
+    if client is None:
+        return False
+    key = f'{DEBOUNCE_PREFIX}:{project_id}'
+    try:
+        acquired = await client.set(key, b'1', ex=DEBOUNCE_SECONDS, nx=True)
+        if not acquired:
+            return False
+        await client.xadd(
+            STREAM,
+            {
+                'org_slug': org_slug,
+                'project_id': project_id,
+                'requested_by': requested_by or 'system',
+            },
+        )
+    except Exception:
+        try:
+            await client.delete(key)
+        except Exception:
+            LOGGER.exception('failed to clear debounce key for %s', project_id)
+        LOGGER.exception('enqueue_pr_sync failed for %s', project_id)
+        return False
+    return True
+
+
+async def ensure_group(client: valkey.Valkey) -> None:
+    try:
+        await client.xgroup_create(STREAM, GROUP, id='$', mkstream=True)
+    except Exception as err:
+        if 'BUSYGROUP' not in str(err):
+            LOGGER.exception('xgroup_create failed')
+            raise
+
+
+async def _process_message(db: graph.Graph, fields: dict[str, str]) -> None:
+    project_id = fields.get('project_id')
+    org_slug = fields.get('org_slug') or ''
+    requested_by = fields.get('requested_by') or 'system'
+    if not project_id:
+        return
+    await set_status(
+        db, project_id, status='running', requested_by=requested_by
+    )
+    try:
+        prs = await run_sync(db, org_slug, project_id)
+    except PRSyncUnavailable as exc:
+        LOGGER.warning('pr-sync unavailable for %s: %s', project_id, exc)
+        await set_status(
+            db,
+            project_id,
+            status='failed',
+            requested_by=requested_by,
+            error=str(exc),
+        )
+        return
+    except PluginRateLimited:
+        LOGGER.warning(
+            'pr-sync rate-limited for %s; left queued until GitHub resets',
+            project_id,
+        )
+        await set_status(
+            db, project_id, status='queued', requested_by=requested_by
+        )
+        raise
+    except Exception:
+        LOGGER.exception('pr-sync run failed for %s', project_id)
+        await set_status(
+            db,
+            project_id,
+            status='failed',
+            requested_by=requested_by,
+            error='PR sync failed. See server logs for details.',
+        )
+        raise
+    LOGGER.info(
+        'pr-sync for %s recorded %d pull requests',
+        project_id,
+        prs,
+    )
+    await set_status(
+        db,
+        project_id,
+        status='success',
+        requested_by=requested_by,
+        prs=prs,
+    )
+
+
+def _decode_fields(
+    raw: abc.Mapping[bytes | str, bytes | str],
+) -> dict[str, str]:
+    return {
+        (k.decode() if isinstance(k, bytes) else k): (
+            v.decode() if isinstance(v, bytes) else v
+        )
+        for k, v in raw.items()
+    }
+
+
+async def _paused_remaining(client: valkey.Valkey) -> float:
+    try:
+        raw = await client.get(PAUSE_KEY)
+    except Exception:  # noqa: BLE001
+        return 0.0
+    if raw is None:
+        return 0.0
+    try:
+        until = float(raw.decode() if isinstance(raw, bytes) else raw)
+    except ValueError:
+        return 0.0
+    return max(0.0, until - time.time())
+
+
+async def _pause_until(client: valkey.Valkey, retry_at: float) -> None:
+    ttl = max(1, int(retry_at - time.time()) + PAUSE_KEY_BUFFER_SECONDS)
+    try:
+        await client.set(PAUSE_KEY, str(retry_at), ex=ttl)
+    except Exception:
+        LOGGER.exception('failed to set pr-sync pause marker')
+
+
+async def _claim_stale(
+    client: valkey.Valkey,
+    consumer: str,
+) -> list[tuple[bytes, abc.Mapping[bytes | str, bytes | str]]]:
+    try:
+        result = await client.xautoclaim(
+            STREAM,
+            GROUP,
+            consumer,
+            min_idle_time=CLAIM_IDLE_MS,
+            start_id='0-0',
+            count=16,
+        )
+    except Exception as err:  # noqa: BLE001
+        LOGGER.debug('xautoclaim failed: %s', err)
+        return []
+    if isinstance(result, (list, tuple)) and len(result) >= 2:  # type: ignore[arg-type]
+        msgs: object = result[1]  # type: ignore[index]
+        if isinstance(msgs, list):
+            return msgs  # type: ignore[return-value]
+    return []
+
+
+async def _maybe_dead_letter(
+    client: valkey.Valkey,
+    msg_id: bytes,
+    fields: dict[str, str],
+) -> bool:
+    try:
+        info = await client.xpending_range(
+            STREAM, GROUP, min=msg_id, max=msg_id, count=1
+        )
+    except Exception:  # noqa: BLE001
+        return False
+    if not info:
+        return False
+    entry: object = info[0]  # type: ignore[index]
+    delivered: int | None = None
+    if isinstance(entry, dict):
+        raw_delivered = entry.get('times_delivered')  # type: ignore[union-attr]
+        if raw_delivered is not None:
+            delivered = int(raw_delivered)  # type: ignore[arg-type]
+    elif isinstance(entry, (list, tuple)) and len(entry) >= 4:  # type: ignore[arg-type]
+        raw_delivered = entry[3]  # type: ignore[index]
+        if raw_delivered is not None:
+            delivered = int(raw_delivered)  # type: ignore[arg-type]
+    if delivered is not None and delivered >= MAX_DELIVERIES:
+        await client.xadd(DLQ, fields)
+        await client.xack(STREAM, GROUP, msg_id)
+        LOGGER.warning(
+            'dead-lettered pr-sync msg %s after %s deliveries',
+            msg_id,
+            delivered,
+        )
+        return True
+    return False
+
+
+async def _handle_entries(
+    client: valkey.Valkey,
+    entries: list[tuple[bytes, abc.Mapping[bytes | str, bytes | str]]],
+    db: graph.Graph,
+    check_dlq: bool = False,
+) -> None:
+    for msg_id, raw_fields in entries:
+        fields = _decode_fields(raw_fields)
+        if check_dlq and await _maybe_dead_letter(client, msg_id, fields):
+            continue
+        try:
+            await _process_message(db, fields)
+        except PluginRateLimited as exc:
+            await _pause_until(client, exc.retry_at)
+            LOGGER.warning(
+                'pr-sync paused ~%.0fs (GitHub rate limit); %d job(s) '
+                'left queued',
+                max(0.0, exc.retry_at - time.time()),
+                len(entries),
+            )
+            return
+        except Exception:
+            LOGGER.exception('pr-sync failed for %s', fields)
+            continue
+        await client.xack(STREAM, GROUP, msg_id)
+
+
+async def consume_pr_sync(
+    client: valkey.Valkey,
+    db: graph.Graph,
+    consumer: str | None = None,
+    stop: asyncio.Event | None = None,
+) -> None:
+    """Run the PR-sync consumer loop until *stop* is set."""
+    consumer = (
+        consumer or f'{CONSUMER_PREFIX}-{socket.gethostname()}-{os.getpid()}'
+    )
+    await ensure_group(client)
+    LOGGER.info('PR-sync consumer loop running (consumer=%s)', consumer)
+    while stop is None or not stop.is_set():
+        paused = await _paused_remaining(client)
+        if paused > 0:
+            await asyncio.sleep(min(paused, PAUSE_POLL_CAP_SECONDS))
+            continue
+        stale = await _claim_stale(client, consumer)
+        if stale:
+            try:
+                await _handle_entries(client, stale, db, check_dlq=True)
+            except Exception:
+                LOGGER.exception('pr-sync stale-entry handling failed')
+                await asyncio.sleep(1)
+                continue
+        if await _paused_remaining(client) > 0:
+            continue
+        try:
+            response = await client.xreadgroup(
+                GROUP,
+                consumer,
+                {STREAM: '>'},
+                count=16,
+                block=2000,
+            )
+        except Exception:
+            LOGGER.exception('xreadgroup failed')
+            await asyncio.sleep(1)
+            continue
+        if not response:
+            continue
+        for _stream, entries in typing.cast(
+            'list[tuple[object, list[typing.Any]]]', response
+        ):
+            try:
+                await _handle_entries(client, entries, db)
+            except Exception:
+                LOGGER.exception('pr-sync entry handling failed')
+                await asyncio.sleep(1)
+                break

--- a/src/imbi_api/pr_sync/service.py
+++ b/src/imbi_api/pr_sync/service.py
@@ -1,0 +1,313 @@
+"""Resolve + invoke the PR-sync plugin and track its status.
+
+The on-demand sync acts with the ``github-pr-sync`` plugin's *service*
+credential (PAT or GitHub App), so there is no acting user: the worker
+resolves the plugin attached to a ``ThirdPartyService`` the project
+``EXISTS_IN``, builds the :class:`PluginContext` it needs (project links
++ the connected ``service_plugins`` for host resolution), decrypts the
+credential, and awaits the plugin's ``sync_all_history`` method.
+
+Last-sync state is persisted as properties on the ``Project`` node so
+the UI can poll it without a dedicated status store.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import datetime
+import logging
+import typing
+from collections import abc
+
+import pydantic
+from imbi_common import graph
+from imbi_common.plugins.base import PluginContext, ServicePlugin
+from imbi_common.plugins.errors import PluginNotFoundError
+from imbi_common.plugins.registry import RegistryEntry, get_plugin
+
+from imbi_api.identity import attribution
+from imbi_api.plugins import parse_options
+from imbi_api.plugins.credentials import get_plugin_credentials
+
+LOGGER = logging.getLogger(__name__)
+
+_PR_SYNC_SLUG = 'github-pr-sync'
+_MAX_ERROR_LEN = 500
+_STATUS_WRITE_RETRIES = 3
+_STATUS_RETRY_BACKOFF = 0.05
+
+SyncState = typing.Literal['idle', 'queued', 'running', 'success', 'failed']
+
+
+class PRSyncUnavailable(Exception):
+    """No ``github-pr-sync`` plugin is reachable for the project."""
+
+
+class PRSyncStatus(pydantic.BaseModel):
+    """Last-sync state for a project's pull-request history."""
+
+    status: SyncState = 'idle'
+    last_synced_at: datetime.datetime | None = None
+    prs_synced: int | None = None
+    error: str | None = None
+    requested_by: str | None = None
+
+
+class _ResolvedPRSync(typing.NamedTuple):
+    plugin_id: str
+    entry: RegistryEntry
+    tps_slug: str
+    service_endpoint: str | None
+    service_plugins: list[ServicePlugin]
+
+
+async def _resolve_plugin(db: graph.Graph, project_id: str) -> _ResolvedPRSync:
+    """Find the ``github-pr-sync`` plugin attached to a service the
+    project ``EXISTS_IN`` and gather the sibling plugins on that service.
+
+    Raises :class:`PRSyncUnavailable` when no such plugin is configured.
+    """
+    query: typing.LiteralString = """
+    MATCH (proj:Project {{id: {project_id}}})
+      -[:EXISTS_IN]->(tps:ThirdPartyService)
+      -[:HAS_PLUGIN]->(psp:Plugin {{plugin_slug: {slug}}})
+    OPTIONAL MATCH (tps)-[:HAS_PLUGIN]->(sib:Plugin)
+    WITH tps, psp,
+      collect(DISTINCT {{slug: sib.plugin_slug, options: sib.options}})
+        AS siblings
+    RETURN psp.id AS plugin_id,
+           tps.slug AS tps_slug,
+           tps.api_endpoint AS api_endpoint,
+           siblings AS siblings
+    LIMIT 1
+    """
+    records = await db.execute(
+        query,
+        {'project_id': project_id, 'slug': _PR_SYNC_SLUG},
+        ['plugin_id', 'tps_slug', 'api_endpoint', 'siblings'],
+    )
+    if not records:
+        raise PRSyncUnavailable(
+            'No github-pr-sync plugin is connected to a service this '
+            'project belongs to; configure it on the GitHub service.'
+        )
+    record = records[0]
+    plugin_id = graph.parse_agtype(record.get('plugin_id'))
+    if not plugin_id:
+        raise PRSyncUnavailable('github-pr-sync plugin row is missing an id')
+    try:
+        entry = get_plugin(_PR_SYNC_SLUG)
+    except PluginNotFoundError as exc:
+        raise PRSyncUnavailable(
+            'github-pr-sync plugin is not loaded in the registry'
+        ) from exc
+    tps_slug = graph.parse_agtype(record.get('tps_slug'))
+    api_endpoint = graph.parse_agtype(record.get('api_endpoint'))
+    siblings = typing.cast(
+        'list[dict[str, typing.Any]]',
+        graph.parse_agtype(record.get('siblings')) or [],
+    )
+    service_plugins: list[ServicePlugin] = []
+    for sib in siblings:
+        slug = sib.get('slug')
+        if not slug:
+            continue
+        service_plugins.append(
+            ServicePlugin(
+                slug=str(slug), options=parse_options(sib.get('options'))
+            )
+        )
+    return _ResolvedPRSync(
+        plugin_id=str(plugin_id),
+        entry=entry,
+        tps_slug=str(tps_slug) if tps_slug else '',
+        service_endpoint=str(api_endpoint) if api_endpoint else None,
+        service_plugins=service_plugins,
+    )
+
+
+async def _build_context(
+    db: graph.Graph,
+    org_slug: str,
+    project_id: str,
+    resolved: _ResolvedPRSync,
+) -> PluginContext:
+    """Assemble the :class:`PluginContext` the plugin needs (no actor)."""
+    from imbi_api.endpoints import _helpers
+
+    project_slug, team_slug = await _helpers.lookup_project_slugs(
+        db, project_id
+    )
+    project_links = await _helpers.lookup_project_links(db, project_id)
+    project_type_slugs = await _helpers.lookup_project_type_slugs(
+        db, project_id
+    )
+    service_connections = await _helpers.lookup_project_exists_in(
+        db, project_id
+    )
+    assignment_options: dict[str, typing.Any] = {
+        'service_slug': resolved.tps_slug,
+    }
+    if resolved.service_endpoint:
+        assignment_options['service_endpoint'] = resolved.service_endpoint
+    return PluginContext(
+        project_id=project_id,
+        project_slug=project_slug,
+        org_slug=org_slug,
+        team_slug=team_slug,
+        assignment_options=assignment_options,
+        service_plugins=resolved.service_plugins,
+        project_links=project_links,
+        project_type_slugs=project_type_slugs,
+        third_party_service_slug=resolved.tps_slug or None,
+        service_connections=service_connections,
+        resolve_user_by_identity=attribution.make_user_resolver(
+            db, resolved.service_plugins
+        ),
+    )
+
+
+async def check_available(db: graph.Graph, project_id: str) -> None:
+    """Raise :class:`PRSyncUnavailable` if the project can't be synced."""
+    await _resolve_plugin(db, project_id)
+
+
+async def run_sync(db: graph.Graph, org_slug: str, project_id: str) -> int:
+    """Resolve the PR-sync plugin and run a full history backfill.
+
+    Returns the number of PRs recorded.  Raises :class:`PRSyncUnavailable`
+    when no plugin/credential is configured; other failures propagate so
+    the caller can record them.
+    """
+    resolved = await _resolve_plugin(db, project_id)
+    ctx = await _build_context(db, org_slug, project_id, resolved)
+    credentials = await get_plugin_credentials(
+        db, resolved.plugin_id, resolved.entry
+    )
+    handler = resolved.entry.handler_cls()
+    sync = getattr(handler, 'sync_all_history', None)
+    if sync is None:
+        raise PRSyncUnavailable(
+            'github-pr-sync plugin does not implement sync_all_history; '
+            'upgrade imbi-plugin-github'
+        )
+    sync_fn = typing.cast('abc.Callable[..., abc.Awaitable[int]]', sync)
+    return await sync_fn(ctx=ctx, credentials=credentials)
+
+
+def _now_iso() -> str:
+    return datetime.datetime.now(datetime.UTC).isoformat()
+
+
+def _is_write_conflict(exc: Exception) -> bool:
+    return 'failed to be updated' in str(exc)
+
+
+async def set_status(
+    db: graph.Graph,
+    project_id: str,
+    *,
+    status: SyncState,
+    requested_by: str = '',
+    prs: int = 0,
+    error: str = '',
+    retry: bool = True,
+) -> None:
+    """Persist last-sync state on the ``Project`` node (best-effort)."""
+    query: typing.LiteralString = """
+    MATCH (p:Project {{id: {project_id}}})
+    SET p.pr_sync_status = {status},
+        p.pr_sync_at = {at},
+        p.pr_sync_by = {by},
+        p.pr_sync_prs = {prs},
+        p.pr_sync_error = {error}
+    RETURN p.id AS id
+    """
+    params = {
+        'project_id': project_id,
+        'status': status,
+        'at': _now_iso(),
+        'by': requested_by,
+        'prs': prs,
+        'error': error[:_MAX_ERROR_LEN],
+    }
+    attempts = _STATUS_WRITE_RETRIES if retry else 1
+    for attempt in range(attempts):
+        try:
+            await db.execute(query, params, ['id'])
+            return
+        except Exception as exc:  # noqa: BLE001
+            conflict = _is_write_conflict(exc)
+            if retry and conflict and attempt + 1 < attempts:
+                await asyncio.sleep(_STATUS_RETRY_BACKOFF * (attempt + 1))
+                continue
+            if conflict:
+                LOGGER.debug(
+                    'pr-sync status write for %s lost a concurrent '
+                    'update (status=%s); leaving the newer state in place',
+                    project_id,
+                    status,
+                )
+            else:
+                LOGGER.warning(
+                    'Failed to persist pr-sync status for project %s',
+                    project_id,
+                    exc_info=True,
+                )
+            return
+
+
+def _opt_str(value: object) -> str | None:
+    text = str(value) if value is not None else ''
+    return text or None
+
+
+def _opt_int(value: object) -> int | None:
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        try:
+            return int(value)
+        except ValueError:
+            return None
+    return None
+
+
+async def read_status(db: graph.Graph, project_id: str) -> PRSyncStatus:
+    """Read last-sync state from the ``Project`` node (``idle`` default)."""
+    query: typing.LiteralString = """
+    MATCH (p:Project {{id: {project_id}}})
+    RETURN p.pr_sync_status AS status,
+           p.pr_sync_at AS at,
+           p.pr_sync_by AS requested_by,
+           p.pr_sync_prs AS prs,
+           p.pr_sync_error AS error
+    """
+    records = await db.execute(
+        query,
+        {'project_id': project_id},
+        ['status', 'at', 'requested_by', 'prs', 'error'],
+    )
+    if not records:
+        return PRSyncStatus()
+    row = records[0]
+    status_raw = graph.parse_agtype(row.get('status'))
+    status: SyncState = 'idle'
+    if status_raw in ('queued', 'running', 'success', 'failed', 'idle'):
+        status = status_raw
+    at_raw = _opt_str(graph.parse_agtype(row.get('at')))
+    last_synced_at: datetime.datetime | None = None
+    if at_raw:
+        try:
+            last_synced_at = datetime.datetime.fromisoformat(at_raw)
+        except ValueError:
+            last_synced_at = None
+    return PRSyncStatus(
+        status=status,
+        last_synced_at=last_synced_at,
+        prs_synced=_opt_int(graph.parse_agtype(row.get('prs'))),
+        error=_opt_str(graph.parse_agtype(row.get('error'))),
+        requested_by=_opt_str(graph.parse_agtype(row.get('requested_by'))),
+    )

--- a/src/imbi_api/pr_sync/service.py
+++ b/src/imbi_api/pr_sync/service.py
@@ -17,7 +17,6 @@ import asyncio
 import datetime
 import logging
 import typing
-from collections import abc
 
 import pydantic
 from imbi_common import graph
@@ -59,6 +58,15 @@ class _ResolvedPRSync(typing.NamedTuple):
     tps_slug: str
     service_endpoint: str | None
     service_plugins: list[ServicePlugin]
+
+
+class _SyncAllHistoryHandler(typing.Protocol):
+    async def sync_all_history(
+        self,
+        *,
+        ctx: PluginContext,
+        credentials: dict[str, typing.Any],
+    ) -> int: ...
 
 
 async def _resolve_plugin(db: graph.Graph, project_id: str) -> _ResolvedPRSync:
@@ -191,8 +199,8 @@ async def run_sync(db: graph.Graph, org_slug: str, project_id: str) -> int:
             'github-pr-sync plugin does not implement sync_all_history; '
             'upgrade imbi-plugin-github'
         )
-    sync_fn = typing.cast('abc.Callable[..., abc.Awaitable[int]]', sync)
-    return await sync_fn(ctx=ctx, credentials=credentials)
+    sync_fn = typing.cast('_SyncAllHistoryHandler', handler)
+    return await sync_fn.sync_all_history(ctx=ctx, credentials=credentials)
 
 
 def _now_iso() -> str:

--- a/tests/endpoints/test_events.py
+++ b/tests/endpoints/test_events.py
@@ -265,7 +265,7 @@ class GlobalListTests(_EventsTestBase):
         response = self.client.get('/events/')
         self.assertEqual(response.status_code, 200)
         sql = self.mock_query.await_args.args[0]
-        self.assertIn('FROM events', sql)
+        self.assertIn('FROM events WHERE', sql)
 
     def test_list_with_since_until(self) -> None:
         self.mock_query.return_value = []
@@ -368,7 +368,7 @@ class GetEventByIdTests(_EventsTestBase):
         response = self.client.get('/events/evt-1')
         self.assertEqual(response.status_code, 200)
         sql = self.mock_query.await_args.args[0]
-        self.assertIn('FROM events', sql)
+        self.assertIn('FROM events ', sql)
         params = self.mock_query.await_args.args[1]
         self.assertEqual(params['event_id'], 'evt-1')
 

--- a/tests/endpoints/test_project_analysis.py
+++ b/tests/endpoints/test_project_analysis.py
@@ -145,6 +145,12 @@ class ProjectAnalysisTestCase(unittest.TestCase):
                 return_value={},
             )
         )
+        self.mocks['check_blueprint_compliance'] = self._start(
+            mock.patch(
+                f'{_MODULE}.check_blueprint_compliance',
+                return_value=[],
+            )
+        )
 
     def _start(self, patcher: typing.Any) -> mock.MagicMock:
         m = patcher.start()

--- a/tests/endpoints/test_project_analysis.py
+++ b/tests/endpoints/test_project_analysis.py
@@ -280,3 +280,50 @@ class ProjectAnalysisTestCase(unittest.TestCase):
                     '/organizations/acme/projects/proj-1/analysis/run'
                 )
         self.assertEqual(403, resp.status_code, resp.text)
+
+    def test_apply_blueprint_defaults_returns_counts(self) -> None:
+        with (
+            mock.patch(
+                f'{_MODULE}.apply_blueprint_defaults',
+                return_value=3,
+            ),
+            mock.patch(
+                f'{_MODULE}.remove_stale_blueprint_properties',
+                return_value=1,
+            ),
+        ):
+            with testclient.TestClient(self.test_app) as client:
+                resp = client.post(
+                    '/organizations/acme/projects/proj-1/analysis'
+                    '/apply-blueprint-defaults'
+                )
+        self.assertEqual(200, resp.status_code, resp.text)
+        body = resp.json()
+        self.assertEqual(3, body['properties_updated'])
+        self.assertEqual(1, body['properties_removed'])
+
+    def test_apply_blueprint_defaults_requires_project_write_permission(
+        self,
+    ) -> None:
+        self.auth_context = permissions.AuthContext(
+            user=self.test_user,
+            session_id='test-session',
+            auth_method='jwt',
+            permissions={'project:read'},
+        )
+        self.auth_context.user = self.test_user.model_copy(
+            update={'is_admin': False}
+        )
+
+        async def mock_get_current_user() -> permissions.AuthContext:
+            return self.auth_context
+
+        self.test_app.dependency_overrides[permissions.get_current_user] = (
+            mock_get_current_user
+        )
+        with testclient.TestClient(self.test_app) as client:
+            resp = client.post(
+                '/organizations/acme/projects/proj-1/analysis'
+                '/apply-blueprint-defaults'
+            )
+        self.assertEqual(403, resp.status_code, resp.text)

--- a/tests/test_pr_sync_queue.py
+++ b/tests/test_pr_sync_queue.py
@@ -1,0 +1,204 @@
+"""Tests for the PR-sync queue."""
+
+from __future__ import annotations
+
+import time
+import unittest
+from unittest import mock
+
+from imbi_common.plugins.errors import PluginRateLimited
+
+from imbi_api.pr_sync import queue
+from imbi_api.pr_sync.service import PRSyncUnavailable
+
+
+class EnqueueTests(unittest.IsolatedAsyncioTestCase):
+    async def test_enqueue_xadds_when_debounce_acquired(self) -> None:
+        client = mock.AsyncMock()
+        client.set = mock.AsyncMock(return_value=True)
+        client.xadd = mock.AsyncMock()
+        result = await queue.enqueue_pr_sync(client, 'octo', 'p1', 'alice')
+        self.assertTrue(result)
+        client.xadd.assert_awaited_once()
+        args, _ = client.xadd.await_args
+        self.assertEqual(args[0], queue.STREAM)
+        self.assertEqual(args[1]['project_id'], 'p1')
+        self.assertEqual(args[1]['org_slug'], 'octo')
+        self.assertEqual(args[1]['requested_by'], 'alice')
+
+    async def test_enqueue_skips_when_debounced(self) -> None:
+        client = mock.AsyncMock()
+        client.set = mock.AsyncMock(return_value=None)
+        client.xadd = mock.AsyncMock()
+        result = await queue.enqueue_pr_sync(client, 'octo', 'p1')
+        self.assertFalse(result)
+        client.xadd.assert_not_called()
+
+    async def test_enqueue_none_client_returns_false(self) -> None:
+        self.assertFalse(await queue.enqueue_pr_sync(None, 'octo', 'p1'))
+
+    async def test_enqueue_clears_debounce_on_xadd_failure(self) -> None:
+        client = mock.AsyncMock()
+        client.set = mock.AsyncMock(return_value=True)
+        client.xadd = mock.AsyncMock(side_effect=RuntimeError('redis gone'))
+        result = await queue.enqueue_pr_sync(client, 'octo', 'p1')
+        self.assertFalse(result)
+        client.delete.assert_awaited_once()
+
+
+class ProcessMessageTests(unittest.IsolatedAsyncioTestCase):
+    async def test_success_sets_running_then_success(self) -> None:
+        db = mock.AsyncMock()
+        with (
+            mock.patch.object(
+                queue, 'run_sync', mock.AsyncMock(return_value=5)
+            ),
+            mock.patch.object(queue, 'set_status', mock.AsyncMock()) as ss,
+        ):
+            await queue._process_message(
+                db,
+                {'project_id': 'p1', 'org_slug': 'octo', 'requested_by': 'a'},
+            )
+        statuses = [c.kwargs['status'] for c in ss.await_args_list]
+        self.assertEqual(['running', 'success'], statuses)
+        success = ss.await_args_list[-1].kwargs
+        self.assertEqual(5, success['prs'])
+
+    async def test_unavailable_marks_failed_without_raising(self) -> None:
+        db = mock.AsyncMock()
+        with (
+            mock.patch.object(
+                queue,
+                'run_sync',
+                mock.AsyncMock(side_effect=PRSyncUnavailable('nope')),
+            ),
+            mock.patch.object(queue, 'set_status', mock.AsyncMock()) as ss,
+        ):
+            await queue._process_message(db, {'project_id': 'p1'})
+        self.assertEqual('failed', ss.await_args_list[-1].kwargs['status'])
+
+    async def test_other_error_marks_failed_and_raises(self) -> None:
+        db = mock.AsyncMock()
+        with (
+            mock.patch.object(
+                queue,
+                'run_sync',
+                mock.AsyncMock(side_effect=RuntimeError('boom')),
+            ),
+            mock.patch.object(queue, 'set_status', mock.AsyncMock()) as ss,
+        ):
+            with self.assertRaises(RuntimeError):
+                await queue._process_message(db, {'project_id': 'p1'})
+        self.assertEqual('failed', ss.await_args_list[-1].kwargs['status'])
+
+    async def test_missing_project_id_is_noop(self) -> None:
+        db = mock.AsyncMock()
+        with mock.patch.object(queue, 'set_status', mock.AsyncMock()) as ss:
+            await queue._process_message(db, {})
+        ss.assert_not_awaited()
+
+    async def test_rate_limited_marks_queued_and_raises(self) -> None:
+        db = mock.AsyncMock()
+        with (
+            mock.patch.object(
+                queue,
+                'run_sync',
+                mock.AsyncMock(
+                    side_effect=PluginRateLimited(retry_at=time.time() + 600)
+                ),
+            ),
+            mock.patch.object(queue, 'set_status', mock.AsyncMock()) as ss,
+        ):
+            with self.assertRaises(PluginRateLimited):
+                await queue._process_message(db, {'project_id': 'p1'})
+        statuses = [c.kwargs['status'] for c in ss.await_args_list]
+        # running -> queued (NOT failed); re-raised for the pause handler
+        self.assertEqual(['running', 'queued'], statuses)
+
+
+class ConsumerTests(unittest.IsolatedAsyncioTestCase):
+    async def test_xack_on_success(self) -> None:
+        client = mock.AsyncMock()
+        with mock.patch.object(queue, '_process_message', mock.AsyncMock()):
+            await queue._handle_entries(
+                client, [(b'1-0', {b'project_id': b'p1'})], mock.AsyncMock()
+            )
+        client.xack.assert_awaited_once()
+
+    async def test_no_xack_on_exception(self) -> None:
+        client = mock.AsyncMock()
+        with mock.patch.object(
+            queue,
+            '_process_message',
+            mock.AsyncMock(side_effect=RuntimeError('boom')),
+        ):
+            await queue._handle_entries(
+                client, [(b'1-0', {b'project_id': b'p1'})], mock.AsyncMock()
+            )
+        client.xack.assert_not_called()
+
+    async def test_dlq_after_max_deliveries(self) -> None:
+        client = mock.AsyncMock()
+        client.xpending_range = mock.AsyncMock(
+            return_value=[{'times_delivered': queue.MAX_DELIVERIES}]
+        )
+        result = await queue._maybe_dead_letter(
+            client, b'1-0', {'project_id': 'p1'}
+        )
+        self.assertTrue(result)
+        client.xadd.assert_awaited_once()
+        client.xack.assert_awaited_once()
+
+    async def test_rate_limited_pauses_without_ack_or_dlq(self) -> None:
+        client = mock.AsyncMock()
+        retry_at = time.time() + 1800
+        with mock.patch.object(
+            queue,
+            '_process_message',
+            mock.AsyncMock(side_effect=PluginRateLimited(retry_at=retry_at)),
+        ):
+            await queue._handle_entries(
+                client,
+                [
+                    (b'1-0', {b'project_id': b'p1'}),
+                    (b'2-0', {b'project_id': b'p2'}),
+                ],
+                mock.AsyncMock(),
+            )
+        # Pause marker set; message left pending (no ack), not dead-lettered,
+        # and the batch stopped before the sibling job was attempted.
+        client.set.assert_awaited_once()
+        self.assertEqual(queue.PAUSE_KEY, client.set.await_args.args[0])
+        client.xack.assert_not_called()
+        client.xadd.assert_not_called()
+
+
+class PauseTests(unittest.IsolatedAsyncioTestCase):
+    async def test_paused_remaining_future_and_past(self) -> None:
+        client = mock.AsyncMock()
+        client.get = mock.AsyncMock(
+            return_value=str(time.time() + 120).encode()
+        )
+        self.assertGreater(await queue._paused_remaining(client), 60)
+        client.get = mock.AsyncMock(return_value=str(time.time() - 5).encode())
+        self.assertEqual(0.0, await queue._paused_remaining(client))
+
+    async def test_paused_remaining_absent_is_zero(self) -> None:
+        client = mock.AsyncMock()
+        client.get = mock.AsyncMock(return_value=None)
+        self.assertEqual(0.0, await queue._paused_remaining(client))
+
+    async def test_consume_loop_honors_pause_and_skips_read(self) -> None:
+        client = mock.AsyncMock()
+        client.get = mock.AsyncMock(
+            return_value=str(time.time() + 300).encode()
+        )
+        stop = mock.Mock()
+        # Paused this tick -> sleep, then stop the loop before any read.
+        stop.is_set = mock.Mock(side_effect=[False, True])
+        with mock.patch.object(queue.asyncio, 'sleep', mock.AsyncMock()):
+            await queue.consume_pr_sync(
+                client, mock.AsyncMock(), consumer='w', stop=stop
+            )
+        client.xreadgroup.assert_not_called()
+        client.xautoclaim.assert_not_called()

--- a/tests/test_pr_sync_service.py
+++ b/tests/test_pr_sync_service.py
@@ -1,0 +1,192 @@
+"""Tests for the PR-sync service (resolution, status, run)."""
+
+from __future__ import annotations
+
+import unittest
+from unittest import mock
+
+from imbi_common.plugins.base import ServicePlugin
+
+from imbi_api.pr_sync import service
+
+
+def _resolve_rows() -> list[dict[str, object]]:
+    return [
+        {
+            'plugin_id': '"plg-1"',
+            'tps_slug': '"github"',
+            'api_endpoint': '"https://api.github.com"',
+            'siblings': (
+                '[{"slug": "github-pr-sync", "options": {}}, '
+                '{"slug": "github-deployment", "options": {}}]'
+            ),
+        }
+    ]
+
+
+class ResolvePluginTests(unittest.IsolatedAsyncioTestCase):
+    async def test_resolves_plugin_and_siblings(self) -> None:
+        db = mock.AsyncMock()
+        db.execute.return_value = _resolve_rows()
+        with mock.patch.object(
+            service, 'get_plugin', return_value=mock.Mock()
+        ):
+            resolved = await service._resolve_plugin(db, 'p1')
+        self.assertEqual('plg-1', resolved.plugin_id)
+        self.assertEqual('github', resolved.tps_slug)
+        self.assertEqual('https://api.github.com', resolved.service_endpoint)
+        slugs = {sp.slug for sp in resolved.service_plugins}
+        self.assertEqual({'github-pr-sync', 'github-deployment'}, slugs)
+
+    async def test_no_plugin_raises_unavailable(self) -> None:
+        db = mock.AsyncMock()
+        db.execute.return_value = []
+        with self.assertRaises(service.PRSyncUnavailable):
+            await service._resolve_plugin(db, 'p1')
+
+
+class RunSyncTests(unittest.IsolatedAsyncioTestCase):
+    async def test_invokes_handler_sync_all_history(self) -> None:
+        db = mock.AsyncMock()
+        handler = mock.Mock()
+        handler.sync_all_history = mock.AsyncMock(return_value=7)
+        entry = mock.Mock()
+        entry.handler_cls.return_value = handler
+        resolved = service._ResolvedPRSync(
+            plugin_id='plg-1',
+            entry=entry,
+            tps_slug='github',
+            service_endpoint='https://api.github.com',
+            service_plugins=[ServicePlugin(slug='github')],
+        )
+        with (
+            mock.patch.object(
+                service,
+                '_resolve_plugin',
+                mock.AsyncMock(return_value=resolved),
+            ),
+            mock.patch.object(
+                service,
+                '_build_context',
+                mock.AsyncMock(return_value=mock.Mock()),
+            ),
+            mock.patch.object(
+                service,
+                'get_plugin_credentials',
+                mock.AsyncMock(return_value={'access_token': 'x'}),
+            ),
+        ):
+            result = await service.run_sync(db, 'octo', 'p1')
+        self.assertEqual(7, result)
+        handler.sync_all_history.assert_awaited_once()
+
+    async def test_missing_method_raises_unavailable(self) -> None:
+        db = mock.AsyncMock()
+        handler = object()  # no sync_all_history
+        entry = mock.Mock()
+        entry.handler_cls.return_value = handler
+        resolved = service._ResolvedPRSync(
+            plugin_id='plg-1',
+            entry=entry,
+            tps_slug='github',
+            service_endpoint=None,
+            service_plugins=[],
+        )
+        with (
+            mock.patch.object(
+                service,
+                '_resolve_plugin',
+                mock.AsyncMock(return_value=resolved),
+            ),
+            mock.patch.object(
+                service,
+                '_build_context',
+                mock.AsyncMock(return_value=mock.Mock()),
+            ),
+            mock.patch.object(
+                service,
+                'get_plugin_credentials',
+                mock.AsyncMock(return_value={}),
+            ),
+        ):
+            with self.assertRaises(service.PRSyncUnavailable):
+                await service.run_sync(db, 'octo', 'p1')
+
+
+class StatusTests(unittest.IsolatedAsyncioTestCase):
+    async def test_set_status_writes_all_fields(self) -> None:
+        db = mock.AsyncMock()
+        await service.set_status(
+            db,
+            'p1',
+            status='success',
+            requested_by='alice',
+            prs=7,
+        )
+        db.execute.assert_awaited_once()
+        params = db.execute.await_args.args[1]
+        self.assertEqual('success', params['status'])
+        self.assertEqual(7, params['prs'])
+        self.assertEqual('alice', params['by'])
+
+    async def test_set_status_retries_on_write_conflict(self) -> None:
+        db = mock.AsyncMock()
+        db.execute.side_effect = [
+            Exception('Entity failed to be updated: 3'),
+            [{'id': '"p1"'}],
+        ]
+        with mock.patch.object(service.asyncio, 'sleep'):
+            await service.set_status(db, 'p1', status='running')
+        self.assertEqual(2, db.execute.await_count)
+
+    async def test_set_status_no_retry_drops_conflict(self) -> None:
+        db = mock.AsyncMock()
+        db.execute.side_effect = Exception('Entity failed to be updated: 3')
+        await service.set_status(db, 'p1', status='queued', retry=False)
+        db.execute.assert_awaited_once()
+
+    async def test_set_status_swallows_unrelated_error(self) -> None:
+        db = mock.AsyncMock()
+        db.execute.side_effect = Exception('boom')
+        await service.set_status(db, 'p1', status='running')
+        db.execute.assert_awaited_once()
+
+    async def test_read_status_idle_when_unset(self) -> None:
+        db = mock.AsyncMock()
+        db.execute.return_value = [
+            {
+                'status': None,
+                'at': None,
+                'requested_by': None,
+                'prs': None,
+                'error': None,
+            }
+        ]
+        status = await service.read_status(db, 'p1')
+        self.assertEqual('idle', status.status)
+        self.assertIsNone(status.last_synced_at)
+        self.assertIsNone(status.prs_synced)
+
+    async def test_read_status_parses_success(self) -> None:
+        db = mock.AsyncMock()
+        db.execute.return_value = [
+            {
+                'status': '"success"',
+                'at': '"2026-06-04T12:00:00+00:00"',
+                'requested_by': '"alice"',
+                'prs': 12,
+                'error': '""',
+            }
+        ]
+        status = await service.read_status(db, 'p1')
+        self.assertEqual('success', status.status)
+        self.assertEqual(12, status.prs_synced)
+        self.assertEqual('alice', status.requested_by)
+        self.assertIsNotNone(status.last_synced_at)
+        self.assertIsNone(status.error)
+
+    async def test_read_status_no_rows_returns_idle(self) -> None:
+        db = mock.AsyncMock()
+        db.execute.return_value = []
+        status = await service.read_status(db, 'p1')
+        self.assertEqual('idle', status.status)

--- a/uv.lock
+++ b/uv.lock
@@ -2844,14 +2844,14 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "1.0.0"
+version = "1.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/44/ec35f1b6e83094b997da438a02c8c9b0ade2b1e84cfc48bd4656780760a6/starlette-1.2.1.tar.gz", hash = "sha256:9b9b5ebb992e67d6093741e63c2f59e4f6fff986f81163c087867bd7b924b3f6", size = 2701854, upload-time = "2026-05-31T01:07:51.847Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/54/196d0c1db10af76baa4f64894448505d60d3cdf70ef92cbb35f46a4e4c71/starlette-1.2.1-py3-none-any.whl", hash = "sha256:4de0082d08c8f6764a85a54cf1120d6939507a19905c7768acad2a9f875d2b89", size = 73350, upload-time = "2026-05-31T01:07:50.09Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Adds GitHub PR sync via a Valkey Streams worker (`feature/github-pr-sync`): ingests PR events from the `imbi:pr-sync` stream and stores them in ClickHouse
- Adds built-in blueprint compliance check to Project Doctor (`blueprint_compliance.py`): compares each project's AGE node properties against applicable blueprint JSON Schemas, reporting missing required fields, invalid enum values, out-of-range numerics, and missing defaults
- Adds `POST /analysis/apply-blueprint-defaults` endpoint that applies blueprint defaults to unset properties AND removes stale blueprint-managed properties (those no longer in any applicable blueprint after a type change)
- Bumps starlette 1.0.0 → 1.2.1

## Test plan

- [ ] Run existing test suite: `just test`
- [ ] Manually trigger a PR sync event and confirm ClickHouse row appears
- [ ] Open a project in the Doctor tab — verify `blueprint-compliance` findings appear
- [ ] Click "Apply Blueprint Fixes" — confirm defaults are applied and stale props removed, then analysis re-runs
- [ ] Confirm starlette version in `uv.lock` is 1.2.1