### PR TITLE
Wire GitHub connection plugin into context + credentials

### DIFF
--- a/src/imbi_api/endpoints/project_deployments.py
+++ b/src/imbi_api/endpoints/project_deployments.py
@@ -58,7 +58,11 @@ from imbi_api.identity.host_integration import (
 from imbi_api.llm.dependencies import InjectAnthropicClient
 from imbi_api.plugins import call_with_timeout
 from imbi_api.plugins.credentials import get_plugin_credentials
-from imbi_api.plugins.resolution import ResolvedPlugin, resolve_plugin
+from imbi_api.plugins.resolution import (
+    ResolvedPlugin,
+    resolve_plugin,
+    resolve_service_plugins,
+)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -354,6 +358,7 @@ async def _resolve_and_context(
         environment_config=environment_config,
         project_links=project_links,
         project_type_slugs=project_type_slugs,
+        service_plugins=await resolve_service_plugins(db, project_id),
     )
     ctx = await attach_identity(db, ctx, resolved, auth)
 

--- a/src/imbi_api/identity/flows.py
+++ b/src/imbi_api/identity/flows.py
@@ -10,6 +10,7 @@ from imbi_common.plugins.base import (
     IdentityPlugin,
     IdentityProfile,
     PluginContext,
+    ServicePlugin,
 )
 from imbi_common.plugins.errors import PluginNotFoundError
 from imbi_common.plugins.registry import RegistryEntry, get_plugin
@@ -25,13 +26,50 @@ LOGGER = logging.getLogger(__name__)
 PluginRefKind = typing.Literal['auto', 'id', 'slug']
 
 
+async def _connection_service_plugins(
+    db: graph.Graph, plugin_id: str
+) -> list[ServicePlugin]:
+    """Surface the connection sibling on the plugin's service.
+
+    An identity plugin reads its flavor/host from the ``connection``
+    plugin attached to the same ``ThirdPartyService``. The OAuth flow
+    has no other service context, so this is the one place that lookup
+    happens. Returns an empty list when the plugin is not a service-bound
+    node (e.g. a bare-slug catalog lookup) or no connection plugin is
+    attached.
+    """
+    query: typing.LiteralString = """
+    MATCH (p:Plugin {{id: {plugin_id}}})<-[:HAS_PLUGIN]-
+      (:ThirdPartyService)-[:HAS_PLUGIN]->(conn:Plugin)
+    WHERE conn.plugin_type = 'connection'
+    RETURN conn.plugin_slug AS slug, conn.options AS options
+    LIMIT 1
+    """
+    rows = await db.execute(
+        query, {'plugin_id': plugin_id}, ['slug', 'options']
+    )
+    if not rows or not rows[0].get('slug'):
+        return []
+    return [
+        ServicePlugin(
+            slug=str(graph.parse_agtype(rows[0]['slug'])),
+            options=parse_options(rows[0].get('options')),
+        )
+    ]
+
+
 async def _load_plugin_handler(
     db: graph.Graph,
     plugin_id: str,
     *,
     lookup: PluginRefKind = 'auto',
 ) -> tuple[
-    str, RegistryEntry, IdentityPlugin, dict[str, str], dict[str, typing.Any]
+    str,
+    RegistryEntry,
+    IdentityPlugin,
+    dict[str, str],
+    dict[str, typing.Any],
+    list[ServicePlugin],
 ]:
     """Resolve ``plugin_id`` and load handler, credentials, and options.
 
@@ -55,7 +93,9 @@ async def _load_plugin_handler(
     plugins with required manifest options will surface their own
     error from ``authorization_request``.
 
-    Returns ``(resolved_plugin_id, entry, handler, creds, options)``.
+    Returns ``(resolved_plugin_id, entry, handler, creds, options,
+    service_plugins)`` where ``service_plugins`` carries the connection
+    sibling so the identity plugin can resolve its flavor/host.
     Raises :class:`PluginNotFoundError` when nothing resolves.
     """
     by_id: typing.LiteralString = (
@@ -103,7 +143,8 @@ async def _load_plugin_handler(
     creds = await plugin_credentials.get_plugin_credentials(
         db, resolved_id, entry
     )
-    return resolved_id, entry, handler, creds, options
+    service_plugins = await _connection_service_plugins(db, resolved_id)
+    return resolved_id, entry, handler, creds, options, service_plugins
 
 
 async def start_flow(
@@ -123,9 +164,14 @@ async def start_flow(
     device-code plugins (AWS IAM IC) the UI uses it to render the user
     code and poll until the user completes the flow.
     """
-    resolved_id, entry, handler, creds, options = await _load_plugin_handler(
-        db, plugin_id
-    )
+    (
+        resolved_id,
+        entry,
+        handler,
+        creds,
+        options,
+        service_plugins,
+    ) = await _load_plugin_handler(db, plugin_id)
 
     ctx = PluginContext(
         project_id='',
@@ -133,6 +179,7 @@ async def start_flow(
         org_slug='',
         actor_user_id=actor_user_id,
         assignment_options=options,
+        service_plugins=service_plugins,
     )
     request = await handler.authorization_request(
         ctx,
@@ -231,9 +278,14 @@ async def complete_flow(
     if not await state.consume_identity_nonce(valkey_client, state_data.nonce):
         raise ValueError('state token has already been used')
 
-    resolved_id, _entry, handler, creds, options = await _load_plugin_handler(
-        db, plugin_id
-    )
+    (
+        resolved_id,
+        _entry,
+        handler,
+        creds,
+        options,
+        service_plugins,
+    ) = await _load_plugin_handler(db, plugin_id)
 
     ctx = PluginContext(
         project_id='',
@@ -241,6 +293,7 @@ async def complete_flow(
         org_slug='',
         actor_user_id=state_data.actor_user_id,
         assignment_options=options,
+        service_plugins=service_plugins,
     )
     profile, credentials = await handler.exchange_code(
         ctx,
@@ -283,9 +336,14 @@ async def poll_flow(
     if not state_data.device_code:
         raise ValueError('state token missing device_code (not a device flow)')
 
-    resolved_id, _entry, handler, creds, options = await _load_plugin_handler(
-        db, plugin_id
-    )
+    (
+        resolved_id,
+        _entry,
+        handler,
+        creds,
+        options,
+        service_plugins,
+    ) = await _load_plugin_handler(db, plugin_id)
 
     ctx = PluginContext(
         project_id='',
@@ -293,6 +351,7 @@ async def poll_flow(
         org_slug='',
         actor_user_id=state_data.actor_user_id,
         assignment_options=options,
+        service_plugins=service_plugins,
     )
     profile, credentials = await handler.exchange_code(
         ctx,
@@ -339,14 +398,20 @@ async def complete_login_flow(
     if not await state.consume_identity_nonce(valkey_client, state_data.nonce):
         raise ValueError('state token has already been used')
 
-    resolved_id, _entry, handler, creds, options = await _load_plugin_handler(
-        db, plugin_id
-    )
+    (
+        resolved_id,
+        _entry,
+        handler,
+        creds,
+        options,
+        service_plugins,
+    ) = await _load_plugin_handler(db, plugin_id)
     ctx = PluginContext(
         project_id='',
         project_slug='',
         org_slug='',
         assignment_options=options,
+        service_plugins=service_plugins,
     )
     profile, credentials = await handler.exchange_code(
         ctx,
@@ -365,9 +430,14 @@ async def refresh_connection(
     actor_user_id: str,
 ) -> IdentityCredentials:
     """Force-refresh the actor's connection for ``plugin_id``."""
-    resolved_id, _entry, handler, creds, options = await _load_plugin_handler(
-        db, plugin_id
-    )
+    (
+        resolved_id,
+        _entry,
+        handler,
+        creds,
+        options,
+        service_plugins,
+    ) = await _load_plugin_handler(db, plugin_id)
     connection = await repository.load_connection(
         db, resolved_id, actor_user_id
     )
@@ -386,6 +456,7 @@ async def refresh_connection(
         org_slug='',
         actor_user_id=actor_user_id,
         assignment_options=options,
+        service_plugins=service_plugins,
     )
     try:
         new_credentials = await handler.refresh(
@@ -444,6 +515,7 @@ async def revoke_connection(
             handler,
             creds,
             options,
+            service_plugins,
         ) = await _load_plugin_handler(db, plugin_id)
     except PluginNotFoundError:
         # Plugin uninstalled out from under us.  Nothing to revoke at
@@ -471,6 +543,7 @@ async def revoke_connection(
                 org_slug='',
                 actor_user_id=actor_user_id,
                 assignment_options=options,
+                service_plugins=service_plugins,
             )
             await handler.revoke(ctx, creds, connection.access_token)
         except Exception as exc:  # noqa: BLE001

--- a/src/imbi_api/plugins/credentials.py
+++ b/src/imbi_api/plugins/credentials.py
@@ -53,45 +53,77 @@ async def get_plugin_credentials(
     return await _get_application_credentials(db, plugin_id, entry)
 
 
+_OWN_BLOB: typing.LiteralString = """
+MATCH (p:Plugin {{id: {plugin_id}}})
+RETURN p.plugin_configuration AS creds
+LIMIT 1
+"""
+
+# The shared connection plugin on the same ThirdPartyService holds the
+# service-account credentials when the invoked plugin carries none of
+# its own (the GitHub consolidation: deployment/lifecycle read the
+# App/PAT off the github-connection sibling).
+_CONNECTION_BLOB: typing.LiteralString = """
+MATCH (p:Plugin {{id: {plugin_id}}})<-[:HAS_PLUGIN]-(:ThirdPartyService)
+  -[:HAS_PLUGIN]->(conn:Plugin)
+WHERE conn.plugin_type = 'connection'
+RETURN conn.plugin_configuration AS creds
+LIMIT 1
+"""
+
+
+async def _read_blob(
+    db: graph.Graph, query: typing.LiteralString, plugin_id: str
+) -> dict[str, typing.Any]:
+    """Read + decrypt a ``plugin_configuration`` blob to a dict.
+
+    Treats a missing row, decrypt failure, or JSON parse error as "no
+    credentials" (empty dict) rather than raising, so the caller can fall
+    through to the next credential source.
+    """
+    records = await db.execute(query, {'plugin_id': plugin_id}, ['creds'])
+    if not records or records[0].get('creds') is None:
+        return {}
+    creds_raw: str | None = graph.parse_agtype(records[0]['creds'])
+    if not creds_raw:
+        return {}
+    try:
+        decrypted_str = TokenEncryption.get_instance().decrypt(creds_raw)
+    except Exception:  # noqa: BLE001
+        LOGGER.warning(
+            'Plugin credentials decrypt failed for plugin_id=%s', plugin_id
+        )
+        return {}
+    if not decrypted_str:
+        return {}
+    try:
+        parsed = json.loads(decrypted_str)
+    except json.JSONDecodeError:
+        LOGGER.warning(
+            'Plugin credentials JSON parse failed for plugin_id=%s', plugin_id
+        )
+        return {}
+    if not isinstance(parsed, dict):
+        return {}
+    return typing.cast('dict[str, typing.Any]', parsed)
+
+
 async def _get_plugin_configuration_credentials(
     db: graph.Graph,
     plugin_id: str,
     entry: RegistryEntry,
 ) -> dict[str, str]:
-    """Resolve credentials for ``api_token``/``aws-iam-ic`` plugins."""
-    query: typing.LiteralString = """
-    MATCH (p:Plugin {{id: {plugin_id}}})
-    RETURN p.plugin_configuration AS creds
-    LIMIT 1
-    """
-    records = await db.execute(query, {'plugin_id': plugin_id}, ['creds'])
-    if not records or records[0].get('creds') is None:
-        creds_raw: str | None = None
-    else:
-        creds_raw = graph.parse_agtype(records[0]['creds'])
+    """Resolve credentials for ``api_token``/``aws-iam-ic`` plugins.
 
-    credentials: dict[str, typing.Any] = {}
-    if creds_raw:
-        # Treat decrypt failures and JSON parse errors as "no credentials"
-        # rather than silently passing an empty dict that satisfies a
-        # ``key in dict`` check downstream.
-        try:
-            decrypted_str = TokenEncryption.get_instance().decrypt(creds_raw)
-        except Exception:  # noqa: BLE001
-            LOGGER.warning(
-                'Plugin credentials decrypt failed for plugin_id=%s',
-                plugin_id,
-            )
-            decrypted_str = None
-        if decrypted_str:
-            try:
-                credentials = json.loads(decrypted_str)
-            except json.JSONDecodeError:
-                LOGGER.warning(
-                    'Plugin credentials JSON parse failed for plugin_id=%s',
-                    plugin_id,
-                )
-                credentials = {}
+    Reads the plugin's own ``plugin_configuration`` blob; if it carries
+    nothing usable, falls back to the ``connection`` plugin attached to
+    the same ``ThirdPartyService`` (the shared service-account creds).
+    """
+    credentials: dict[str, typing.Any] = await _read_blob(
+        db, _OWN_BLOB, plugin_id
+    )
+    if not credentials:
+        credentials = await _read_blob(db, _CONNECTION_BLOB, plugin_id)
 
     required_fields = [f for f in entry.manifest.credentials if f.required]
     # ``null`` JSON values must be treated as missing — otherwise

--- a/src/imbi_api/plugins/lifecycle_dispatch.py
+++ b/src/imbi_api/plugins/lifecycle_dispatch.py
@@ -39,7 +39,11 @@ from imbi_api.auth import permissions
 from imbi_api.identity.host_integration import call_with_identity_retry
 from imbi_api.plugins import call_with_timeout
 from imbi_api.plugins.credentials import get_plugin_credentials
-from imbi_api.plugins.resolution import ResolvedPlugin, resolve_all_plugins
+from imbi_api.plugins.resolution import (
+    ResolvedPlugin,
+    resolve_all_plugins,
+    resolve_service_plugins,
+)
 
 # ``_helpers`` lives in ``imbi_api.endpoints`` whose package ``__init__``
 # imports every endpoint module (including ``projects``).  Since
@@ -177,6 +181,8 @@ async def dispatch_lifecycle(
     if bundle is None:
         bundle = await build_lifecycle_context_bundle(db, project_id)
 
+    service_plugins = await resolve_service_plugins(db, project_id)
+
     results: list[LifecycleInvocation] = []
     for resolved in resolved_plugins:
         ctx = PluginContext(
@@ -195,6 +201,7 @@ async def dispatch_lifecycle(
             project_ui_url=project_ui_url,
             third_party_service_slug=resolved.third_party_service_slug,
             service_connections=bundle.service_connections,
+            service_plugins=service_plugins,
         )
         invocation = await _invoke_one(db, ctx, resolved, event, auth)
         results.append(invocation)

--- a/src/imbi_api/plugins/resolution.py
+++ b/src/imbi_api/plugins/resolution.py
@@ -5,6 +5,7 @@ import typing
 
 import fastapi
 from imbi_common import graph
+from imbi_common.plugins.base import ServicePlugin
 from imbi_common.plugins.errors import (
     PluginNotFoundError,
     PluginUnavailableError,
@@ -17,6 +18,41 @@ from imbi_common.plugins.registry import (
 from imbi_api.plugins import parse_options
 
 LOGGER = logging.getLogger(__name__)
+
+
+async def resolve_service_plugins(
+    db: graph.Graph, project_id: str
+) -> list[ServicePlugin]:
+    """Return the sibling plugins on the project's connected services.
+
+    Walks ``(:Project)-[:EXISTS_IN]->(:ThirdPartyService)-[:HAS_PLUGIN]
+    ->(:Plugin)`` and surfaces each plugin as a ``ServicePlugin`` (slug +
+    non-secret ``options``), mirroring how ``imbi-gateway`` populates
+    ``PluginContext.service_plugins`` for the webhook path. Behavioral
+    plugins read these to resolve shared config -- e.g. the GitHub host
+    from the ``github-connection`` sibling. Credentials are deliberately
+    excluded; secrets are resolved separately by the host.
+    """
+    query: typing.LiteralString = """
+    MATCH (proj:Project {{id: {project_id}}})-[:EXISTS_IN]->
+      (:ThirdPartyService)-[:HAS_PLUGIN]->(p:Plugin)
+    RETURN collect(DISTINCT {{slug: p.plugin_slug, options: p.options}})
+      AS plugins
+    """
+    records = await db.execute(query, {'project_id': project_id}, ['plugins'])
+    if not records or records[0].get('plugins') is None:
+        return []
+    rows: list[dict[str, typing.Any]] = (
+        graph.parse_agtype(records[0]['plugins']) or []
+    )
+    return [
+        ServicePlugin(
+            slug=str(row['slug']),
+            options=parse_options(row.get('options')),
+        )
+        for row in rows
+        if row.get('slug')
+    ]
 
 
 class ResolvedPlugin(typing.NamedTuple):

--- a/tests/identity/test_flows.py
+++ b/tests/identity/test_flows.py
@@ -29,6 +29,7 @@ def _patch_load_handler(
     creds: dict[str, str] | None = None,
     resolved_id: str = 'plugin-1',
     options: dict[str, typing.Any] | None = None,
+    service_plugins: list[typing.Any] | None = None,
 ) -> contextlib.AbstractContextManager[typing.Any]:
     """Common patch helper for ``flows._load_plugin_handler``."""
     entry = mock.MagicMock()
@@ -43,6 +44,7 @@ def _patch_load_handler(
                 handler,
                 creds or {},
                 options or {},
+                service_plugins or [],
             )
         ),
     )
@@ -130,6 +132,27 @@ class LoadPluginHandlerTestCase(unittest.IsolatedAsyncioTestCase):
                 db, 'nonexistent-test-slug-xyz', lookup='slug'
             )
         self.assertEqual(db.execute.await_count, 1)
+
+
+class ConnectionServicePluginsTestCase(unittest.IsolatedAsyncioTestCase):
+    """``_connection_service_plugins`` surfaces the connection sibling."""
+
+    async def test_empty_when_no_connection(self) -> None:
+        db = mock.AsyncMock()
+        db.execute.return_value = []
+        result = await flows._connection_service_plugins(db, 'plugin-1')
+        self.assertEqual(result, [])
+
+    async def test_returns_connection_sibling(self) -> None:
+        db = mock.AsyncMock()
+        db.execute.return_value = [
+            {'slug': '"github-connection"', 'options': None}
+        ]
+        with mock.patch.object(
+            flows.graph, 'parse_agtype', side_effect=_parse_agtype_stub
+        ):
+            result = await flows._connection_service_plugins(db, 'plugin-1')
+        self.assertEqual([p.slug for p in result], ['github-connection'])
 
 
 class StartFlowTestCase(unittest.IsolatedAsyncioTestCase):

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1195,6 +1195,96 @@ class CredentialsTestCase(unittest.TestCase):
             asyncio.run(get_plugin_credentials(mock_db, 'p1', entry))
         self.assertIn('client_id or client_secret', str(ctx.exception))
 
+    def test_falls_back_to_connection_blob(self) -> None:
+        from imbi_api.plugins.credentials import get_plugin_credentials
+
+        mock_db = mock.AsyncMock()
+        # First call: the plugin's own blob is empty. Second call: the
+        # github-connection sibling carries the service-account token.
+        mock_db.execute.side_effect = [
+            [{'creds': None}],
+            [{'creds': '"ENCRYPTED"'}],
+        ]
+        encryptor = mock.MagicMock()
+        encryptor.decrypt.return_value = json.dumps({'access_token': 'pat'})
+        entry = _make_registry_entry('github-deployment', required_creds=False)
+        with mock.patch(
+            'imbi_api.plugins.credentials.TokenEncryption.get_instance',
+            return_value=encryptor,
+        ):
+            creds = asyncio.run(get_plugin_credentials(mock_db, 'p1', entry))
+        self.assertEqual(creds, {'access_token': 'pat'})
+        self.assertEqual(mock_db.execute.await_count, 2)
+
+    def test_own_blob_wins_over_connection(self) -> None:
+        from imbi_api.plugins.credentials import get_plugin_credentials
+
+        mock_db = mock.AsyncMock()
+        mock_db.execute.return_value = [{'creds': '"ENCRYPTED"'}]
+        encryptor = mock.MagicMock()
+        encryptor.decrypt.return_value = json.dumps({'access_token': 'own'})
+        entry = _make_registry_entry('github-deployment', required_creds=False)
+        with mock.patch(
+            'imbi_api.plugins.credentials.TokenEncryption.get_instance',
+            return_value=encryptor,
+        ):
+            creds = asyncio.run(get_plugin_credentials(mock_db, 'p1', entry))
+        # The own blob satisfied the request, so the connection query is
+        # never issued.
+        self.assertEqual(creds, {'access_token': 'own'})
+        self.assertEqual(mock_db.execute.await_count, 1)
+
+
+class ResolveServicePluginsTestCase(unittest.TestCase):
+    """Coverage for ``resolve_service_plugins`` (sibling discovery)."""
+
+    def test_empty_when_no_records(self) -> None:
+        from imbi_api.plugins.resolution import resolve_service_plugins
+
+        mock_db = mock.AsyncMock()
+        mock_db.execute.return_value = []
+        result = asyncio.run(resolve_service_plugins(mock_db, 'p1'))
+        self.assertEqual(result, [])
+
+    def test_empty_when_plugins_column_null(self) -> None:
+        from imbi_api.plugins.resolution import resolve_service_plugins
+
+        mock_db = mock.AsyncMock()
+        mock_db.execute.return_value = [{'plugins': None}]
+        result = asyncio.run(resolve_service_plugins(mock_db, 'p1'))
+        self.assertEqual(result, [])
+
+    def test_returns_connection_sibling(self) -> None:
+        from imbi_api.plugins.resolution import resolve_service_plugins
+
+        mock_db = mock.AsyncMock()
+        mock_db.execute.return_value = [
+            {
+                'plugins': json.dumps(
+                    [
+                        {
+                            'slug': 'github-connection',
+                            'options': json.dumps(
+                                {'flavor': 'ghec', 'host': 'tenant.ghe.com'}
+                            ),
+                        },
+                        {'slug': 'github-deployment', 'options': '{}'},
+                    ]
+                )
+            }
+        ]
+        result = asyncio.run(resolve_service_plugins(mock_db, 'p1'))
+        self.assertEqual(
+            [p.slug for p in result],
+            [
+                'github-connection',
+                'github-deployment',
+            ],
+        )
+        conn = next(p for p in result if p.slug == 'github-connection')
+        self.assertEqual(conn.options['flavor'], 'ghec')
+        self.assertEqual(conn.options['host'], 'tenant.ghe.com')
+
 
 class PatchPluginConfigurationTestCase(unittest.IsolatedAsyncioTestCase):
     """Compare-and-swap behavior of ``patch_plugin_configuration`` (M19)."""


### PR DESCRIPTION
## Summary

Wires the new `github-connection` plugin into imbi-api so the
host-agnostic GitHub plugins can resolve their flavor/host and shared
credentials. Companion to the consolidation in
AWeber-Imbi/imbi-plugin-github#41 and the `ConnectionPlugin` type in
AWeber-Imbi/imbi-common#173.

## Problem

The collapsed GitHub plugins read their host from a `github-connection`
sibling on `ctx.service_plugins`. But imbi-api never populated
`service_plugins` for identity/deployment/lifecycle calls (only
imbi-gateway does, for webhooks), and the OAuth flow had no
ThirdPartyService context at all. Credentials also lived on each plugin,
not on a shared connection.

## Solution

- **`resolve_service_plugins(db, project_id)`** — walks
  `(:Project)-[:EXISTS_IN]->(:ThirdPartyService)-[:HAS_PLUGIN]->(:Plugin)`
  and surfaces each connected plugin as a `ServicePlugin` (slug +
  non-secret options), mirroring imbi-gateway's webhook population.
- **Context population** — deployment (`_resolve_and_context`) and
  lifecycle (`dispatch_lifecycle`) now pass `service_plugins`.
- **OAuth flow** — `_load_plugin_handler` additionally looks up the
  `connection` sibling on the plugin's service and threads it through
  all six flow `PluginContext` constructions, so the identity plugin can
  resolve its OAuth host (the flow has no other service context).
- **Credentials** — `api_token` plugins that carry no
  `plugin_configuration` of their own fall back to the `connection`
  plugin's blob (the shared service account). Per-user identity tokens
  still take precedence; `oauth2`/ServiceApplication resolution is
  unchanged.

## Scope note

Deployment/lifecycle consume a bearer `access_token` directly, so the
connection plugin's PAT works as-is. App-auth (`app_id`/`private_key`)
token minting for deployment/lifecycle (commit-sync already does this)
is a deliberate follow-up.

## Testing

- Full suite: **2333 passed, 1 skipped**.
- `just lint`: basedpyright 0 errors, mypy clean, ruff clean.
- New unit tests: `resolve_service_plugins` (sibling walk), the
  credential connection-fallback + own-blob precedence, and the OAuth
  `_connection_service_plugins` lookup.

## Dependency

Functionally depends on imbi-plugin-github#41 (the connection plugin
must exist on the service) and imbi-common#173 (the `connection` type).
imbi-api itself only references the `'connection'` plugin_type string and
the existing `ServicePlugin`, so this PR's own CI is independent.
