### PR TITLE
Populate deployment release notes on create and resync

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -225,12 +225,14 @@ max-complexity = 15
 exclude-newer = "7 days"
 exclude-newer-package = { "clickhouse-connect" = false, "imbi-common" = false }
 
-# TEMPORARY: resolve imbi-common from git main for the unreleased
-# get_release_notes capability (AWeber-Imbi/imbi-common#187). main is
-# still 2.14.0 so the ==2.14.0 pin is satisfied. Revert to the plain
-# PyPI pin once imbi-common cuts a release. See AWeber-Imbi/imbi-api#480.
+# TEMPORARY: resolve imbi-common from a pinned git commit for the
+# unreleased get_release_notes capability (AWeber-Imbi/imbi-common#187).
+# The rev is the reviewed merge state on main; it is still 2.14.0 so the
+# ==2.14.0 pin is satisfied. An immutable rev (not a branch) keeps re-locks
+# reproducible. Revert to the plain PyPI pin once imbi-common cuts a
+# release. See AWeber-Imbi/imbi-api#480.
 [tool.uv.sources]
-imbi-common = { git = "https://github.com/AWeber-Imbi/imbi-common.git", branch = "main" }
+imbi-common = { git = "https://github.com/AWeber-Imbi/imbi-common.git", rev = "1ac105c7aad0624e9e3b8b9ae7a4ef150b6294c4" }
 
 [[tool.uv.index]]
 url = "https://pypi.org/simple"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -225,6 +225,13 @@ max-complexity = 15
 exclude-newer = "7 days"
 exclude-newer-package = { "clickhouse-connect" = false, "imbi-common" = false }
 
+# TEMPORARY: resolve imbi-common from git main for the unreleased
+# get_release_notes capability (AWeber-Imbi/imbi-common#187). main is
+# still 2.14.0 so the ==2.14.0 pin is satisfied. Revert to the plain
+# PyPI pin once imbi-common cuts a release. See AWeber-Imbi/imbi-api#480.
+[tool.uv.sources]
+imbi-common = { git = "https://github.com/AWeber-Imbi/imbi-common.git", branch = "main" }
+
 [[tool.uv.index]]
 url = "https://pypi.org/simple"
 default = true

