### PR TITLE
Add Remediate Findings maintenance operation

### DIFF
--- a/src/imbi_api/endpoints/project_analysis.py
+++ b/src/imbi_api/endpoints/project_analysis.py
@@ -663,30 +663,26 @@ async def remediate_project_finding(
     return RemediateResponse(result=result, report=report)
 
 
-@project_analysis_router.post(
-    '/remediate-all', response_model=RemediateAllResponse
-)
-async def remediate_all_project_findings(
+async def remediate_all_for_project(
+    db: graph.Graph,
+    *,
     org_slug: str,
     project_id: str,
-    db: graph.Pool,
-    auth: typing.Annotated[
-        permissions.AuthContext,
-        fastapi.Depends(permissions.require_permission('project:write')),
-    ],
-) -> RemediateAllResponse:
-    """Apply every fixable finding in the current report (best-effort).
+    auth: permissions.AuthContext,
+) -> RemediateAllResponse | None:
+    """Apply every fixable finding in a project's report (best-effort).
 
-    Each finding is remediated independently; a failure on one is
-    captured in its outcome rather than aborting the rest. Analysis is
+    Returns ``None`` when the project has no persisted report (nothing to
+    remediate). Each finding is remediated independently; a failure on one
+    is captured in its outcome rather than aborting the rest. Analysis is
     re-run once at the end so the returned report reflects every fix.
+
+    Shared by the per-project endpoint and the ``remediate`` maintenance
+    sweep, so both apply findings identically.
     """
     report = await _fetch_report(db, project_id)
     if report is None:
-        raise fastapi.HTTPException(
-            status_code=404,
-            detail='No analysis report exists for this project',
-        )
+        return None
     # Resolve plugins and project-type slugs once and reuse them across
     # every finding, rather than re-running these graph queries per
     # finding inside _remediate_one.
@@ -730,3 +726,27 @@ async def remediate_all_project_findings(
         )
     fresh = await run_and_persist(db, org_slug, project_id, auth)
     return RemediateAllResponse(outcomes=outcomes, report=fresh)
+
+
+@project_analysis_router.post(
+    '/remediate-all', response_model=RemediateAllResponse
+)
+async def remediate_all_project_findings(
+    org_slug: str,
+    project_id: str,
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(permissions.require_permission('project:write')),
+    ],
+) -> RemediateAllResponse:
+    """Apply every fixable finding in the current report (best-effort)."""
+    response = await remediate_all_for_project(
+        db, org_slug=org_slug, project_id=project_id, auth=auth
+    )
+    if response is None:
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail='No analysis report exists for this project',
+        )
+    return response

--- a/src/imbi_api/maintenance/operations.py
+++ b/src/imbi_api/maintenance/operations.py
@@ -98,6 +98,36 @@ async def execute_analysis(
     return 'succeeded'
 
 
+async def execute_remediate(
+    db: graph.Graph, client: valkey.Valkey, project_id: str
+) -> ExecuteOutcome:
+    """Apply every fixable Project Doctor finding for one project.
+
+    Skipped when the project has no persisted report or no fixable
+    findings.  Each finding is applied best-effort; if any remediation
+    reports ``failed`` the item is a failure (with a count), otherwise it
+    succeeded.  The report is re-run and persisted so it reflects the
+    fixes, mirroring the per-project ``remediate-all`` endpoint.
+    """
+    from imbi_api.endpoints import project_analysis
+
+    org_slug = await _org_slug_for(db, project_id)
+    if org_slug is None:
+        return 'skipped'
+    response = await project_analysis.remediate_all_for_project(
+        db, org_slug=org_slug, project_id=project_id, auth=_system_auth()
+    )
+    if response is None or not response.outcomes:
+        return 'skipped'
+    failed = sum(1 for o in response.outcomes if o.result.status == 'failed')
+    if failed:
+        raise MaintenanceItemFailed(
+            f'{failed} of {len(response.outcomes)} remediations failed; '
+            'see server logs for details.'
+        )
+    return 'succeeded'
+
+
 async def execute_commit_sync(
     db: graph.Graph, client: valkey.Valkey, project_id: str
 ) -> ExecuteOutcome:

--- a/src/imbi_api/maintenance/registry.py
+++ b/src/imbi_api/maintenance/registry.py
@@ -21,6 +21,7 @@ from imbi_api.pr_sync import queue as pr_sync_queue
 
 MaintenanceSlug = typing.Literal[
     'run-analysis',
+    'remediate',
     'rescore',
     'deployment-resync',
     'commit-sync',
@@ -57,6 +58,18 @@ OPERATIONS: dict[MaintenanceSlug, OperationDefinition] = {
             pause_key=None,
             enumerate=operations.enumerate_all_projects,
             execute=operations.execute_analysis,
+        ),
+        OperationDefinition(
+            slug='remediate',
+            label='Remediate Findings',
+            description=(
+                'Apply every fixable Project Doctor finding for every '
+                'project, then refresh its report. Projects with no '
+                'report or no fixable findings are skipped.'
+            ),
+            pause_key=None,
+            enumerate=operations.enumerate_all_projects,
+            execute=operations.execute_remediate,
         ),
         OperationDefinition(
             slug='rescore',

--- a/tests/test_maintenance_operations.py
+++ b/tests/test_maintenance_operations.py
@@ -52,6 +52,76 @@ class ExecuteAnalysisTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual('maintenance', args[3].principal_name)
 
 
+def _remediate_response(*statuses: str) -> mock.Mock:
+    """A fake RemediateAllResponse carrying outcomes of the given statuses."""
+    outcomes = [
+        mock.Mock(result=mock.Mock(status=status)) for status in statuses
+    ]
+    return mock.Mock(outcomes=outcomes)
+
+
+class ExecuteRemediateTests(unittest.IsolatedAsyncioTestCase):
+    def _patch(self, remediate: mock.AsyncMock) -> contextlib.ExitStack:
+        stack = contextlib.ExitStack()
+        stack.enter_context(
+            mock.patch.object(operations, '_org_slug_for', _org_slug('org'))
+        )
+        stack.enter_context(
+            mock.patch(
+                'imbi_api.endpoints.project_analysis'
+                '.remediate_all_for_project',
+                remediate,
+            )
+        )
+        return stack
+
+    async def test_skipped_without_org(self) -> None:
+        with mock.patch.object(operations, '_org_slug_for', _org_slug(None)):
+            outcome = await operations.execute_remediate(
+                mock.AsyncMock(), mock.AsyncMock(), 'p1'
+            )
+        self.assertEqual('skipped', outcome)
+
+    async def test_skipped_without_report(self) -> None:
+        remediate = mock.AsyncMock(return_value=None)
+        with self._patch(remediate):
+            outcome = await operations.execute_remediate(
+                mock.AsyncMock(), mock.AsyncMock(), 'p1'
+            )
+        self.assertEqual('skipped', outcome)
+        self.assertEqual(
+            'maintenance', remediate.await_args.kwargs['auth'].principal_name
+        )
+
+    async def test_skipped_without_fixable_findings(self) -> None:
+        remediate = mock.AsyncMock(return_value=_remediate_response())
+        with self._patch(remediate):
+            outcome = await operations.execute_remediate(
+                mock.AsyncMock(), mock.AsyncMock(), 'p1'
+            )
+        self.assertEqual('skipped', outcome)
+
+    async def test_all_fixed_is_succeeded(self) -> None:
+        remediate = mock.AsyncMock(
+            return_value=_remediate_response('fixed', 'noop')
+        )
+        with self._patch(remediate):
+            outcome = await operations.execute_remediate(
+                mock.AsyncMock(), mock.AsyncMock(), 'p1'
+            )
+        self.assertEqual('succeeded', outcome)
+
+    async def test_any_failed_raises_item_failed(self) -> None:
+        remediate = mock.AsyncMock(
+            return_value=_remediate_response('fixed', 'failed')
+        )
+        with self._patch(remediate):
+            with self.assertRaises(operations.MaintenanceItemFailed):
+                await operations.execute_remediate(
+                    mock.AsyncMock(), mock.AsyncMock(), 'p1'
+                )
+
+
 class ExecuteCommitSyncTests(unittest.IsolatedAsyncioTestCase):
     def _patches(
         self, run_sync: mock.AsyncMock


### PR DESCRIPTION
## Summary
Add a global **Remediate Findings** maintenance operation that applies every fixable Project Doctor finding across all projects. It renders directly under **Run Analysis** on the Maintenance admin page.

## Problem
The Maintenance page can run Doctor analysis for every project, but there was no way to *apply* the resulting fixes in bulk — remediation was per-project only (`POST /remediate-all`). Fixing findings across a large fleet meant clicking through each project.

## Solution
- Extract `remediate_all_for_project()` from the per-project `remediate-all` endpoint (returns `None` when a project has no persisted report) so the endpoint and the sweep apply findings identically; the endpoint now wraps it and 404s on no report.
- Add `execute_remediate`: skips projects with no report or no fixable findings, applies each finding best-effort under the `maintenance` principal (identity-optional, like analysis), refreshes and persists the report, and marks the item failed only when a remediation reports `failed`.
- Register the `remediate` operation immediately after `run-analysis`. The Maintenance UI is registry-driven (no hardcoded slugs), so it appears under Run Analysis with no frontend change.

## Testing
- 5 new `execute_remediate` unit cases (no org → skipped; no report → skipped; no fixable findings → skipped; all fixed/noop → succeeded; any failed → `MaintenanceItemFailed`).
- The maintenance-list endpoint test is dynamic (derives from the registry) and auto-covers the new op.
- Green: unit (19), DB-backed analysis + maintenance endpoints (26), mypy, basedpyright, ruff.

## Notes
The generated OpenAPI types in imbi-ui (`api-generated.ts`) will pick up the new `remediate` slug on the next regen — not required for the feature to function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)