### PR TITLE
Add PUT endpoint to edit a project integration edge

### DIFF
--- a/src/imbi_api/endpoints/webhooks.py
+++ b/src/imbi_api/endpoints/webhooks.py
@@ -855,6 +855,94 @@ async def create_project_service(
     )
 
 
+@project_services_router.put('/{service_slug}')
+async def update_project_service(
+    org_slug: str,
+    project_id: str,
+    service_slug: str,
+    data: models.ExistsInCreate,
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('project:write'),
+        ),
+    ],
+) -> models.ExistsInResponse:
+    """Update an existing EXISTS_IN link's identifier and URLs.
+
+    The edge must already exist; the ``service_slug`` path segment is
+    authoritative for which link is updated. Clearing ``dashboard_url``
+    (empty/absent) removes the mirrored ``Project.links`` entry.
+    """
+    query: typing.LiteralString = """
+    MATCH (p:Project {{id: {project_id}}})
+          -[:OWNED_BY]->(:Team)
+          -[:BELONGS_TO]->(o:Organization {{slug: {org_slug}}})
+    MATCH (p)-[ei:EXISTS_IN]->
+          (tps:Integration {{slug: {tps_slug}}})
+    SET ei.identifier = {identifier},
+        ei.canonical_url = {canonical_url}
+    RETURN tps.slug AS service_slug,
+           tps.name AS service_name,
+           ei.identifier AS identifier,
+           ei.canonical_url AS canonical_url
+    """
+    records = await db.execute(
+        query,
+        {
+            'org_slug': org_slug,
+            'project_id': project_id,
+            'tps_slug': service_slug,
+            'identifier': data.identifier,
+            'canonical_url': data.canonical_url,
+        },
+        [
+            'service_slug',
+            'service_name',
+            'identifier',
+            'canonical_url',
+        ],
+    )
+
+    if not records:
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail=(
+                f'EXISTS_IN link between project '
+                f'{project_id!r} and integration '
+                f'{service_slug!r} not found'
+            ),
+        )
+
+    # Set or clear the mirrored dashboard link so an edit that empties the
+    # field drops the stale ``Project.links`` entry rather than leaving it.
+    dashboard_url = str(data.dashboard_url) if data.dashboard_url else None
+    if dashboard_url:
+        await merge_project_links(
+            db,
+            project_id,
+            add={service_slug: dashboard_url},
+        )
+    else:
+        await merge_project_links(db, project_id, remove=[service_slug])
+
+    r = records[0]
+    return models.ExistsInResponse(
+        integration_slug=graph.parse_agtype(
+            r['service_slug'],
+        ),
+        integration_name=graph.parse_agtype(
+            r['service_name'],
+        ),
+        identifier=graph.parse_agtype(r['identifier']),
+        canonical_url=graph.parse_agtype(
+            r.get('canonical_url'),
+        ),
+        dashboard_url=dashboard_url,
+    )
+
+
 @project_services_router.delete(
     '/{service_slug}',
     status_code=204,

--- a/tests/endpoints/test_webhooks.py
+++ b/tests/endpoints/test_webhooks.py
@@ -1554,6 +1554,86 @@ class ProjectServicesEndpointsTestCase(support.SharedAppTestCase):
         self.assertEqual(response.status_code, 404)
         self.assertIn('not found', response.json()['detail'])
 
+    # -- Update --
+
+    def test_update_project_service(self) -> None:
+        self.mock_db.execute.return_value = [self.service_record]
+        merge = mock.AsyncMock(return_value=True)
+        with (
+            mock.patch(
+                'imbi_common.graph.parse_agtype',
+                side_effect=lambda x: x,
+            ),
+            mock.patch(
+                'imbi_api.endpoints.webhooks.merge_project_links',
+                new=merge,
+            ),
+        ):
+            response = self.client.put(
+                '/organizations/engineering/projects/my-project/services/github',
+                json={
+                    'integration_slug': 'github',
+                    'identifier': 'org/repo',
+                    'canonical_url': 'https://github.com/org/repo',
+                    'dashboard_url': 'https://aweber.ghe.com/o/r',
+                },
+            )
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data['identifier'], 'org/repo')
+        self.assertEqual(data['dashboard_url'], 'https://aweber.ghe.com/o/r')
+        merge.assert_awaited_once_with(
+            self.mock_db,
+            'my-project',
+            add={'github': 'https://aweber.ghe.com/o/r'},
+        )
+
+    def test_update_project_service_clears_dashboard(self) -> None:
+        self.mock_db.execute.return_value = [self.service_record]
+        merge = mock.AsyncMock(return_value=True)
+        with (
+            mock.patch(
+                'imbi_common.graph.parse_agtype',
+                side_effect=lambda x: x,
+            ),
+            mock.patch(
+                'imbi_api.endpoints.webhooks.merge_project_links',
+                new=merge,
+            ),
+        ):
+            response = self.client.put(
+                '/organizations/engineering/projects/my-project/services/github',
+                json={
+                    'integration_slug': 'github',
+                    'identifier': 'org/repo',
+                },
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNone(response.json()['dashboard_url'])
+        merge.assert_awaited_once_with(
+            self.mock_db, 'my-project', remove=['github']
+        )
+
+    def test_update_project_service_not_found(self) -> None:
+        self.mock_db.execute.return_value = []
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            response = self.client.put(
+                '/organizations/engineering'
+                '/projects/my-project/services/nonexistent',
+                json={
+                    'integration_slug': 'nonexistent',
+                    'identifier': 'org/repo',
+                },
+            )
+
+        self.assertEqual(response.status_code, 404)
+        self.assertIn('not found', response.json()['detail'])
+
     # -- Dashboard URL folding --
 
     def test_list_includes_dashboard_url_from_links(self) -> None:


### PR DESCRIPTION
## Summary

Adds an update endpoint for a project's integration (`EXISTS_IN`) edge so the UI can edit a connected integration's identifier and URLs. Previously only create and delete were supported.

## Problem

The project-services router exposed only `GET`, `POST`, and `DELETE`. There was no way to edit an existing integration's identifier, API URL, or dashboard URL — and the create path's dashboard handling was add-only, so it could never clear a previously-set dashboard link.

## Solution

- Add `PUT /organizations/{org}/projects/{project_id}/services/{service_slug}`:
  - Requires the edge to already exist (404 otherwise); the path slug is authoritative.
  - Upserts `ei.identifier` and `ei.canonical_url` on the edge.
  - Sets **or clears** the mirrored `Project.links[slug]` dashboard entry — an empty/absent `dashboard_url` now removes the stale entry instead of leaving it behind.
- Adds tests for update, dashboard clearing, and the not-found case.

## Notes

Paired with the imbi-ui PR that adds the edit dialog (the UI feature needs this endpoint deployed). This change is additive and backward compatible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
