### PR TITLE
Add global maintenance operations API and worker

### DIFF
--- a/src/imbi_api/app.py
+++ b/src/imbi_api/app.py
@@ -27,6 +27,7 @@ def create_app() -> fastapi.FastAPI:
             lifespans.score_worker_hook,
             lifespans.commit_sync_worker_hook,
             lifespans.pr_sync_worker_hook,
+            lifespans.maintenance_worker_hook,
             lifespans.identity_refresh_hook,
         ),
         version=version,

--- a/src/imbi_api/auth/seed.py
+++ b/src/imbi_api/auth/seed.py
@@ -378,6 +378,19 @@ STANDARD_PERMISSIONS: list[tuple[str, str, str, str]] = [
         'plugins:manage',
         'Install and uninstall plugins',
     ),
+    # Global maintenance operations
+    (
+        'admin:maintenance:read',
+        'admin',
+        'maintenance:read',
+        'View global maintenance operations',
+    ),
+    (
+        'admin:maintenance:manage',
+        'admin',
+        'maintenance:manage',
+        'Run and cancel global maintenance operations',
+    ),
     # Project plugin access
     (
         'project:configuration:read',

--- a/src/imbi_api/endpoints/__init__.py
+++ b/src/imbi_api/endpoints/__init__.py
@@ -16,6 +16,7 @@ from .dashboard import dashboard_router
 from .events import events_router
 from .graph_query import graph_query_router
 from .local_auth import local_auth_router
+from .maintenance import maintenance_router
 from .mcp_servers import mcp_servers_router
 from .mfa import mfa_router
 from .oauth_metadata import oauth_metadata_router
@@ -46,6 +47,7 @@ prefixed_routers: list[fastapi.APIRouter] = [
     events_router,
     graph_query_router,
     local_auth_router,
+    maintenance_router,
     mcp_servers_router,
     me_identities_router,
     mfa_router,

--- a/src/imbi_api/endpoints/maintenance.py
+++ b/src/imbi_api/endpoints/maintenance.py
@@ -1,0 +1,212 @@
+"""Global maintenance operation endpoints (admin Maintenance page).
+
+The operation list is registry-driven (:mod:`imbi_api.maintenance`):
+the UI renders whatever this returns, so adding an operation to the
+registry is all that is required for a new button to appear.
+"""
+
+import datetime
+import logging
+import typing
+
+import fastapi
+import pydantic
+from imbi_common import graph
+
+from imbi_api.auth import permissions
+from imbi_api.maintenance import (
+    OPERATIONS,
+    MaintenanceSlug,
+    OperationDefinition,
+    state,
+)
+from imbi_api.scoring import OptionalValkeyClient
+
+LOGGER = logging.getLogger(__name__)
+
+maintenance_router = fastapi.APIRouter(
+    prefix='/maintenance', tags=['Admin: Maintenance']
+)
+
+RequireRead = typing.Annotated[
+    permissions.AuthContext,
+    fastapi.Depends(
+        permissions.require_permission('admin:maintenance:read'),
+    ),
+]
+RequireManage = typing.Annotated[
+    permissions.AuthContext,
+    fastapi.Depends(
+        permissions.require_permission('admin:maintenance:manage'),
+    ),
+]
+
+
+class MaintenanceProgress(pydantic.BaseModel):
+    """Counters for an operation's current or last run."""
+
+    total: int = 0
+    remaining: int = 0
+    in_flight: int = 0
+    succeeded: int = 0
+    failed: int = 0
+    skipped: int = 0
+
+
+class MaintenanceOperation(pydantic.BaseModel):
+    """One registry operation merged with its run state."""
+
+    slug: str
+    label: str
+    description: str
+    running: bool
+    state: state.RunState
+    progress: MaintenanceProgress | None = None
+    started_at: datetime.datetime | None = None
+    started_by: str | None = None
+    completed_at: datetime.datetime | None = None
+    #: Per-project failure detail; only populated on the per-operation
+    #: GET to keep the list response small.
+    failures: dict[str, str] | None = None
+
+
+class MaintenanceRunResponse(pydantic.BaseModel):
+    """Acknowledgement that a run was started."""
+
+    run_id: str
+    total: int
+
+
+def _to_operation(
+    definition: OperationDefinition,
+    status: state.RunStatus,
+    failures: dict[str, str] | None = None,
+) -> MaintenanceOperation:
+    progress: MaintenanceProgress | None = None
+    if status.state != 'idle':
+        progress = MaintenanceProgress(
+            total=status.total,
+            remaining=status.remaining,
+            in_flight=status.in_flight,
+            succeeded=status.succeeded,
+            failed=status.failed,
+            skipped=status.skipped,
+        )
+    return MaintenanceOperation(
+        slug=definition.slug,
+        label=definition.label,
+        description=definition.description,
+        running=status.state == 'running',
+        state=status.state,
+        progress=progress,
+        started_at=status.started_at,
+        started_by=status.started_by,
+        completed_at=status.completed_at,
+        failures=failures,
+    )
+
+
+def _definition_or_404(slug: str) -> OperationDefinition:
+    definition = OPERATIONS.get(typing.cast('MaintenanceSlug', slug))
+    if definition is None:
+        raise fastapi.HTTPException(
+            status_code=404, detail=f'Unknown maintenance operation {slug!r}'
+        )
+    return definition
+
+
+@maintenance_router.get('/operations')
+async def list_maintenance_operations(
+    auth: RequireRead,
+    client: OptionalValkeyClient,
+) -> list[MaintenanceOperation]:
+    """The operation registry merged with each operation's run state."""
+    _ = auth
+    results: list[MaintenanceOperation] = []
+    for definition in OPERATIONS.values():
+        status = (
+            await state.read_status(client, definition.slug)
+            if client is not None
+            else state.RunStatus()
+        )
+        results.append(_to_operation(definition, status))
+    return results
+
+
+@maintenance_router.get('/operations/{slug}')
+async def get_maintenance_operation(
+    slug: str,
+    auth: RequireRead,
+    client: OptionalValkeyClient,
+) -> MaintenanceOperation:
+    """One operation's run state, including per-project failures."""
+    _ = auth
+    definition = _definition_or_404(slug)
+    if client is None:
+        return _to_operation(definition, state.RunStatus())
+    status = await state.read_status(client, definition.slug)
+    failures = await state.read_failures(client, definition.slug)
+    return _to_operation(definition, status, failures or None)
+
+
+@maintenance_router.post('/operations/{slug}/run', status_code=202)
+async def run_maintenance_operation(
+    slug: str,
+    auth: RequireManage,
+    db: graph.Pool,
+    client: OptionalValkeyClient,
+) -> MaintenanceRunResponse:
+    """Start a global run of the operation across all projects."""
+    definition = _definition_or_404(slug)
+    if client is None:
+        raise fastapi.HTTPException(
+            status_code=503,
+            detail='Queueing is unavailable (Valkey is not connected).',
+        )
+    project_ids = await definition.enumerate(db)
+    status = await state.start_run(
+        client, definition.slug, project_ids, auth.principal_name
+    )
+    if status is None:
+        raise fastapi.HTTPException(
+            status_code=409,
+            detail=f'{definition.label} is already running.',
+        )
+    LOGGER.info(
+        'maintenance %s run %s started by %s (%d projects)',
+        definition.slug,
+        status.run_id,
+        auth.principal_name,
+        status.total,
+    )
+    return MaintenanceRunResponse(
+        run_id=status.run_id or '', total=status.total
+    )
+
+
+@maintenance_router.post('/operations/{slug}/cancel')
+async def cancel_maintenance_operation(
+    slug: str,
+    auth: RequireManage,
+    client: OptionalValkeyClient,
+) -> MaintenanceOperation:
+    """Cancel the operation's in-progress run."""
+    definition = _definition_or_404(slug)
+    if client is None:
+        raise fastapi.HTTPException(
+            status_code=503,
+            detail='Queueing is unavailable (Valkey is not connected).',
+        )
+    cancelled = await state.cancel_run(client, definition.slug)
+    if not cancelled:
+        raise fastapi.HTTPException(
+            status_code=409,
+            detail=f'{definition.label} is not running.',
+        )
+    LOGGER.info(
+        'maintenance %s run cancelled by %s',
+        definition.slug,
+        auth.principal_name,
+    )
+    status = await state.read_status(client, definition.slug)
+    return _to_operation(definition, status)

--- a/src/imbi_api/endpoints/maintenance.py
+++ b/src/imbi_api/endpoints/maintenance.py
@@ -122,13 +122,15 @@ async def list_maintenance_operations(
 ) -> list[MaintenanceOperation]:
     """The operation registry merged with each operation's run state."""
     _ = auth
+    if client is None:
+        raise fastapi.HTTPException(
+            status_code=503,
+            detail='Maintenance state is unavailable '
+            '(Valkey is not connected).',
+        )
     results: list[MaintenanceOperation] = []
     for definition in OPERATIONS.values():
-        status = (
-            await state.read_status(client, definition.slug)
-            if client is not None
-            else state.RunStatus()
-        )
+        status = await state.read_status(client, definition.slug)
         results.append(_to_operation(definition, status))
     return results
 
@@ -143,7 +145,11 @@ async def get_maintenance_operation(
     _ = auth
     definition = _definition_or_404(slug)
     if client is None:
-        return _to_operation(definition, state.RunStatus())
+        raise fastapi.HTTPException(
+            status_code=503,
+            detail='Maintenance state is unavailable '
+            '(Valkey is not connected).',
+        )
     status = await state.read_status(client, definition.slug)
     failures = await state.read_failures(client, definition.slug)
     return _to_operation(definition, status, failures or None)

--- a/src/imbi_api/endpoints/project_analysis.py
+++ b/src/imbi_api/endpoints/project_analysis.py
@@ -499,7 +499,7 @@ async def _collect_results(
     return results
 
 
-async def _run_and_persist(
+async def run_and_persist(
     db: graph.Graph,
     org_slug: str,
     project_id: str,
@@ -526,7 +526,7 @@ async def run_project_analysis(
         fastapi.Depends(permissions.require_permission('project:write')),
     ],
 ) -> AnalysisReport:
-    return await _run_and_persist(db, org_slug, project_id, auth)
+    return await run_and_persist(db, org_slug, project_id, auth)
 
 
 class RemediateRequest(pydantic.BaseModel):
@@ -659,7 +659,7 @@ async def remediate_project_finding(
     result = await _remediate_one(
         db, org_slug, project_id, body.plugin_id, body.remediation_id, auth
     )
-    report = await _run_and_persist(db, org_slug, project_id, auth)
+    report = await run_and_persist(db, org_slug, project_id, auth)
     return RemediateResponse(result=result, report=report)
 
 
@@ -728,5 +728,5 @@ async def remediate_all_project_findings(
                 result=result,
             )
         )
-    fresh = await _run_and_persist(db, org_slug, project_id, auth)
+    fresh = await run_and_persist(db, org_slug, project_id, auth)
     return RemediateAllResponse(outcomes=outcomes, report=fresh)

--- a/src/imbi_api/lifespans.py
+++ b/src/imbi_api/lifespans.py
@@ -18,6 +18,7 @@ from imbi_api.commit_sync import queue as commit_sync_queue
 from imbi_api.email.client import EmailClient
 from imbi_api.email.templates import TemplateManager
 from imbi_api.identity import sweeper as identity_sweeper
+from imbi_api.maintenance import worker as maintenance_worker
 from imbi_api.plugins import lifecycle as plugin_lifecycle
 from imbi_api.pr_sync import queue as pr_sync_queue
 from imbi_api.scoring import queue as score_queue
@@ -196,6 +197,39 @@ async def pr_sync_worker_hook() -> abc.AsyncGenerator[None]:
         except Exception:  # noqa: BLE001
             LOGGER.warning(
                 'PR-sync worker task exited with error', exc_info=True
+            )
+
+
+@contextlib.asynccontextmanager
+async def maintenance_worker_hook() -> abc.AsyncGenerator[None]:
+    """Run the global maintenance operation consumer loop."""
+    try:
+        client = valkey.get_client()
+    except RuntimeError:
+        LOGGER.warning('Valkey unavailable; maintenance worker not started')
+        yield None
+        return
+    if _graph is None:
+        LOGGER.warning('Graph not ready; maintenance worker not started')
+        yield None
+        return
+    stop = asyncio.Event()
+    LOGGER.info('Maintenance worker starting')
+    consumer_task = asyncio.create_task(
+        maintenance_worker.run_worker(client, _graph, stop=stop)
+    )
+    try:
+        yield None
+    finally:
+        stop.set()
+        consumer_task.cancel()
+        try:
+            await consumer_task
+        except asyncio.CancelledError:
+            pass
+        except Exception:  # noqa: BLE001
+            LOGGER.warning(
+                'Maintenance worker task exited with error', exc_info=True
             )
 
 

--- a/src/imbi_api/maintenance/__init__.py
+++ b/src/imbi_api/maintenance/__init__.py
@@ -1,0 +1,9 @@
+"""Global maintenance operations (admin Maintenance page)."""
+
+from imbi_api.maintenance.registry import (
+    OPERATIONS,
+    MaintenanceSlug,
+    OperationDefinition,
+)
+
+__all__ = ['OPERATIONS', 'MaintenanceSlug', 'OperationDefinition']

--- a/src/imbi_api/maintenance/operations.py
+++ b/src/imbi_api/maintenance/operations.py
@@ -1,0 +1,241 @@
+"""Per-project execute functions for global maintenance operations.
+
+Each ``execute_*`` runs one project's slice of a global run by reusing
+the same service code the per-project Doctor endpoints call.  Outcomes:
+
+- return ``'succeeded'`` / ``'skipped'`` (skipped means the operation
+  does not apply -- e.g. no integration provides the capability);
+- raise :class:`MaintenanceItemFailed` with a user-safe message for
+  recordable failures (raw detail belongs in logs only);
+- let :class:`~imbi_common.plugins.errors.PluginRateLimited` propagate
+  so the worker can requeue the project and pause the operation.
+
+Endpoint modules are imported inside function bodies (the
+``commit_sync.service`` pattern) so this module never pulls the
+endpoints package at import time.
+"""
+
+from __future__ import annotations
+
+import functools
+import logging
+import typing
+
+import fastapi
+from imbi_common import graph
+from imbi_common.plugins.errors import PluginRateLimited
+from valkey import asyncio as valkey
+
+from imbi_api import models
+from imbi_api.auth import permissions
+from imbi_api.scoring import queue as score_queue
+
+LOGGER = logging.getLogger(__name__)
+
+#: ``requested_by`` / ``principal_name`` recorded on work this runs.
+REQUESTED_BY = 'maintenance'
+
+ExecuteOutcome = typing.Literal['succeeded', 'skipped']
+
+_ORG_SLUG_QUERY: typing.LiteralString = (
+    'MATCH (p:Project {{id: {project_id}}})-[:OWNED_BY]->(:Team)'
+    '-[:BELONGS_TO]->(o:Organization) RETURN o.slug AS slug'
+)
+
+
+class MaintenanceItemFailed(Exception):
+    """One project's operation failed; the message is user-safe."""
+
+
+@functools.cache
+def _system_auth() -> permissions.AuthContext:
+    """Synthetic principal for background maintenance work.
+
+    Never persisted; exists so service functions that record
+    ``principal_name`` attribute the work to ``'maintenance'``.
+    """
+    return permissions.AuthContext(
+        auth_method='client_credentials',
+        service_account=models.ServiceAccount(
+            slug=REQUESTED_BY, display_name='Imbi Maintenance'
+        ),
+    )
+
+
+async def enumerate_all_projects(db: graph.Graph) -> list[str]:
+    """Every project id -- maintenance operations self-classify
+    inapplicable projects as skipped rather than pre-filtering (which
+    would cost a capability resolution per project up front)."""
+    return await score_queue.all_project_ids(db)
+
+
+async def _org_slug_for(db: graph.Graph, project_id: str) -> str | None:
+    rows = await db.execute(
+        _ORG_SLUG_QUERY, {'project_id': project_id}, ['slug']
+    )
+    if not rows:
+        return None
+    value = graph.parse_agtype(rows[0].get('slug'))
+    return str(value) if value else None
+
+
+async def execute_analysis(
+    db: graph.Graph, client: valkey.Valkey, project_id: str
+) -> ExecuteOutcome:
+    """Run the Doctor analysis and persist the report.
+
+    Per-plugin errors already surface as synthetic ``fail`` findings
+    inside the report, so an exception here is infrastructural.
+    """
+    from imbi_api.endpoints import project_analysis
+
+    org_slug = await _org_slug_for(db, project_id)
+    if org_slug is None:
+        return 'skipped'
+    await project_analysis.run_and_persist(
+        db, org_slug, project_id, _system_auth()
+    )
+    return 'succeeded'
+
+
+async def execute_commit_sync(
+    db: graph.Graph, client: valkey.Valkey, project_id: str
+) -> ExecuteOutcome:
+    """Full commit/tag backfill, mirroring the queue consumer's status
+    transitions so the per-project Doctor status stays truthful."""
+    from imbi_api.commit_sync import service
+
+    org_slug = await _org_slug_for(db, project_id)
+    if org_slug is None:
+        return 'skipped'
+    await service.set_status(
+        db, project_id, status='running', requested_by=REQUESTED_BY
+    )
+    try:
+        commits, tags = await service.run_sync(db, org_slug, project_id)
+    except service.CommitSyncUnavailable as exc:
+        await service.set_status(
+            db,
+            project_id,
+            status='failed',
+            requested_by=REQUESTED_BY,
+            error=str(exc),
+        )
+        return 'skipped'
+    except PluginRateLimited:
+        # Leave the project requeue-able; the worker pauses the op.
+        await service.set_status(
+            db, project_id, status='queued', requested_by=REQUESTED_BY
+        )
+        raise
+    except Exception as exc:
+        LOGGER.exception('maintenance commit-sync failed for %s', project_id)
+        message = 'Commit sync failed. See server logs for details.'
+        await service.set_status(
+            db,
+            project_id,
+            status='failed',
+            requested_by=REQUESTED_BY,
+            error=message,
+        )
+        raise MaintenanceItemFailed(message) from exc
+    await service.set_status(
+        db,
+        project_id,
+        status='success',
+        requested_by=REQUESTED_BY,
+        commits=commits,
+        tags=tags,
+    )
+    return 'succeeded'
+
+
+async def execute_pr_sync(
+    db: graph.Graph, client: valkey.Valkey, project_id: str
+) -> ExecuteOutcome:
+    """Full PR-history backfill; same shape as commit sync."""
+    from imbi_api.pr_sync import service
+
+    org_slug = await _org_slug_for(db, project_id)
+    if org_slug is None:
+        return 'skipped'
+    await service.set_status(
+        db, project_id, status='running', requested_by=REQUESTED_BY
+    )
+    try:
+        prs = await service.run_sync(db, org_slug, project_id)
+    except service.PRSyncUnavailable as exc:
+        await service.set_status(
+            db,
+            project_id,
+            status='failed',
+            requested_by=REQUESTED_BY,
+            error=str(exc),
+        )
+        return 'skipped'
+    except PluginRateLimited:
+        # Leave the project requeue-able; the worker pauses the op.
+        await service.set_status(
+            db, project_id, status='queued', requested_by=REQUESTED_BY
+        )
+        raise
+    except Exception as exc:
+        LOGGER.exception('maintenance pr-sync failed for %s', project_id)
+        message = 'PR sync failed. See server logs for details.'
+        await service.set_status(
+            db,
+            project_id,
+            status='failed',
+            requested_by=REQUESTED_BY,
+            error=message,
+        )
+        raise MaintenanceItemFailed(message) from exc
+    await service.set_status(
+        db,
+        project_id,
+        status='success',
+        requested_by=REQUESTED_BY,
+        prs=prs,
+    )
+    return 'succeeded'
+
+
+async def execute_deployment_resync(
+    db: graph.Graph, client: valkey.Valkey, project_id: str
+) -> ExecuteOutcome:
+    """Backfill recent remote deployments via the deployment plugin."""
+    from imbi_api.endpoints import project_deployments
+
+    org_slug = await _org_slug_for(db, project_id)
+    if org_slug is None:
+        return 'skipped'
+    try:
+        await project_deployments.resync_for_project(
+            db,
+            org_slug=org_slug,
+            project_id=project_id,
+            auth=_system_auth(),
+            limit=1,
+        )
+    except fastapi.HTTPException as exc:
+        # 404: no deployment capability bound; 400: the plugin doesn't
+        # support deployment sync. Neither is a failure of this run.
+        if exc.status_code in (400, 404):
+            return 'skipped'
+        raise MaintenanceItemFailed(str(exc.detail)) from exc
+    return 'succeeded'
+
+
+async def execute_rescore(
+    db: graph.Graph, client: valkey.Valkey, project_id: str
+) -> ExecuteOutcome:
+    """Enqueue a score recompute onto the existing scoring stream.
+
+    Succeeded means enqueued -- the scoring workers do the computation
+    with their own debounce/DLQ/history handling. Skipped means the
+    project was debounced (a recompute is already queued).
+    """
+    enqueued = await score_queue.enqueue_recompute(
+        client, project_id, 'bulk_rescore', REQUESTED_BY
+    )
+    return 'succeeded' if enqueued else 'skipped'

--- a/src/imbi_api/maintenance/registry.py
+++ b/src/imbi_api/maintenance/registry.py
@@ -1,0 +1,110 @@
+"""Registry of global maintenance operations.
+
+The registry is the single source of truth for what the Maintenance
+admin page offers: the ``GET /maintenance/operations`` endpoint renders
+buttons from it, and the per-instance worker iterates it looking for
+active runs. Adding an operation here is all that is required for it to
+appear in the UI.
+"""
+
+from __future__ import annotations
+
+import typing
+from collections import abc
+
+from imbi_common import graph
+from valkey import asyncio as valkey
+
+from imbi_api.commit_sync import queue as commit_sync_queue
+from imbi_api.maintenance import operations
+from imbi_api.pr_sync import queue as pr_sync_queue
+
+MaintenanceSlug = typing.Literal[
+    'run-analysis',
+    'rescore',
+    'deployment-resync',
+    'commit-sync',
+    'pr-sync',
+]
+
+
+class OperationDefinition(typing.NamedTuple):
+    """One global maintenance operation."""
+
+    slug: MaintenanceSlug
+    label: str
+    description: str
+    #: Rate-limit pause key honored before checkout, shared with the
+    #: operation's stream consumers; ``None`` when not rate-limited.
+    pause_key: str | None
+    enumerate: abc.Callable[[graph.Graph], abc.Awaitable[list[str]]]
+    execute: abc.Callable[
+        [graph.Graph, valkey.Valkey, str],
+        abc.Awaitable[operations.ExecuteOutcome],
+    ]
+
+
+OPERATIONS: dict[MaintenanceSlug, OperationDefinition] = {
+    definition.slug: definition
+    for definition in (
+        OperationDefinition(
+            slug='run-analysis',
+            label='Run Analysis',
+            description=(
+                'Run the Project Doctor analysis and persist a fresh '
+                'report for every project.'
+            ),
+            pause_key=None,
+            enumerate=operations.enumerate_all_projects,
+            execute=operations.execute_analysis,
+        ),
+        OperationDefinition(
+            slug='rescore',
+            label='Recompute Scores',
+            description=(
+                'Enqueue a score recomputation for every project; the '
+                'scoring workers process the queue. Completion means '
+                'all projects were enqueued.'
+            ),
+            pause_key=None,
+            enumerate=operations.enumerate_all_projects,
+            execute=operations.execute_rescore,
+        ),
+        OperationDefinition(
+            slug='deployment-resync',
+            label='Sync Deployments',
+            description=(
+                'Backfill recent remote deployments for every project '
+                'with a deployment integration; projects without one '
+                'are skipped.'
+            ),
+            pause_key=None,
+            enumerate=operations.enumerate_all_projects,
+            execute=operations.execute_deployment_resync,
+        ),
+        OperationDefinition(
+            slug='commit-sync',
+            label='Sync Commits & Tags',
+            description=(
+                'Backfill full commit and tag history for every '
+                'project with a commit-sync integration; projects '
+                'without one are skipped.'
+            ),
+            pause_key=commit_sync_queue.PAUSE_KEY,
+            enumerate=operations.enumerate_all_projects,
+            execute=operations.execute_commit_sync,
+        ),
+        OperationDefinition(
+            slug='pr-sync',
+            label='Sync Pull Requests',
+            description=(
+                'Backfill full pull-request history for every project '
+                'with a PR-sync integration; projects without one are '
+                'skipped.'
+            ),
+            pause_key=pr_sync_queue.PAUSE_KEY,
+            enumerate=operations.enumerate_all_projects,
+            execute=operations.execute_pr_sync,
+        ),
+    )
+}

--- a/src/imbi_api/maintenance/state.py
+++ b/src/imbi_api/maintenance/state.py
@@ -149,6 +149,7 @@ async def start_run(
         await pipe.execute()  # pyright: ignore[reportUnknownMemberType]
     if not ids:
         await maybe_finalize(client, slug)
+        return await read_status(client, slug)
     return RunStatus(
         state='running',
         run_id=run_id,

--- a/src/imbi_api/maintenance/state.py
+++ b/src/imbi_api/maintenance/state.py
@@ -1,0 +1,345 @@
+"""Valkey-backed run state for global maintenance operations.
+
+A maintenance run distributes work across every API instance through a
+Valkey SET of pending project ids: :func:`start_run` seeds the set, each
+instance's worker :func:`checkout`\\ s (``SPOP``) ids and records
+per-project outcomes on a shared run hash, and :func:`maybe_finalize`
+completes the run once the set is drained and nothing is in flight.
+There is no delivery guarantee: a hard-killed instance loses the id it
+had checked out and the run surfaces as ``abandoned`` once the lock's
+TTL lapses -- acceptable for an idempotent admin tool.
+
+Keys (all under ``imbi:maintenance:{slug}:``):
+
+- ``lock`` -- run id via ``SET NX EX``; existence means "running".
+- ``pending`` -- SET of project ids awaiting execution.
+- ``run`` -- HASH of run metadata and outcome counters.
+- ``failures`` -- HASH of ``project_id -> error`` for failed items.
+"""
+
+from __future__ import annotations
+
+import datetime
+import inspect
+import typing
+import uuid
+from collections import abc
+
+import pydantic
+from valkey import asyncio as valkey
+
+KEY_PREFIX = 'imbi:maintenance'
+#: Backstop for a run whose instances all died mid-flight; a healthy run
+#: deletes the lock at finalize.
+LOCK_TTL_SECONDS = 43_200
+PENDING_TTL_SECONDS = 86_400
+#: How long the last run's result stays visible in the registry.
+RESULT_TTL_SECONDS = 604_800
+SADD_CHUNK = 1_000
+MAX_ERROR_LEN = 500
+#: Stop recording per-project failure detail past this many entries;
+#: the ``failed`` counter keeps counting.
+MAX_FAILURE_DETAILS = 500
+
+RunState = typing.Literal[
+    'idle', 'running', 'completed', 'cancelled', 'abandoned'
+]
+Outcome = typing.Literal['succeeded', 'failed', 'skipped']
+
+
+class RunStatus(pydantic.BaseModel):
+    """Point-in-time view of an operation's current or last run."""
+
+    state: RunState = 'idle'
+    run_id: str | None = None
+    total: int = 0
+    remaining: int = 0
+    in_flight: int = 0
+    succeeded: int = 0
+    failed: int = 0
+    skipped: int = 0
+    started_at: datetime.datetime | None = None
+    started_by: str | None = None
+    completed_at: datetime.datetime | None = None
+
+
+def _key(slug: str, part: str) -> str:
+    return f'{KEY_PREFIX}:{slug}:{part}'
+
+
+async def _resolve(value: object) -> object:
+    """Resolve valkey-py's ``Awaitable[T] | T`` command return typing."""
+    if inspect.isawaitable(value):
+        return await value
+    return value
+
+
+def _now_iso() -> str:
+    return datetime.datetime.now(datetime.UTC).isoformat()
+
+
+def _decode(value: object) -> str:
+    if isinstance(value, bytes):
+        return value.decode()
+    return str(value)
+
+
+def _opt_int(value: object) -> int:
+    try:
+        return int(_decode(value)) if value is not None else 0
+    except ValueError:
+        return 0
+
+
+def _opt_datetime(value: object) -> datetime.datetime | None:
+    if value is None:
+        return None
+    try:
+        return datetime.datetime.fromisoformat(_decode(value))
+    except ValueError:
+        return None
+
+
+async def start_run(
+    client: valkey.Valkey,
+    slug: str,
+    project_ids: abc.Iterable[str],
+    started_by: str,
+) -> RunStatus | None:
+    """Begin a run: acquire the lock and seed the pending set.
+
+    Returns ``None`` when a run is already in progress (lock held).
+    Leftover state from a previous run is cleared before seeding.
+    """
+    run_id = uuid.uuid4().hex
+    acquired = await client.set(
+        _key(slug, 'lock'), run_id, nx=True, ex=LOCK_TTL_SECONDS
+    )
+    if not acquired:
+        return None
+    ids = list(project_ids)
+    started_at = _now_iso()
+    async with client.pipeline(transaction=False) as pipe:
+        pipe.delete(  # pyright: ignore[reportUnknownMemberType]
+            _key(slug, 'pending'),
+            _key(slug, 'failures'),
+            _key(slug, 'run'),
+        )
+        for offset in range(0, len(ids), SADD_CHUNK):
+            pipe.sadd(  # pyright: ignore[reportUnknownMemberType]
+                _key(slug, 'pending'), *ids[offset : offset + SADD_CHUNK]
+            )
+        pipe.hset(  # pyright: ignore[reportUnknownMemberType]
+            _key(slug, 'run'),
+            mapping={
+                'run_id': run_id,
+                'total': len(ids),
+                'started_at': started_at,
+                'started_by': started_by,
+                'state': 'running',
+                'in_flight': 0,
+                'succeeded': 0,
+                'failed': 0,
+                'skipped': 0,
+            },
+        )
+        pipe.expire(  # pyright: ignore[reportUnknownMemberType]
+            _key(slug, 'pending'), PENDING_TTL_SECONDS
+        )
+        await pipe.execute()  # pyright: ignore[reportUnknownMemberType]
+    if not ids:
+        await maybe_finalize(client, slug)
+    return RunStatus(
+        state='running',
+        run_id=run_id,
+        total=len(ids),
+        remaining=len(ids),
+        started_at=datetime.datetime.fromisoformat(started_at),
+        started_by=started_by,
+    )
+
+
+async def has_active_run(client: valkey.Valkey, slug: str) -> bool:
+    """Whether the run lock is currently held."""
+    return bool(await client.exists(_key(slug, 'lock')))
+
+
+async def checkout(client: valkey.Valkey, slug: str) -> str | None:
+    """Pop one pending project id, marking it in flight."""
+    popped = await _resolve(
+        client.spop(  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType]
+            _key(slug, 'pending')
+        )
+    )
+    if popped is None:
+        return None
+    await _resolve(client.hincrby(_key(slug, 'run'), 'in_flight', 1))
+    return _decode(popped)
+
+
+async def record_outcome(
+    client: valkey.Valkey,
+    slug: str,
+    project_id: str,
+    outcome: Outcome,
+    error: str = '',
+) -> None:
+    """Record a checked-out project's outcome on the run hash."""
+    record_detail = False
+    if outcome == 'failed' and error:
+        details = await _resolve(client.hlen(_key(slug, 'failures')))
+        record_detail = _opt_int(details) < MAX_FAILURE_DETAILS
+    async with client.pipeline(transaction=False) as pipe:
+        pipe.hincrby(  # pyright: ignore[reportUnknownMemberType]
+            _key(slug, 'run'), 'in_flight', -1
+        )
+        pipe.hincrby(  # pyright: ignore[reportUnknownMemberType]
+            _key(slug, 'run'), outcome, 1
+        )
+        if record_detail:
+            pipe.hset(  # pyright: ignore[reportUnknownMemberType]
+                _key(slug, 'failures'), project_id, error[:MAX_ERROR_LEN]
+            )
+        await pipe.execute()  # pyright: ignore[reportUnknownMemberType]
+
+
+async def requeue(client: valkey.Valkey, slug: str, project_id: str) -> None:
+    """Return a checked-out id to the pending set (rate limit/shutdown)."""
+    async with client.pipeline(transaction=False) as pipe:
+        pipe.sadd(  # pyright: ignore[reportUnknownMemberType]
+            _key(slug, 'pending'), project_id
+        )
+        pipe.hincrby(  # pyright: ignore[reportUnknownMemberType]
+            _key(slug, 'run'), 'in_flight', -1
+        )
+        await pipe.execute()  # pyright: ignore[reportUnknownMemberType]
+
+
+async def maybe_finalize(client: valkey.Valkey, slug: str) -> bool:
+    """Complete the run if the set is drained and nothing is in flight.
+
+    Safe to call from any instance after every outcome; the benign race
+    where two instances both pass the check is idempotent (both write
+    ``state=completed``).
+    """
+    async with client.pipeline(transaction=False) as pipe:
+        pipe.scard(  # pyright: ignore[reportUnknownMemberType]
+            _key(slug, 'pending')
+        )
+        pipe.hget(  # pyright: ignore[reportUnknownMemberType]
+            _key(slug, 'run'), 'in_flight'
+        )
+        pipe.hget(  # pyright: ignore[reportUnknownMemberType]
+            _key(slug, 'run'), 'state'
+        )
+        results = typing.cast(
+            'list[object]',
+            await pipe.execute(),  # pyright: ignore[reportUnknownMemberType]
+        )
+    pending, in_flight, run_state = results
+    if int(typing.cast('int', pending)) > 0:
+        return False
+    if _opt_int(in_flight) > 0:
+        return False
+    if run_state is None or _decode(run_state) != 'running':
+        return False
+    await _finish(client, slug, 'completed')
+    return True
+
+
+async def cancel_run(client: valkey.Valkey, slug: str) -> bool:
+    """Cancel the in-progress run; returns ``False`` when none is."""
+    if not await has_active_run(client, slug):
+        return False
+    run_state = await _resolve(client.hget(_key(slug, 'run'), 'state'))
+    if run_state is None or _decode(run_state) != 'running':
+        return False
+    await client.delete(_key(slug, 'pending'))
+    await _finish(client, slug, 'cancelled')
+    return True
+
+
+async def _finish(
+    client: valkey.Valkey,
+    slug: str,
+    state: typing.Literal['completed', 'cancelled'],
+) -> None:
+    async with client.pipeline(transaction=False) as pipe:
+        pipe.hset(  # pyright: ignore[reportUnknownMemberType]
+            _key(slug, 'run'),
+            mapping={'state': state, 'completed_at': _now_iso()},
+        )
+        pipe.delete(  # pyright: ignore[reportUnknownMemberType]
+            _key(slug, 'lock')
+        )
+        pipe.expire(  # pyright: ignore[reportUnknownMemberType]
+            _key(slug, 'run'), RESULT_TTL_SECONDS
+        )
+        pipe.expire(  # pyright: ignore[reportUnknownMemberType]
+            _key(slug, 'failures'), RESULT_TTL_SECONDS
+        )
+        await pipe.execute()  # pyright: ignore[reportUnknownMemberType]
+
+
+async def read_status(client: valkey.Valkey, slug: str) -> RunStatus:
+    """Read the operation's current (or last) run state.
+
+    A run hash claiming ``running`` with no lock present means every
+    worker died holding work -- reported as the derived ``abandoned``
+    state rather than stored.
+    """
+    async with client.pipeline(transaction=False) as pipe:
+        pipe.exists(  # pyright: ignore[reportUnknownMemberType]
+            _key(slug, 'lock')
+        )
+        pipe.hgetall(  # pyright: ignore[reportUnknownMemberType]
+            _key(slug, 'run')
+        )
+        pipe.scard(  # pyright: ignore[reportUnknownMemberType]
+            _key(slug, 'pending')
+        )
+        results = typing.cast(
+            'list[object]',
+            await pipe.execute(),  # pyright: ignore[reportUnknownMemberType]
+        )
+    locked, raw_run, pending = results
+    run = {
+        _decode(k): v
+        for k, v in typing.cast('dict[object, object]', raw_run).items()
+    }
+    if not run:
+        return RunStatus()
+    raw_state = _decode(run.get('state', 'idle'))
+    state: RunState = 'idle'
+    if raw_state in ('running', 'completed', 'cancelled'):
+        state = typing.cast('RunState', raw_state)
+    if state == 'running' and not locked:
+        state = 'abandoned'
+    run_id = run.get('run_id')
+    started_by = run.get('started_by')
+    return RunStatus(
+        state=state,
+        run_id=_decode(run_id) if run_id is not None else None,
+        total=_opt_int(run.get('total')),
+        remaining=int(typing.cast('int', pending)),
+        in_flight=_opt_int(run.get('in_flight')),
+        succeeded=_opt_int(run.get('succeeded')),
+        failed=_opt_int(run.get('failed')),
+        skipped=_opt_int(run.get('skipped')),
+        started_at=_opt_datetime(run.get('started_at')),
+        started_by=_decode(started_by) if started_by is not None else None,
+        completed_at=_opt_datetime(run.get('completed_at')),
+    )
+
+
+async def read_failures(client: valkey.Valkey, slug: str) -> dict[str, str]:
+    """Per-project failure detail for the current/last run."""
+    raw = typing.cast(
+        'dict[object, object]',
+        await _resolve(
+            client.hgetall(  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType]
+                _key(slug, 'failures')
+            )
+        ),
+    )
+    return {_decode(k): _decode(v) for k, v in raw.items()}

--- a/src/imbi_api/maintenance/worker.py
+++ b/src/imbi_api/maintenance/worker.py
@@ -1,0 +1,141 @@
+"""Per-instance consumer for global maintenance runs.
+
+Every API instance runs one of these; work is distributed through the
+Valkey pending SET (:mod:`imbi_api.maintenance.state`), so N instances
+give N-way parallelism with one in-flight project per instance -- the
+gentlest shape for plugin APIs that share a rate-limited token.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+
+from imbi_common import graph
+from imbi_common.plugins.errors import PluginRateLimited
+from valkey import asyncio as valkey
+
+from imbi_api.maintenance import registry, state
+from imbi_api.maintenance.operations import MaintenanceItemFailed
+
+LOGGER = logging.getLogger(__name__)
+
+POLL_IDLE_SECONDS = 2.0
+#: Cushion on the pause key's TTL so it outlives the resume time.
+PAUSE_KEY_BUFFER_SECONDS = 5
+
+
+async def paused_remaining(client: valkey.Valkey, key: str) -> float:
+    """Seconds left on a rate-limit pause key, ``0.0`` when clear."""
+    try:
+        raw = await client.get(key)
+    except Exception:  # noqa: BLE001
+        return 0.0
+    if raw is None:
+        return 0.0
+    try:
+        until = float(raw.decode() if isinstance(raw, bytes) else raw)
+    except ValueError:
+        return 0.0
+    return max(0.0, until - time.time())
+
+
+async def pause_until(
+    client: valkey.Valkey, key: str, retry_at: float
+) -> None:
+    """Record the resume time so every consumer of *key* backs off."""
+    ttl = max(1, int(retry_at - time.time()) + PAUSE_KEY_BUFFER_SECONDS)
+    try:
+        await client.set(key, str(retry_at), ex=ttl)
+    except Exception:
+        LOGGER.exception('failed to set pause marker %s', key)
+
+
+async def _tick_operation(
+    client: valkey.Valkey,
+    db: graph.Graph,
+    operation: registry.OperationDefinition,
+) -> bool:
+    """Execute at most one pending project for *operation*.
+
+    Returns ``True`` when a project was processed (successfully or
+    not), so the caller loops immediately instead of idling.
+    """
+    if not await state.has_active_run(client, operation.slug):
+        return False
+    if (
+        operation.pause_key
+        and await paused_remaining(client, operation.pause_key) > 0
+    ):
+        # Another instance may drain to zero while we're paused.
+        await state.maybe_finalize(client, operation.slug)
+        return False
+    project_id = await state.checkout(client, operation.slug)
+    if project_id is None:
+        await state.maybe_finalize(client, operation.slug)
+        return False
+    try:
+        outcome = await operation.execute(db, client, project_id)
+    except asyncio.CancelledError:
+        # Graceful shutdown: hand the project back so nothing is lost.
+        await state.requeue(client, operation.slug, project_id)
+        raise
+    except PluginRateLimited as exc:
+        await state.requeue(client, operation.slug, project_id)
+        if operation.pause_key:
+            await pause_until(client, operation.pause_key, exc.retry_at)
+        LOGGER.warning(
+            'maintenance %s paused ~%.0fs (rate limit); %s requeued',
+            operation.slug,
+            max(0.0, exc.retry_at - time.time()),
+            project_id,
+        )
+        return False
+    except MaintenanceItemFailed as exc:
+        await state.record_outcome(
+            client, operation.slug, project_id, 'failed', str(exc)
+        )
+    except Exception:
+        LOGGER.exception(
+            'maintenance %s failed for %s', operation.slug, project_id
+        )
+        await state.record_outcome(
+            client,
+            operation.slug,
+            project_id,
+            'failed',
+            'Operation failed. See server logs for details.',
+        )
+    else:
+        await state.record_outcome(client, operation.slug, project_id, outcome)
+    if await state.maybe_finalize(client, operation.slug):
+        LOGGER.info('maintenance %s run completed', operation.slug)
+    return True
+
+
+async def run_worker(
+    client: valkey.Valkey,
+    db: graph.Graph,
+    stop: asyncio.Event,
+) -> None:
+    """Run the maintenance consumer loop until *stop* is set."""
+    LOGGER.info('Maintenance worker loop running')
+    while not stop.is_set():
+        worked = False
+        for operation in registry.OPERATIONS.values():
+            if stop.is_set():
+                break
+            try:
+                worked = await _tick_operation(client, db, operation) or worked
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                LOGGER.exception(
+                    'maintenance tick failed for %s', operation.slug
+                )
+        if not worked:
+            try:
+                await asyncio.wait_for(stop.wait(), POLL_IDLE_SECONDS)
+            except TimeoutError:
+                pass

--- a/src/imbi_api/maintenance/worker.py
+++ b/src/imbi_api/maintenance/worker.py
@@ -75,6 +75,8 @@ async def _tick_operation(
     if project_id is None:
         await state.maybe_finalize(client, operation.slug)
         return False
+    outcome: state.Outcome
+    error = ''
     try:
         outcome = await operation.execute(db, client, project_id)
     except asyncio.CancelledError:
@@ -93,22 +95,26 @@ async def _tick_operation(
         )
         return False
     except MaintenanceItemFailed as exc:
-        await state.record_outcome(
-            client, operation.slug, project_id, 'failed', str(exc)
-        )
+        outcome, error = 'failed', str(exc)
     except Exception:
         LOGGER.exception(
             'maintenance %s failed for %s', operation.slug, project_id
         )
+        outcome = 'failed'
+        error = 'Operation failed. See server logs for details.'
+    try:
         await state.record_outcome(
-            client,
+            client, operation.slug, project_id, outcome, error
+        )
+    except Exception:
+        # Compensate so in_flight cannot stay stuck until the lock TTL:
+        # hand the project back; its outcome is recorded on the retry.
+        LOGGER.exception(
+            'maintenance %s failed to record outcome for %s; requeueing',
             operation.slug,
             project_id,
-            'failed',
-            'Operation failed. See server logs for details.',
         )
-    else:
-        await state.record_outcome(client, operation.slug, project_id, outcome)
+        await state.requeue(client, operation.slug, project_id)
     if await state.maybe_finalize(client, operation.slug):
         LOGGER.info('maintenance %s run completed', operation.slug)
     return True

--- a/tests/endpoints/test_maintenance.py
+++ b/tests/endpoints/test_maintenance.py
@@ -1,0 +1,182 @@
+"""Tests for the global maintenance endpoints."""
+
+import datetime
+from unittest import mock
+
+from fastapi import testclient
+from imbi_common import graph
+
+from imbi_api import models, scoring
+from imbi_api.auth import permissions
+from imbi_api.maintenance import OPERATIONS, state
+from tests import support
+
+
+class MaintenanceEndpointTestCase(support.SharedAppTestCase):
+    def setUp(self) -> None:
+        self.auth_context = permissions.AuthContext(
+            user=models.User(
+                email='admin@example.com',
+                display_name='Admin User',
+                is_active=True,
+                is_admin=True,
+                created_at=datetime.datetime.now(datetime.UTC),
+            ),
+            session_id='test-session',
+            auth_method='jwt',
+            permissions={
+                'admin:maintenance:read',
+                'admin:maintenance:manage',
+            },
+        )
+
+        async def mock_get_current_user() -> permissions.AuthContext:
+            return self.auth_context
+
+        self.test_app.dependency_overrides[permissions.get_current_user] = (
+            mock_get_current_user
+        )
+        self.mock_db = mock.AsyncMock(spec=graph.Graph)
+        self.mock_db.execute.return_value = []
+        self.test_app.dependency_overrides[graph._inject_graph] = lambda: (
+            self.mock_db
+        )
+        self.mock_valkey = mock.AsyncMock()
+        self.test_app.dependency_overrides[scoring._inject_optional_client] = (
+            lambda: self.mock_valkey
+        )
+
+    def _use_non_admin(self) -> None:
+        self.auth_context = permissions.AuthContext(
+            user=models.User(
+                email='user@example.com',
+                display_name='Plain User',
+                is_active=True,
+                is_admin=False,
+                created_at=datetime.datetime.now(datetime.UTC),
+            ),
+            session_id='test-session',
+            auth_method='jwt',
+            permissions=set(),
+        )
+
+    def test_list_operations(self) -> None:
+        with mock.patch.object(
+            state,
+            'read_status',
+            mock.AsyncMock(return_value=state.RunStatus()),
+        ):
+            with testclient.TestClient(self.test_app) as client:
+                response = client.get('/maintenance/operations')
+        self.assertEqual(200, response.status_code)
+        payload = response.json()
+        self.assertEqual(
+            sorted(OPERATIONS), sorted(op['slug'] for op in payload)
+        )
+        for op in payload:
+            self.assertEqual('idle', op['state'])
+            self.assertFalse(op['running'])
+            self.assertIsNone(op['progress'])
+            self.assertTrue(op['label'])
+            self.assertTrue(op['description'])
+
+    def test_list_operations_requires_permission(self) -> None:
+        self._use_non_admin()
+        with testclient.TestClient(self.test_app) as client:
+            response = client.get('/maintenance/operations')
+        self.assertEqual(403, response.status_code)
+
+    def test_get_operation_includes_failures(self) -> None:
+        status = state.RunStatus(
+            state='completed',
+            run_id='r1',
+            total=3,
+            succeeded=2,
+            failed=1,
+        )
+        with (
+            mock.patch.object(
+                state, 'read_status', mock.AsyncMock(return_value=status)
+            ),
+            mock.patch.object(
+                state,
+                'read_failures',
+                mock.AsyncMock(return_value={'p1': 'boom'}),
+            ),
+        ):
+            with testclient.TestClient(self.test_app) as client:
+                response = client.get('/maintenance/operations/rescore')
+        self.assertEqual(200, response.status_code)
+        payload = response.json()
+        self.assertEqual('completed', payload['state'])
+        self.assertEqual({'p1': 'boom'}, payload['failures'])
+        self.assertEqual(1, payload['progress']['failed'])
+
+    def test_get_operation_unknown_slug(self) -> None:
+        with testclient.TestClient(self.test_app) as client:
+            response = client.get('/maintenance/operations/nope')
+        self.assertEqual(404, response.status_code)
+
+    def test_run_starts_operation(self) -> None:
+        started = state.RunStatus(
+            state='running', run_id='r1', total=2, remaining=2
+        )
+        with mock.patch.object(
+            state, 'start_run', mock.AsyncMock(return_value=started)
+        ) as start:
+            with testclient.TestClient(self.test_app) as client:
+                response = client.post('/maintenance/operations/rescore/run')
+        self.assertEqual(202, response.status_code)
+        self.assertEqual({'run_id': 'r1', 'total': 2}, response.json())
+        self.assertEqual('admin@example.com', start.await_args.args[3])
+
+    def test_run_conflicts_when_already_running(self) -> None:
+        with mock.patch.object(
+            state, 'start_run', mock.AsyncMock(return_value=None)
+        ):
+            with testclient.TestClient(self.test_app) as client:
+                response = client.post('/maintenance/operations/rescore/run')
+        self.assertEqual(409, response.status_code)
+
+    def test_run_unavailable_without_valkey(self) -> None:
+        self.test_app.dependency_overrides[scoring._inject_optional_client] = (
+            lambda: None
+        )
+        with testclient.TestClient(self.test_app) as client:
+            response = client.post('/maintenance/operations/rescore/run')
+        self.assertEqual(503, response.status_code)
+
+    def test_run_requires_manage_permission(self) -> None:
+        self._use_non_admin()
+        with testclient.TestClient(self.test_app) as client:
+            response = client.post('/maintenance/operations/rescore/run')
+        self.assertEqual(403, response.status_code)
+
+    def test_cancel_running_operation(self) -> None:
+        cancelled = state.RunStatus(state='cancelled', run_id='r1', total=2)
+        with (
+            mock.patch.object(
+                state, 'cancel_run', mock.AsyncMock(return_value=True)
+            ),
+            mock.patch.object(
+                state,
+                'read_status',
+                mock.AsyncMock(return_value=cancelled),
+            ),
+        ):
+            with testclient.TestClient(self.test_app) as client:
+                response = client.post(
+                    '/maintenance/operations/rescore/cancel'
+                )
+        self.assertEqual(200, response.status_code)
+        self.assertEqual('cancelled', response.json()['state'])
+
+    def test_cancel_conflicts_when_idle(self) -> None:
+        with mock.patch.object(
+            state, 'cancel_run', mock.AsyncMock(return_value=False)
+        ):
+            with testclient.TestClient(self.test_app) as client:
+                response = client.post(
+                    '/maintenance/operations/rescore/cancel'
+                )
+        self.assertEqual(409, response.status_code)

--- a/tests/endpoints/test_maintenance.py
+++ b/tests/endpoints/test_maintenance.py
@@ -80,6 +80,22 @@ class MaintenanceEndpointTestCase(support.SharedAppTestCase):
             self.assertTrue(op['label'])
             self.assertTrue(op['description'])
 
+    def test_list_operations_unavailable_without_valkey(self) -> None:
+        self.test_app.dependency_overrides[scoring._inject_optional_client] = (
+            lambda: None
+        )
+        with testclient.TestClient(self.test_app) as client:
+            response = client.get('/maintenance/operations')
+        self.assertEqual(503, response.status_code)
+
+    def test_get_operation_unavailable_without_valkey(self) -> None:
+        self.test_app.dependency_overrides[scoring._inject_optional_client] = (
+            lambda: None
+        )
+        with testclient.TestClient(self.test_app) as client:
+            response = client.get('/maintenance/operations/rescore')
+        self.assertEqual(503, response.status_code)
+
     def test_list_operations_requires_permission(self) -> None:
         self._use_non_admin()
         with testclient.TestClient(self.test_app) as client:

--- a/tests/test_maintenance_operations.py
+++ b/tests/test_maintenance_operations.py
@@ -1,0 +1,234 @@
+"""Tests for the maintenance per-project execute functions."""
+
+from __future__ import annotations
+
+import time
+import unittest
+from unittest import mock
+
+import fastapi
+from imbi_common.plugins.errors import PluginRateLimited
+
+from imbi_api.commit_sync.service import CommitSyncUnavailable
+from imbi_api.maintenance import operations
+from imbi_api.pr_sync.service import PRSyncUnavailable
+
+
+def _org_slug(value: str | None) -> mock.AsyncMock:
+    return mock.AsyncMock(return_value=value)
+
+
+class SystemAuthTests(unittest.TestCase):
+    def test_principal_name_is_maintenance(self) -> None:
+        auth = operations._system_auth()
+        self.assertEqual('maintenance', auth.principal_name)
+        self.assertFalse(auth.is_admin)
+
+
+class ExecuteAnalysisTests(unittest.IsolatedAsyncioTestCase):
+    async def test_skipped_without_org(self) -> None:
+        with mock.patch.object(operations, '_org_slug_for', _org_slug(None)):
+            outcome = await operations.execute_analysis(
+                mock.AsyncMock(), mock.AsyncMock(), 'p1'
+            )
+        self.assertEqual('skipped', outcome)
+
+    async def test_runs_and_persists(self) -> None:
+        run = mock.AsyncMock()
+        with (
+            mock.patch.object(operations, '_org_slug_for', _org_slug('org')),
+            mock.patch(
+                'imbi_api.endpoints.project_analysis.run_and_persist', run
+            ),
+        ):
+            outcome = await operations.execute_analysis(
+                mock.AsyncMock(), mock.AsyncMock(), 'p1'
+            )
+        self.assertEqual('succeeded', outcome)
+        args = run.await_args.args
+        self.assertEqual('org', args[1])
+        self.assertEqual('p1', args[2])
+        self.assertEqual('maintenance', args[3].principal_name)
+
+
+class ExecuteCommitSyncTests(unittest.IsolatedAsyncioTestCase):
+    def _patches(
+        self, run_sync: mock.AsyncMock
+    ) -> tuple[mock.AsyncMock, list[object]]:
+        set_status = mock.AsyncMock()
+        return set_status, [
+            mock.patch.object(operations, '_org_slug_for', _org_slug('org')),
+            mock.patch('imbi_api.commit_sync.service.run_sync', run_sync),
+            mock.patch('imbi_api.commit_sync.service.set_status', set_status),
+        ]
+
+    async def test_success(self) -> None:
+        set_status, patches = self._patches(
+            mock.AsyncMock(return_value=(3, 2))
+        )
+        with patches[0], patches[1], patches[2]:
+            outcome = await operations.execute_commit_sync(
+                mock.AsyncMock(), mock.AsyncMock(), 'p1'
+            )
+        self.assertEqual('succeeded', outcome)
+        statuses = [c.kwargs['status'] for c in set_status.await_args_list]
+        self.assertEqual(['running', 'success'], statuses)
+        self.assertEqual(3, set_status.await_args_list[-1].kwargs['commits'])
+
+    async def test_unavailable_is_skipped(self) -> None:
+        set_status, patches = self._patches(
+            mock.AsyncMock(side_effect=CommitSyncUnavailable('unbound'))
+        )
+        with patches[0], patches[1], patches[2]:
+            outcome = await operations.execute_commit_sync(
+                mock.AsyncMock(), mock.AsyncMock(), 'p1'
+            )
+        self.assertEqual('skipped', outcome)
+        self.assertEqual(
+            'failed', set_status.await_args_list[-1].kwargs['status']
+        )
+
+    async def test_rate_limited_propagates_with_queued_status(self) -> None:
+        set_status, patches = self._patches(
+            mock.AsyncMock(side_effect=PluginRateLimited(time.time() + 60))
+        )
+        with patches[0], patches[1], patches[2]:
+            with self.assertRaises(PluginRateLimited):
+                await operations.execute_commit_sync(
+                    mock.AsyncMock(), mock.AsyncMock(), 'p1'
+                )
+        self.assertEqual(
+            'queued', set_status.await_args_list[-1].kwargs['status']
+        )
+
+    async def test_other_error_raises_item_failed(self) -> None:
+        set_status, patches = self._patches(
+            mock.AsyncMock(side_effect=RuntimeError('boom'))
+        )
+        with patches[0], patches[1], patches[2]:
+            with self.assertRaises(operations.MaintenanceItemFailed):
+                await operations.execute_commit_sync(
+                    mock.AsyncMock(), mock.AsyncMock(), 'p1'
+                )
+        self.assertEqual(
+            'failed', set_status.await_args_list[-1].kwargs['status']
+        )
+
+
+class ExecutePRSyncTests(unittest.IsolatedAsyncioTestCase):
+    async def test_success(self) -> None:
+        set_status = mock.AsyncMock()
+        with (
+            mock.patch.object(operations, '_org_slug_for', _org_slug('org')),
+            mock.patch(
+                'imbi_api.pr_sync.service.run_sync',
+                mock.AsyncMock(return_value=7),
+            ),
+            mock.patch('imbi_api.pr_sync.service.set_status', set_status),
+        ):
+            outcome = await operations.execute_pr_sync(
+                mock.AsyncMock(), mock.AsyncMock(), 'p1'
+            )
+        self.assertEqual('succeeded', outcome)
+        self.assertEqual(7, set_status.await_args_list[-1].kwargs['prs'])
+
+    async def test_unavailable_is_skipped(self) -> None:
+        with (
+            mock.patch.object(operations, '_org_slug_for', _org_slug('org')),
+            mock.patch(
+                'imbi_api.pr_sync.service.run_sync',
+                mock.AsyncMock(side_effect=PRSyncUnavailable('unbound')),
+            ),
+            mock.patch(
+                'imbi_api.pr_sync.service.set_status', mock.AsyncMock()
+            ),
+        ):
+            outcome = await operations.execute_pr_sync(
+                mock.AsyncMock(), mock.AsyncMock(), 'p1'
+            )
+        self.assertEqual('skipped', outcome)
+
+
+class ExecuteDeploymentResyncTests(unittest.IsolatedAsyncioTestCase):
+    async def test_success(self) -> None:
+        resync = mock.AsyncMock()
+        with (
+            mock.patch.object(operations, '_org_slug_for', _org_slug('org')),
+            mock.patch(
+                'imbi_api.endpoints.project_deployments.resync_for_project',
+                resync,
+            ),
+        ):
+            outcome = await operations.execute_deployment_resync(
+                mock.AsyncMock(), mock.AsyncMock(), 'p1'
+            )
+        self.assertEqual('succeeded', outcome)
+        self.assertEqual(
+            'maintenance', resync.await_args.kwargs['auth'].principal_name
+        )
+
+    async def test_no_capability_is_skipped(self) -> None:
+        for status_code in (400, 404):
+            with (
+                mock.patch.object(
+                    operations, '_org_slug_for', _org_slug('org')
+                ),
+                mock.patch(
+                    'imbi_api.endpoints.project_deployments'
+                    '.resync_for_project',
+                    mock.AsyncMock(
+                        side_effect=fastapi.HTTPException(
+                            status_code=status_code, detail='nope'
+                        )
+                    ),
+                ),
+            ):
+                outcome = await operations.execute_deployment_resync(
+                    mock.AsyncMock(), mock.AsyncMock(), 'p1'
+                )
+            self.assertEqual('skipped', outcome)
+
+    async def test_other_http_error_fails(self) -> None:
+        with (
+            mock.patch.object(operations, '_org_slug_for', _org_slug('org')),
+            mock.patch(
+                'imbi_api.endpoints.project_deployments.resync_for_project',
+                mock.AsyncMock(
+                    side_effect=fastapi.HTTPException(
+                        status_code=503, detail='no credentials'
+                    )
+                ),
+            ),
+        ):
+            with self.assertRaises(operations.MaintenanceItemFailed) as ctx:
+                await operations.execute_deployment_resync(
+                    mock.AsyncMock(), mock.AsyncMock(), 'p1'
+                )
+        self.assertIn('no credentials', str(ctx.exception))
+
+
+class ExecuteRescoreTests(unittest.IsolatedAsyncioTestCase):
+    async def test_enqueued_is_succeeded(self) -> None:
+        enqueue = mock.AsyncMock(return_value=True)
+        with mock.patch.object(
+            operations.score_queue, 'enqueue_recompute', enqueue
+        ):
+            outcome = await operations.execute_rescore(
+                mock.AsyncMock(), mock.AsyncMock(), 'p1'
+            )
+        self.assertEqual('succeeded', outcome)
+        args = enqueue.await_args.args
+        self.assertEqual('p1', args[1])
+        self.assertEqual('bulk_rescore', args[2])
+        self.assertEqual('maintenance', args[3])
+
+    async def test_debounced_is_skipped(self) -> None:
+        with mock.patch.object(
+            operations.score_queue,
+            'enqueue_recompute',
+            mock.AsyncMock(return_value=False),
+        ):
+            outcome = await operations.execute_rescore(
+                mock.AsyncMock(), mock.AsyncMock(), 'p1'
+            )
+        self.assertEqual('skipped', outcome)

--- a/tests/test_maintenance_operations.py
+++ b/tests/test_maintenance_operations.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import time
 import unittest
 from unittest import mock
@@ -54,7 +55,9 @@ class ExecuteAnalysisTests(unittest.IsolatedAsyncioTestCase):
 class ExecuteCommitSyncTests(unittest.IsolatedAsyncioTestCase):
     def _patches(
         self, run_sync: mock.AsyncMock
-    ) -> tuple[mock.AsyncMock, list[object]]:
+    ) -> tuple[
+        mock.AsyncMock, list[contextlib.AbstractContextManager[object]]
+    ]:
         set_status = mock.AsyncMock()
         return set_status, [
             mock.patch.object(operations, '_org_slug_for', _org_slug('org')),

--- a/tests/test_maintenance_state.py
+++ b/tests/test_maintenance_state.py
@@ -65,11 +65,20 @@ class StartRunTests(unittest.IsolatedAsyncioTestCase):
     async def test_empty_project_set_finalizes_immediately(self) -> None:
         client, _ = _client_with_pipeline()
         client.set = mock.AsyncMock(return_value=True)
-        with mock.patch.object(
-            state, 'maybe_finalize', mock.AsyncMock()
-        ) as finalize:
+        completed = state.RunStatus(state='completed', total=0)
+        with (
+            mock.patch.object(
+                state, 'maybe_finalize', mock.AsyncMock()
+            ) as finalize,
+            mock.patch.object(
+                state,
+                'read_status',
+                mock.AsyncMock(return_value=completed),
+            ),
+        ):
             status = await state.start_run(client, 'op', [], 'alice')
         assert status is not None
+        self.assertEqual('completed', status.state)
         self.assertEqual(0, status.total)
         finalize.assert_awaited_once_with(client, 'op')
 

--- a/tests/test_maintenance_state.py
+++ b/tests/test_maintenance_state.py
@@ -1,0 +1,230 @@
+"""Tests for the maintenance run-state primitives."""
+
+from __future__ import annotations
+
+import typing
+import unittest
+from unittest import mock
+
+from imbi_api.maintenance import state
+
+
+def _client_with_pipeline(
+    results: list[object] | None = None,
+) -> tuple[mock.AsyncMock, mock.Mock]:
+    """A mock client whose pipeline queues commands synchronously."""
+    client = mock.AsyncMock()
+    pipe = mock.MagicMock()
+    for name in (
+        'delete',
+        'sadd',
+        'hset',
+        'expire',
+        'hincrby',
+        'scard',
+        'hget',
+        'hgetall',
+        'exists',
+    ):
+        setattr(pipe, name, mock.Mock())
+    pipe.execute = mock.AsyncMock(return_value=results or [])
+    pipe.__aenter__ = mock.AsyncMock(return_value=pipe)
+    pipe.__aexit__ = mock.AsyncMock(return_value=False)
+    client.pipeline = mock.Mock(return_value=pipe)
+    return client, pipe
+
+
+class StartRunTests(unittest.IsolatedAsyncioTestCase):
+    async def test_acquires_lock_and_seeds_pending(self) -> None:
+        client, pipe = _client_with_pipeline()
+        client.set = mock.AsyncMock(return_value=True)
+        status = await state.start_run(client, 'op', ['p1', 'p2'], 'alice')
+        assert status is not None
+        self.assertEqual('running', status.state)
+        self.assertEqual(2, status.total)
+        self.assertEqual('alice', status.started_by)
+        args, kwargs = client.set.await_args
+        self.assertEqual('imbi:maintenance:op:lock', args[0])
+        self.assertTrue(kwargs['nx'])
+        self.assertEqual(state.LOCK_TTL_SECONDS, kwargs['ex'])
+        sadd_args = pipe.sadd.call_args
+        self.assertEqual(
+            ('imbi:maintenance:op:pending', 'p1', 'p2'), sadd_args.args
+        )
+        mapping = pipe.hset.call_args.kwargs['mapping']
+        self.assertEqual(2, mapping['total'])
+        self.assertEqual('running', mapping['state'])
+
+    async def test_returns_none_when_lock_held(self) -> None:
+        client, pipe = _client_with_pipeline()
+        client.set = mock.AsyncMock(return_value=None)
+        result = await state.start_run(client, 'op', ['p1'], 'alice')
+        self.assertIsNone(result)
+        pipe.execute.assert_not_awaited()
+
+    async def test_empty_project_set_finalizes_immediately(self) -> None:
+        client, _ = _client_with_pipeline()
+        client.set = mock.AsyncMock(return_value=True)
+        with mock.patch.object(
+            state, 'maybe_finalize', mock.AsyncMock()
+        ) as finalize:
+            status = await state.start_run(client, 'op', [], 'alice')
+        assert status is not None
+        self.assertEqual(0, status.total)
+        finalize.assert_awaited_once_with(client, 'op')
+
+
+class CheckoutTests(unittest.IsolatedAsyncioTestCase):
+    async def test_pops_and_marks_in_flight(self) -> None:
+        client = mock.AsyncMock()
+        client.spop = mock.AsyncMock(return_value=b'p1')
+        client.hincrby = mock.AsyncMock()
+        result = await state.checkout(client, 'op')
+        self.assertEqual('p1', result)
+        client.hincrby.assert_awaited_once_with(
+            'imbi:maintenance:op:run', 'in_flight', 1
+        )
+
+    async def test_returns_none_when_drained(self) -> None:
+        client = mock.AsyncMock()
+        client.spop = mock.AsyncMock(return_value=None)
+        client.hincrby = mock.AsyncMock()
+        self.assertIsNone(await state.checkout(client, 'op'))
+        client.hincrby.assert_not_awaited()
+
+
+class RecordOutcomeTests(unittest.IsolatedAsyncioTestCase):
+    async def test_success_moves_counters(self) -> None:
+        client, pipe = _client_with_pipeline()
+        await state.record_outcome(client, 'op', 'p1', 'succeeded')
+        calls = pipe.hincrby.call_args_list
+        self.assertEqual(
+            ('imbi:maintenance:op:run', 'in_flight', -1), calls[0].args
+        )
+        self.assertEqual(
+            ('imbi:maintenance:op:run', 'succeeded', 1), calls[1].args
+        )
+        pipe.hset.assert_not_called()
+
+    async def test_failure_records_truncated_detail(self) -> None:
+        client, pipe = _client_with_pipeline()
+        client.hlen = mock.AsyncMock(return_value=0)
+        await state.record_outcome(client, 'op', 'p1', 'failed', 'x' * 600)
+        args = pipe.hset.call_args.args
+        self.assertEqual('imbi:maintenance:op:failures', args[0])
+        self.assertEqual('p1', args[1])
+        self.assertEqual(state.MAX_ERROR_LEN, len(args[2]))
+
+    async def test_failure_detail_capped(self) -> None:
+        client, pipe = _client_with_pipeline()
+        client.hlen = mock.AsyncMock(return_value=state.MAX_FAILURE_DETAILS)
+        await state.record_outcome(client, 'op', 'p1', 'failed', 'boom')
+        pipe.hset.assert_not_called()
+        # The counter still moves even without the detail.
+        self.assertEqual(
+            ('imbi:maintenance:op:run', 'failed', 1),
+            pipe.hincrby.call_args_list[1].args,
+        )
+
+
+class RequeueTests(unittest.IsolatedAsyncioTestCase):
+    async def test_returns_id_and_decrements(self) -> None:
+        client, pipe = _client_with_pipeline()
+        await state.requeue(client, 'op', 'p1')
+        self.assertEqual(
+            ('imbi:maintenance:op:pending', 'p1'), pipe.sadd.call_args.args
+        )
+        self.assertEqual(
+            ('imbi:maintenance:op:run', 'in_flight', -1),
+            pipe.hincrby.call_args.args,
+        )
+
+
+class MaybeFinalizeTests(unittest.IsolatedAsyncioTestCase):
+    async def test_finalizes_when_drained(self) -> None:
+        client, _ = _client_with_pipeline([0, b'0', b'running'])
+        with mock.patch.object(state, '_finish', mock.AsyncMock()) as finish:
+            result = await state.maybe_finalize(client, 'op')
+        self.assertTrue(result)
+        finish.assert_awaited_once_with(client, 'op', 'completed')
+
+    async def test_skips_when_pending_remain(self) -> None:
+        client, _ = _client_with_pipeline([3, b'0', b'running'])
+        with mock.patch.object(state, '_finish', mock.AsyncMock()) as finish:
+            self.assertFalse(await state.maybe_finalize(client, 'op'))
+        finish.assert_not_awaited()
+
+    async def test_skips_when_in_flight(self) -> None:
+        client, _ = _client_with_pipeline([0, b'2', b'running'])
+        with mock.patch.object(state, '_finish', mock.AsyncMock()) as finish:
+            self.assertFalse(await state.maybe_finalize(client, 'op'))
+        finish.assert_not_awaited()
+
+    async def test_skips_when_not_running(self) -> None:
+        client, _ = _client_with_pipeline([0, b'0', b'completed'])
+        with mock.patch.object(state, '_finish', mock.AsyncMock()) as finish:
+            self.assertFalse(await state.maybe_finalize(client, 'op'))
+        finish.assert_not_awaited()
+
+
+class CancelRunTests(unittest.IsolatedAsyncioTestCase):
+    async def test_cancels_running(self) -> None:
+        client, _ = _client_with_pipeline()
+        client.exists = mock.AsyncMock(return_value=1)
+        client.hget = mock.AsyncMock(return_value=b'running')
+        client.delete = mock.AsyncMock()
+        with mock.patch.object(state, '_finish', mock.AsyncMock()) as finish:
+            self.assertTrue(await state.cancel_run(client, 'op'))
+        client.delete.assert_awaited_once_with('imbi:maintenance:op:pending')
+        finish.assert_awaited_once_with(client, 'op', 'cancelled')
+
+    async def test_returns_false_when_idle(self) -> None:
+        client, _ = _client_with_pipeline()
+        client.exists = mock.AsyncMock(return_value=0)
+        self.assertFalse(await state.cancel_run(client, 'op'))
+
+
+class ReadStatusTests(unittest.IsolatedAsyncioTestCase):
+    @staticmethod
+    def _run_hash(run_state: bytes) -> dict[bytes, bytes]:
+        return {
+            b'run_id': b'r1',
+            b'total': b'10',
+            b'started_at': b'2026-07-13T00:00:00+00:00',
+            b'started_by': b'alice',
+            b'state': run_state,
+            b'in_flight': b'1',
+            b'succeeded': b'4',
+            b'failed': b'1',
+            b'skipped': b'2',
+        }
+
+    async def test_running(self) -> None:
+        client, _ = _client_with_pipeline([1, self._run_hash(b'running'), 2])
+        status = await state.read_status(client, 'op')
+        self.assertEqual('running', status.state)
+        self.assertEqual(10, status.total)
+        self.assertEqual(2, status.remaining)
+        self.assertEqual(4, status.succeeded)
+        self.assertEqual('alice', status.started_by)
+
+    async def test_abandoned_when_running_without_lock(self) -> None:
+        client, _ = _client_with_pipeline([0, self._run_hash(b'running'), 2])
+        status = await state.read_status(client, 'op')
+        self.assertEqual('abandoned', status.state)
+
+    async def test_idle_when_no_run_hash(self) -> None:
+        client, _ = _client_with_pipeline(
+            [0, typing.cast('dict[bytes, bytes]', {}), 0]
+        )
+        status = await state.read_status(client, 'op')
+        self.assertEqual('idle', status.state)
+
+
+class ReadFailuresTests(unittest.IsolatedAsyncioTestCase):
+    async def test_decodes_entries(self) -> None:
+        client = mock.AsyncMock()
+        client.hgetall = mock.AsyncMock(return_value={b'p1': b'boom'})
+        self.assertEqual(
+            {'p1': 'boom'}, await state.read_failures(client, 'op')
+        )

--- a/tests/test_maintenance_worker.py
+++ b/tests/test_maintenance_worker.py
@@ -1,0 +1,184 @@
+"""Tests for the maintenance worker loop."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+import typing
+import unittest
+from unittest import mock
+
+from imbi_common.plugins.errors import PluginRateLimited
+
+from imbi_api.maintenance import registry, worker
+from imbi_api.maintenance.operations import MaintenanceItemFailed
+
+
+def _operation(
+    execute: mock.AsyncMock,
+    pause_key: str | None = None,
+) -> registry.OperationDefinition:
+    return registry.OperationDefinition(
+        slug=typing.cast('registry.MaintenanceSlug', 'op'),
+        label='Op',
+        description='Test operation',
+        pause_key=pause_key,
+        enumerate=mock.AsyncMock(return_value=[]),
+        execute=execute,
+    )
+
+
+class TickOperationTests(unittest.IsolatedAsyncioTestCase):
+    def setUp(self) -> None:
+        self.client = mock.AsyncMock()
+        self.db = mock.AsyncMock()
+        self.state: dict[str, mock.AsyncMock] = {}
+        for name in (
+            'has_active_run',
+            'checkout',
+            'record_outcome',
+            'requeue',
+            'maybe_finalize',
+        ):
+            patcher = mock.patch.object(worker.state, name, mock.AsyncMock())
+            self.state[name] = patcher.start()
+            self.addCleanup(patcher.stop)
+        self.state['has_active_run'].return_value = True
+        self.state['checkout'].return_value = 'p1'
+        self.state['maybe_finalize'].return_value = False
+
+    async def test_no_active_run_is_noop(self) -> None:
+        self.state['has_active_run'].return_value = False
+        operation = _operation(mock.AsyncMock())
+        result = await worker._tick_operation(self.client, self.db, operation)
+        self.assertFalse(result)
+        self.state['checkout'].assert_not_awaited()
+
+    async def test_success_records_outcome(self) -> None:
+        operation = _operation(mock.AsyncMock(return_value='succeeded'))
+        result = await worker._tick_operation(self.client, self.db, operation)
+        self.assertTrue(result)
+        self.state['record_outcome'].assert_awaited_once_with(
+            self.client, 'op', 'p1', 'succeeded'
+        )
+        self.state['maybe_finalize'].assert_awaited()
+
+    async def test_drained_finalizes(self) -> None:
+        self.state['checkout'].return_value = None
+        operation = _operation(mock.AsyncMock())
+        result = await worker._tick_operation(self.client, self.db, operation)
+        self.assertFalse(result)
+        self.state['maybe_finalize'].assert_awaited_once()
+
+    async def test_item_failed_records_message(self) -> None:
+        operation = _operation(
+            mock.AsyncMock(side_effect=MaintenanceItemFailed('boom'))
+        )
+        result = await worker._tick_operation(self.client, self.db, operation)
+        self.assertTrue(result)
+        self.state['record_outcome'].assert_awaited_once_with(
+            self.client, 'op', 'p1', 'failed', 'boom'
+        )
+
+    async def test_unexpected_error_records_generic_message(self) -> None:
+        operation = _operation(
+            mock.AsyncMock(side_effect=RuntimeError('secret detail'))
+        )
+        result = await worker._tick_operation(self.client, self.db, operation)
+        self.assertTrue(result)
+        error = self.state['record_outcome'].await_args.args[4]
+        self.assertNotIn('secret detail', error)
+
+    async def test_rate_limited_requeues_and_pauses(self) -> None:
+        retry_at = time.time() + 120
+        operation = _operation(
+            mock.AsyncMock(side_effect=PluginRateLimited(retry_at)),
+            pause_key='imbi:test:paused-until',
+        )
+        with mock.patch.object(
+            worker, 'pause_until', mock.AsyncMock()
+        ) as pause:
+            result = await worker._tick_operation(
+                self.client, self.db, operation
+            )
+        self.assertFalse(result)
+        self.state['requeue'].assert_awaited_once_with(self.client, 'op', 'p1')
+        self.state['record_outcome'].assert_not_awaited()
+        pause.assert_awaited_once_with(
+            self.client, 'imbi:test:paused-until', retry_at
+        )
+
+    async def test_pause_key_honored_before_checkout(self) -> None:
+        operation = _operation(
+            mock.AsyncMock(), pause_key='imbi:test:paused-until'
+        )
+        with mock.patch.object(
+            worker,
+            'paused_remaining',
+            mock.AsyncMock(return_value=30.0),
+        ):
+            result = await worker._tick_operation(
+                self.client, self.db, operation
+            )
+        self.assertFalse(result)
+        self.state['checkout'].assert_not_awaited()
+        self.state['maybe_finalize'].assert_awaited_once()
+
+    async def test_cancelled_requeues_and_reraises(self) -> None:
+        operation = _operation(
+            mock.AsyncMock(side_effect=asyncio.CancelledError())
+        )
+        with self.assertRaises(asyncio.CancelledError):
+            await worker._tick_operation(self.client, self.db, operation)
+        self.state['requeue'].assert_awaited_once_with(self.client, 'op', 'p1')
+
+
+class RunWorkerTests(unittest.IsolatedAsyncioTestCase):
+    async def test_stop_event_exits_promptly(self) -> None:
+        stop = asyncio.Event()
+        stop.set()
+        await asyncio.wait_for(
+            worker.run_worker(mock.AsyncMock(), mock.AsyncMock(), stop),
+            timeout=1.0,
+        )
+
+    async def test_processes_until_stopped(self) -> None:
+        stop = asyncio.Event()
+        calls = 0
+
+        async def tick(*_args: object) -> bool:
+            nonlocal calls
+            calls += 1
+            if calls >= len(registry.OPERATIONS) * 2:
+                stop.set()
+            return True
+
+        with mock.patch.object(worker, '_tick_operation', tick):
+            await asyncio.wait_for(
+                worker.run_worker(mock.AsyncMock(), mock.AsyncMock(), stop),
+                timeout=2.0,
+            )
+        self.assertGreaterEqual(calls, len(registry.OPERATIONS))
+
+
+class PauseHelperTests(unittest.IsolatedAsyncioTestCase):
+    async def test_paused_remaining_reads_future_epoch(self) -> None:
+        client = mock.AsyncMock()
+        client.get = mock.AsyncMock(
+            return_value=str(time.time() + 60).encode()
+        )
+        remaining = await worker.paused_remaining(client, 'k')
+        self.assertGreater(remaining, 55.0)
+
+    async def test_paused_remaining_clear_when_absent(self) -> None:
+        client = mock.AsyncMock()
+        client.get = mock.AsyncMock(return_value=None)
+        self.assertEqual(0.0, await worker.paused_remaining(client, 'k'))
+
+    async def test_pause_until_sets_key_with_ttl(self) -> None:
+        client = mock.AsyncMock()
+        retry_at = time.time() + 60
+        await worker.pause_until(client, 'k', retry_at)
+        args, kwargs = client.set.await_args
+        self.assertEqual('k', args[0])
+        self.assertGreaterEqual(kwargs['ex'], 60)

--- a/tests/test_maintenance_worker.py
+++ b/tests/test_maintenance_worker.py
@@ -59,9 +59,16 @@ class TickOperationTests(unittest.IsolatedAsyncioTestCase):
         result = await worker._tick_operation(self.client, self.db, operation)
         self.assertTrue(result)
         self.state['record_outcome'].assert_awaited_once_with(
-            self.client, 'op', 'p1', 'succeeded'
+            self.client, 'op', 'p1', 'succeeded', ''
         )
         self.state['maybe_finalize'].assert_awaited()
+
+    async def test_record_outcome_failure_requeues(self) -> None:
+        self.state['record_outcome'].side_effect = RuntimeError('valkey down')
+        operation = _operation(mock.AsyncMock(return_value='succeeded'))
+        result = await worker._tick_operation(self.client, self.db, operation)
+        self.assertTrue(result)
+        self.state['requeue'].assert_awaited_once_with(self.client, 'op', 'p1')
 
     async def test_drained_finalizes(self) -> None:
         self.state['checkout'].return_value = None


### PR DESCRIPTION
## Summary
Add an admin-only global maintenance API that runs the Project Doctor operations (analysis, rescore, deployment resync, commit/tag sync, PR sync) across every project, distributed over all API instances via a Valkey set.

## Problem
The Doctor's utility actions only exist per-project. There is no way to re-run analysis or the sync operations platform-wide (the lone precedent is the global `POST /scoring/rescore`), and any global mechanism must work across multiple API instances rather than an in-process queue.

## Solution
- New `maintenance` package: starting a run `SADD`s every project id into `imbi:maintenance:{slug}:pending`; a worker on each instance `SPOP`s ids and executes the operation directly, reusing the existing per-project services (`run_and_persist`, `commit_sync/pr_sync service.run_sync`, `resync_for_project`, `scoring enqueue_recompute`). Progress, outcome counters, and per-project failure detail live in shared Valkey keys; a `SET NX EX` lock allows one run per operation.
- The operation list is a backend registry, exposed via `GET /maintenance/operations` so the UI renders buttons dynamically; `POST .../run`, `POST .../cancel`, and a per-operation detail endpoint round it out, gated by new `admin:maintenance:read`/`manage` permissions.
- Sync executes under a synthetic `maintenance` service-account principal, honors the existing commit/PR-sync rate-limit pause keys (requeueing the project and pausing the whole operation on `PluginRateLimited`), and counts projects without the capability as skipped rather than failed.

## Impact
- New endpoints and two new seeded admin permissions (`imbi-api setup` re-run seeds them; admins bypass regardless).
- One additional background task per instance (idle 2s poll when no run is active).
- `project_analysis._run_and_persist` renamed to `run_and_persist` (internal).
- Companion UI PR: AWeber-Imbi/imbi-ui feature/global-maintenance-operations.

## Testing
- 56 new unit/endpoint tests (`tests/test_maintenance_*.py`, `tests/endpoints/test_maintenance.py`); `just lint` clean.
- Verified end-to-end in the Okteto dev environment together with the UI PR.