### PR TITLE
Match connection plugin sibling by slug, not plugin_type

### DIFF
--- a/src/imbi_api/identity/flows.py
+++ b/src/imbi_api/identity/flows.py
@@ -39,13 +39,13 @@ async def _connection_service_plugins(
     attached. The sibling is matched by ``plugin_slug`` (the node does
     not persist ``plugin_type``); see ``connection_plugin_slugs``.
     """
-    query: typing.LiteralString = """
-    MATCH (p:Plugin {{id: {plugin_id}}})<-[:HAS_PLUGIN]-
-      (:ThirdPartyService)-[:HAS_PLUGIN]->(conn:Plugin)
-    WHERE conn.plugin_slug IN {connection_slugs}
-    RETURN conn.plugin_slug AS slug, conn.options AS options
-    LIMIT 1
-    """
+    # Shares the connection-sibling MATCH/WHERE with credentials.py so the
+    # slug filter can't drift between the two lookups (see
+    # ``CONNECTION_SIBLING_MATCH``); only the RETURN differs.
+    query: typing.LiteralString = (
+        plugin_credentials.CONNECTION_SIBLING_MATCH
+        + 'RETURN conn.plugin_slug AS slug, conn.options AS options\nLIMIT 1\n'
+    )
     rows = await db.execute(
         query,
         {

--- a/src/imbi_api/identity/flows.py
+++ b/src/imbi_api/identity/flows.py
@@ -36,17 +36,23 @@ async def _connection_service_plugins(
     has no other service context, so this is the one place that lookup
     happens. Returns an empty list when the plugin is not a service-bound
     node (e.g. a bare-slug catalog lookup) or no connection plugin is
-    attached.
+    attached. The sibling is matched by ``plugin_slug`` (the node does
+    not persist ``plugin_type``); see ``connection_plugin_slugs``.
     """
     query: typing.LiteralString = """
     MATCH (p:Plugin {{id: {plugin_id}}})<-[:HAS_PLUGIN]-
       (:ThirdPartyService)-[:HAS_PLUGIN]->(conn:Plugin)
-    WHERE conn.plugin_type = 'connection'
+    WHERE conn.plugin_slug IN {connection_slugs}
     RETURN conn.plugin_slug AS slug, conn.options AS options
     LIMIT 1
     """
     rows = await db.execute(
-        query, {'plugin_id': plugin_id}, ['slug', 'options']
+        query,
+        {
+            'plugin_id': plugin_id,
+            'connection_slugs': plugin_credentials.connection_plugin_slugs(),
+        },
+        ['slug', 'options'],
     )
     if not rows or not rows[0].get('slug'):
         return []

--- a/src/imbi_api/plugins/credentials.py
+++ b/src/imbi_api/plugins/credentials.py
@@ -12,9 +12,28 @@ from imbi_common.plugins.errors import (
 )
 from imbi_common.plugins.registry import (
     RegistryEntry,
+    list_plugins,
 )
 
 LOGGER = logging.getLogger(__name__)
+
+
+def connection_plugin_slugs() -> list[str]:
+    """Return the slugs of every registered ``connection``-type plugin.
+
+    The connection sibling on a ``ThirdPartyService`` is identified by
+    its manifest ``plugin_type``, but the graph ``Plugin`` node persists
+    only ``plugin_slug`` (never ``plugin_type`` — that property lives on
+    ``USES_PLUGIN`` assignment edges, not on the node or the
+    ``HAS_PLUGIN`` edge). Callers that locate the connection sibling
+    therefore match on ``plugin_slug`` against this registry-derived set.
+    """
+    return [
+        e.manifest.slug
+        for e in list_plugins()
+        if e.manifest.plugin_type == 'connection'
+    ]
+
 
 # Bounded retries for the patch_plugin_configuration compare-and-swap
 # (M19). Each retry re-reads the committed blob and re-applies the
@@ -62,18 +81,23 @@ LIMIT 1
 # The shared connection plugin on the same ThirdPartyService holds the
 # service-account credentials when the invoked plugin carries none of
 # its own (the GitHub consolidation: deployment/lifecycle read the
-# App/PAT off the github-connection sibling).
+# App/PAT off the github-connection sibling). The sibling is matched by
+# ``plugin_slug`` (see ``connection_plugin_slugs``) because the node does
+# not persist ``plugin_type``.
 _CONNECTION_BLOB: typing.LiteralString = """
 MATCH (p:Plugin {{id: {plugin_id}}})<-[:HAS_PLUGIN]-(:ThirdPartyService)
   -[:HAS_PLUGIN]->(conn:Plugin)
-WHERE conn.plugin_type = 'connection'
+WHERE conn.plugin_slug IN {connection_slugs}
 RETURN conn.plugin_configuration AS creds
 LIMIT 1
 """
 
 
 async def _read_blob(
-    db: graph.Graph, query: typing.LiteralString, plugin_id: str
+    db: graph.Graph,
+    query: typing.LiteralString,
+    plugin_id: str,
+    extra_params: dict[str, typing.Any] | None = None,
 ) -> dict[str, typing.Any]:
     """Read + decrypt a ``plugin_configuration`` blob to a dict.
 
@@ -81,7 +105,10 @@ async def _read_blob(
     credentials" (empty dict) rather than raising, so the caller can fall
     through to the next credential source.
     """
-    records = await db.execute(query, {'plugin_id': plugin_id}, ['creds'])
+    params: dict[str, typing.Any] = {'plugin_id': plugin_id}
+    if extra_params:
+        params.update(extra_params)
+    records = await db.execute(query, params, ['creds'])
     if not records or records[0].get('creds') is None:
         return {}
     creds_raw: str | None = graph.parse_agtype(records[0]['creds'])
@@ -123,7 +150,12 @@ async def _get_plugin_configuration_credentials(
         db, _OWN_BLOB, plugin_id
     )
     if not credentials:
-        credentials = await _read_blob(db, _CONNECTION_BLOB, plugin_id)
+        credentials = await _read_blob(
+            db,
+            _CONNECTION_BLOB,
+            plugin_id,
+            {'connection_slugs': connection_plugin_slugs()},
+        )
 
     required_fields = [f for f in entry.manifest.credentials if f.required]
     # ``null`` JSON values must be treated as missing — otherwise

--- a/src/imbi_api/plugins/credentials.py
+++ b/src/imbi_api/plugins/credentials.py
@@ -78,19 +78,27 @@ RETURN p.plugin_configuration AS creds
 LIMIT 1
 """
 
-# The shared connection plugin on the same ThirdPartyService holds the
-# service-account credentials when the invoked plugin carries none of
-# its own (the GitHub consolidation: deployment/lifecycle read the
-# App/PAT off the github-connection sibling). The sibling is matched by
+# Single source for the connection-sibling traversal: locate the
+# ``connection`` plugin on the invoked plugin's ThirdPartyService by
 # ``plugin_slug`` (see ``connection_plugin_slugs``) because the node does
-# not persist ``plugin_type``.
-_CONNECTION_BLOB: typing.LiteralString = """
+# not persist ``plugin_type``. Reused by both the credential fallback
+# here (``_CONNECTION_BLOB``) and identity host resolution in
+# ``identity/flows.py``, so the filter can't drift between the two — the
+# ``plugin_type = 'connection'`` bug this replaced lived in both copies
+# and had to be patched twice. Callers append only their ``RETURN``.
+CONNECTION_SIBLING_MATCH: typing.LiteralString = """
 MATCH (p:Plugin {{id: {plugin_id}}})<-[:HAS_PLUGIN]-(:ThirdPartyService)
   -[:HAS_PLUGIN]->(conn:Plugin)
 WHERE conn.plugin_slug IN {connection_slugs}
-RETURN conn.plugin_configuration AS creds
-LIMIT 1
 """
+
+# The shared connection plugin holds the service-account credentials when
+# the invoked plugin carries none of its own (deployment/lifecycle read
+# the App/PAT off the github-connection sibling).
+_CONNECTION_BLOB: typing.LiteralString = (
+    CONNECTION_SIBLING_MATCH
+    + 'RETURN conn.plugin_configuration AS creds\nLIMIT 1\n'
+)
 
 
 async def _read_blob(

--- a/tests/identity/test_flows.py
+++ b/tests/identity/test_flows.py
@@ -154,6 +154,28 @@ class ConnectionServicePluginsTestCase(unittest.IsolatedAsyncioTestCase):
             result = await flows._connection_service_plugins(db, 'plugin-1')
         self.assertEqual([p.slug for p in result], ['github-connection'])
 
+    async def test_matches_connection_by_slug_not_plugin_type(self) -> None:
+        """Regression: locate the sibling by ``plugin_slug`` against the
+        registry-derived connection slugs.
+
+        The graph ``Plugin`` node never persists ``plugin_type`` (that
+        property lives on ``USES_PLUGIN`` assignment edges), so the old
+        ``WHERE conn.plugin_type = 'connection'`` filter matched nothing
+        and the OAuth flow 500'd resolving the GitHub host.
+        """
+        db = mock.AsyncMock()
+        db.execute.return_value = []
+        with mock.patch.object(
+            flows.plugin_credentials,
+            'connection_plugin_slugs',
+            return_value=['github-connection'],
+        ):
+            await flows._connection_service_plugins(db, 'plugin-1')
+        query, params, _cols = db.execute.await_args.args
+        self.assertIn('plugin_slug IN', query)
+        self.assertNotIn('plugin_type', query)
+        self.assertEqual(params['connection_slugs'], ['github-connection'])
+
 
 class StartFlowTestCase(unittest.IsolatedAsyncioTestCase):
     """Verify start_flow returns auth URL + state token."""

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1090,6 +1090,70 @@ class CredentialsTestCase(unittest.TestCase):
             asyncio.run(get_plugin_credentials(mock_db, 'p1', entry))
         self.assertIn('token', str(ctx.exception))
 
+    def test_connection_plugin_slugs_filters_by_type(self) -> None:
+        from imbi_api.plugins import credentials
+
+        def _entry(slug: str, plugin_type: str) -> mock.MagicMock:
+            entry = mock.MagicMock()
+            entry.manifest.slug = slug
+            entry.manifest.plugin_type = plugin_type
+            return entry
+
+        entries = [
+            _entry('github-connection', 'connection'),
+            _entry('github-identity', 'identity'),
+            _entry('ssm', 'configuration'),
+        ]
+        with mock.patch.object(
+            credentials, 'list_plugins', return_value=entries
+        ):
+            self.assertEqual(
+                credentials.connection_plugin_slugs(), ['github-connection']
+            )
+
+    def test_connection_fallback_matches_by_slug(self) -> None:
+        """Regression: when the plugin's own blob is empty, the connection
+        sibling is located by ``plugin_slug`` against the registry
+        connection slugs — not the absent node ``plugin_type``.
+
+        The old ``WHERE conn.plugin_type = 'connection'`` filter matched
+        nothing, so the doctor fell through to an anonymous GitHub
+        request and got a 401 despite a PAT on the github-connection.
+        """
+        from imbi_api.plugins import credentials
+
+        mock_db = mock.AsyncMock()
+        mock_db.execute.side_effect = [
+            [],  # the plugin's own blob is empty
+            [{'creds': '"ENCRYPTED"'}],  # connection sibling blob
+        ]
+        encryptor = mock.MagicMock()
+        encryptor.decrypt.return_value = json.dumps({'access_token': 'pat'})
+        entry = _make_registry_entry('github-doctor', required_creds=False)
+        with (
+            mock.patch.object(
+                credentials,
+                'connection_plugin_slugs',
+                return_value=['github-connection'],
+            ),
+            mock.patch(
+                'imbi_api.plugins.credentials.TokenEncryption.get_instance',
+                return_value=encryptor,
+            ),
+        ):
+            creds = asyncio.run(
+                credentials.get_plugin_credentials(mock_db, 'p1', entry)
+            )
+        self.assertEqual(creds, {'access_token': 'pat'})
+        conn_query, conn_params, _cols = mock_db.execute.await_args_list[
+            1
+        ].args
+        self.assertIn('plugin_slug IN', conn_query)
+        self.assertNotIn('plugin_type', conn_query)
+        self.assertEqual(
+            conn_params['connection_slugs'], ['github-connection']
+        )
+
     def test_decrypt_returns_dict(self) -> None:
         from imbi_api.plugins.credentials import get_plugin_credentials
 


### PR DESCRIPTION
## Summary

Locate the shared `github-connection` sibling on a `ThirdPartyService` by
`plugin_slug` (against the plugin registry) instead of by a `plugin_type`
property that service-attached `Plugin` nodes never carry. This repairs
both the Doctor's PAT fallback and the "Connect to GitHub" OAuth flow.

## Problem

Two credential/host lookups filter on a Plugin **node** property that is
never persisted:

- `plugins/credentials.py` `_CONNECTION_BLOB` — the fallback that lets an
  `api_token` plugin (doctor, deployment, lifecycle) read the App/PAT off
  the `github-connection` sibling.
- `identity/flows.py` `_connection_service_plugins` — surfaces the
  connection sibling so the identity plugin can resolve its OAuth host.

Both use `WHERE conn.plugin_type = 'connection'`. But a service-attached
`:Plugin` node is created with only `{id, plugin_slug, label, options,
api_version}` and the `HAS_PLUGIN` edge carries no properties — so
`plugin_type` lives exclusively on `USES_PLUGIN` assignment edges (renamed
from `tab` in #425), never on the node. Both queries therefore match
nothing.

Observed against a live GitHub Enterprise service:

- **Doctor → 401.** The connection blob is never found, so the GitHub
  request is sent anonymously and `api.<host>/repositories/<id>` returns
  401 — even though the `github-connection` has a valid `access_token`
  configured.
- **Connect to GitHub → 500.** `resolve_connection_host` raises
  `ValueError: no github-connection plugin is attached to the service`.

## Solution

Match the connection sibling by `plugin_slug` against the registry-derived
set of `connection`-type plugin slugs (new `connection_plugin_slugs()`
helper), which is the same approach `resolve_service_plugins` /
`resolve_analysis_plugins` already use. `plugin_slug` is stored on the
node, so no data migration or backfill is required.

Verified end-to-end against a live GHE service: the Doctor's
`canonical-url` check goes 401 → HTTP 200 (and the dependent checks pass),
and the identity start endpoint goes 500 → 200 with the correct
`https://<host>/login/oauth/authorize` URL.

Regression tests added for both lookups asserting they filter by
`plugin_slug` (and not `plugin_type`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
