### PR TITLE
Enforce configurable tag-format policies on release/deploy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -233,6 +233,12 @@ max-complexity = 15
 exclude-newer = "7 days"
 exclude-newer-package = { "clickhouse-connect" = false, "imbi-common" = false, "imbi-plugin-aws" = false, "imbi-plugin-github" = false, "imbi-plugin-logzio" = false, "imbi-plugin-oidc" = false, "imbi-plugin-pagerduty" = false, "imbi-plugin-sentry" = false, "imbi-plugin-sonarqube" = false }
 
+[tool.uv.sources]
+# Temporary: point at imbi-common main for the unreleased configurable
+# tag-format symbols (PR #175, merged). Revert to the published ==<version>
+# pin once imbi-common is released to PyPI.
+imbi-common = { git = "https://github.com/AWeber-Imbi/imbi-common.git", branch = "main" }
+
 [[tool.uv.index]]
 url = "https://pypi.org/simple"
 default = true

--- a/src/imbi_api/endpoints/organizations.py
+++ b/src/imbi_api/endpoints/organizations.py
@@ -418,6 +418,7 @@ async def _persist_organization(
             ' n.slug = {slug},'
             ' n.description = {description},'
             ' n.icon = {icon},'
+            ' n.tag_formats = {tag_formats},'
             ' n.updated_at = {updated_at},'
             ' n.previous_slugs = {previous_slugs}'
             ' RETURN n'
@@ -429,6 +430,7 @@ async def _persist_organization(
             ' n.slug = {slug},'
             ' n.description = {description},'
             ' n.icon = {icon},'
+            ' n.tag_formats = {tag_formats},'
             ' n.updated_at = {updated_at}'
             ' RETURN n'
         )
@@ -439,6 +441,7 @@ async def _persist_organization(
         'slug': props['slug'],
         'description': props.get('description'),
         'icon': props.get('icon'),
+        'tag_formats': props.get('tag_formats', []),
         'updated_at': props['updated_at'],
     }
     if previous_slugs is not None:

--- a/src/imbi_api/endpoints/project_deployments.py
+++ b/src/imbi_api/endpoints/project_deployments.py
@@ -422,26 +422,40 @@ async def _resolve_tag_formats(
         return []
 
     pt_raw = graph.parse_agtype(records[0].get('pt_formats'))
-    chosen: list[dict[str, typing.Any]] = []
+    pt_entries: list[dict[str, typing.Any]] = []
     if isinstance(pt_raw, list):
         for entry in typing.cast(list[object], pt_raw):
             if isinstance(entry, list):
-                chosen.extend(
+                pt_entries.extend(
                     typing.cast(dict[str, typing.Any], e)
                     for e in typing.cast(list[object], entry)
                     if isinstance(e, dict)
                 )
-    if not chosen:
-        org_raw = graph.parse_agtype(records[0].get('org_formats'))
-        if isinstance(org_raw, list):
-            chosen = [
-                typing.cast(dict[str, typing.Any], e)
-                for e in typing.cast(list[object], org_raw)
-                if isinstance(e, dict)
-            ]
 
+    # Fall back to the org policy unless the project type produced at
+    # least one *valid* format; a project type whose stored formats are
+    # all malformed must inherit the org gate, not disable enforcement.
+    formats = _validate_tag_formats(pt_entries)
+    if formats:
+        return formats
+
+    org_raw = graph.parse_agtype(records[0].get('org_formats'))
+    org_entries: list[dict[str, typing.Any]] = []
+    if isinstance(org_raw, list):
+        org_entries = [
+            typing.cast(dict[str, typing.Any], e)
+            for e in typing.cast(list[object], org_raw)
+            if isinstance(e, dict)
+        ]
+    return _validate_tag_formats(org_entries)
+
+
+def _validate_tag_formats(
+    entries: list[dict[str, typing.Any]],
+) -> list[common_models.TagFormat]:
+    """Validate stored format dicts, dropping (and logging) malformed ones."""
     formats: list[common_models.TagFormat] = []
-    for entry in chosen:
+    for entry in entries:
         try:
             formats.append(common_models.TagFormat.model_validate(entry))
         except pydantic.ValidationError:

--- a/src/imbi_api/endpoints/project_deployments.py
+++ b/src/imbi_api/endpoints/project_deployments.py
@@ -389,6 +389,66 @@ async def _resolve_and_context(
     return resolved, ctx, credentials
 
 
+async def _resolve_tag_formats(
+    db: graph.Graph,
+    org_slug: str,
+    project_id: str,
+) -> list[common_models.TagFormat]:
+    """Resolve the effective release/deploy tag-format policy.
+
+    The project's type(s) override the organization: when any of the
+    project's ``ProjectType`` nodes configure ``tag_formats`` those apply
+    (unioned across types); otherwise the organization's ``tag_formats``
+    apply. When neither configures any, the result is empty -- meaning
+    "no restriction" (see ``versioning.matches_tag_formats``).
+    """
+    query: typing.LiteralString = (
+        'MATCH (o:Organization {{slug: {org_slug}}})'
+        ' OPTIONAL MATCH (p:Project {{id: {project_id}}})'
+        '-[:TYPE]->(pt:ProjectType)-[:BELONGS_TO]->(o)'
+        ' RETURN o.tag_formats AS org_formats,'
+        ' collect(pt.tag_formats) AS pt_formats'
+    )
+    try:
+        records = await db.execute(
+            query,
+            {'org_slug': org_slug, 'project_id': project_id},
+            columns=['org_formats', 'pt_formats'],
+        )
+    except Exception:  # noqa: BLE001
+        LOGGER.debug('Tag-format lookup failed', exc_info=True)
+        return []
+    if not records:
+        return []
+
+    pt_raw = graph.parse_agtype(records[0].get('pt_formats'))
+    chosen: list[dict[str, typing.Any]] = []
+    if isinstance(pt_raw, list):
+        for entry in typing.cast(list[object], pt_raw):
+            if isinstance(entry, list):
+                chosen.extend(
+                    typing.cast(dict[str, typing.Any], e)
+                    for e in typing.cast(list[object], entry)
+                    if isinstance(e, dict)
+                )
+    if not chosen:
+        org_raw = graph.parse_agtype(records[0].get('org_formats'))
+        if isinstance(org_raw, list):
+            chosen = [
+                typing.cast(dict[str, typing.Any], e)
+                for e in typing.cast(list[object], org_raw)
+                if isinstance(e, dict)
+            ]
+
+    formats: list[common_models.TagFormat] = []
+    for entry in chosen:
+        try:
+            formats.append(common_models.TagFormat.model_validate(entry))
+        except pydantic.ValidationError:
+            LOGGER.warning('Skipping invalid stored tag format: %r', entry)
+    return formats
+
+
 class _EnvFlags(typing.NamedTuple):
     """Release-train flags resolved from an ``Environment`` node.
 
@@ -1496,26 +1556,30 @@ async def _handle_promote(
 
     # Infer promote behaviour from the ref shape of ``body.tag``:
     #
-    # * Semver-shaped (``1.2.3`` / ``v1.2.3``)  -> already a tag.  Skip
-    #   ``create_tag`` + ``create_release``; call ``trigger_deployment``
-    #   so the repo's ``on: deployment`` workflow fires.  This is the
-    #   "promote to prod from a stage release tag" path.
+    # * Matches a configured tag format (or, with none configured, any
+    #   non-SHA ref) -> already a tag.  Skip ``create_tag`` +
+    #   ``create_release``; call ``trigger_deployment`` so the repo's
+    #   ``on: deployment`` workflow fires.  This is the "promote to prod
+    #   from a stage release tag" path.
     # * Git short/full SHA                       -> cut a tag at the SHA,
     #   create a GitHub Release; the repo's ``on: release`` workflow
     #   handles the deploy server-side.  This is the "first promote off
     #   a build commit" path.
-    # * Anything else (e.g. ``main``)            -> 400.  We refuse to
-    #   silently cut a tag named after a branch; a typo at the API
-    #   boundary should fail loudly rather than mint ``refs/tags/main``.
-    if not versioning.is_semver_tag(body.tag) and not versioning.is_commitish(
-        body.tag
-    ):
+    # * A ref that fails a configured tag format  -> 400.  We refuse to
+    #   silently cut a tag that violates the org/project-type policy; a
+    #   typo at the API boundary should fail loudly.
+    tag_formats = await _resolve_tag_formats(db, org_slug, project_id)
+    patterns = [fmt.pattern for fmt in tag_formats]
+    if not versioning.matches_tag_formats(
+        body.tag, patterns
+    ) and not versioning.is_commitish(body.tag):
+        allowed = ', '.join(fmt.label for fmt in tag_formats)
         raise fastapi.HTTPException(
             status_code=400,
             detail=(
-                f'Promote target {body.tag!r} is neither a semver tag '
-                '(e.g. "v1.2.3") nor a git SHA (7-40 hex chars); refusing '
-                'to cut a tag at an ambiguous ref.'
+                f'Promote target {body.tag!r} does not match any configured '
+                f'tag format ({allowed}) and is not a git SHA (7-40 hex '
+                'chars); refusing to cut a tag at an ambiguous ref.'
             ),
         )
 
@@ -2479,16 +2543,20 @@ async def cut_release(
     """Cut a git tag + GitHub release at ``committish`` -- no deployment.
 
     The build-and-release-only (library / image) flow: validate the
-    semver tag and committish, cut the tag + release via the deployment
-    plugin (reusing the promote machinery minus the deploy step), upsert
-    the matching ``Release`` node, and record an audit row.
+    tag against the configured formats and the committish, cut the tag +
+    release via the deployment plugin (reusing the promote machinery
+    minus the deploy step), upsert the matching ``Release`` node, and
+    record an audit row.
     """
-    if not versioning.is_semver_tag(body.tag):
+    tag_formats = await _resolve_tag_formats(db, org_slug, project_id)
+    patterns = [fmt.pattern for fmt in tag_formats]
+    if not versioning.matches_tag_formats(body.tag, patterns):
+        allowed = ', '.join(fmt.label for fmt in tag_formats)
         raise fastapi.HTTPException(
             status_code=400,
             detail=(
-                f'Release tag {body.tag!r} is not a semver tag '
-                '(e.g. "v1.2.3").'
+                f'Release tag {body.tag!r} does not match any configured '
+                f'tag format ({allowed}).'
             ),
         )
     if not versioning.is_commitish(body.committish):

--- a/tests/endpoints/test_organizations.py
+++ b/tests/endpoints/test_organizations.py
@@ -48,8 +48,8 @@ class OrganizationEndpointsTestCase(support.SharedAppTestCase):
         )
 
         self.mock_db = mock.AsyncMock(spec=graph.Graph)
-        self.test_app.dependency_overrides[graph._inject_graph] = (
-            lambda: self.mock_db
+        self.test_app.dependency_overrides[graph._inject_graph] = lambda: (
+            self.mock_db
         )
 
         self.client = testclient.TestClient(self.test_app)
@@ -424,3 +424,50 @@ class OrganizationEndpointsTestCase(support.SharedAppTestCase):
         set_call = self.mock_db.execute.call_args_list[0]
         params = set_call.args[1]
         self.assertNotIn('previous_slugs', params)
+
+    def test_patch_organization_tag_formats(self) -> None:
+        """Patching tag_formats persists the list in the SET params."""
+        self.mock_db.match.return_value = [self.test_org]
+        updated_org = {
+            'id': self.test_org.id,
+            'name': self.test_org.name,
+            'slug': self.test_org.slug,
+            'description': self.test_org.description,
+            'icon': self.test_org.icon,
+            'created_at': self.test_org.created_at.isoformat(),
+            'updated_at': self.test_org.updated_at,
+        }
+        self.mock_db.execute.side_effect = [
+            [{'n': updated_org}],
+            [{'team_count': 0, 'member_count': 0, 'project_count': 0}],
+        ]
+        formats = [{'label': 'Semver', 'pattern': r'^v?\d+\.\d+\.\d+$'}]
+
+        response = self.client.patch(
+            '/organizations/engineering',
+            json=[{'op': 'add', 'path': '/tag_formats', 'value': formats}],
+        )
+
+        self.assertEqual(response.status_code, 200)
+        set_call = self.mock_db.execute.call_args_list[0]
+        params = set_call.args[1]
+        self.assertEqual(params['tag_formats'], formats)
+        # The SET clause must include the tag_formats assignment.
+        self.assertIn('n.tag_formats = {tag_formats}', set_call.args[0])
+
+    def test_patch_organization_rejects_invalid_tag_format(self) -> None:
+        """An uncompilable regex pattern is rejected with 400."""
+        self.mock_db.match.return_value = [self.test_org]
+
+        response = self.client.patch(
+            '/organizations/engineering',
+            json=[
+                {
+                    'op': 'add',
+                    'path': '/tag_formats',
+                    'value': [{'label': 'Bad', 'pattern': '('}],
+                }
+            ],
+        )
+
+        self.assertEqual(response.status_code, 400)

--- a/tests/endpoints/test_project_deployments.py
+++ b/tests/endpoints/test_project_deployments.py
@@ -2303,3 +2303,15 @@ class ResolveTagFormatsTestCase(unittest.IsolatedAsyncioTestCase):
             db, 'org', 'pid'
         )
         self.assertEqual([f.label for f in result], ['Good'])
+
+    async def test_falls_back_to_org_when_project_type_all_malformed(
+        self,
+    ) -> None:
+        db = self._db(
+            org_formats=[{'label': 'Org', 'pattern': 'a'}],
+            pt_formats=[[{'oops': 1}]],
+        )
+        result = await project_deployments._resolve_tag_formats(
+            db, 'org', 'pid'
+        )
+        self.assertEqual([f.label for f in result], ['Org'])

--- a/tests/endpoints/test_project_deployments.py
+++ b/tests/endpoints/test_project_deployments.py
@@ -9,6 +9,7 @@ from unittest import mock
 from fastapi import testclient
 from imbi_common import graph
 from imbi_common.llm import AnthropicClient, CompletionResult
+from imbi_common.models import SEMVER_TAG_FORMAT, TagFormat
 from imbi_common.plugins.base import (
     Commit,
     CompareResult,
@@ -25,7 +26,7 @@ from imbi_common.plugins.registry import RegistryEntry
 
 from imbi_api import models
 from imbi_api.auth import password, permissions
-from imbi_api.endpoints import _helpers
+from imbi_api.endpoints import _helpers, project_deployments
 from imbi_api.endpoints.project_deployments import (
     DraftReleaseNotes,
     _EnvFlags,
@@ -257,6 +258,14 @@ class ProjectDeploymentsTestCase(support.SharedAppTestCase):
                         can_deploy=True,
                         can_promote=True,
                     ),
+                )
+            ),
+            # Default tag-format policy: none configured (any tag allowed).
+            # Tests exercising the policy guardrails override the return.
+            '_resolve_tag_formats': self._start(
+                mock.patch(
+                    f'{_MODULE}._resolve_tag_formats',
+                    return_value=[],
                 )
             ),
             'clickhouse': self._start(
@@ -669,9 +678,11 @@ class ProjectDeploymentsTestCase(support.SharedAppTestCase):
         self.assertEqual(call.kwargs['external_run_id'], '42')
         self.assertEqual(call.kwargs['external_run_url'], 'https://gh/runs/42')
 
-    def test_promote_400_on_non_semver_non_sha_ref(self) -> None:
-        # A branch-shaped ref like ``main`` is neither a tag nor a SHA;
-        # the handler must refuse rather than silently cut a tag.
+    def test_promote_400_on_ref_violating_configured_format(self) -> None:
+        # With a semver policy configured, a branch-shaped ref like
+        # ``main`` matches no format and is not a SHA; the handler must
+        # refuse rather than silently cut a tag.
+        self.mocks['_resolve_tag_formats'].return_value = [SEMVER_TAG_FORMAT]
         with testclient.TestClient(self.test_app) as client:
             response = client.post(
                 '/organizations/myorg/projects/proj1/deployments',
@@ -684,7 +695,30 @@ class ProjectDeploymentsTestCase(support.SharedAppTestCase):
                 },
             )
         self.assertEqual(response.status_code, 400)
-        self.assertIn('neither a semver tag', response.json()['detail'])
+        detail = response.json()['detail']
+        self.assertIn('does not match any configured tag format', detail)
+        self.assertIn('Semver', detail)
+
+    def test_promote_allows_ref_matching_custom_format(self) -> None:
+        # A non-semver ref is accepted when it matches a configured
+        # custom format (here a CalVer-style tag).
+        self.mocks['append_deployment_event'].return_value = mock.Mock()
+        self.mocks['_resolve_tag_formats'].return_value = [
+            TagFormat(label='CalVer', pattern=r'\d{4}\.\d{2}\.\d+')
+        ]
+        with testclient.TestClient(self.test_app) as client:
+            response = client.post(
+                '/organizations/myorg/projects/proj1/deployments',
+                json={
+                    'action': 'promote',
+                    'from_environment': 'staging',
+                    'to_environment': 'production',
+                    'from_committish': '1a9c610',
+                    'tag': '2026.06.1',
+                },
+            )
+        self.assertEqual(response.status_code, 202)
+        self.assertEqual(response.json()['tag'], '2026.06.1')
 
     def test_promote_400_when_can_promote_false(self) -> None:
         self.mocks['_load_env_flags'].return_value = _EnvFlags(
@@ -2110,14 +2144,45 @@ class ReleasesTabEndpointsTestCase(ProjectDeploymentsTestCase):
         # No deployment is dispatched for a library release.
         self.assertFalse(triggered['called'])
 
-    def test_cut_release_rejects_non_semver_tag(self) -> None:
+    def test_cut_release_rejects_tag_violating_configured_format(
+        self,
+    ) -> None:
+        self.mocks['_resolve_tag_formats'].return_value = [SEMVER_TAG_FORMAT]
         with testclient.TestClient(self.test_app) as client:
             response = client.post(
                 f'{self._BASE}/releases/cut',
                 json={'committish': '1a9c610', 'tag': 'main'},
             )
         self.assertEqual(response.status_code, 400)
-        self.assertIn('semver', response.json()['detail'])
+        detail = response.json()['detail']
+        self.assertIn('does not match any configured tag format', detail)
+        self.assertIn('Semver', detail)
+
+    def test_cut_release_accepts_tag_matching_custom_format(self) -> None:
+        self.mocks['_resolve_tag_formats'].return_value = [
+            TagFormat(label='CalVer', pattern=r'\d{4}\.\d{2}\.\d+')
+        ]
+        self.mock_db.execute = mock.AsyncMock(return_value=[])
+        with testclient.TestClient(self.test_app) as client:
+            response = client.post(
+                f'{self._BASE}/releases/cut',
+                json={'committish': '1a9c610', 'tag': '2026.06.1'},
+            )
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.json()['tag'], '2026.06.1')
+
+    def test_cut_release_allows_any_tag_when_no_format_configured(
+        self,
+    ) -> None:
+        # Default policy is empty -> any tag is accepted.
+        self.mock_db.execute = mock.AsyncMock(return_value=[])
+        with testclient.TestClient(self.test_app) as client:
+            response = client.post(
+                f'{self._BASE}/releases/cut',
+                json={'committish': '1a9c610', 'tag': 'nightly-build'},
+            )
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.json()['tag'], 'nightly-build')
 
     def test_cut_release_rejects_non_sha_committish(self) -> None:
         with testclient.TestClient(self.test_app) as client:
@@ -2164,3 +2229,77 @@ class ReleasesTabEndpointsTestCase(ProjectDeploymentsTestCase):
         data = response.json()
         self.assertIsNotNone(data['warning'])
         self.assertIn('create_release', data['warning'])
+
+
+class ResolveTagFormatsTestCase(unittest.IsolatedAsyncioTestCase):
+    """Unit tests for the ``_resolve_tag_formats`` cascade helper."""
+
+    @staticmethod
+    def _db(org_formats: typing.Any, pt_formats: typing.Any) -> mock.AsyncMock:
+        db = mock.AsyncMock(spec=graph.Graph)
+        db.execute = mock.AsyncMock(
+            return_value=[
+                {'org_formats': org_formats, 'pt_formats': pt_formats}
+            ]
+        )
+        return db
+
+    async def test_project_type_overrides_org(self) -> None:
+        db = self._db(
+            org_formats=[{'label': 'Org', 'pattern': 'a'}],
+            pt_formats=[[{'label': 'PT', 'pattern': 'b'}]],
+        )
+        result = await project_deployments._resolve_tag_formats(
+            db, 'org', 'pid'
+        )
+        self.assertEqual([f.label for f in result], ['PT'])
+
+    async def test_falls_back_to_org_when_no_project_type_formats(
+        self,
+    ) -> None:
+        db = self._db(
+            org_formats=[{'label': 'Org', 'pattern': 'a'}],
+            pt_formats=[[]],
+        )
+        result = await project_deployments._resolve_tag_formats(
+            db, 'org', 'pid'
+        )
+        self.assertEqual([f.label for f in result], ['Org'])
+
+    async def test_empty_when_neither_configured(self) -> None:
+        db = self._db(org_formats=None, pt_formats=[])
+        result = await project_deployments._resolve_tag_formats(
+            db, 'org', 'pid'
+        )
+        self.assertEqual(result, [])
+
+    async def test_unions_multiple_project_types(self) -> None:
+        db = self._db(
+            org_formats=[{'label': 'Org', 'pattern': 'a'}],
+            pt_formats=[
+                [{'label': 'A', 'pattern': 'a'}],
+                [{'label': 'B', 'pattern': 'b'}],
+            ],
+        )
+        result = await project_deployments._resolve_tag_formats(
+            db, 'org', 'pid'
+        )
+        self.assertEqual({f.label for f in result}, {'A', 'B'})
+
+    async def test_lookup_failure_returns_empty(self) -> None:
+        db = mock.AsyncMock(spec=graph.Graph)
+        db.execute = mock.AsyncMock(side_effect=RuntimeError('boom'))
+        result = await project_deployments._resolve_tag_formats(
+            db, 'org', 'pid'
+        )
+        self.assertEqual(result, [])
+
+    async def test_skips_malformed_stored_format(self) -> None:
+        db = self._db(
+            org_formats=None,
+            pt_formats=[[{'label': 'Good', 'pattern': 'a'}, {'oops': 1}]],
+        )
+        result = await project_deployments._resolve_tag_formats(
+            db, 'org', 'pid'
+        )
+        self.assertEqual([f.label for f in result], ['Good'])

--- a/tests/endpoints/test_project_types.py
+++ b/tests/endpoints/test_project_types.py
@@ -101,6 +101,62 @@ class ProjectTypeEndpointsTestCase(support.SharedAppTestCase):
             0,
         )
 
+    def test_create_project_type_with_tag_formats(self) -> None:
+        """tag_formats round-trips into the CREATE props/params."""
+        formats = [{'label': 'CalVer', 'pattern': r'\d{4}\.\d{2}\.\d+'}]
+        self.mock_db.execute.return_value = [
+            {
+                'pt': {
+                    'name': 'API Service',
+                    'slug': 'api-service',
+                    'tag_formats': formats,
+                },
+                'o': {'name': 'Engineering', 'slug': 'engineering'},
+            }
+        ]
+
+        with (
+            mock.patch(
+                'imbi_common.blueprints.get_model',
+            ) as mock_get_model,
+            mock.patch(
+                'imbi_common.graph.parse_agtype',
+                side_effect=lambda x: x,
+            ),
+        ):
+            mock_get_model.return_value = models.ProjectType
+
+            response = self.client.post(
+                '/organizations/engineering/project-types/',
+                json={
+                    'name': 'API Service',
+                    'slug': 'api-service',
+                    'tag_formats': formats,
+                },
+            )
+
+        self.assertEqual(response.status_code, 201)
+        params = self.mock_db.execute.call_args.args[1]
+        self.assertEqual(params['tag_formats'], formats)
+
+    def test_create_project_type_rejects_invalid_tag_format(self) -> None:
+        """An uncompilable tag-format pattern is rejected with 400."""
+        with mock.patch(
+            'imbi_common.blueprints.get_model',
+        ) as mock_get_model:
+            mock_get_model.return_value = models.ProjectType
+
+            response = self.client.post(
+                '/organizations/engineering/project-types/',
+                json={
+                    'name': 'API Service',
+                    'slug': 'api-service',
+                    'tag_formats': [{'label': 'Bad', 'pattern': '('}],
+                },
+            )
+
+        self.assertEqual(response.status_code, 400)
+
     def test_create_project_type_org_not_found_in_url(self) -> None:
         """Test creating project type with nonexistent org in URL."""
         self.mock_db.execute.return_value = []

--- a/uv.lock
+++ b/uv.lock
@@ -1103,7 +1103,7 @@ requires-dist = [
     { name = "fastapi" },
     { name = "filetype" },
     { name = "httpx", specifier = ">=0.28.1,<1" },
-    { name = "imbi-common", extras = ["databases", "llm", "sentry", "server"], specifier = "==2.11.5" },
+    { name = "imbi-common", extras = ["databases", "llm", "sentry", "server"], git = "https://github.com/AWeber-Imbi/imbi-common.git?branch=main" },
     { name = "imbi-plugin-aws", marker = "extra == 'plugins'", specifier = ">=2.1.0" },
     { name = "imbi-plugin-github", marker = "extra == 'plugins'", specifier = ">=2.1.0" },
     { name = "imbi-plugin-logzio", marker = "extra == 'plugins'", specifier = ">=2.1.0" },
@@ -1158,7 +1158,7 @@ docs = [
 [[package]]
 name = "imbi-common"
 version = "2.11.5"
-source = { registry = "https://pypi.org/simple" }
+source = { git = "https://github.com/AWeber-Imbi/imbi-common.git?branch=main#e659b3bf75c71af23a6a5b2c162e69c75a6c0e38" }
 dependencies = [
     { name = "cryptography" },
     { name = "httpx" },
@@ -1172,10 +1172,6 @@ dependencies = [
     { name = "pyjwt" },
     { name = "python-slugify" },
     { name = "typer" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/8a/46/bdf7e04755239b46f003327d7474ca93083c2b083591929f8fb3b15a1ab6/imbi_common-2.11.5.tar.gz", hash = "sha256:09b453fefe9916cfb7292a0e43a2997b6aeec2663478e217841c79d114415582", size = 349523, upload-time = "2026-06-12T18:03:17.891Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/36/cf/e449133065933322bb8c7970f2905e66cb7680d6bd322f76caa816511979/imbi_common-2.11.5-py3-none-any.whl", hash = "sha256:df895c9698bd00ead82dc457cddcfb71bbf12872b04e87420e663f4e16955fba", size = 113174, upload-time = "2026-06-12T18:03:16.341Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

Enforces the configurable tag-format policies (introduced in imbi-common) on the release/deploy paths, replacing the hard-coded semver check.

## Changes

- **`_resolve_tag_formats(db, org_slug, project_id)`** in `endpoints/project_deployments.py` — resolves the effective formats via the org→project-type cascade (project-type formats, unioned across the project's types, override the org's; else fall back to the org).
- **Promote gate** and **cut-release gate** now validate `body.tag` with `versioning.matches_tag_formats(...)`, returning `400` on no match. The promote path keeps its existing git-SHA/commitish allowance.
- **`_persist_organization`** SET clauses now persist `n.tag_formats`. Project-type `tag_formats` flow automatically through the generic `set_clause`/`props_template`.

## Dependency

Requires the imbi-common changes (`TagFormat`, `tag_formats`, `matches_tag_formats`, `SEMVER_TAG_PATTERN`). **Lockstep:** imbi-common must be released to PyPI before this can drop the editable install. Currently developed against an editable imbi-common.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
