### PR TITLE
Add condition scoring support and relationship cascade

### DIFF
--- a/src/imbi_api/domain/scoring.py
+++ b/src/imbi_api/domain/scoring.py
@@ -10,6 +10,8 @@ from imbi_common.scoring import (
     AnalysisResultPolicy,
     AttributeContribution,
     AttributePolicy,
+    Condition,
+    ConditionPolicy,
     LinkPresencePolicy,
     PolicyContribution,
     PresencePolicy,
@@ -22,6 +24,8 @@ __all__ = [
     'AnalysisResultPolicy',
     'AttributeContribution',
     'AttributePolicy',
+    'Condition',
+    'ConditionPolicy',
     'GlobalScoreEvent',
     'LinkPresencePolicy',
     'MonthlyImprovementRow',
@@ -64,6 +68,7 @@ class PolicyCreate(pydantic.BaseModel):
         'age',
         'analysis_result',
         'deployment_status',
+        'condition',
     ] = 'attribute'
     weight: int = pydantic.Field(ge=0, le=100)
     enabled: bool = True
@@ -79,6 +84,9 @@ class PolicyCreate(pydantic.BaseModel):
     range_score_map: dict[str, int] | None = None
     age_score_map: dict[str, int] | None = None
     status_score_map: dict[str, int] | None = None
+    condition: Condition | None = None
+    true_score: int | None = pydantic.Field(default=None, ge=0, le=100)
+    false_score: int | None = pydantic.Field(default=None, ge=0, le=100)
 
 
 class PolicyUpdate(pydantic.BaseModel):
@@ -99,6 +107,9 @@ class PolicyUpdate(pydantic.BaseModel):
     range_score_map: dict[str, int] | None = None
     age_score_map: dict[str, int] | None = None
     status_score_map: dict[str, int] | None = None
+    condition: Condition | None = None
+    true_score: int | None = pydantic.Field(default=None, ge=0, le=100)
+    false_score: int | None = pydantic.Field(default=None, ge=0, le=100)
     present_score: int | None = pydantic.Field(default=None, ge=0, le=100)
     missing_score: int | None = pydantic.Field(default=None, ge=0, le=100)
     targets: list[str] | None = None

--- a/src/imbi_api/endpoints/projects.py
+++ b/src/imbi_api/endpoints/projects.py
@@ -2309,9 +2309,10 @@ async def create_project_relationship(
     # The source project gained a dependency, which can change a
     # condition-policy score that reads its neighbours. No-op unless a
     # condition policy exists.
-    await score_queue.enqueue_recompute(
-        valkey_client, project_id, 'dependency_change'
-    )
+    if await score_queue.condition_policies_exist(db):
+        await score_queue.enqueue_recompute(
+            valkey_client, project_id, 'dependency_change'
+        )
 
 
 @projects_router.delete(
@@ -2367,9 +2368,10 @@ async def delete_project_relationship(
     # The source project lost a dependency; re-score it so a condition
     # policy reading its neighbours reflects the change. No-op unless a
     # condition policy exists.
-    await score_queue.enqueue_recompute(
-        valkey_client, project_id, 'dependency_change'
-    )
+    if await score_queue.condition_policies_exist(db):
+        await score_queue.enqueue_recompute(
+            valkey_client, project_id, 'dependency_change'
+        )
 
 
 async def _validate_update_refs(

--- a/src/imbi_api/endpoints/projects.py
+++ b/src/imbi_api/endpoints/projects.py
@@ -2258,6 +2258,7 @@ async def create_project_relationship(
     project_id: str,
     target_id: str,
     db: graph.Pool,
+    valkey_client: OptionalValkeyClient,
     auth: typing.Annotated[
         permissions.AuthContext,
         fastapi.Depends(
@@ -2305,6 +2306,12 @@ async def create_project_relationship(
                 f'Project {project_id!r} or target {target_id!r} not found'
             ),
         )
+    # The source project gained a dependency, which can change a
+    # condition-policy score that reads its neighbours. No-op unless a
+    # condition policy exists.
+    await score_queue.enqueue_recompute(
+        valkey_client, project_id, 'dependency_change'
+    )
 
 
 @projects_router.delete(
@@ -2316,6 +2323,7 @@ async def delete_project_relationship(
     project_id: str,
     target_id: str,
     db: graph.Pool,
+    valkey_client: OptionalValkeyClient,
     auth: typing.Annotated[
         permissions.AuthContext,
         fastapi.Depends(
@@ -2356,6 +2364,12 @@ async def delete_project_relationship(
                 f'Relationship from {project_id!r} to {target_id!r} not found'
             ),
         )
+    # The source project lost a dependency; re-score it so a condition
+    # policy reading its neighbours reflects the change. No-op unless a
+    # condition policy exists.
+    await score_queue.enqueue_recompute(
+        valkey_client, project_id, 'dependency_change'
+    )
 
 
 async def _validate_update_refs(
@@ -2834,6 +2848,10 @@ async def patch_project(
     await score_queue.enqueue_recompute(
         valkey_client, project_id, 'attribute_change'
     )
+    # A changed attribute (e.g. ``deprecated``) can flip a condition
+    # policy on any project that depends on this one, so re-score the
+    # one-hop dependents too. No-op unless a condition policy exists.
+    await score_queue.enqueue_dependents(valkey_client, db, project_id)
     # H13: ClickHouse insert is non-critical for the response, so move
     # it off the hot path. The graph write already succeeded; the
     # events row exists to feed the activity log and can lag by

--- a/src/imbi_api/endpoints/scoring_policies.py
+++ b/src/imbi_api/endpoints/scoring_policies.py
@@ -32,6 +32,7 @@ PolicyType = (
     | scoring_common.AgePolicy
     | scoring_common.AnalysisResultPolicy
     | scoring_common.DeploymentStatusPolicy
+    | scoring_common.ConditionPolicy
 )
 
 
@@ -41,6 +42,7 @@ _JSON_PROPS_KEYS = (
     'range_score_map',
     'age_score_map',
     'status_score_map',
+    'condition',
 )
 
 
@@ -66,6 +68,9 @@ _NODE_PROPERTY_KEYS: frozenset[str] = frozenset(
         'range_score_map',
         'age_score_map',
         'status_score_map',
+        'condition',
+        'true_score',
+        'false_score',
     }
 )
 
@@ -82,7 +87,7 @@ def _parse_node(raw: dict[str, typing.Any]) -> dict[str, typing.Any]:
         if isinstance(val, str):
             try:
                 out[key] = json.loads(val)
-            except (TypeError, ValueError):
+            except TypeError, ValueError:
                 out[key] = None
     return out
 

--- a/src/imbi_api/scoring/queue.py
+++ b/src/imbi_api/scoring/queue.py
@@ -18,6 +18,7 @@ from imbi_common.scoring import (
     AgePolicy,
     AnalysisResultPolicy,
     AttributePolicy,
+    ConditionPolicy,
     DeploymentStatusPolicy,
     LinkPresencePolicy,
     PresencePolicy,
@@ -34,6 +35,7 @@ Policy = (
     | AgePolicy
     | AnalysisResultPolicy
     | DeploymentStatusPolicy
+    | ConditionPolicy
 )
 
 STREAM = 'imbi:score-recompute'
@@ -57,6 +59,7 @@ ChangeReason = typing.Literal[
     'bulk_rescore',
     'scheduled_recompute',
     'deployment_status_change',
+    'dependency_change',
 ]
 
 
@@ -166,14 +169,20 @@ async def affected_projects(
 
     For attribute/presence/age policies, ``policy.attribute_name`` must
     exist on the blueprint-extended Project model. For link_presence,
-    analysis_result, and deployment_status policies, no attribute check
-    is required — they key off project links / analysis-report results
-    / deployment edges instead. In all cases, the result is intersected
-    with the policy's TARGETS edges when set.
+    analysis_result, deployment_status, and condition policies, no
+    attribute check is required — they key off project links /
+    analysis-report results / deployment edges / dependency relationships
+    instead. In all cases, the result is intersected with the policy's
+    TARGETS edges when set.
     """
     if not isinstance(
         policy,
-        (LinkPresencePolicy, AnalysisResultPolicy, DeploymentStatusPolicy),
+        (
+            LinkPresencePolicy,
+            AnalysisResultPolicy,
+            DeploymentStatusPolicy,
+            ConditionPolicy,
+        ),
     ):
         extended = await blueprints.get_model(db, models.Project)
         if policy.attribute_name not in extended.model_fields:
@@ -213,6 +222,61 @@ async def all_project_ids(
         return await projects_of_type(db, project_type_slug)
     rows = await db.execute('MATCH (p:Project) RETURN p.id AS id', {}, ['id'])
     return [v for r in rows if (v := graph.parse_agtype(r['id']))]
+
+
+_CONDITION_POLICY_EXISTS_QUERY: typing.LiteralString = (
+    "MATCH (p:ScoringPolicy {{enabled: true, category: 'condition'}})"
+    ' RETURN p.id AS id LIMIT 1'
+)
+
+_DEPENDENTS_QUERY: typing.LiteralString = (
+    'MATCH (b:Project)-[:DEPENDS_ON]->(:Project {{id: {project_id}}})'
+    ' RETURN b.id AS id'
+)
+
+
+async def condition_policies_exist(db: graph.Graph) -> bool:
+    """Whether any enabled ``condition`` scoring policy is defined.
+
+    Guards the dependent-cascade fan-out: relationship-aware scoring only
+    matters when a condition policy exists, so the dependents query is
+    skipped entirely otherwise.
+    """
+    rows = await db.execute(_CONDITION_POLICY_EXISTS_QUERY, {}, ['id'])
+    return bool(rows)
+
+
+async def dependent_project_ids(db: graph.Graph, project_id: str) -> list[str]:
+    """Ids of projects with an outgoing ``DEPENDS_ON`` edge to *project_id*.
+
+    These are the projects whose condition-policy scores can change when
+    *project_id*'s attributes change (one hop — a relationship leaf reads
+    the neighbour's attribute, not its score, so there is no transitive
+    cascade).
+    """
+    rows = await db.execute(
+        _DEPENDENTS_QUERY, {'project_id': project_id}, ['id']
+    )
+    return [v for r in rows if (v := graph.parse_agtype(r['id']))]
+
+
+async def enqueue_dependents(
+    client: valkey.Valkey | None,
+    db: graph.Graph,
+    project_id: str,
+    reason: ChangeReason = 'dependency_change',
+) -> int:
+    """Enqueue re-score for projects that depend on *project_id*.
+
+    No-op (returns 0) when no enabled condition policy exists, so the
+    fan-out query is only paid for when relationship scoring is in use.
+    """
+    if client is None:
+        return 0
+    if not await condition_policies_exist(db):
+        return 0
+    dependents = await dependent_project_ids(db, project_id)
+    return await enqueue_recompute_bulk(client, dependents, reason)
 
 
 async def _process_message(

--- a/tests/endpoints/test_projects.py
+++ b/tests/endpoints/test_projects.py
@@ -2122,9 +2122,16 @@ class CreateProjectRelationshipTestCase(_RelationshipsTestBase):
         """Creates a DEPENDS_ON edge and returns 204."""
         self.mock_db.execute.return_value = [{'source_id': PROJECT_ID}]
 
-        with mock.patch(
-            'imbi_common.graph.parse_agtype',
-            side_effect=lambda x: x,
+        with (
+            mock.patch(
+                'imbi_common.graph.parse_agtype',
+                side_effect=lambda x: x,
+            ),
+            mock.patch(
+                'imbi_api.endpoints.projects.score_queue'
+                '.condition_policies_exist',
+                mock.AsyncMock(return_value=False),
+            ),
         ):
             response = self.client.post(self._target_url('target1'))
 
@@ -2138,9 +2145,16 @@ class CreateProjectRelationshipTestCase(_RelationshipsTestBase):
         """MERGE makes repeated calls safe; still returns 204."""
         self.mock_db.execute.return_value = [{'source_id': PROJECT_ID}]
 
-        with mock.patch(
-            'imbi_common.graph.parse_agtype',
-            side_effect=lambda x: x,
+        with (
+            mock.patch(
+                'imbi_common.graph.parse_agtype',
+                side_effect=lambda x: x,
+            ),
+            mock.patch(
+                'imbi_api.endpoints.projects.score_queue'
+                '.condition_policies_exist',
+                mock.AsyncMock(return_value=False),
+            ),
         ):
             first = self.client.post(self._target_url('target1'))
             second = self.client.post(self._target_url('target1'))
@@ -2203,6 +2217,11 @@ class CreateProjectRelationshipTestCase(_RelationshipsTestBase):
                 side_effect=lambda x: x,
             ),
             mock.patch(
+                'imbi_api.endpoints.projects.score_queue'
+                '.condition_policies_exist',
+                mock.AsyncMock(return_value=True),
+            ),
+            mock.patch(
                 'imbi_api.endpoints.projects.score_queue.enqueue_recompute',
                 mock.AsyncMock(return_value=True),
             ) as enqueue,
@@ -2213,6 +2232,30 @@ class CreateProjectRelationshipTestCase(_RelationshipsTestBase):
         enqueue.assert_awaited_once()
         self.assertEqual(enqueue.await_args.args[1], PROJECT_ID)
         self.assertEqual(enqueue.await_args.args[2], 'dependency_change')
+
+    def test_create_skips_recompute_without_condition_policy(self) -> None:
+        """No re-score is enqueued when no condition policy exists."""
+        self.mock_db.execute.return_value = [{'source_id': PROJECT_ID}]
+
+        with (
+            mock.patch(
+                'imbi_common.graph.parse_agtype',
+                side_effect=lambda x: x,
+            ),
+            mock.patch(
+                'imbi_api.endpoints.projects.score_queue'
+                '.condition_policies_exist',
+                mock.AsyncMock(return_value=False),
+            ),
+            mock.patch(
+                'imbi_api.endpoints.projects.score_queue.enqueue_recompute',
+                mock.AsyncMock(return_value=True),
+            ) as enqueue,
+        ):
+            response = self.client.post(self._target_url('target1'))
+
+        self.assertEqual(response.status_code, 204)
+        enqueue.assert_not_awaited()
 
 
 class DeleteProjectRelationshipTestCase(_RelationshipsTestBase):
@@ -2230,9 +2273,16 @@ class DeleteProjectRelationshipTestCase(_RelationshipsTestBase):
         """Removes a DEPENDS_ON edge and returns 204."""
         self.mock_db.execute.return_value = [{'source_id': PROJECT_ID}]
 
-        with mock.patch(
-            'imbi_common.graph.parse_agtype',
-            side_effect=lambda x: x,
+        with (
+            mock.patch(
+                'imbi_common.graph.parse_agtype',
+                side_effect=lambda x: x,
+            ),
+            mock.patch(
+                'imbi_api.endpoints.projects.score_queue'
+                '.condition_policies_exist',
+                mock.AsyncMock(return_value=False),
+            ),
         ):
             response = self.client.delete(self._target_url('target1'))
 
@@ -2251,6 +2301,11 @@ class DeleteProjectRelationshipTestCase(_RelationshipsTestBase):
                 side_effect=lambda x: x,
             ),
             mock.patch(
+                'imbi_api.endpoints.projects.score_queue'
+                '.condition_policies_exist',
+                mock.AsyncMock(return_value=True),
+            ),
+            mock.patch(
                 'imbi_api.endpoints.projects.score_queue.enqueue_recompute',
                 mock.AsyncMock(return_value=True),
             ) as enqueue,
@@ -2261,6 +2316,30 @@ class DeleteProjectRelationshipTestCase(_RelationshipsTestBase):
         enqueue.assert_awaited_once()
         self.assertEqual(enqueue.await_args.args[1], PROJECT_ID)
         self.assertEqual(enqueue.await_args.args[2], 'dependency_change')
+
+    def test_delete_skips_recompute_without_condition_policy(self) -> None:
+        """No re-score is enqueued when no condition policy exists."""
+        self.mock_db.execute.return_value = [{'source_id': PROJECT_ID}]
+
+        with (
+            mock.patch(
+                'imbi_common.graph.parse_agtype',
+                side_effect=lambda x: x,
+            ),
+            mock.patch(
+                'imbi_api.endpoints.projects.score_queue'
+                '.condition_policies_exist',
+                mock.AsyncMock(return_value=False),
+            ),
+            mock.patch(
+                'imbi_api.endpoints.projects.score_queue.enqueue_recompute',
+                mock.AsyncMock(return_value=True),
+            ) as enqueue,
+        ):
+            response = self.client.delete(self._target_url('target1'))
+
+        self.assertEqual(response.status_code, 204)
+        enqueue.assert_not_awaited()
 
     def test_edge_missing(self) -> None:
         """Returns 404 when the edge does not exist."""

--- a/tests/endpoints/test_projects.py
+++ b/tests/endpoints/test_projects.py
@@ -622,6 +622,43 @@ class ProjectEndpointsTestCase(support.SharedAppTestCase):
         self.assertEqual(data['name'], 'New Name')
         self.assertIn('relationships', data)
 
+    def test_patch_project_enqueues_dependents(self) -> None:
+        """A patched attribute re-scores the project's dependents."""
+        existing = self._project_data()
+        updated = self._project_data(name='New Name')
+
+        self.mock_db.execute.side_effect = [
+            [{'project': existing, 'outbound_count': 0, 'inbound_count': 0}],
+            [{'slug': 'platform'}],
+            [{'pt_slug': 'api-service', 'found': True}],
+            [{'project': updated, 'outbound_count': 0, 'inbound_count': 0}],
+        ]
+
+        with (
+            mock.patch(
+                'imbi_common.blueprints.get_model',
+            ) as mock_get_model,
+            mock.patch(
+                'imbi_common.graph.parse_agtype',
+                side_effect=lambda x: x,
+            ),
+            mock.patch(
+                'imbi_api.endpoints.projects.score_queue.enqueue_dependents',
+                mock.AsyncMock(return_value=0),
+            ) as enqueue_dependents,
+        ):
+            mock_get_model.return_value = models.Project
+            response = self.client.patch(
+                f'/organizations/engineering/projects/{PROJECT_ID}',
+                json=[
+                    {'op': 'replace', 'path': '/name', 'value': 'New Name'},
+                ],
+            )
+
+        self.assertEqual(response.status_code, 200)
+        enqueue_dependents.assert_awaited_once()
+        self.assertEqual(enqueue_dependents.await_args.args[2], PROJECT_ID)
+
     def test_patch_project_not_found(self) -> None:
         """Test patching non-existent project returns 404."""
         self.mock_db.execute.return_value = []
@@ -2156,6 +2193,27 @@ class CreateProjectRelationshipTestCase(_RelationshipsTestBase):
         self.assertIn('itself', response.json()['detail'])
         self.mock_db.execute.assert_not_called()
 
+    def test_create_enqueues_source_recompute(self) -> None:
+        """Adding a dependency re-scores the source project."""
+        self.mock_db.execute.return_value = [{'source_id': PROJECT_ID}]
+
+        with (
+            mock.patch(
+                'imbi_common.graph.parse_agtype',
+                side_effect=lambda x: x,
+            ),
+            mock.patch(
+                'imbi_api.endpoints.projects.score_queue.enqueue_recompute',
+                mock.AsyncMock(return_value=True),
+            ) as enqueue,
+        ):
+            response = self.client.post(self._target_url('target1'))
+
+        self.assertEqual(response.status_code, 204)
+        enqueue.assert_awaited_once()
+        self.assertEqual(enqueue.await_args.args[1], PROJECT_ID)
+        self.assertEqual(enqueue.await_args.args[2], 'dependency_change')
+
 
 class DeleteProjectRelationshipTestCase(_RelationshipsTestBase):
     """Tests for DELETE /projects/{id}/relationships/{target_id}."""
@@ -2182,6 +2240,27 @@ class DeleteProjectRelationshipTestCase(_RelationshipsTestBase):
         query = self.mock_db.execute.call_args.args[0]
         self.assertIn('DELETE r', query)
         self.assertIn('DEPENDS_ON', query)
+
+    def test_delete_enqueues_source_recompute(self) -> None:
+        """Removing a dependency re-scores the source project."""
+        self.mock_db.execute.return_value = [{'source_id': PROJECT_ID}]
+
+        with (
+            mock.patch(
+                'imbi_common.graph.parse_agtype',
+                side_effect=lambda x: x,
+            ),
+            mock.patch(
+                'imbi_api.endpoints.projects.score_queue.enqueue_recompute',
+                mock.AsyncMock(return_value=True),
+            ) as enqueue,
+        ):
+            response = self.client.delete(self._target_url('target1'))
+
+        self.assertEqual(response.status_code, 204)
+        enqueue.assert_awaited_once()
+        self.assertEqual(enqueue.await_args.args[1], PROJECT_ID)
+        self.assertEqual(enqueue.await_args.args[2], 'dependency_change')
 
     def test_edge_missing(self) -> None:
         """Returns 404 when the edge does not exist."""

--- a/tests/endpoints/test_scoring_policies.py
+++ b/tests/endpoints/test_scoring_policies.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import datetime
+import json
 import typing
 from unittest import mock
 
@@ -147,6 +148,96 @@ class ScoringPolicyEndpointsTestCase(support.SharedAppTestCase):
         self.assertEqual(data['category'], 'deployment_status')
         self.assertEqual(data['environment_slug'], 'production')
         self.assertEqual(data['status_score_map']['failed'], 0)
+
+    def test_create_condition_policy(self) -> None:
+        condition = {
+            'relationship': {
+                'edge': 'DEPENDS_ON',
+                'direction': 'outgoing',
+                'quantifier': 'none',
+                'where': {
+                    'attribute': 'deprecated',
+                    'op': 'eq',
+                    'value': True,
+                },
+            }
+        }
+        # AGE stores the tree as a JSON string; the reload path parses it.
+        props = {
+            'id': 'c1id',
+            'name': 'No Deprecated Dependencies',
+            'slug': 'no-deprecated-dependencies',
+            'category': 'condition',
+            'weight': 15,
+            'enabled': True,
+            'priority': 0,
+            'description': None,
+            'true_score': 100,
+            'false_score': 0,
+            'condition': json.dumps(condition),
+        }
+        self.mock_db.execute = mock.AsyncMock(
+            side_effect=[
+                [{'sp': props}],
+                [{'sp': props, 'targets': []}],
+                [],
+            ]
+        )
+        with mock.patch(
+            'imbi_api.endpoints.scoring_policies.score_queue.'
+            'affected_projects',
+            mock.AsyncMock(return_value=['p1']),
+        ):
+            response = self.client.post(
+                '/scoring/policies/',
+                json={
+                    'name': 'No Deprecated Dependencies',
+                    'slug': 'no-deprecated-dependencies',
+                    'category': 'condition',
+                    'weight': 15,
+                    'false_score': 0,
+                    'condition': condition,
+                },
+            )
+        self.assertEqual(response.status_code, 201, response.text)
+        data = response.json()
+        self.assertEqual(data['category'], 'condition')
+        self.assertEqual(
+            data['condition']['relationship']['quantifier'], 'none'
+        )
+        self.assertEqual(
+            data['condition']['relationship']['where']['attribute'],
+            'deprecated',
+        )
+
+    def test_create_condition_policy_rejects_nested_relationship(self) -> None:
+        # The one-hop rule is enforced by the ConditionPolicy validator;
+        # the endpoint surfaces it as a 400.
+        self.mock_db.execute = mock.AsyncMock(return_value=[])
+        response = self.client.post(
+            '/scoring/policies/',
+            json={
+                'name': 'Bad',
+                'slug': 'bad',
+                'category': 'condition',
+                'weight': 10,
+                'condition': {
+                    'relationship': {
+                        'quantifier': 'any',
+                        'where': {
+                            'relationship': {
+                                'quantifier': 'any',
+                                'where': {
+                                    'attribute': 'deprecated',
+                                    'op': 'present',
+                                },
+                            }
+                        },
+                    }
+                },
+            },
+        )
+        self.assertEqual(response.status_code, 400, response.text)
 
     def test_get_policy_not_found(self) -> None:
         self.mock_db.execute = mock.AsyncMock(return_value=[])

--- a/tests/test_scoring_queue.py
+++ b/tests/test_scoring_queue.py
@@ -513,6 +513,88 @@ class AffectedProjectsTests(unittest.IsolatedAsyncioTestCase):
             result = await score_queue.affected_projects(db, policy)
         self.assertEqual(['p1'], result)
 
+    async def test_condition_skips_attribute_check(self) -> None:
+        from imbi_common.scoring import models as sm
+
+        policy = sm.ConditionPolicy.model_validate(
+            {
+                'name': 'no-deprecated-deps',
+                'slug': 'no-deprecated-deps',
+                'weight': 10,
+                'condition': {
+                    'relationship': {
+                        'quantifier': 'none',
+                        'where': {
+                            'attribute': 'deprecated',
+                            'op': 'eq',
+                            'value': True,
+                        },
+                    }
+                },
+            }
+        )
+        db = mock.AsyncMock()
+        db.execute = mock.AsyncMock(return_value=[{'id': 'p1'}])
+        with mock.patch(
+            'imbi_api.scoring.queue.blueprints.get_model',
+            mock.AsyncMock(side_effect=AssertionError('should not be called')),
+        ):
+            result = await score_queue.affected_projects(db, policy)
+        self.assertEqual(['p1'], result)
+
+
+class DependentCascadeTests(unittest.IsolatedAsyncioTestCase):
+    async def test_condition_policies_exist_true(self) -> None:
+        db = mock.AsyncMock()
+        db.execute = mock.AsyncMock(return_value=[{'id': 'sp1'}])
+        self.assertTrue(await score_queue.condition_policies_exist(db))
+
+    async def test_condition_policies_exist_false(self) -> None:
+        db = mock.AsyncMock()
+        db.execute = mock.AsyncMock(return_value=[])
+        self.assertFalse(await score_queue.condition_policies_exist(db))
+
+    async def test_dependent_project_ids(self) -> None:
+        db = mock.AsyncMock()
+        db.execute = mock.AsyncMock(return_value=[{'id': 'b1'}, {'id': 'c2'}])
+        result = await score_queue.dependent_project_ids(db, 'a0')
+        self.assertEqual(['b1', 'c2'], result)
+
+    async def test_enqueue_dependents_none_client(self) -> None:
+        db = mock.AsyncMock()
+        result = await score_queue.enqueue_dependents(None, db, 'a0')
+        self.assertEqual(0, result)
+        db.execute.assert_not_called()
+
+    async def test_enqueue_dependents_skips_when_no_condition_policy(
+        self,
+    ) -> None:
+        client = mock.AsyncMock()
+        db = mock.AsyncMock()
+        db.execute = mock.AsyncMock(return_value=[])  # no condition policies
+        result = await score_queue.enqueue_dependents(client, db, 'a0')
+        self.assertEqual(0, result)
+        # Only the existence check ran; no dependents query.
+        self.assertEqual(1, db.execute.call_count)
+
+    async def test_enqueue_dependents_enqueues_dependents(self) -> None:
+        client = mock.AsyncMock()
+        db = mock.AsyncMock()
+        # 1st execute: condition policy exists; 2nd: dependents.
+        db.execute = mock.AsyncMock(
+            side_effect=[[{'id': 'sp1'}], [{'id': 'b1'}, {'id': 'c2'}]]
+        )
+        with mock.patch.object(
+            score_queue,
+            'enqueue_recompute_bulk',
+            mock.AsyncMock(return_value=2),
+        ) as bulk:
+            result = await score_queue.enqueue_dependents(client, db, 'a0')
+        self.assertEqual(2, result)
+        bulk.assert_awaited_once_with(
+            client, ['b1', 'c2'], 'dependency_change'
+        )
+
 
 class DailyTickTests(unittest.IsolatedAsyncioTestCase):
     async def test_acquires_lock_and_enqueues_all(self) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1158,7 +1158,7 @@ docs = [
 [[package]]
 name = "imbi-common"
 version = "2.11.5"
-source = { git = "https://github.com/AWeber-Imbi/imbi-common.git?branch=main#e659b3bf75c71af23a6a5b2c162e69c75a6c0e38" }
+source = { git = "https://github.com/AWeber-Imbi/imbi-common.git?branch=main#4b3ce9584a4f949d77f012e4e8d52f81000fb9db" }
 dependencies = [
     { name = "cryptography" },
     { name = "httpx" },


### PR DESCRIPTION
## Summary
Wires condition scoring policy support into the API and adds relationship
cascade re-scoring, per the
[Relationship & Compound Scoring functional spec](../imbi/docs/relationship-compound-scoring-functional-spec.md) (§6, §7).

## Problem
With the new condition expression language in imbi-common, the API needed to
evaluate condition-based policies, expose them through the scoring-policies
endpoint, and re-score related projects when a project changes (cascade).

## Solution
- Condition-aware scoring in `scoring/queue.py` with cascade re-scoring of
  related entities.
- `domain/scoring.py` and `endpoints/scoring_policies.py` updated for the new
  policy shape; projects endpoint surfaces results.
- Relationship create/delete only enqueues a score recompute when condition
  policies exist (guarded behind `condition_policies_exist`, matching the
  existing dependents pattern).
- Adds tests for the scoring queue, scoring-policies endpoint, and projects.

Depends on AWeber-Imbi/imbi-common#176 (now merged). The branch needs a rebase
on `main` and an imbi-common lock refresh so CI resolves the new symbols.
