### PR TITLE
Fix webhook identifier_selector description: JSON Pointer, not JSON Path

### DIFF
--- a/src/imbi_api/domain/models.py
+++ b/src/imbi_api/domain/models.py
@@ -974,7 +974,10 @@ class WebhookCreate(pydantic.BaseModel):
     integration_slug: str | None = None
     identifier_selector: str | None = pydantic.Field(
         default=None,
-        description='JSON Path expression to extract project identifier',
+        description=(
+            'JSON Pointer that extracts the project identifier from the '
+            'webhook payload (e.g. /repository/id).'
+        ),
     )
     user_subject_selector: str | None = pydantic.Field(
         default=None,
@@ -1041,7 +1044,10 @@ class WebhookUpdate(pydantic.BaseModel):
     integration_slug: str | None = None
     identifier_selector: str | None = pydantic.Field(
         default=None,
-        description='JSON Path expression to extract project identifier',
+        description=(
+            'JSON Pointer that extracts the project identifier from the '
+            'webhook payload (e.g. /repository/id).'
+        ),
     )
     user_subject_selector: str | None = pydantic.Field(
         default=None,


### PR DESCRIPTION
## Summary

The webhook `identifier_selector` field was described as a *"JSON Path expression"*, but the gateway resolves it as an RFC 6901 **JSON Pointer** (`jsonpointer.JsonPointer(...).resolve(body)` in `imbi-gateway`'s `notifications.py`). Existing values like `/repository/id` are pointer syntax, not JSONPath.

This corrects the `description` on `WebhookCreate.identifier_selector` and `WebhookUpdate.identifier_selector`, and adds a pointer-format example. The sibling `user_subject_selector` field was already correctly labeled "JSON Pointer".

## Notes

- This changes the OpenAPI field description, so `imbi-ui`'s generated types will pick up the new text on the next `codegen:fetch`. The UI label fix is in a companion PR (AWeber-Imbi/imbi-ui).

## Verification

- `just lint` hooks (ruff + mypy) pass locally.