### PR TITLE
Use release notes body for resynced Release node notes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
   "fastapi",
   "filetype",
   "httpx>=0.28.1,<1",
-  "imbi-common[databases,llm,sentry,server]==2.13.3",
+  "imbi-common[databases,llm,sentry,server]==2.14.0",
   "jinja2",
   "jsonpatch>=1.33",
   "mcp>=1.26.0",

--- a/src/imbi_api/endpoints/project_deployments.py
+++ b/src/imbi_api/endpoints/project_deployments.py
@@ -930,7 +930,7 @@ async def _apply_remote_deployment(
         tag=tag,
         committish=committish,
         title=title,
-        notes_markdown=observed.description or '',
+        notes_markdown=observed.release_notes or observed.description or '',
         release_url=observed.deployment_url,
         created_by=recorded_by,
     )

--- a/tests/endpoints/test_project_deployments.py
+++ b/tests/endpoints/test_project_deployments.py
@@ -1216,6 +1216,7 @@ class ResyncProjectDeploymentsTestCase(ProjectDeploymentsTestCase):
         external_run_id: str = '12345',
         creator: str | None = 'octocat',
         creator_subject: str | None = None,
+        release_notes: str | None = None,
     ) -> RemoteDeployment:
         return RemoteDeployment(
             environment=environment,
@@ -1231,6 +1232,7 @@ class ResyncProjectDeploymentsTestCase(ProjectDeploymentsTestCase):
                 'https://api.github.com/repos/octo/demo/deployments/12345'
             ),
             description='Bump foo',
+            release_notes=release_notes,
             creator=creator,
             creator_subject=creator_subject,
         )
@@ -1280,6 +1282,46 @@ class ResyncProjectDeploymentsTestCase(ProjectDeploymentsTestCase):
         upsert_call = self.mocks['upsert_release_node'].call_args
         self.assertEqual(upsert_call.kwargs['tag'], 'v1.2.3')
         self.assertEqual(upsert_call.kwargs['committish'], 'deadbee')
+
+    def test_resync_prefers_release_notes_over_description(self) -> None:
+        # A deployment against a release tag carries the release body; it
+        # becomes the Release node's notes while the short deploy
+        # description still supplies the title.
+        self._arm(
+            [
+                self._observed(
+                    ref='v2.0.0',
+                    sha='deadbeefcafebabe',
+                    release_notes="## What's Changed\n- servicelib",
+                )
+            ],
+            release_exists=False,
+        )
+        with testclient.TestClient(self.test_app) as client:
+            response = client.post(
+                '/organizations/myorg/projects/proj1/deployments/resync'
+            )
+        self.assertEqual(response.status_code, 200, response.text)
+        upsert_call = self.mocks['upsert_release_node'].call_args
+        self.assertEqual(
+            upsert_call.kwargs['notes_markdown'],
+            "## What's Changed\n- servicelib",
+        )
+        self.assertEqual(upsert_call.kwargs['title'], 'Bump foo')
+
+    def test_resync_falls_back_to_description_without_release_notes(
+        self,
+    ) -> None:
+        # No release body (branch/SHA deploy) keeps the prior behavior:
+        # the short deploy description supplies the notes.
+        self._arm([self._observed(release_notes=None)], release_exists=False)
+        with testclient.TestClient(self.test_app) as client:
+            response = client.post(
+                '/organizations/myorg/projects/proj1/deployments/resync'
+            )
+        self.assertEqual(response.status_code, 200, response.text)
+        upsert_call = self.mocks['upsert_release_node'].call_args
+        self.assertEqual(upsert_call.kwargs['notes_markdown'], 'Bump foo')
 
     def test_resync_400_when_plugin_opts_out(self) -> None:
         # Override the resolved plugin to advertise the no-sync flavor.

--- a/uv.lock
+++ b/uv.lock
@@ -1088,7 +1088,7 @@ requires-dist = [
     { name = "fastapi" },
     { name = "filetype" },
     { name = "httpx", specifier = ">=0.28.1,<1" },
-    { name = "imbi-common", extras = ["databases", "llm", "sentry", "server"], specifier = "==2.13.3" },
+    { name = "imbi-common", extras = ["databases", "llm", "sentry", "server"], specifier = "==2.14.0" },
     { name = "jinja2" },
     { name = "jsonpatch", specifier = ">=1.33" },
     { name = "mcp", specifier = ">=1.26.0" },
@@ -1136,7 +1136,7 @@ docs = [
 
 [[package]]
 name = "imbi-common"
-version = "2.13.3"
+version = "2.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
@@ -1152,9 +1152,9 @@ dependencies = [
     { name = "python-slugify" },
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9c/c0/b763c967428c8a804046a62d52bba1e61121193fff526484906383bb9bce/imbi_common-2.13.3.tar.gz", hash = "sha256:76de3f2a1d2191275e3fa4ef2370484b61bd4ad5dff50eb996dd63539f72010e", size = 360800, upload-time = "2026-07-15T14:55:53.31Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/61/4c/c8837aef3cbbb5e886ce51085f0bd4c315fcc8b0325fc6060b6167e25296/imbi_common-2.14.0.tar.gz", hash = "sha256:b0a8d2168e72892a51df9054ae90b4f9e1ba668a490d673c7e9077996f8635f3", size = 361115, upload-time = "2026-07-15T21:52:14.795Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/35/07/5c9274570493763e570f0e10a5dee627f958cc60b60fbf2df081c6a97795/imbi_common-2.13.3-py3-none-any.whl", hash = "sha256:d073a53080e6b9f1c8d895b23b30f4cd03da8e8f359cccc77b6230c639d072c7", size = 120605, upload-time = "2026-07-15T14:55:51.732Z" },
+    { url = "https://files.pythonhosted.org/packages/af/17/32614176cb1772f0c973d313d2d82f43d11e6892817c868e75b9b269323c/imbi_common-2.14.0-py3-none-any.whl", hash = "sha256:34e1b05e8e165aed8e7fc61fdd2ddbbaff55f733de58ce5de4174d7bb4f93647", size = 120818, upload-time = "2026-07-15T21:52:13.461Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

Persist the GitHub release body (not the short deploy note) as the `Release` node's notes during deployment resync, so releases authored on GitHub show their notes in the Deployments tab.

## Problem

`_apply_remote_deployment` wrote `notes_markdown=observed.description or ''`, where `description` is the GitHub Deployments API description — a short, usually-empty deploy note. So resynced `Release` nodes had no real notes and the UI showed "No release notes".

## Solution

Prefer the new `RemoteDeployment.release_notes` (the release body) for the notes, falling back to `description`:

```python
notes_markdown=observed.release_notes or observed.description or ''
```

The short `description` still supplies the `Release` title, so titles stay concise.

## Dependency

Requires the new `release_notes` field from **AWeber-Imbi/imbi-common#186** (populated by **AWeber-Imbi/imbi-plugin-github** `feature/deployment-release-notes`). CI here is red until `imbi-common` is released and re-pinned; verified green locally with the field present.

## Testing

`imbi-common` overlaid locally: `ResyncProjectDeploymentsTestCase` **49 passed** against live Postgres/AGE, including two new tests (release body wins for notes; falls back to description when absent). `basedpyright` and `mypy` clean on the changed module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
