### PR TITLE
Add EXISTS_IN service filter to project listing

### DIFF
--- a/src/imbi_api/endpoints/projects.py
+++ b/src/imbi_api/endpoints/projects.py
@@ -1572,6 +1572,28 @@ async def list_projects(
     project_type: str | None = None,
     include_archived: bool = False,
     slim: bool = False,
+    third_party_service_slug: typing.Annotated[
+        str | None,
+        fastapi.Query(
+            description=(
+                'Restrict results to projects that have an EXISTS_IN '
+                'relationship to the third-party service with this slug '
+                'in the organization. Combine with ``identifier`` to '
+                'match a specific external identifier on that service.'
+            ),
+        ),
+    ] = None,
+    identifier: typing.Annotated[
+        str | None,
+        fastapi.Query(
+            description=(
+                'Restrict results to projects whose EXISTS_IN edge to '
+                '``third_party_service_slug`` carries this external '
+                'identifier (exact match). Requires '
+                '``third_party_service_slug``.'
+            ),
+        ),
+    ] = None,
     filters: typing.Annotated[
         list[str] | None,
         fastapi.Query(
@@ -1598,6 +1620,13 @@ async def list_projects(
     stored on the project (e.g. ``framework``, ``programming_language``)
     using the field/operator grammar described on the parameter.
 
+    ``third_party_service_slug`` restricts the listing to projects that
+    have an ``EXISTS_IN`` relationship to that service within the
+    organization; adding ``identifier`` further restricts to the
+    project(s) whose edge carries that external identifier. ``identifier``
+    is only meaningful alongside ``third_party_service_slug`` and is
+    rejected on its own. An unknown service slug simply matches nothing.
+
     ``slim=true`` returns a stripped payload tailored to the
     projects-list UI: only the fields the list view reads (id, name,
     score, team slug+name, project_type slug+name+deployable,
@@ -1608,6 +1637,33 @@ async def list_projects(
     ``relationships`` block. Cuts the response from megabytes to
     kilobytes for large orgs.
     """
+    if identifier is not None and third_party_service_slug is None:
+        raise fastapi.HTTPException(
+            status_code=422,
+            detail=(
+                'identifier requires third_party_service_slug; an '
+                'external identifier is only meaningful for a specific '
+                'third-party service'
+            ),
+        )
+    # Restrict to projects linked to a third-party service (and,
+    # optionally, a specific external identifier on that edge). Closed
+    # with ``WITH DISTINCT p, o`` so the optional ``identifier`` WHERE
+    # never lands adjacent to the attribute filter's WHERE below.
+    service_filter: typing.LiteralString = ''
+    if third_party_service_slug is not None:
+        identifier_clause: typing.LiteralString = (
+            'WHERE ei.identifier = {identifier}\n'
+            if identifier is not None
+            else ''
+        )
+        service_filter = (
+            'MATCH (p)-[ei:EXISTS_IN]->'
+            '(tps:ThirdPartyService {{slug: {tps_slug}}})'
+            '-[:BELONGS_TO]->(o)\n'
+            + identifier_clause
+            + 'WITH DISTINCT p, o\n'
+        )
     type_filter: typing.LiteralString = (
         'MATCH (p)-[:TYPE]->(filter_pt:ProjectType {{slug: {project_type}}})'
         if project_type
@@ -1637,6 +1693,7 @@ async def list_projects(
         + """
     WITH DISTINCT p, o
     """
+        + service_filter
         + type_filter
         + attr_filter
         + return_fragment
@@ -1652,6 +1709,8 @@ async def list_projects(
         {
             'org_slug': org_slug,
             'project_type': project_type,
+            'tps_slug': third_party_service_slug,
+            'identifier': identifier,
             **attr_params,
         },
         columns,

--- a/tests/endpoints/test_projects.py
+++ b/tests/endpoints/test_projects.py
@@ -1263,6 +1263,98 @@ class ProjectEndpointsTestCase(support.SharedAppTestCase):
         query = self.mock_db.execute.call_args.args[0]
         self.assertNotIn('coalesce(p.archived, false)', query)
 
+    # -- EXISTS_IN service filtering -----------------------------------
+
+    def test_list_by_service_returns_matching_projects(self) -> None:
+        """``third_party_service_slug`` + ``identifier`` restrict to the
+        EXISTS_IN edge carrying that external identifier."""
+        self.mock_db.execute.return_value = [
+            {
+                'project': self._project_data(),
+                'outbound_count': 0,
+                'inbound_count': 0,
+            },
+        ]
+
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            response = self.client.get(
+                '/organizations/engineering/projects/'
+                '?third_party_service_slug=github&identifier=octo/api',
+            )
+
+        self.assertEqual(response.status_code, 200, response.text)
+        data = response.json()
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]['slug'], 'my-api')
+
+        # The list query is the first execute call; later calls fetch
+        # release/PR data once a project row comes back.
+        query = self.mock_db.execute.call_args_list[0].args[0]
+        params = self.mock_db.execute.call_args_list[0].args[1]
+        self.assertIn('-[ei:EXISTS_IN]->', query)
+        self.assertIn('ThirdPartyService {{slug: {tps_slug}}}', query)
+        self.assertIn('-[:BELONGS_TO]->(o)', query)
+        self.assertIn('WHERE ei.identifier = {identifier}', query)
+        self.assertEqual(params['tps_slug'], 'github')
+        self.assertEqual(params['identifier'], 'octo/api')
+
+    def test_list_by_service_slug_only_omits_identifier(self) -> None:
+        """``third_party_service_slug`` alone matches every project in
+        the service without an identifier predicate."""
+        self.mock_db.execute.return_value = []
+
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            response = self.client.get(
+                '/organizations/engineering/projects/'
+                '?third_party_service_slug=github',
+            )
+
+        self.assertEqual(response.status_code, 200)
+        query = self.mock_db.execute.call_args.args[0]
+        params = self.mock_db.execute.call_args.args[1]
+        self.assertIn('-[ei:EXISTS_IN]->', query)
+        self.assertNotIn('WHERE ei.identifier', query)
+        self.assertEqual(params['tps_slug'], 'github')
+        self.assertIsNone(params['identifier'])
+
+    def test_list_identifier_without_service_rejected(self) -> None:
+        """``identifier`` is meaningless without a service slug."""
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            response = self.client.get(
+                '/organizations/engineering/projects/?identifier=octo/api',
+            )
+
+        self.assertEqual(response.status_code, 422)
+        self.assertIn('third_party_service_slug', response.json()['detail'])
+        self.mock_db.execute.assert_not_called()
+
+    def test_list_unknown_service_returns_empty(self) -> None:
+        """An unknown service slug matches nothing (no 404, no extra
+        lookup query)."""
+        self.mock_db.execute.return_value = []
+
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            response = self.client.get(
+                '/organizations/engineering/projects/'
+                '?third_party_service_slug=does-not-exist',
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), [])
+        self.assertEqual(self.mock_db.execute.call_count, 1)
+
     # -- Attribute filtering -------------------------------------------
 
     def _framework_blueprint(self) -> models.Blueprint:


### PR DESCRIPTION
## Summary

Adds two optional query parameters to the existing project-listing endpoint so callers can find an Imbi project by its external identity on a third-party service:

```
GET /organizations/{org_slug}/projects/?third_party_service_slug={slug}&identifier={external_id}
```

This is the lookup primitive needed to resolve an Imbi project from inside a GitHub workflow (loosely related to the SBOM-ingest work): given a repository's third-party-service slug and external identifier, return the matching project(s).

## Problem

There was no way to query projects by their `EXISTS_IN` relationship to a `ThirdPartyService`. Callers that know a project only by its external identity (e.g. a GitHub Actions run that has the repo's service slug + identifier, not the Imbi project id) had no endpoint to resolve it.

## Solution

Extend `list_projects` (`GET /organizations/{org_slug}/projects/`) rather than add a new route — the requested URL *is* that path, and FastAPI can't bind a second handler to `GET /`.

- `third_party_service_slug` — restrict results to projects with an `EXISTS_IN` edge to that service within the organization.
- `identifier` — further restrict to the edge carrying that external identifier (exact match).

Behavior:
- `?third_party_service_slug=github&identifier=octo/api` → exact match (the documented case).
- `?third_party_service_slug=github` → all projects that exist in that service.
- `?identifier=...` with no service slug → **422** (an identifier is meaningless without a service).
- Unknown service slug → **200 `[]`** (treated as a filter, not a lookup — no 404).

The filter is injected as a `MATCH` after `WITH DISTINCT p, o`, mirroring the existing `type_filter`, and closed with its own `WITH DISTINCT p, o` so the optional `identifier` `WHERE` never lands adjacent to the attribute-filter `WHERE`. Edge predicate uses `WHERE ei.identifier = {identifier}`, matching the repo's convention for edge filters.

Generated Cypher (both params):

```cypher
MATCH (p:Project)-[:OWNED_BY]->(:Team)-[:BELONGS_TO]->(o:Organization {slug: $org_slug})
WHERE coalesce(p.archived, false) = false
WITH DISTINCT p, o
MATCH (p)-[ei:EXISTS_IN]->(tps:ThirdPartyService {slug: $tps_slug})-[:BELONGS_TO]->(o)
WHERE ei.identifier = $identifier
WITH DISTINCT p, o
... existing return fragment ...
ORDER BY p.name
```

## Testing

- `tests/endpoints/test_projects.py`: 4 new tests (both params, slug-only, identifier-without-slug → 422, unknown-slug → empty). Full file: **72 passed**.
- `just lint`: ruff clean, basedpyright 0 errors, mypy success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)