### PR TITLE
Fix operations-log OOM, AGE reuse retry, delete lifecycle order

### DIFF
--- a/src/imbi_api/endpoints/auth.py
+++ b/src/imbi_api/endpoints/auth.py
@@ -9,6 +9,7 @@ from urllib import parse as urlparse
 
 import fastapi
 import jwt
+import psycopg
 import pydantic
 from imbi_common import graph
 from imbi_common.auth import core
@@ -921,11 +922,29 @@ async def _handle_refresh_reuse(
         'SET t.revoked = true, t.revoked_at = {revoked_at} '
         'RETURN count(t) AS revoked_count'
     )
-    cascade_rows = await db.execute(
-        cascade,
-        {'family_id': family_id_val, 'revoked_at': revoked_at_iso},
-        columns=['revoked_count'],
-    )
+    # AGE sporadically raises "Entity failed to be updated" on this
+    # multi-row SET even when the entities exist -- transient write
+    # concurrency that clears on retry. Wrap the cascade in a short
+    # bounded retry loop so a leaked-token cascade isn't dropped.
+    cascade_rows: list[dict[str, typing.Any]] = []
+    for attempt in range(3):
+        try:
+            cascade_rows = await db.execute(
+                cascade,
+                {'family_id': family_id_val, 'revoked_at': revoked_at_iso},
+                columns=['revoked_count'],
+            )
+            break
+        except psycopg.errors.InternalError as e:
+            if 'Entity failed to be updated' not in str(e) or attempt == 2:
+                raise
+            LOGGER.warning(
+                'AGE cascade-revoke retry %d/3 for family %r: %s',
+                attempt + 1,
+                family_id_val,
+                e,
+            )
+            await asyncio.sleep(0.05 * (attempt + 1))
     cascaded = 0
     if cascade_rows:
         raw = graph.parse_agtype(cascade_rows[0].get('revoked_count'))

