### PR TITLE
Fall back to service credentials for deployment resync

### DIFF
--- a/src/imbi_api/endpoints/project_deployments.py
+++ b/src/imbi_api/endpoints/project_deployments.py
@@ -328,8 +328,19 @@ async def _resolve_and_context(
     *,
     source: str | None = None,
     environment: str | None = None,
+    best_effort_identity: bool = False,
 ) -> tuple[ResolvedCapability, PluginContext, dict[str, str]]:
-    """Common boilerplate: resolve plugin, attach identity, build creds."""
+    """Common boilerplate: resolve plugin, attach identity, build creds.
+
+    When ``best_effort_identity`` is set (the resync/backfill path), a
+    missing per-user identity connection is not fatal: the actor is still
+    stamped for attribution, but credential resolution falls back to the
+    Integration's own service credentials (a PAT or GitHub App) rather
+    than raising ``identity_required``.  This lets the headless
+    deployment-resync sweep -- which acts as a synthetic principal with
+    no user -- backfill via the App installation token, mirroring how
+    project analysis and pr-sync already behave.
+    """
     resolved = await resolve_capability(db, project_id, 'deployment', source)
     project_slug, team_slug = await lookup_project_slugs(db, project_id)
     project_links = await lookup_project_links(db, project_id)
@@ -356,7 +367,10 @@ async def _resolve_and_context(
         project_links=project_links,
         project_type_slugs=project_type_slugs,
     )
