### PR TITLE
Fix ClickHouse Map param binding for release commit counts

### DIFF
--- a/src/imbi_api/endpoints/projects.py
+++ b/src/imbi_api/endpoints/projects.py
@@ -913,18 +913,25 @@ async def _fetch_release_summaries(
             ]
             if pid_cutoff:
                 cutoff_map = dict(pid_cutoff)
+                # Build the per-project cutoff map server-side from two
+                # parallel arrays.  Passing a dict for a Map(...) parameter
+                # trips a clickhouse-connect binding bug: dicts serialize as
+                # JSON (double-quoted), but ClickHouse's Map text parser
+                # requires single-quoted strings (CANNOT_PARSE_QUOTED_STRING).
+                # Arrays serialize correctly, so mapFromArrays sidesteps it.
                 count_rows = await clickhouse.query(
                     'SELECT project_id,'
-                    ' countIf(authored_at'
-                    ' > {cutoffs:Map(String,DateTime64(3))}'
+                    ' countIf(authored_at > mapFromArrays('
+                    '{pids:Array(String)},'
+                    ' {cuts:Array(DateTime64(3))})'
                     '[project_id]) AS c'
                     ' FROM commits FINAL'
                     ' WHERE project_id'
-                    ' IN {project_ids:Array(String)}'
+                    ' IN {pids:Array(String)}'
                     ' GROUP BY project_id',
                     {
-                        'project_ids': list(cutoff_map.keys()),
-                        'cutoffs': cutoff_map,
+                        'pids': list(cutoff_map.keys()),
+                        'cuts': list(cutoff_map.values()),
                     },
                 )
                 counts_since_tag = {


### PR DESCRIPTION
## Summary

The `/projects` release-summaries path (`_fetch_release_summaries`) issues a ClickHouse query that counts unreleased commits per project using a `{cutoffs:Map(String,DateTime64(3))}` server-side parameter, passing a Python `dict`.

## Problem

`clickhouse-connect` serializes a `dict` as JSON — double-quoted strings:

```
{"abc":"2026-07-10T21:53:02", ...}
```

ClickHouse's Map text deserializer (`ReplaceQueryParameterVisitor` → `SerializationMap::deserializeText`) requires **single-quoted** string literals, so every request raised:

```
Code: 26. DB::Exception: Cannot parse quoted string: expected opening quote ''', got '"' ...
cannot be parsed as Map(String,DateTime64(3)) for query parameter 'cutoffs'. (CANNOT_PARSE_QUOTED_STRING)
```

The exception was swallowed by the surrounding `try/except`, so the endpoint still returned 200 but silently dropped the "commits since latest tag" counts and logged `Failed to fetch commit counts since tag`.

## Solution

Pass two parallel arrays (`pids`, `cuts`) instead of a dict and build the map server-side with `mapFromArrays`. Arrays serialize with correct single-quoting, sidestepping the `clickhouse-connect` dict-binding bug while keeping the query fully parameterized (no injection risk). `mapFromArrays` is available on the deployed server (25.3.8).

This is the only ClickHouse `Map(...)` parameter usage in imbi-api / imbi-common.

🤖 Generated with [Claude Code](https://claude.com/claude-code)