--- a/src/imbi_api/endpoints/operations_log.py
+++ b/src/imbi_api/endpoints/operations_log.py
@@ -400,10 +400,22 @@ async def _list_impl(
 
     where = ' AND '.join(clauses)
     params['row_limit'] = limit + 1
+    # operations_log is sorted by ``(project_id, id)``, so ordering by
+    # ``occurred_at`` can't short-circuit the LIMIT against the sort key.
+    # ``SELECT * ... FINAL`` therefore reads and merges *every* column --
+    # including the unbounded ``description``/``notes`` text -- for the
+    # entire filter universe before sorting and discarding all but the
+    # page, exhausting ClickHouse memory. Select the page's keys first
+    # using only the light ``(occurred_at, id)`` columns (FINAL kept so
+    # dedup/tombstone hiding is honored), then read the heavy columns
+    # FINAL for just those rows.
     sql: str = (
-        'SELECT * FROM operations_log FINAL WHERE '  # noqa: S608
+        'SELECT * FROM operations_log FINAL '  # noqa: S608
+        'WHERE (occurred_at, id) IN ('
+        'SELECT occurred_at, id FROM operations_log FINAL WHERE '
         + where
-        + ' ORDER BY occurred_at DESC, id DESC LIMIT {row_limit:UInt32}'
+        + ' ORDER BY occurred_at DESC, id DESC LIMIT {row_limit:UInt32})'
+        ' ORDER BY occurred_at DESC, id DESC'
     )
 
     rows = await clickhouse.query(sql, params)

--- a/src/imbi_api/endpoints/projects.py
+++ b/src/imbi_api/endpoints/projects.py
@@ -3226,15 +3226,18 @@ async def delete_project(
     were assigned, or ``delete_repository=false`` short-circuited the
     dispatch.
     """
-    # Capture the lifecycle context bundle *before* the DETACH DELETE
-    # so the project's links / slug / type slugs survive the write and
-    # the downstream dispatcher doesn't try to look them up against a
-    # node that no longer exists.
-    bundle = (
-        await build_lifecycle_context_bundle(db, project_id)
-        if delete_repository
-        else None
-    )
+    # Capture the lifecycle context bundle *and* the resolved plugin
+    # bindings *before* the DETACH DELETE so both survive the write and
+    # the downstream dispatcher never looks them up against a node that
+    # no longer exists.  Resolving bindings after the delete raised
+    # ``LookupError`` -> a spurious "Project not found" (IMBI-3T).
+    bundle = None
+    resolved_lifecycle = None
+    if delete_repository:
+        bundle = await build_lifecycle_context_bundle(db, project_id)
+        resolved_lifecycle = await resolve_all_capabilities(
+            db, project_id, 'lifecycle'
+        )
 
     query: typing.LiteralString = """
     MATCH (p:Project {{id: {project_id}}})
@@ -3271,6 +3274,7 @@ async def delete_project(
                 'deleted',
                 auth,
                 bundle=bundle,
+                resolved_list=resolved_lifecycle,
             )
         except Exception:
             LOGGER.exception(

--- a/src/imbi_api/endpoints/projects.py
+++ b/src/imbi_api/endpoints/projects.py
@@ -3234,10 +3234,19 @@ async def delete_project(
     bundle = None
     resolved_lifecycle = None
     if delete_repository:
-        bundle = await build_lifecycle_context_bundle(db, project_id)
-        resolved_lifecycle = await resolve_all_capabilities(
-            db, project_id, 'lifecycle'
-        )
+        try:
+            bundle = await build_lifecycle_context_bundle(db, project_id)
+            resolved_lifecycle = await resolve_all_capabilities(
+                db, project_id, 'lifecycle'
+            )
+        except Exception:
+            LOGGER.exception(
+                'Unable to snapshot lifecycle bindings for project %s; '
+                'proceeding with delete and skipping dispatch',
+                project_id,
+            )
+            bundle = None
+            resolved_lifecycle = None
 
     query: typing.LiteralString = """
     MATCH (p:Project {{id: {project_id}}})

--- a/src/imbi_api/plugins/lifecycle_dispatch.py
+++ b/src/imbi_api/plugins/lifecycle_dispatch.py
@@ -153,6 +153,7 @@ async def dispatch_lifecycle(
     auth: permissions.AuthContext,
     *,
     bundle: LifecycleContextBundle | None = None,
+    resolved_list: list[ResolvedCapability] | None = None,
     previous_project_slug: str | None = None,
     previous_project_type_slugs: list[str] | None = None,
     previous_team_slug: str | None = None,
@@ -169,11 +170,19 @@ async def dispatch_lifecycle(
 
     Pass ``bundle`` for events like ``'deleted'`` where the caller
     needs to capture project context before a destructive write;
-    otherwise the dispatcher looks the data up.  The optional
-    ``previous_*`` fields populate :class:`PluginContext` for plugins
-    that need a before/after view (``'updated'`` / ``'relocated'``).
+    otherwise the dispatcher looks the data up.  ``resolved_list`` is
+    the sibling escape hatch for the bound capabilities: on ``'deleted'``
+    the project node is already gone by dispatch time, so resolving its
+    bindings here would raise ``LookupError`` ("Project not found") --
+    the caller resolves them before the ``DETACH DELETE`` and passes
+    them in.  The optional ``previous_*`` fields populate
+    :class:`PluginContext` for plugins that need a before/after view
+    (``'updated'`` / ``'relocated'``).
     """
-    resolved_list = await resolve_all_capabilities(db, project_id, 'lifecycle')
+    if resolved_list is None:
+        resolved_list = await resolve_all_capabilities(
+            db, project_id, 'lifecycle'
+        )
     if not resolved_list:
         return []
 

--- a/tests/endpoints/test_auth.py
+++ b/tests/endpoints/test_auth.py
@@ -1330,6 +1330,61 @@ class TokenRefreshTestCase(support.SharedAppTestCase):
         third_call_params = self.mock_db.execute.call_args_list[2][0][1]
         self.assertEqual(third_call_params['family_id'], 'fam-leak')
 
+    def test_refresh_reuse_cascade_retries_on_age_write_error(self) -> None:
+        """The family cascade retries transient AGE write failures.
+
+        AGE sporadically raises ``InternalError: Entity failed to be
+        updated`` on the multi-row cascade SET even when the entities
+        exist. The write must be retried so a leaked-token cascade is
+        not dropped; here the first cascade attempt fails and the
+        second succeeds.
+        """
+        import psycopg
+        from imbi_common.auth import core
+
+        auth_settings = settings.Auth(
+            jwt_secret='test-secret-key-min-32-chars-long',
+        )
+        refresh_token = core.create_refresh_token(
+            'test@example.com',
+            auth_settings=auth_settings,
+        )
+
+        self.mock_db.execute.side_effect = [
+            # Atomic revoke matches nothing (already revoked).
+            [],
+            # Reuse lookup finds the row revoked w/ family_id.
+            [{'revoked': True, 'family_id': 'fam-leak'}],
+            # First cascade attempt hits transient AGE write error.
+            psycopg.errors.InternalError('Entity failed to be updated: 3'),
+            # Retry succeeds and reports the siblings revoked.
+            [{'revoked_count': 3}],
+        ]
+
+        with (
+            mock.patch(
+                'imbi_api.settings.get_auth_settings',
+                return_value=auth_settings,
+            ),
+            mock.patch(
+                'imbi_api.endpoints.auth.asyncio.sleep',
+                new_callable=mock.AsyncMock,
+            ) as mock_sleep,
+        ):
+            response = self.client.post(
+                '/auth/token/refresh',
+                json={'refresh_token': refresh_token},
+            )
+
+        self.assertEqual(response.status_code, 401)
+        # 4 execute() calls: atomic SET, reuse lookup, failed cascade,
+        # retried cascade.
+        self.assertEqual(self.mock_db.execute.call_count, 4)
+        mock_sleep.assert_awaited_once()
+        # Both cascade attempts carry the family_id from the lookup.
+        cascade_params = self.mock_db.execute.call_args_list[3][0][1]
+        self.assertEqual(cascade_params['family_id'], 'fam-leak')
+
 
 class LogoutTestCase(support.SharedAppTestCase):
     """Test logout endpoint."""

--- a/tests/endpoints/test_operations_log.py
+++ b/tests/endpoints/test_operations_log.py
@@ -321,6 +321,32 @@ class ListEntriesTests(_OpsLogTestBase):
         response = self.client.get('/operations-log/?limit=501')
         self.assertEqual(response.status_code, 400)
 
+    def test_list_reads_payload_only_for_the_selected_page(self) -> None:
+        # operations_log is sorted by ``(project_id, id)``, so ordering
+        # by ``occurred_at`` can't short-circuit the LIMIT. Reading and
+        # merging every column (including the unbounded ``description``/
+        # ``notes`` text) for the whole filter universe before discarding
+        # all but the page exhausted ClickHouse memory. The query must
+        # pick the page keys from the light ``(occurred_at, id)`` columns
+        # in a subquery, then read the full row only for those keys.
+        self._stub_list([])
+        response = self.client.get('/operations-log/')
+        self.assertEqual(response.status_code, 200)
+        sql = self.mock_query.await_args_list[0].args[0]
+        # Outer query reads the full (heavy) row exactly once...
+        self.assertEqual(sql.count('SELECT * FROM operations_log FINAL'), 1)
+        # ...and only for the page selected by the light-column subquery.
+        self.assertIn('(occurred_at, id) IN (', sql)
+        self.assertIn(
+            'SELECT occurred_at, id FROM operations_log FINAL WHERE', sql
+        )
+        inner = sql.split('(occurred_at, id) IN (', 1)[1]
+        inner_page = inner.split('LIMIT', 1)[0]
+        self.assertNotIn('SELECT *', inner_page)
+        self.assertNotIn('description', inner_page)
+        self.assertNotIn('notes', inner_page)
+        self.assertIn('LIMIT {row_limit:UInt32}', inner)
+
     def test_list_project_slug_filter(self) -> None:
         self._stub_list(self._rows(1))
         response = self.client.get('/operations-log/?project_slug=imbi-api')

--- a/tests/endpoints/test_projects.py
+++ b/tests/endpoints/test_projects.py
@@ -1119,6 +1119,38 @@ class ProjectEndpointsTestCase(support.SharedAppTestCase):
         self.assertEqual(response.status_code, 404)
         self.assertIn('not found', response.json()['detail'])
 
+    def test_delete_succeeds_when_snapshot_raises(self) -> None:
+        """A lifecycle snapshot failure must not abort the delete.
+
+        ``build_lifecycle_context_bundle`` /
+        ``resolve_all_capabilities`` run before the ``DETACH DELETE``;
+        a transient failure there must be logged, the delete must still
+        proceed, and dispatch must be skipped (no complete snapshot).
+        """
+        self.mock_db.execute.return_value = [{'deleted': 1}]
+
+        with (
+            mock.patch(
+                'imbi_common.graph.parse_agtype',
+                side_effect=lambda x: x,
+            ),
+            mock.patch(
+                'imbi_api.endpoints.projects.build_lifecycle_context_bundle',
+                new=mock.AsyncMock(side_effect=RuntimeError('boom')),
+            ),
+            mock.patch(
+                'imbi_api.endpoints.projects.dispatch_lifecycle',
+                new=mock.AsyncMock(return_value=[]),
+            ) as mock_dispatch,
+        ):
+            response = self.client.delete(
+                f'/organizations/engineering/projects/{PROJECT_ID}',
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {'lifecycle_results': []})
+        mock_dispatch.assert_not_awaited()
+
     # -- Archive -------------------------------------------------------
 
     def test_archive_success(self) -> None:

--- a/tests/endpoints/test_projects.py
+++ b/tests/endpoints/test_projects.py
@@ -86,6 +86,17 @@ class ProjectEndpointsTestCase(support.SharedAppTestCase):
         self._bundle_patcher.start()
         self.addCleanup(self._bundle_patcher.stop)
 
+        # ``delete_project`` resolves the bound lifecycle capabilities
+        # before the DETACH DELETE (so they survive the write); stub it
+        # so CRUD tests don't need to seed the binding-resolution
+        # ``db.execute`` side-effects. Dispatch tests override locally.
+        self._resolve_patcher = mock.patch(
+            'imbi_api.endpoints.projects.resolve_all_capabilities',
+            new=mock.AsyncMock(return_value=[]),
+        )
+        self._resolve_patcher.start()
+        self.addCleanup(self._resolve_patcher.stop)
+
         self.client = TestClient(self.test_app)
 
     def _project_data(self, **overrides: typing.Any) -> dict:
@@ -1797,6 +1808,72 @@ class ProjectEndpointsTestCase(support.SharedAppTestCase):
         self.assertEqual(response.json(), {'lifecycle_results': []})
         mock_dispatch.assert_not_awaited()
         mock_bundle.assert_not_awaited()
+
+    def test_delete_resolves_bindings_before_delete(self) -> None:
+        """Lifecycle bindings resolve *before* the DETACH DELETE.
+
+        Regression for IMBI-3T: resolving the project's plugin bindings
+        after the node was deleted raised ``LookupError`` -> a spurious
+        "Project not found" logged from the dispatcher. The endpoint must
+        resolve them first and hand the snapshot to ``dispatch_lifecycle``
+        so no post-delete lookup happens.
+        """
+        from imbi_api.plugins.resolution import ResolvedCapability
+
+        resolved = ResolvedCapability(
+            integration_id='p-a',
+            integration_slug='gh-a',
+            plugin_slug='gh-a',
+            kind='lifecycle',
+            entry=mock.MagicMock(),
+            capability_cls=lambda: mock.AsyncMock(),  # type: ignore[arg-type]
+            integration={},
+            integration_options={},
+            capability_options={},
+            encrypted_credentials={},
+        )
+
+        order: list[str] = []
+
+        async def _resolve(
+            *_a: typing.Any, **_k: typing.Any
+        ) -> list[ResolvedCapability]:
+            order.append('resolve')
+            return [resolved]
+
+        async def _delete(*_a: typing.Any, **_k: typing.Any) -> list[dict]:
+            order.append('delete')
+            return [{'deleted': 1}]
+
+        self.mock_db.execute.side_effect = _delete
+
+        with (
+            mock.patch(
+                'imbi_common.graph.parse_agtype',
+                side_effect=lambda x: x,
+            ),
+            mock.patch(
+                'imbi_api.endpoints.projects.resolve_all_capabilities',
+                new=mock.AsyncMock(side_effect=_resolve),
+            ),
+            mock.patch(
+                'imbi_api.endpoints.projects.dispatch_lifecycle',
+                new=mock.AsyncMock(return_value=[]),
+            ) as mock_dispatch,
+        ):
+            response = self.client.delete(
+                f'/organizations/engineering/projects/{PROJECT_ID}',
+            )
+
+        self.assertEqual(response.status_code, 200)
+        # Bindings resolved before the DETACH DELETE ran.
+        self.assertEqual(order, ['resolve', 'delete'])
+        # ...and the pre-delete snapshot was handed to the dispatcher so
+        # it never re-resolves against the deleted node.
+        mock_dispatch.assert_awaited_once()
+        self.assertEqual(
+            mock_dispatch.await_args.kwargs['resolved_list'], [resolved]
+        )
 
     def test_preview_returns_would_relocate_per_plugin(self) -> None:
         """``GET /lifecycle/preview`` fans out per plugin and flags diffs.


### PR DESCRIPTION
## Summary

Fix three production issues found via Sentry: the operations-log list OOM, a
transient AGE write failure on refresh-token reuse, and a spurious "Project not
found" error logged on project delete.

## Problem / Solution

### IMBI-3V — `/api/operations-log/` OOM (ClickHouse `MEMORY_LIMIT_EXCEEDED`)

The list query issued `SELECT * FROM operations_log FINAL ... ORDER BY
occurred_at DESC LIMIT n`. The table is sorted by `(project_id, id)`, so ordering
by `occurred_at` can't short-circuit the LIMIT against the sort key — `SELECT * ...
FINAL` reads and merges every column (including the unbounded `description`/`notes`
text) for the entire filter universe before discarding all but the page.

Applies the same two-phase pattern as #474 (events feed): an inner subquery selects
the page's `(occurred_at, id)` keys using only the light columns (FINAL kept for
dedup/tombstone correctness), then the outer query reads the full row FINAL for just
the `<= limit+1` selected keys. Cursor pagination and first-page metrics unchanged.

### IMBI-1W — AGE "Entity failed to be updated: 3" on refresh-reuse cascade

`_handle_refresh_reuse`'s cascade-revoke `SET` write hit transient AGE
write-concurrency with no retry. Wraps it in the existing bounded-retry idiom from
`projects.py:2684` (3 attempts, retry only on `InternalError` containing "Entity
failed to be updated", `0.05 * (attempt + 1)` backoff).

### IMBI-3T — spurious "Project not found" on delete

`delete_project` dispatched the `deleted` lifecycle hooks after the `DETACH DELETE`.
The dispatcher resolves the project's effective bindings, which queried the
now-deleted node and raised `LookupError`. Resolves the lifecycle capabilities
before the delete and passes the snapshot to `dispatch_lifecycle` via a new optional
`resolved_list=` parameter (sibling of the existing `bundle=` escape hatch). Delete
vs dispatch ordering is unchanged; only the spurious error is removed.

## Testing

`just test` for the affected files: 185 passed, including three new regression tests
(payload read only for the selected page; cascade revoke retried on transient error;
bindings resolved before delete). `just lint` clean (ruff, basedpyright, mypy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