--- a/src/imbi_api/endpoints/project_deployments.py
+++ b/src/imbi_api/endpoints/project_deployments.py
@@ -828,7 +828,9 @@ async def _existing_tag_for_committish(
     existing tagged ``Release`` node -- the one the release-history UI
     reads, keyed by tag -- rather than spawning a duplicate untagged node
     the UI never surfaces.  Returns ``None`` when no tagged release exists
-    for the commit.
+    for the commit, and raises ``ValueError`` when the commit carries more
+    than one distinct tag -- a retagged commit is ambiguous, so we fail the
+    observation rather than silently attaching notes to the wrong release.
     """
     query: typing.LiteralString = """
     MATCH (:Project {{id: {project_id}}})
@@ -841,10 +843,17 @@ async def _existing_tag_for_committish(
         {'project_id': project_id, 'committish': committish},
         ['tag'],
     )
+    tags: set[str] = set()
     for row in rows:
         tag = graph.parse_agtype(row.get('tag'))
         if tag:
-            return str(tag)
+            tags.add(str(tag))
+    if len(tags) == 1:
+        return tags.pop()
+    if len(tags) > 1:
+        raise ValueError(
+            'Multiple tagged Releases match this deployment committish'
+        )
     return None
 
 

--- a/src/imbi_api/endpoints/project_deployments.py
+++ b/src/imbi_api/endpoints/project_deployments.py
@@ -815,6 +815,95 @@ async def _release_id_for(
     return str(rid) if rid else None
 
 
+async def _existing_tag_for_committish(
+    db: graph.Graph,
+    *,
+    project_id: str,
+    committish: str,
+) -> str | None:
+    """Return a tag already recorded for ``committish`` on this project.
+
+    The resync path uses this to reconcile a deployment whose ``ref`` was
+    a raw SHA (so ``_resync_release_identity`` derives no tag) onto the
+    existing tagged ``Release`` node -- the one the release-history UI
+    reads, keyed by tag -- rather than spawning a duplicate untagged node
+    the UI never surfaces.  Returns ``None`` when no tagged release exists
+    for the commit.
+    """
+    query: typing.LiteralString = """
+    MATCH (:Project {{id: {project_id}}})
+        -[:HAS_RELEASE]->(r:Release {{committish: {committish}}})
+    WHERE r.tag IS NOT NULL
+    RETURN r.tag AS tag
+    """
+    rows = await db.execute(
+        query,
+        {'project_id': project_id, 'committish': committish},
+        ['tag'],
+    )
+    for row in rows:
+        tag = graph.parse_agtype(row.get('tag'))
+        if tag:
+            return str(tag)
+    return None
+
+
+async def _get_release_notes(
+    handler: DeploymentCapability,
+    ctx: PluginContext,
+    credentials: dict[str, str],
+    tag: str,
+) -> str | None:
+    """Best-effort fetch of the remote release body for ``tag``.
+
+    Wraps the deployment capability's optional ``get_release_notes`` so
+    callers can enrich a ``Release`` node's notes when they know the tag
+    but not the body (a webhook-created release, a SHA-ref resync).  Any
+    failure -- the capability doesn't implement it, the remote 404s/403s,
+    a timeout -- degrades to ``None`` so a notes lookup never blocks the
+    surrounding write.
+    """
+    try:
+        return await call_with_timeout(
+            handler.get_release_notes(ctx, credentials, tag)
+        )
+    except NotImplementedError:
+        return None
+    except Exception:  # noqa: BLE001
+        LOGGER.warning(
+            'get_release_notes failed for tag=%s', tag, exc_info=True
+        )
+        return None
+
+
+async def fetch_release_notes_for_tag(
+    db: graph.Graph,
+    *,
+    org_slug: str,
+    project_id: str,
+    tag: str,
+    auth: permissions.AuthContext,
+) -> str | None:
+    """Resolve the project's deployment capability and fetch ``tag``'s notes.
+
+    Used by the release-create path to enrich a ``Release`` created from a
+    deployment webhook, whose payload carries no release body.  Best-effort:
+    a project without a deployment capability, missing service credentials,
+    or a remote error all yield ``None`` so release creation is never
+    blocked on the notes lookup.
+    """
+    try:
+        resolved, ctx, credentials = await _resolve_and_context(
+            db, org_slug, project_id, auth, best_effort_identity=True
+        )
+    except fastapi.HTTPException:
+        return None
+    handler = _handler(resolved)
+    return await _get_release_notes(
+        handler, ctx, _resolve_credentials(ctx, credentials), tag
+    )
+
+
 async def resync_for_project(
     db: graph.Graph,
     *,
@@ -910,6 +999,15 @@ async def resync_for_project(
         db, project_id
     )
     resolve_user = attribution.make_user_resolver(db, integration_ids)
+
+    async def _fetch_notes(tag: str) -> str | None:
+        # Enrichment for deployments whose ref was a raw SHA (so the
+        # plugin couldn't populate ``release_notes`` from the ref): once
+        # the tag is known, ask the remote for the release body by tag.
+        return await _get_release_notes(
+            handler, ctx, _resolve_credentials(ctx, credentials), tag
+        )
+
     # Track identities we've already touched so ``releases_created`` /
     # ``releases_updated`` are counted once per distinct
     # ``(committish, tag)`` pair -- the same tag promoted across
@@ -927,6 +1025,7 @@ async def resync_for_project(
                 summary=summary,
                 seen_identities=seen_identities,
                 resolve_user=resolve_user,
+                fetch_notes=_fetch_notes,
             )
         except Exception as exc:
             LOGGER.exception(
@@ -964,6 +1063,10 @@ async def _apply_remote_deployment(
         [str], collections.abc.Awaitable[str | None]
     ]
     | None = None,
+    fetch_notes: collections.abc.Callable[
+        [str], collections.abc.Awaitable[str | None]
+    ]
+    | None = None,
 ) -> None:
     """Persist one observed remote deployment.
 
@@ -979,8 +1082,24 @@ async def _apply_remote_deployment(
     ``releases_created`` / ``releases_updated`` during this resync,
     so a tag promoted across multiple environments is counted as one
     Release node, not N.
+
+    ``fetch_notes`` (optional) resolves a release body by tag; it is used
+    to enrich notes when the deployment ``ref`` was a raw SHA, so the
+    plugin couldn't populate ``release_notes`` from the ref itself.
     """
     tag, committish = _resync_release_identity(observed)
+    # A deployment whose ref was a raw SHA carries no semver tag.  Reconcile
+    # onto the existing tagged Release for this commit (the node the UI
+    # reads, keyed by tag) instead of spawning a duplicate untagged node.
+    if tag is None:
+        tag = await _existing_tag_for_committish(
+            db, project_id=project_id, committish=committish
+        )
+    # Prefer notes the plugin already fetched from the deployment ref; when
+    # absent but the tag is now known, ask the remote for the body by tag.
+    notes = observed.release_notes
+    if not notes and tag is not None and fetch_notes is not None:
+        notes = await fetch_notes(tag)
     title = observed.description or observed.ref or tag or committish
     identity = (committish, tag)
     first_time_this_resync = identity not in seen_identities
@@ -999,7 +1118,7 @@ async def _apply_remote_deployment(
         tag=tag,
         committish=committish,
         title=title,
-        notes_markdown=observed.release_notes or observed.description or '',
+        notes_markdown=notes or observed.description or '',
         release_url=observed.deployment_url,
         created_by=recorded_by,
     )
@@ -1875,12 +1994,19 @@ async def _upsert_release_node(
     # Update notes / links on a pre-existing release (idempotent re-run).
     # Match on (committish, tag) — tag matching uses COALESCE so a NULL
     # tag compares equal to a NULL tag (AGE has no NULL equality).
+    #
+    # Never overwrite existing data with nothing: an empty ``description``
+    # (no notes could be resolved) or an empty ``links`` (no release URL)
+    # preserves whatever the node already holds.  Without this guard a
+    # resync that can't fetch notes would wipe the "What's Changed" body a
+    # promote (or an earlier enriched create) had already written.
     update_query: typing.LiteralString = """
     MATCH (p:Project {{id: {project_id}}})
           -[:HAS_RELEASE]->(r:Release {{committish: {committish}}})
     WHERE COALESCE(r.tag, '') = COALESCE({tag}, '')
-    SET r.description = {description},
-        r.links = {links},
+    SET r.description = CASE WHEN {description} = ''
+            THEN r.description ELSE {description} END,
+        r.links = CASE WHEN {links} = '[]' THEN r.links ELSE {links} END,
         r.updated_at = {now}
     RETURN r.id AS rid
     """

--- a/src/imbi_api/endpoints/releases.py
+++ b/src/imbi_api/endpoints/releases.py
@@ -533,13 +533,34 @@ async def create_release(
     # ``principal_name`` returns the user's email or the service
     # account's slug — matching the convention used by opslog.
     created_by = data.created_by or auth.principal_name
+    # A release created from a deployment webhook carries no notes body --
+    # the ``deployment_status`` payload has none. When a tag is present and
+    # no description was supplied, enrich from the remote release (keyed by
+    # tag) so the release-history UI shows the "What's Changed" markdown.
+    # Best-effort: a missing capability / release / credential yields None
+    # and the release is still created (identified by committish + tag).
+    description = data.description
+    if data.tag and not description:
+        # Local import avoids a circular import: project_deployments
+        # imports append_deployment_event from this module.
+        from imbi_api.endpoints.project_deployments import (
+            fetch_release_notes_for_tag,
+        )
+
+        description = await fetch_release_notes_for_tag(
+            db,
+            org_slug=org_slug,
+            project_id=project_id,
+            tag=data.tag,
+            auth=auth,
+        )
     now = datetime.datetime.now(datetime.UTC)
     props: dict[str, typing.Any] = {
         'id': nanoid.generate(),
         'tag': data.tag,
         'committish': data.committish,
         'title': data.title,
-        'description': data.description,
+        'description': description,
         'links': _serialize_links(data.links),
         'created_by': created_by,
         'created_at': now.isoformat(),

--- a/tests/endpoints/test_project_deployments.py
+++ b/tests/endpoints/test_project_deployments.py
@@ -1192,6 +1192,14 @@ class ResyncProjectDeploymentsTestCase(ProjectDeploymentsTestCase):
                 return_value='upserted-release-id',
             )
         )
+        # No pre-existing tagged Release for the commit by default; a
+        # reconcile test overrides this to exercise the SHA-ref path.
+        self.mocks['existing_tag'] = self._start(
+            mock.patch(
+                f'{_MODULE}._existing_tag_for_committish',
+                return_value=None,
+            )
+        )
         if edge_status == 'missing':
             self.mocks['append_deployment_event'].return_value = None
         else:
@@ -1323,6 +1331,28 @@ class ResyncProjectDeploymentsTestCase(ProjectDeploymentsTestCase):
         self.assertEqual(response.status_code, 200, response.text)
         upsert_call = self.mocks['upsert_release_node'].call_args
         self.assertEqual(upsert_call.kwargs['notes_markdown'], 'Bump foo')
+
+    def test_resync_reconciles_sha_ref_onto_existing_tag(self) -> None:
+        # A deployment whose ref was a raw SHA carries no semver tag. When
+        # a tagged Release already exists for the commit (created by the
+        # webhook), resync reconciles onto that tag -- rather than spawning
+        # a duplicate untagged node -- and enriches its notes by tag.
+        self._arm([self._observed(ref='main')], release_exists=True)
+        self.mocks['existing_tag'].return_value = '3.23.4'
+        notes = "## What's Changed\n- Fixed the breadcrumb"
+        self.mocks['get_release_notes'] = self._start(
+            mock.patch(f'{_MODULE}._get_release_notes', return_value=notes)
+        )
+        with testclient.TestClient(self.test_app) as client:
+            response = client.post(
+                '/organizations/myorg/projects/proj1/deployments/resync'
+            )
+        self.assertEqual(response.status_code, 200, response.text)
+        upsert_call = self.mocks['upsert_release_node'].call_args
+        # Reconciled onto the existing tag, and notes fetched by that tag.
+        self.assertEqual(upsert_call.kwargs['tag'], '3.23.4')
+        self.assertEqual(upsert_call.kwargs['committish'], '2668cd0')
+        self.assertEqual(upsert_call.kwargs['notes_markdown'], notes)
 
     def test_resync_400_when_plugin_opts_out(self) -> None:
         # Override the resolved plugin to advertise the no-sync flavor.

--- a/tests/endpoints/test_project_deployments.py
+++ b/tests/endpoints/test_project_deployments.py
@@ -2416,3 +2416,41 @@ class ResolveTagFormatsTestCase(unittest.IsolatedAsyncioTestCase):
             db, 'org', 'pid'
         )
         self.assertEqual([f.label for f in result], ['Org'])
+
+
+class ExistingTagForCommittishTestCase(unittest.IsolatedAsyncioTestCase):
+    """Unit tests for the ``_existing_tag_for_committish`` reconcile helper."""
+
+    @staticmethod
+    def _db(rows: list[dict[str, typing.Any]]) -> mock.AsyncMock:
+        db = mock.AsyncMock(spec=graph.Graph)
+        db.execute = mock.AsyncMock(return_value=rows)
+        return db
+
+    async def test_returns_none_when_no_tagged_release(self) -> None:
+        db = self._db([])
+        result = await project_deployments._existing_tag_for_committish(
+            db, project_id='pid', committish='deadbeef'
+        )
+        self.assertIsNone(result)
+
+    async def test_returns_single_tag(self) -> None:
+        db = self._db([{'tag': 'v1.0.0'}])
+        result = await project_deployments._existing_tag_for_committish(
+            db, project_id='pid', committish='deadbeef'
+        )
+        self.assertEqual(result, 'v1.0.0')
+
+    async def test_deduplicates_repeated_tag(self) -> None:
+        db = self._db([{'tag': 'v1.0.0'}, {'tag': 'v1.0.0'}])
+        result = await project_deployments._existing_tag_for_committish(
+            db, project_id='pid', committish='deadbeef'
+        )
+        self.assertEqual(result, 'v1.0.0')
+
+    async def test_raises_when_commit_has_multiple_tags(self) -> None:
+        db = self._db([{'tag': 'v1.0.0'}, {'tag': 'v2.0.0'}])
+        with self.assertRaises(ValueError):
+            await project_deployments._existing_tag_for_committish(
+                db, project_id='pid', committish='deadbeef'
+            )

--- a/tests/endpoints/test_releases.py
+++ b/tests/endpoints/test_releases.py
@@ -73,6 +73,18 @@ class _ReleasesTestBase(support.SharedAppTestCase):
         self.test_app.dependency_overrides[graph._inject_graph] = lambda: (
             self.mock_db
         )
+        # The create path enriches a tagged, note-less release from the
+        # remote release body; that resolves the deployment capability and
+        # makes its own DB/HTTP calls. Neutralize it here so create-logic
+        # tests exercise only the create query sequence; the enrichment
+        # itself is covered by a dedicated test.
+        self._notes_patch = mock.patch(
+            'imbi_api.endpoints.project_deployments'
+            '.fetch_release_notes_for_tag',
+            new=mock.AsyncMock(return_value=None),
+        )
+        self._notes_patch.start()
+        self.addCleanup(self._notes_patch.stop)
         self.client = fastapi.testclient.TestClient(self.test_app)
         self.addCleanup(self.client.close)
 
@@ -152,6 +164,82 @@ class CreateReleaseTestCase(_ReleasesTestBase):
             )
         self.assertEqual(response.status_code, 201)
         self.assertEqual(response.json()['created_by'], 'deploy-bot')
+
+    def test_create_enriches_notes_from_remote_release(self) -> None:
+        # A release created from a deployment webhook (tag present, no
+        # description) is enriched with the remote release body so the
+        # UI's release history shows the "What's Changed" markdown.
+        self.mock_db.execute.side_effect = [
+            [{'id': PROJECT_ID}],  # project_exists
+            [],  # version uniqueness check
+            [{'release': _release_row()}],  # create
+        ]
+        notes = "## What's Changed\n- Fixed the breadcrumb"
+        with (
+            mock.patch(
+                'imbi_common.graph.parse_agtype',
+                side_effect=lambda x: x,
+            ),
+            mock.patch(
+                'imbi_api.endpoints.releases.nanoid.generate',
+                return_value=RELEASE_ID,
+            ),
+            mock.patch(
+                'imbi_api.endpoints.project_deployments'
+                '.fetch_release_notes_for_tag',
+                new=mock.AsyncMock(return_value=notes),
+            ) as enrich,
+        ):
+            response = self.client.post(
+                self._url('/'),
+                json={
+                    'tag': '3.23.4',
+                    'committish': DEFAULT_COMMITTISH,
+                    'title': 'Deploy 3.23.4',
+                },
+            )
+        self.assertEqual(response.status_code, 201, response.text)
+        enrich.assert_awaited_once()
+        self.assertEqual(enrich.await_args.kwargs['tag'], '3.23.4')
+        # The fetched body is what gets persisted as the node description.
+        create_params = self.mock_db.execute.call_args_list[2].args[1]
+        self.assertEqual(create_params['description'], notes)
+
+    def test_create_does_not_enrich_when_description_supplied(self) -> None:
+        # An explicit description is authoritative; no remote lookup runs.
+        self.mock_db.execute.side_effect = [
+            [{'id': PROJECT_ID}],
+            [],
+            [{'release': _release_row()}],
+        ]
+        with (
+            mock.patch(
+                'imbi_common.graph.parse_agtype',
+                side_effect=lambda x: x,
+            ),
+            mock.patch(
+                'imbi_api.endpoints.releases.nanoid.generate',
+                return_value=RELEASE_ID,
+            ),
+            mock.patch(
+                'imbi_api.endpoints.project_deployments'
+                '.fetch_release_notes_for_tag',
+                new=mock.AsyncMock(return_value='ignored'),
+            ) as enrich,
+        ):
+            response = self.client.post(
+                self._url('/'),
+                json={
+                    'tag': '3.23.4',
+                    'committish': DEFAULT_COMMITTISH,
+                    'title': 'Deploy 3.23.4',
+                    'description': 'Author-supplied notes',
+                },
+            )
+        self.assertEqual(response.status_code, 201, response.text)
+        enrich.assert_not_awaited()
+        create_params = self.mock_db.execute.call_args_list[2].args[1]
+        self.assertEqual(create_params['description'], 'Author-supplied notes')
 
     def test_create_project_not_found(self) -> None:
         self.mock_db.execute.side_effect = [[]]  # project_exists -> no rows

--- a/uv.lock
+++ b/uv.lock
@@ -1088,7 +1088,7 @@ requires-dist = [
     { name = "fastapi" },
     { name = "filetype" },
     { name = "httpx", specifier = ">=0.28.1,<1" },
-    { name = "imbi-common", extras = ["databases", "llm", "sentry", "server"], git = "https://github.com/AWeber-Imbi/imbi-common.git?branch=main" },
+    { name = "imbi-common", extras = ["databases", "llm", "sentry", "server"], git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=1ac105c7aad0624e9e3b8b9ae7a4ef150b6294c4" },
     { name = "jinja2" },
     { name = "jsonpatch", specifier = ">=1.33" },
     { name = "mcp", specifier = ">=1.26.0" },
@@ -1137,7 +1137,7 @@ docs = [
 [[package]]
 name = "imbi-common"
 version = "2.14.0"
-source = { git = "https://github.com/AWeber-Imbi/imbi-common.git?branch=main#1ac105c7aad0624e9e3b8b9ae7a4ef150b6294c4" }
+source = { git = "https://github.com/AWeber-Imbi/imbi-common.git?rev=1ac105c7aad0624e9e3b8b9ae7a4ef150b6294c4#1ac105c7aad0624e9e3b8b9ae7a4ef150b6294c4" }
 dependencies = [
     { name = "cryptography" },
     { name = "httpx" },

--- a/uv.lock
+++ b/uv.lock
@@ -1088,7 +1088,7 @@ requires-dist = [
     { name = "fastapi" },
     { name = "filetype" },
     { name = "httpx", specifier = ">=0.28.1,<1" },
-    { name = "imbi-common", extras = ["databases", "llm", "sentry", "server"], specifier = "==2.14.0" },
+    { name = "imbi-common", extras = ["databases", "llm", "sentry", "server"], git = "https://github.com/AWeber-Imbi/imbi-common.git?branch=main" },
     { name = "jinja2" },
     { name = "jsonpatch", specifier = ">=1.33" },
     { name = "mcp", specifier = ">=1.26.0" },
@@ -1137,7 +1137,7 @@ docs = [
 [[package]]
 name = "imbi-common"
 version = "2.14.0"
-source = { registry = "https://pypi.org/simple" }
+source = { git = "https://github.com/AWeber-Imbi/imbi-common.git?branch=main#1ac105c7aad0624e9e3b8b9ae7a4ef150b6294c4" }
 dependencies = [
     { name = "cryptography" },
     { name = "httpx" },
@@ -1151,10 +1151,6 @@ dependencies = [
     { name = "pyjwt" },
     { name = "python-slugify" },
     { name = "typer" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/61/4c/c8837aef3cbbb5e886ce51085f0bd4c315fcc8b0325fc6060b6167e25296/imbi_common-2.14.0.tar.gz", hash = "sha256:b0a8d2168e72892a51df9054ae90b4f9e1ba668a490d673c7e9077996f8635f3", size = 361115, upload-time = "2026-07-15T21:52:14.795Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/af/17/32614176cb1772f0c973d313d2d82f43d11e6892817c868e75b9b269323c/imbi_common-2.14.0-py3-none-any.whl", hash = "sha256:34e1b05e8e165aed8e7fc61fdd2ddbbaff55f733de58ce5de4174d7bb4f93647", size = 120818, upload-time = "2026-07-15T21:52:13.461Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

Populates deployment release notes on the paths that actually create the `Release` node the UI displays — release creation (webhook) and resync — fixing the "No release notes" panel for externally-deployed releases.

## Problem

The 2.14.0 fix only enriched notes when a deployment's `ref` was a semver tag. In production (verified on `campaign-builder`), externally-deployed releases have **two** `Release` nodes per commit, both with empty notes:

- `tag=3.23.4, committish=88edf09` — created by the **webhook** (`create_release` fires on `deployment_status`, sends no body; the payload has none, and the gateway's native actions get an empty credentials dict so they can't call GitHub).
- `tag=null, committish=88edf09` — created by **resync** (the deployment `ref` is a raw SHA → no semver tag → a duplicate untagged node, and `GET /releases/tags/<sha>` 404s).

The release-history UI reads the tagged node (ClickHouse tags → node by tag), so its notes stay `NULL`. A latent bug also let a re-sync with empty notes **wipe** promote-authored "What's Changed" text.

## Solution

- **create_release**: when a tag is present and no description was supplied (the webhook case), enrich from the remote release body by tag via the deployment capability. Best-effort — a missing capability/release/credential leaves notes empty and the release is still created.
- **resync**: reconcile a SHA-ref deployment onto the existing tagged `Release` for the commit (`_existing_tag_for_committish`) instead of spawning a duplicate untagged node, then fetch its notes by tag.
- **`_upsert_release_node`**: guard the update so an empty description or links never overwrites existing data (prevents the note-wipe).
- Add `_get_release_notes` / `fetch_release_notes_for_tag` helpers and tests for the create-enrich and resync-reconcile paths.

The gateway needs no change — it already POSTs to this API, which has the credentials and plugin to reach GitHub.

## Dependencies

Requires `DeploymentCapability.get_release_notes` — AWeber-Imbi/imbi-common#187 and its GitHub implementation AWeber-Imbi/imbi-plugin-github#49. **Merge/release order: imbi-common → imbi-plugin-github → imbi-api.** CI here will stay red until imbi-common ships the method.

## Note

Existing broken `Release` nodes won't self-heal — they need a resync after deploy to backfill. New deployments get notes at create time.
