### PR TITLE
Fall back to plugin manifest icon for integration links

### DIFF
--- a/src/imbi_api/endpoints/integrations.py
+++ b/src/imbi_api/endpoints/integrations.py
@@ -51,7 +51,8 @@ def build_response(
         name=integration['name'],
         slug=integration['slug'],
         description=integration.get('description'),
-        icon=integration.get('icon'),
+        icon=integration.get('icon')
+        or _plugin_icon(str(integration.get('plugin') or '')),
         vendor=integration.get('vendor'),
         service_url=integration.get('service_url'),
         category=integration.get('category'),
@@ -66,6 +67,21 @@ def build_response(
         used_as_login=bool(integration.get('used_as_login')),
         credential_values=credential_values,
     )
+
+
+def _plugin_icon(plugin_slug: str) -> str | None:
+    """The backing plugin manifest's brand icon (e.g. ``si-github``).
+
+    Integration dashboard links render this so they show the plugin's icon
+    rather than a generic glyph. An Integration's own ``icon`` overrides it
+    when set; this is the fallback.
+    """
+    if not plugin_slug:
+        return None
+    try:
+        return get_plugin(plugin_slug).manifest.icon
+    except PluginNotFoundError:
+        return None
 
 
 def _non_secret_credential_values(

--- a/tests/endpoints/test_integrations.py
+++ b/tests/endpoints/test_integrations.py
@@ -156,6 +156,51 @@ class IntegrationsEndpointTestCase(support.SharedAppTestCase):
         response = self.client.get('/organizations/myorg/integrations/missing')
         self.assertEqual(response.status_code, 404)
 
+    def test_icon_falls_back_to_plugin_manifest(self) -> None:
+        """With no icon of its own, an Integration inherits its plugin's."""
+        manifest = _create_manifest()
+        manifest.icon = 'si-logzio'
+        self.mock_db.execute.return_value = [{'integration': _node()}]
+        with mock.patch(
+            'imbi_api.endpoints.integrations.get_plugin',
+            return_value=_entry(manifest),
+        ):
+            response = self.client.get(
+                '/organizations/myorg/integrations/logzio-prod'
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()['icon'], 'si-logzio')
+
+    def test_icon_prefers_integration_over_plugin(self) -> None:
+        """An Integration's own icon overrides the plugin manifest icon."""
+        manifest = _create_manifest()
+        manifest.icon = 'si-logzio'
+        self.mock_db.execute.return_value = [
+            {'integration': _node(icon='si-custom')}
+        ]
+        with mock.patch(
+            'imbi_api.endpoints.integrations.get_plugin',
+            return_value=_entry(manifest),
+        ):
+            response = self.client.get(
+                '/organizations/myorg/integrations/logzio-prod'
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()['icon'], 'si-custom')
+
+    def test_icon_none_when_plugin_missing(self) -> None:
+        """No plugin registered and no own icon → icon stays null."""
+        self.mock_db.execute.return_value = [{'integration': _node()}]
+        with mock.patch(
+            'imbi_api.endpoints.integrations.get_plugin',
+            side_effect=PluginNotFoundError('logzio'),
+        ):
+            response = self.client.get(
+                '/organizations/myorg/integrations/logzio-prod'
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNone(response.json()['icon'])
+
     # -- create ----------------------------------------------------------
 
     def _patch_encryptor(self) -> typing.Any:
@@ -547,6 +592,8 @@ class IntegrationsEndpointTestCase(support.SharedAppTestCase):
                 '.invalidate_cache'
             ) as invalidate,
         ):
+            # build_response consults the plugin only for the display icon.
+            get_plugin.return_value.manifest.icon = None
             response = self.client.put(
                 '/organizations/myorg/integrations/ghlogin-prod'
                 '/login-provider',
@@ -554,7 +601,7 @@ class IntegrationsEndpointTestCase(support.SharedAppTestCase):
             )
         self.assertEqual(response.status_code, 200)
         # Demotion never checks login capability.
-        get_plugin.assert_not_called()
+        get_plugin.return_value.manifest.get_capability.assert_not_called()
         invalidate.assert_called_once()
 
     def test_set_login_provider_not_login_capable(self) -> None:


### PR DESCRIPTION
## Summary

Integration dashboard links in the project header rendered with a generic
external-link glyph instead of the backing plugin's brand icon (e.g.
**GitHub Enterprise Cloud** showed no GitHub icon).

## Problem

The header renders integration dashboard links via
`getIcon(integration.icon)` (imbi-ui #455). But `IntegrationResponse.icon`
only ever carried the Integration's **own** icon — and no UI form sets it,
so it's always `null`. The real brand icon (e.g. `si-github`) lives on the
**plugin manifest**, keyed by `integration.plugin`. With `icon` null,
`getIcon` falls back to the generic glyph.

(Sentry renders correctly because it's a link *definition*, which carries
its own icon — not an integration link.)

## Solution

`build_response` now falls back to the backing plugin manifest's icon when
the Integration has no icon of its own. This fixes every consumer of the
integrations API with **zero UI change**; the Integration's own icon still
overrides when set.

This is fixed in the backend rather than the UI on purpose: a UI-side fix
would need the manifest icon from `/admin/plugins`, which is admin-only —
non-admin project viewers (who have only `integration:read`) can't call it
and would still see the broken icon.

## Testing

- Added tests: plugin-manifest fallback, own-icon override, missing-plugin
  → `null`.
- Updated `test_set_login_provider_demotes`: `build_response` now consults
  `get_plugin` for the icon, so the test asserts the login-capability check
  (`manifest.get_capability`) is never accessed rather than that
  `get_plugin` is never called — preserving its original intent.
- All 36 tests in `tests/endpoints/test_integrations.py` pass; ruff + mypy
  clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)