### PR TITLE
Populate project_type_slugs in configuration plugin context

### DIFF
--- a/src/imbi_api/endpoints/project_configuration.py
+++ b/src/imbi_api/endpoints/project_configuration.py
@@ -19,7 +19,10 @@ from imbi_common.plugins.base import (
 
 from imbi_api.auth import permissions
 from imbi_api.domain import models
-from imbi_api.endpoints._helpers import lookup_project_slugs
+from imbi_api.endpoints._helpers import (
+    lookup_project_slugs,
+    lookup_project_type_slugs,
+)
 from imbi_api.identity.host_integration import call_with_identity_retry
 from imbi_api.plugins import call_with_timeout
 from imbi_api.plugins.resolution import ResolvedCapability, resolve_capability
@@ -97,12 +100,14 @@ async def _resolve_and_prepare(
         db, project_id, 'configuration', source
     )
     project_slug, team_slug = await lookup_project_slugs(db, project_id)
+    project_type_slugs = await lookup_project_type_slugs(db, project_id)
     ctx = PluginContext(
         project_id=project_id,
         project_slug=project_slug,
         org_slug=org_slug,
         team_slug=team_slug,
         environment=environment,
+        project_type_slugs=project_type_slugs,
         assignment_options=resolved.capability_options,
         integration_options=resolved.integration_options,
         capability_options=resolved.capability_options,

--- a/tests/endpoints/test_project_configuration.py
+++ b/tests/endpoints/test_project_configuration.py
@@ -28,6 +28,7 @@ from imbi_common.plugins.base import (
     ConfigKeyWithValue,
     ConfigurationCapability,
     Plugin,
+    PluginContext,
     PluginManifest,
 )
 from imbi_common.plugins.registry import RegistryEntry
@@ -384,6 +385,86 @@ class ProjectConfigurationEndpointTestCase(unittest.TestCase):
         self.assertEqual(response.json()[0]['key'], '/foo')
         # And it must have populated the scoped key.
         self.assertIsNotNone(scoped_cached)
+
+    def test_context_includes_project_type_slugs(self) -> None:
+        # The plugin context must carry the project's type slugs so
+        # option templates like ``${project_type_slug}`` expand — an
+        # empty list expands to '' and produces invalid paths (e.g. an
+        # SSM path_prefix of ``/pse//imbi``).
+        self._list_cache_key()  # register for cleanup; ensures fresh id
+        captured: list[PluginContext] = []
+
+        class _RecordingHandler(_FakeConfigurationHandler):
+            async def list_keys(self, ctx, credentials):  # type: ignore[override]
+                captured.append(ctx)
+                return await super().list_keys(ctx, credentials)
+
+        entry = RegistryEntry(
+            plugin_cls=_FakePlugin,
+            manifest=PluginManifest(
+                slug='ssm',
+                name='SSM',
+                capabilities=[
+                    Capability(
+                        kind='configuration',
+                        label='Configuration',
+                        handler=_RecordingHandler,
+                    )
+                ],
+            ),
+            package_name='imbi-plugin-ssm',
+            package_version='1.0.0',
+        )
+        resolved = ResolvedCapability(
+            integration_id=self.plugin_id,
+            integration_slug='ssm-prod',
+            plugin_slug='ssm',
+            kind='configuration',
+            entry=entry,
+            capability_cls=_RecordingHandler,
+            integration={
+                'id': self.plugin_id,
+                'slug': 'ssm-prod',
+                'plugin': 'ssm',
+            },
+            integration_options={},
+            capability_options={},
+            encrypted_credentials={},
+        )
+
+        async def _execute(
+            query: str,
+            params: dict[str, typing.Any],
+            columns: list[str] | None = None,
+        ) -> list[dict[str, typing.Any]]:
+            if 'ProjectType' in query:
+                return [{'slug': 'apis'}, {'slug': 'consumer-apis'}]
+            return [{'slug': 'my-project', 'team_slug': 'my-team'}]
+
+        self.mock_db.execute.side_effect = _execute
+        with testclient.TestClient(self.test_app) as client:
+            with (
+                mock.patch(
+                    'imbi_api.endpoints.project_configuration.resolve_capability',
+                    return_value=resolved,
+                ),
+                mock.patch(
+                    'imbi_api.endpoints.project_configuration'
+                    '.decrypt_integration_credentials',
+                    return_value={'token': 'x'},
+                ),
+            ):
+                response = client.get(
+                    f'/organizations/myorg/projects/{self.project_id}'
+                    '/configuration/'
+                )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(captured), 1)
+        self.assertEqual(
+            captured[0].project_type_slugs, ['apis', 'consumer-apis']
+        )
+        self.assertEqual(captured[0].project_slug, 'my-project')
+        self.assertEqual(captured[0].team_slug, 'my-team')
 
     # ----- value fetch ------------------------------------------------
 


### PR DESCRIPTION
## Summary
Populate `project_type_slugs` in the `PluginContext` built by the project configuration endpoints so capability option templates like `${project_type_slug}` expand correctly.

## Problem
The Configuration tab returned HTTP 500 for projects whose integration options use `${project_type_slug}` (e.g. an AWS SSM `path_prefix` of `/pse/${project_type_slug}/imbi`). imbi-plugin-aws 2.13.0 (#17) fixed the plugin side to read the slug from `ctx.project_type_slugs`, but the configuration endpoints never populated that field — it defaulted to `[]`, the variable expanded to an empty string, and the resulting path (`/pse//imbi`) was rejected by SSM with a `ValueError` that surfaced as a 500.

## Solution
`_resolve_and_prepare` now calls `lookup_project_type_slugs` alongside `lookup_project_slugs` and passes the result into `PluginContext`, matching what project_analysis, project_deployments, and pr_sync already do.

## Impact
Fixes the Configuration tab 500 for any project whose configuration capability options reference `${project_type_slug}`. One extra graph lookup per configuration request, in line with the other plugin endpoints.

## Testing
- Added `test_context_includes_project_type_slugs` asserting the capability handler receives the looked-up type slugs, project slug, and team slug
- Ran the full `tests/endpoints/test_project_configuration.py` suite (14 passed) and `just lint` (clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)