### PR TITLE
Bump version to 2.11.6 and guard release tag

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -21,6 +21,18 @@ jobs:
       - name: Set up Python
         run: uv python install 3.14
 
+      - name: Verify release tag matches package version
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          version="$(uv version --short)"
+          if [ "$tag" != "$version" ]; then
+            echo "::error::Release tag '${GITHUB_REF_NAME}' does not match" \
+                 "pyproject.toml version '${version}'. Bump the version in" \
+                 "pyproject.toml (and re-lock) before tagging the release."
+            exit 1
+          fi
+          echo "Release tag '${GITHUB_REF_NAME}' matches package version '${version}'."
+
       - name: Build
         run: uv build
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,10 +164,29 @@ Coverage target: 90% (`pyproject.toml` `tool.coverage.report.fail_under`). Curre
 **GitHub Actions** (`.github/workflows/`):
 - `testing.yaml`: Lint (`just lint`) + tests (`just test`) on Python 3.14 on every push/PR to `main`. Coverage uploaded to Codecov.
 - `docs.yaml`: MkDocs build/deploy to GitHub Pages on doc changes.
-- `deploy.yaml`: On release — `uv build`, multi-platform Docker image to `ghcr.io`, provenance attestation.
+- `deploy.yaml`: On a published GitHub release — verifies the release tag matches the `pyproject.toml` version, then `uv build` and publish the sdist/wheel to PyPI (Trusted Publishing, `pypi` environment). The tag/version guard fails the publish if you forget to bump the version, so a mismatched release never reaches PyPI.
 
 ## Git Workflow
 
 - Main branch: `main`
 - Feature branches: `feature/<feature-name>`
 - All PRs target `main`
+
+## Releasing
+
+The package version is **static** — `[project].version` in `pyproject.toml` is
+the single source of truth (`uv build` reads it; the git tag does not set it).
+To cut a release:
+
+1. Bump `[project].version` in `pyproject.toml` to the new version.
+2. Re-lock so the project's own entry updates: `uv lock` (updates `uv.lock`).
+   Note: `just` recipes export `UV_FROZEN=1`, so run `uv lock` directly.
+3. Commit, open a PR, and merge to `main` once CI is green.
+4. Create a GitHub release whose tag is `v<version>` (e.g. `v2.11.6`) matching
+   the bumped `pyproject.toml` version. Publishing the release runs
+   `deploy.yaml`, which **guards** that the tag matches the package version
+   before building and publishing to PyPI.
+
+If the tag and `pyproject.toml` version disagree, the publish job fails fast
+(before uploading) — PyPI forbids reusing a filename, so an un-bumped release
+would otherwise try to re-publish the previous version and 400.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "imbi-api"
-version = "2.11.5"
+version = "2.11.6"
 description = "Imbi is a DevOps Service Management Platform designed to provide an efficient way to manage a large environment that contains many services and applications."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/uv.lock
+++ b/uv.lock
@@ -7,7 +7,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer = "2026-06-29T21:19:14.4443Z"
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
@@ -1023,7 +1023,7 @@ wheels = [
 
 [[package]]
 name = "imbi-api"
-version = "2.11.5"
+version = "2.11.6"
 source = { editable = "." }
 dependencies = [
     { name = "aioboto3" },


### PR DESCRIPTION
## Summary

The `v2.11.6` release failed to publish to PyPI, and the imbi build/release image failed to build, because of a single missed step: `pyproject.toml` was still at `version = "2.11.5"` even though its dependency pins had already moved to `imbi-common[...]==2.11.6`.

## Problem

- `uv build` reads the version from `pyproject.toml`, not the git tag, so the `v2.11.6` release built `imbi_api-2.11.5` artifacts.
- Publishing to PyPI failed with `400 File already exists (imbi_api-2.11.5-...)` — that filename was already published for the real 2.11.5 release, and PyPI never allows filename reuse.
- Downstream, the `imbi` all-in-one image build failed to resolve dependencies because the imbi-api wheel it built from source was `2.11.5` while the rest of the graph expected `2.11.6`.

## Solution

- Bump `[project].version` to `2.11.6` and re-lock (`uv.lock` imbi-api entry updated `2.11.5 → 2.11.6`).
- Add a guard step to `deploy.yaml` that fails the publish job **before build** if the release tag (`v<version>`) does not match the `pyproject.toml` version — this is what would have caught the miss.
- Document the release/version-bump process in `CLAUDE.md`, and correct the `deploy.yaml` description (it publishes a wheel to PyPI via Trusted Publishing; it was inaccurately described as pushing a Docker image to ghcr.io).

🤖 Generated with [Claude Code](https://claude.com/claude-code)