-    ctx = await attach_identity(db, ctx, resolved, auth)
+    if best_effort_identity:
+        ctx = await _attach_identity_best_effort(db, ctx, resolved, auth)
+    else:
+        ctx = await attach_identity(db, ctx, resolved, auth)
 
     if ctx.identity and ctx.identity.access_token:
         credentials: dict[str, str] = {
@@ -366,8 +380,8 @@ async def _resolve_and_context(
         credentials = decrypt_integration_credentials(
             resolved.encrypted_credentials
         )
-        if not credentials.get('access_token') and not credentials.get(
-            'token'
+        if not _has_service_credentials(
+            credentials, allow_app=best_effort_identity
         ):
             raise fastapi.HTTPException(
                 status_code=503,
@@ -377,6 +391,56 @@ async def _resolve_and_context(
                 ),
             )
     return resolved, ctx, credentials
+
+
+async def _attach_identity_best_effort(
+    db: graph.Graph,
+    ctx: PluginContext,
+    resolved: ResolvedCapability,
+    auth: permissions.AuthContext,
+) -> PluginContext:
+    """Attach the actor's identity when available, else proceed without.
+
+    Resync backfills historical remote activity and must not hard-fail
+    when the acting principal (or a headless sweep) has no per-user
+    identity connection.  On ``identity_required`` we keep the actor
+    stamped and let the caller fall back to the Integration's service
+    credentials.
+    """
+    try:
+        return await attach_identity(db, ctx, resolved, auth)
+    except fastapi.HTTPException as exc:
+        detail: object = exc.detail
+        if not (
+            isinstance(detail, dict)
+            and typing.cast('dict[str, object]', detail).get('error')
+            == 'identity_required'
+        ):
+            raise
+        LOGGER.info(
+            'No identity connection for the deployment integration on '
+            'project %s; falling back to service credentials',
+            ctx.project_id,
+        )
+        actor_user_id = auth.user.id if auth.user else None
+        return ctx.model_copy(update={'actor_user_id': actor_user_id})
+
+
+def _has_service_credentials(
+    credentials: dict[str, str], *, allow_app: bool
+) -> bool:
+    """Whether *credentials* carry a usable non-identity secret.
+
+    A PAT (``access_token``/``token``) always qualifies.  GitHub App
+    credentials (``app_id`` + ``private_key``) qualify only when
+    ``allow_app`` is set -- the backfill paths that can mint an
+    installation token without an acting user.
+    """
+    if credentials.get('access_token') or credentials.get('token'):
+        return True
+    return allow_app and bool(
+        credentials.get('app_id') and credentials.get('private_key')
+    )
 
 
 async def _resolve_tag_formats(
@@ -783,7 +847,12 @@ async def resync_for_project(
     """
     summary = ResyncSummary(projects=1)
     resolved, ctx, credentials = await _resolve_and_context(
-        db, org_slug, project_id, auth, source=source
+        db,
+        org_slug,
+        project_id,
+        auth,
+        source=source,
+        best_effort_identity=True,
     )
     deployment_capability = resolved.entry.manifest.get_capability(
         'deployment'

--- a/tests/endpoints/test_project_deployments.py
+++ b/tests/endpoints/test_project_deployments.py
@@ -6,6 +6,7 @@ import typing
 import unittest
 from unittest import mock
 
+import fastapi
 from fastapi import testclient
 from imbi_common import graph
 from imbi_common.llm import AnthropicClient, CompletionResult
@@ -1475,6 +1476,66 @@ class ResyncProjectDeploymentsTestCase(ProjectDeploymentsTestCase):
                 '/organizations/myorg/projects/proj1/deployments/resync'
             )
         self.assertEqual(response.status_code, 403)
+
+    def test_resync_falls_back_to_app_credentials_without_identity(
+        self,
+    ) -> None:
+        """Identity-gated integration + no user connection must not 401.
+
+        The backfill acts with the Integration's own GitHub App
+        credentials (which the plugin turns into an installation token),
+        so a headless sweep still records deployments.
+        """
+        self._arm([self._observed()], release_exists=False)
+
+        def _identity_required(
+            _db: object, _ctx: object, _resolved: object, _auth: object
+        ) -> typing.NoReturn:
+            raise fastapi.HTTPException(
+                status_code=401,
+                detail={
+                    'error': 'identity_required',
+                    'integration_id': 'int-1',
+                    'start_url': '/me/identities/int-1/start',
+                },
+            )
+
+        self.mocks['attach_identity'].side_effect = _identity_required
+        self.mocks['decrypt_integration_credentials'].return_value = {
+            'app_id': '971',
+            'private_key': 'PEM',
+        }
+        with testclient.TestClient(self.test_app) as client:
+            response = client.post(
+                '/organizations/myorg/projects/proj1/deployments/resync'
+            )
+        self.assertEqual(response.status_code, 200, response.text)
+        self.assertEqual(response.json()['observed'], 1)
+
+    def test_resync_503_when_no_service_credentials(self) -> None:
+        """No identity connection *and* no service secret is a genuine
+        misconfiguration -- surface it rather than silently no-op."""
+        self._arm([self._observed()])
+
+        def _identity_required(
+            _db: object, _ctx: object, _resolved: object, _auth: object
+        ) -> typing.NoReturn:
+            raise fastapi.HTTPException(
+                status_code=401,
+                detail={
+                    'error': 'identity_required',
+                    'integration_id': 'int-1',
+                    'start_url': '/me/identities/int-1/start',
+                },
+            )
+
+        self.mocks['attach_identity'].side_effect = _identity_required
+        self.mocks['decrypt_integration_credentials'].return_value = {}
+        with testclient.TestClient(self.test_app) as client:
+            response = client.post(
+                '/organizations/myorg/projects/proj1/deployments/resync'
+            )
+        self.assertEqual(response.status_code, 503, response.text)
 
 
 class FallbackNotesTestCase(unittest.TestCase):


### PR DESCRIPTION
## Summary
Make the deployment-resync path fall back to the integration's own service credentials when there is no per-user identity, so the headless **Sync Deployments** maintenance sweep can backfill without an acting user.

## Problem
The maintenance sweep runs as a synthetic principal with **no user**. `resync_for_project` → `_resolve_and_context` → `attach_identity` hard-raised `identity_required` (HTTP 401) for every identity-gated deployment integration. `execute_deployment_resync` only maps 400/404 → skipped, so 401 became a hard failure: **0 succeeded, 639 failed**. Because it surfaces as a controlled `MaintenanceItemFailed`, no traceback reached Sentry.

Project analysis and pr-sync already avoid this by falling back to the integration's service credentials — deployment resync was the outlier.

## Solution
- Add `best_effort_identity` to `_resolve_and_context`: on `identity_required`, keep the actor stamped and continue instead of raising, and accept GitHub App credentials (`app_id` + `private_key`) as usable service credentials via `_has_service_credentials`.
- `resync_for_project` opts in, so both the headless sweep and a user-driven resync backfill via the App installation token (minted plugin-side). Strict trigger/promote paths are unchanged.
- Tests cover the credential fallback (200) and the genuine no-credentials misconfiguration (503). Deployment-endpoint (197) and maintenance-operations (14) suites pass; mypy + basedpyright clean.

## Notes
Depends on imbi-plugin-github#45 at runtime (the plugin mints the App token). API tests mock the handler, so this PR is independently green; deploy after the plugin release lands on PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)