### PR TITLE
Fix events list OOM by reading payload for page only

### DIFF
--- a/src/imbi_api/endpoints/events.py
+++ b/src/imbi_api/endpoints/events.py
@@ -189,10 +189,21 @@ async def _list_impl(
 
     where = ' AND '.join(clauses) if clauses else '1=1'
     params['row_limit'] = limit + 1
+    # The events table is sorted by ``(project_id, id)``, so ordering by
+    # ``recorded_at`` can't short-circuit the LIMIT against the sort key.
+    # A naive ``SELECT ..., payload ... ORDER BY recorded_at LIMIT n`` thus
+    # forces ClickHouse to read the full ``payload``/``metadata`` JSON for
+    # *every* matching row before sorting and discarding all but the page —
+    # enough to exhaust server memory on a busy project or the global feed.
+    # Select the page's keys first using only the light ``(recorded_at, id)``
+    # columns, then read the heavy JSON for just those rows.
     sql: str = (
-        f'SELECT {_SELECT_COLUMNS} FROM events WHERE '  # noqa: S608
+        f'SELECT {_SELECT_COLUMNS} FROM events '  # noqa: S608
+        'WHERE (recorded_at, id) IN ('
+        'SELECT recorded_at, id FROM events WHERE '
         + where
-        + ' ORDER BY recorded_at DESC, id DESC LIMIT {row_limit:UInt32}'
+        + ' ORDER BY recorded_at DESC, id DESC LIMIT {row_limit:UInt32})'
+        ' ORDER BY recorded_at DESC, id DESC'
     )
 
     rows = await clickhouse.query(sql, params)

--- a/tests/endpoints/test_events.py
+++ b/tests/endpoints/test_events.py
@@ -278,11 +278,14 @@ class GlobalListTests(_EventsTestBase):
         sql = self.mock_query.await_args.args[0]
         # Outer query reads the heavy JSON columns exactly once...
         self.assertEqual(sql.count('toJSONString(payload)'), 1)
+        self.assertEqual(sql.count('toJSONString(metadata)'), 1)
         # ...and only for the page selected by the light-column subquery.
         self.assertIn('(recorded_at, id) IN (', sql)
         self.assertIn('SELECT recorded_at, id FROM events WHERE', sql)
         inner = sql.split('(recorded_at, id) IN (', 1)[1]
-        self.assertNotIn('payload', inner.split('LIMIT', 1)[0])
+        inner_page = inner.split('LIMIT', 1)[0]
+        self.assertNotIn('payload', inner_page)
+        self.assertNotIn('metadata', inner_page)
         self.assertIn('LIMIT {row_limit:UInt32}', inner)
 
     def test_list_with_since_until(self) -> None:

--- a/tests/endpoints/test_events.py
+++ b/tests/endpoints/test_events.py
@@ -265,6 +265,26 @@ class GlobalListTests(_EventsTestBase):
         sql = self.mock_query.await_args.args[0]
         self.assertIn('FROM events WHERE', sql)
 
+    def test_list_reads_payload_only_for_the_selected_page(self) -> None:
+        # The events table is sorted by ``(project_id, id)``, so ordering
+        # by ``recorded_at`` can't short-circuit the LIMIT. Reading the
+        # heavy ``payload`` JSON for every matching row before discarding
+        # all but the page exhausted ClickHouse memory. The query must
+        # pick the page keys from the light ``(recorded_at, id)`` columns
+        # in a subquery, then read the JSON only for those rows.
+        self.mock_query.return_value = []
+        response = self.client.get('/events/')
+        self.assertEqual(response.status_code, 200)
+        sql = self.mock_query.await_args.args[0]
+        # Outer query reads the heavy JSON columns exactly once...
+        self.assertEqual(sql.count('toJSONString(payload)'), 1)
+        # ...and only for the page selected by the light-column subquery.
+        self.assertIn('(recorded_at, id) IN (', sql)
+        self.assertIn('SELECT recorded_at, id FROM events WHERE', sql)
+        inner = sql.split('(recorded_at, id) IN (', 1)[1]
+        self.assertNotIn('payload', inner.split('LIMIT', 1)[0])
+        self.assertIn('LIMIT {row_limit:UInt32}', inner)
+
     def test_list_with_since_until(self) -> None:
         self.mock_query.return_value = []
         response = self.client.get(


### PR DESCRIPTION
## Summary

The events list endpoints (`GET /api/events/` and the project-scoped
`.../projects/{id}/events/`) are returning 500s with ClickHouse
`MEMORY_LIMIT_EXCEEDED` (code 241) — even for small pages like
`limit=20`.

## Problem

The `imbi.events` table is sorted by `(project_id, id)`:

```sql
ENGINE = ReplacingMergeTree(version)
PARTITION BY toYYYYMM(recorded_at)
ORDER BY (project_id, id)
```

`_list_impl` orders the feed by `recorded_at DESC, id DESC`, which is
**not** a prefix of the sort key (`id` is a random nanoid, not
time-ordered). ClickHouse therefore can't use `optimize_read_in_order`
to short-circuit the `LIMIT`, so it reads the full `payload`/`metadata`
`JSON` for **every** matching row, sorts the whole set, then discards
all but the page. `toJSONString(payload)` forces each blob to be
serialized to text in memory. Webhook payloads are large, so this blows
past the server's 7.2 GiB limit — the exception fails `while reading
column payload`.

The global feed is the worse offender: with no `project_id` filter,
nothing narrows against the sort key, so it materializes the payload of
every webhook event in the time range.

## Solution

Split the read into two phases:

- An inner subquery selects the page's `(recorded_at, id)` keys reading
  **only those light columns** (no JSON), with all existing
  filter/cursor clauses applied.
- The outer query reads the heavy `metadata`/`payload` JSON for just the
  ≤ `limit+1` selected rows via `(recorded_at, id) IN (...)`.

Ordering, pagination probe, and filters are unchanged. Added a
regression test asserting the two-phase structure (payload read exactly
once; inner subquery reads no payload before its `LIMIT`).

## Testing

- `pytest tests/endpoints/test_events.py` → 34 passed
- `ruff format`, `ruff check`, `mypy` clean on changed files

## Follow-up (not in this PR)

The inner scan is now memory-safe but still not *fast* on the global
feed (it scans light columns across the time range). If that feed gets
slow, a time-aligned sort key or a data-skipping index would be the real
optimization.
