### PR TITLE
Run deployment resync as a background Valkey-stream job

### DIFF
--- a/src/imbi_api/app.py
+++ b/src/imbi_api/app.py
@@ -27,6 +27,7 @@ def create_app() -> fastapi.FastAPI:
             lifespans.score_worker_hook,
             lifespans.commit_sync_worker_hook,
             lifespans.pr_sync_worker_hook,
+            lifespans.deployment_sync_worker_hook,
             lifespans.maintenance_worker_hook,
             lifespans.identity_refresh_hook,
         ),

--- a/src/imbi_api/deployment_sync/__init__.py
+++ b/src/imbi_api/deployment_sync/__init__.py
@@ -1,0 +1,7 @@
+"""On-demand deployment resync as a background job.
+
+Mirrors :mod:`imbi_api.commit_sync` / :mod:`imbi_api.pr_sync`: the
+endpoint enqueues onto a Valkey stream and the consumer runs the
+backfill via the deployment plugin, recording last-run state on the
+``Project`` node for the UI to poll.
+"""

--- a/src/imbi_api/deployment_sync/queue.py
+++ b/src/imbi_api/deployment_sync/queue.py
@@ -1,0 +1,352 @@
+"""Deployment-resync queue (Valkey Streams).
+
+Mirrors :mod:`imbi_api.commit_sync.queue`: a single consumer group
+drains an ``imbi:deployment-sync`` stream, with a per-project debounce,
+stale-entry reclaim, and a dead-letter queue after repeated failures.
+Each job backfills recent remote deployments via
+:func:`deployment_sync.service.run_resync` and records the outcome on
+the ``Project`` node.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import socket
+import time
+import typing
+from collections import abc
+
+from imbi_common import graph
+from imbi_common.plugins.errors import PluginRateLimited
+from valkey import asyncio as valkey
+
+from imbi_api.deployment_sync.service import (
+    DeploymentSyncUnavailable,
+    run_resync,
+    set_status,
+)
+
+STREAM = 'imbi:deployment-sync'
+GROUP = 'deployment-sync-workers'
+CONSUMER_PREFIX = 'worker'
+DLQ = 'imbi:deployment-sync:dlq'
+DEBOUNCE_PREFIX = 'imbi:deployment-sync:debounce'
+DEBOUNCE_SECONDS = 10
+MAX_DELIVERIES = 3
+CLAIM_IDLE_MS = 120_000
+PAUSE_KEY = 'imbi:deployment-sync:paused-until'
+PAUSE_POLL_CAP_SECONDS = 30
+PAUSE_KEY_BUFFER_SECONDS = 5
+#: ``limit`` bounds mirror the endpoint's (GitHub's per-page ceiling).
+MAX_LIMIT = 100
+
+LOGGER = logging.getLogger(__name__)
+
+
+async def enqueue_deployment_sync(
+    client: valkey.Valkey | None,
+    org_slug: str,
+    project_id: str,
+    requested_by: str | None = None,
+    limit: int = 1,
+) -> bool:
+    """Debounce-then-XADD a deployment-resync job.
+
+    Returns True if enqueued.  Tolerates *client* being ``None``
+    (returns False) so the endpoint can surface "queueing unavailable"
+    rather than 500 when Valkey is down.
+    """
+    if client is None:
+        return False
+    key = f'{DEBOUNCE_PREFIX}:{project_id}'
+    try:
+        acquired = await client.set(key, b'1', ex=DEBOUNCE_SECONDS, nx=True)
+        if not acquired:
+            return False
+        await client.xadd(
+            STREAM,
+            {
+                'org_slug': org_slug,
+                'project_id': project_id,
+                'requested_by': requested_by or 'system',
+                'limit': str(limit),
+            },
+        )
+    except Exception:
+        # Release the debounce key so a transient Valkey write failure
+        # doesn't block the user's immediate retry for DEBOUNCE_SECONDS.
+        try:
+            await client.delete(key)
+        except Exception:
+            LOGGER.exception('failed to clear debounce key for %s', project_id)
+        LOGGER.exception('enqueue_deployment_sync failed for %s', project_id)
+        return False
+    return True
+
+
+async def ensure_group(client: valkey.Valkey) -> None:
+    try:
+        await client.xgroup_create(STREAM, GROUP, id='$', mkstream=True)
+    except Exception as err:
+        if 'BUSYGROUP' not in str(err):
+            LOGGER.exception('xgroup_create failed')
+            raise
+
+
+def _parse_limit(raw: str | None) -> int:
+    try:
+        limit = int(raw) if raw else 1
+    except ValueError:
+        return 1
+    return max(1, min(limit, MAX_LIMIT))
+
+
+async def _process_message(db: graph.Graph, fields: dict[str, str]) -> None:
+    project_id = fields.get('project_id')
+    org_slug = fields.get('org_slug') or ''
+    requested_by = fields.get('requested_by') or 'system'
+    limit = _parse_limit(fields.get('limit'))
+    if not project_id:
+        return
+    await set_status(
+        db, project_id, status='running', requested_by=requested_by
+    )
+    try:
+        summary = await run_resync(db, org_slug, project_id, limit)
+    except DeploymentSyncUnavailable as exc:
+        # Misconfiguration, not transient: record and don't retry.
+        LOGGER.warning(
+            'deployment-sync unavailable for %s: %s', project_id, exc
+        )
+        await set_status(
+            db,
+            project_id,
+            status='failed',
+            requested_by=requested_by,
+            error=str(exc),
+        )
+        return
+    except PluginRateLimited:
+        # Transient: GitHub's rate limit is exhausted.  Keep the job
+        # queued (the consumer pauses until the reset and retries)
+        # instead of marking it failed -- the failure path would
+        # dead-letter it before the limit clears.
+        LOGGER.warning(
+            'deployment-sync rate-limited for %s; left queued until '
+            'GitHub resets',
+            project_id,
+        )
+        await set_status(
+            db, project_id, status='queued', requested_by=requested_by
+        )
+        raise
+    except Exception:
+        # Persist a generic, user-safe message; the polling endpoint
+        # exposes this status, so keep raw exception detail in logs only.
+        LOGGER.exception('deployment-sync run failed for %s', project_id)
+        await set_status(
+            db,
+            project_id,
+            status='failed',
+            requested_by=requested_by,
+            error='Deployment resync failed. See server logs for details.',
+        )
+        raise
+    LOGGER.info(
+        'deployment-sync for %s observed %d deployments, recorded %d events',
+        project_id,
+        summary.observed,
+        summary.events_recorded,
+    )
+    await set_status(
+        db,
+        project_id,
+        status='success',
+        requested_by=requested_by,
+        summary=summary,
+    )
+
+
+def _decode_fields(
+    raw: abc.Mapping[bytes | str, bytes | str],
+) -> dict[str, str]:
+    return {
+        (k.decode() if isinstance(k, bytes) else k): (
+            v.decode() if isinstance(v, bytes) else v
+        )
+        for k, v in raw.items()
+    }
+
+
+async def _paused_remaining(client: valkey.Valkey) -> float:
+    """Seconds left on the global rate-limit pause, ``0.0`` when clear."""
+    try:
+        raw = await client.get(PAUSE_KEY)
+    except Exception:  # noqa: BLE001
+        return 0.0
+    if raw is None:
+        return 0.0
+    try:
+        until = float(raw.decode() if isinstance(raw, bytes) else raw)
+    except ValueError:
+        return 0.0
+    return max(0.0, until - time.time())
+
+
+async def _pause_until(client: valkey.Valkey, retry_at: float) -> None:
+    """Record the resume time so every worker backs off until *retry_at*."""
+    ttl = max(1, int(retry_at - time.time()) + PAUSE_KEY_BUFFER_SECONDS)
+    try:
+        await client.set(PAUSE_KEY, str(retry_at), ex=ttl)
+    except Exception:
+        LOGGER.exception('failed to set deployment-sync pause marker')
+
+
+async def _claim_stale(
+    client: valkey.Valkey,
+    consumer: str,
+) -> list[tuple[bytes, abc.Mapping[bytes | str, bytes | str]]]:
+    try:
+        result = await client.xautoclaim(
+            STREAM,
+            GROUP,
+            consumer,
+            min_idle_time=CLAIM_IDLE_MS,
+            start_id='0-0',
+            count=16,
+        )
+    except Exception as err:  # noqa: BLE001
+        LOGGER.debug('xautoclaim failed: %s', err)
+        return []
+    if isinstance(result, (list, tuple)) and len(result) >= 2:  # type: ignore[arg-type]
+        msgs: object = result[1]  # type: ignore[index]
+        if isinstance(msgs, list):
+            return msgs  # type: ignore[return-value]
+    return []
+
+
+async def _maybe_dead_letter(
+    client: valkey.Valkey,
+    msg_id: bytes,
+    fields: dict[str, str],
+) -> bool:
+    try:
+        info = await client.xpending_range(
+            STREAM, GROUP, min=msg_id, max=msg_id, count=1
+        )
+    except Exception:  # noqa: BLE001
+        return False
+    if not info:
+        return False
+    entry: object = info[0]  # type: ignore[index]
+    delivered: int | None = None
+    if isinstance(entry, dict):
+        raw_delivered = entry.get('times_delivered')  # type: ignore[union-attr]
+        if raw_delivered is not None:
+            delivered = int(raw_delivered)  # type: ignore[arg-type]
+    elif isinstance(entry, (list, tuple)) and len(entry) >= 4:  # type: ignore[arg-type]
+        raw_delivered = entry[3]  # type: ignore[index]
+        if raw_delivered is not None:
+            delivered = int(raw_delivered)  # type: ignore[arg-type]
+    if delivered is not None and delivered >= MAX_DELIVERIES:
+        await client.xadd(DLQ, fields)
+        await client.xack(STREAM, GROUP, msg_id)
+        LOGGER.warning(
+            'dead-lettered deployment-sync msg %s after %s deliveries',
+            msg_id,
+            delivered,
+        )
+        return True
+    return False
+
+
+async def _handle_entries(
+    client: valkey.Valkey,
+    entries: list[tuple[bytes, abc.Mapping[bytes | str, bytes | str]]],
+    db: graph.Graph,
+    check_dlq: bool = False,
+) -> None:
+    for msg_id, raw_fields in entries:
+        fields = _decode_fields(raw_fields)
+        if check_dlq and await _maybe_dead_letter(client, msg_id, fields):
+            continue
+        try:
+            await _process_message(db, fields)
+        except PluginRateLimited as exc:
+            # Don't ack, don't dead-letter: leave the job pending and
+            # pause every worker until GitHub resets.  Stop the batch --
+            # its siblings hit the same token -- and let the next
+            # reclaim drain it once the pause clears.
+            await _pause_until(client, exc.retry_at)
+            LOGGER.warning(
+                'deployment-sync paused ~%.0fs (GitHub rate limit); %d '
+                'job(s) left queued',
+                max(0.0, exc.retry_at - time.time()),
+                len(entries),
+            )
+            return
+        except Exception:
+            LOGGER.exception('deployment-sync failed for %s', fields)
+            continue
+        await client.xack(STREAM, GROUP, msg_id)
+
+
+async def consume_deployment_sync(
+    client: valkey.Valkey,
+    db: graph.Graph,
+    consumer: str | None = None,
+    stop: asyncio.Event | None = None,
+) -> None:
+    """Run the deployment-sync consumer loop until *stop* is set."""
+    # Derive a per-process consumer name so concurrent workers don't
+    # share a Pending Entries List and stale-claim each other's
+    # in-flight jobs.
+    consumer = (
+        consumer or f'{CONSUMER_PREFIX}-{socket.gethostname()}-{os.getpid()}'
+    )
+    await ensure_group(client)
+    LOGGER.info(
+        'Deployment-sync consumer loop running (consumer=%s)', consumer
+    )
+    while stop is None or not stop.is_set():
+        paused = await _paused_remaining(client)
+        if paused > 0:
+            await asyncio.sleep(min(paused, PAUSE_POLL_CAP_SECONDS))
+            continue
+        stale = await _claim_stale(client, consumer)
+        if stale:
+            try:
+                await _handle_entries(client, stale, db, check_dlq=True)
+            except Exception:
+                LOGGER.exception('deployment-sync stale-entry handling failed')
+                await asyncio.sleep(1)
+                continue
+        # Stale handling may have just paused us; don't read new work
+        # into a guaranteed re-throttle -- loop back and honor the pause.
+        if await _paused_remaining(client) > 0:
+            continue
+        try:
+            response = await client.xreadgroup(
+                GROUP,
+                consumer,
+                {STREAM: '>'},
+                count=16,
+                block=2000,
+            )
+        except Exception:
+            LOGGER.exception('xreadgroup failed')
+            await asyncio.sleep(1)
+            continue
+        if not response:
+            continue
+        for _stream, entries in typing.cast(
+            'list[tuple[object, list[typing.Any]]]', response
+        ):
+            try:
+                await _handle_entries(client, entries, db)
+            except Exception:
+                LOGGER.exception('deployment-sync entry handling failed')
+                await asyncio.sleep(1)
+                break

--- a/src/imbi_api/deployment_sync/queue.py
+++ b/src/imbi_api/deployment_sync/queue.py
@@ -11,6 +11,7 @@ the ``Project`` node.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import os
 import socket
@@ -36,6 +37,10 @@ DEBOUNCE_PREFIX = 'imbi:deployment-sync:debounce'
 DEBOUNCE_SECONDS = 10
 MAX_DELIVERIES = 3
 CLAIM_IDLE_MS = 120_000
+#: How often an in-flight job renews its claim; keeps a deep backfill
+#: (minutes of remote calls) from looking stale to other workers while
+#: leaving crashed-worker recovery at ``CLAIM_IDLE_MS``.
+CLAIM_RENEW_SECONDS = 30
 PAUSE_KEY = 'imbi:deployment-sync:paused-until'
 PAUSE_POLL_CAP_SECONDS = 30
 PAUSE_KEY_BUFFER_SECONDS = 5
@@ -227,6 +232,37 @@ async def _claim_stale(
     return []
 
 
+async def _renew_claim(
+    client: valkey.Valkey,
+    consumer: str,
+    msg_id: bytes,
+) -> None:
+    """Reset *msg_id*'s idle clock while its job is still running.
+
+    ``xautoclaim``'s ``min_idle_time`` measures "no ack yet", not
+    consumer liveness, so a deep backfill that legitimately runs past
+    ``CLAIM_IDLE_MS`` would otherwise be reclaimed and duplicate-
+    processed by another worker mid-flight.  ``JUSTID`` renews without
+    re-reading the entry or bumping the delivery counter, so renewal
+    never pushes a healthy job toward the dead-letter threshold.
+
+    Runs until cancelled by :func:`_handle_entries`.
+    """
+    while True:
+        await asyncio.sleep(CLAIM_RENEW_SECONDS)
+        try:
+            await client.xclaim(
+                STREAM,
+                GROUP,
+                consumer,
+                min_idle_time=0,
+                message_ids=[msg_id],
+                justid=True,
+            )
+        except Exception as err:  # noqa: BLE001
+            LOGGER.debug('claim renewal failed for %s: %s', msg_id, err)
+
+
 async def _maybe_dead_letter(
     client: valkey.Valkey,
     msg_id: bytes,
@@ -266,12 +302,14 @@ async def _handle_entries(
     client: valkey.Valkey,
     entries: list[tuple[bytes, abc.Mapping[bytes | str, bytes | str]]],
     db: graph.Graph,
+    consumer: str,
     check_dlq: bool = False,
 ) -> None:
     for msg_id, raw_fields in entries:
         fields = _decode_fields(raw_fields)
         if check_dlq and await _maybe_dead_letter(client, msg_id, fields):
             continue
+        renewer = asyncio.ensure_future(_renew_claim(client, consumer, msg_id))
         try:
             await _process_message(db, fields)
         except PluginRateLimited as exc:
@@ -290,6 +328,10 @@ async def _handle_entries(
         except Exception:
             LOGGER.exception('deployment-sync failed for %s', fields)
             continue
+        finally:
+            renewer.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await renewer
         await client.xack(STREAM, GROUP, msg_id)
 
 
@@ -318,7 +360,9 @@ async def consume_deployment_sync(
         stale = await _claim_stale(client, consumer)
         if stale:
             try:
-                await _handle_entries(client, stale, db, check_dlq=True)
+                await _handle_entries(
+                    client, stale, db, consumer, check_dlq=True
+                )
             except Exception:
                 LOGGER.exception('deployment-sync stale-entry handling failed')
                 await asyncio.sleep(1)
@@ -345,7 +389,7 @@ async def consume_deployment_sync(
             'list[tuple[object, list[typing.Any]]]', response
         ):
             try:
-                await _handle_entries(client, entries, db)
+                await _handle_entries(client, entries, db, consumer)
             except Exception:
                 LOGGER.exception('deployment-sync entry handling failed')
                 await asyncio.sleep(1)

--- a/src/imbi_api/deployment_sync/service.py
+++ b/src/imbi_api/deployment_sync/service.py
@@ -1,0 +1,262 @@
+"""Run the deployment resync and track its status.
+
+The background resync acts with the resolved Integration's *service*
+credential (PAT or GitHub App) via a synthetic service-account
+principal -- the enqueueing user is recorded on the status for
+display, not used for credentials or attribution (resync deliberately
+writes no ``operations_log`` rows; ``DeploymentEvent.performed_by``
+carries the original deployer resolved from the remote).
+
+Last-sync state is persisted as properties on the ``Project`` node so
+the UI can poll it without a dedicated status store.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import datetime
+import logging
+import typing
+
+import fastapi
+import pydantic
+from imbi_common import graph
+
+from imbi_api import models
+from imbi_api.auth import permissions
+
+if typing.TYPE_CHECKING:
+    from imbi_api.endpoints.project_deployments import ResyncSummary
+
+LOGGER = logging.getLogger(__name__)
+
+_MAX_ERROR_LEN = 500
+_STATUS_WRITE_RETRIES = 3
+_STATUS_RETRY_BACKOFF = 0.05
+
+SyncState = typing.Literal['idle', 'queued', 'running', 'success', 'failed']
+
+#: ``principal_name`` stamped on work the background resync performs.
+REQUESTED_BY = 'deployment-sync'
+
+
+class DeploymentSyncUnavailable(Exception):
+    """The project cannot resync deployments (no capability/support)."""
+
+
+class DeploymentSyncStatus(pydantic.BaseModel):
+    """Last-resync state for a project's deployments."""
+
+    status: SyncState = 'idle'
+    last_synced_at: datetime.datetime | None = None
+    observed: int | None = None
+    releases_created: int | None = None
+    releases_updated: int | None = None
+    events_recorded: int | None = None
+    errors: int | None = None
+    error: str | None = None
+    requested_by: str | None = None
+
+
+def _system_auth() -> permissions.AuthContext:
+    """Synthetic principal for the background resync worker.
+
+    Never persisted; exists so ``resync_for_project`` has an
+    ``AuthContext`` (its identity attach is best-effort and falls back
+    to the Integration's service credentials for a userless principal).
+    """
+    return permissions.AuthContext(
+        auth_method='client_credentials',
+        service_account=models.ServiceAccount(
+            slug=REQUESTED_BY, display_name='Imbi Deployment Sync'
+        ),
+    )
+
+
+async def run_resync(
+    db: graph.Graph, org_slug: str, project_id: str, limit: int
+) -> ResyncSummary:
+    """Run the deployment resync for one project.
+
+    Raises :class:`DeploymentSyncUnavailable` when the project has no
+    deployment capability (404) or its plugin does not support
+    deployment sync (400); other failures propagate so the caller can
+    record them.
+    """
+    # Imported here (not at module load) so the worker/service module
+    # never pulls the endpoints package at import time.
+    from imbi_api.endpoints import project_deployments
+
+    try:
+        return await project_deployments.resync_for_project(
+            db,
+            org_slug=org_slug,
+            project_id=project_id,
+            auth=_system_auth(),
+            limit=limit,
+        )
+    except fastapi.HTTPException as exc:
+        # 404: no deployment capability bound; 400: the plugin doesn't
+        # support deployment sync.  Misconfiguration, not transient.
+        if exc.status_code in (400, 404):
+            raise DeploymentSyncUnavailable(str(exc.detail)) from exc
+        raise
+
+
+def _now_iso() -> str:
+    return datetime.datetime.now(datetime.UTC).isoformat()
+
+
+def _is_write_conflict(exc: Exception) -> bool:
+    """True if *exc* is AGE's concurrent-update conflict (TM_Updated)."""
+    return 'failed to be updated' in str(exc)
+
+
+async def set_status(
+    db: graph.Graph,
+    project_id: str,
+    *,
+    status: SyncState,
+    requested_by: str = '',
+    summary: ResyncSummary | None = None,
+    error: str = '',
+    retry: bool = True,
+) -> None:
+    """Persist last-resync state on the ``Project`` node (best-effort).
+
+    *retry* re-attempts the write when AGE reports a transient
+    concurrent update, so the worker's authoritative transitions
+    (running -> success/failed) still land if a webhook touches the
+    project mid-write.  The enqueue endpoint passes ``retry=False`` for
+    its optimistic ``queued`` write: dropping that on conflict is
+    correct, since the worker's newer ``running`` write must win.
+    """
+    query: typing.LiteralString = """
+    MATCH (p:Project {{id: {project_id}}})
+    SET p.deployment_sync_status = {status},
+        p.deployment_sync_at = {at},
+        p.deployment_sync_by = {by},
+        p.deployment_sync_observed = {observed},
+        p.deployment_sync_releases_created = {releases_created},
+        p.deployment_sync_releases_updated = {releases_updated},
+        p.deployment_sync_events = {events},
+        p.deployment_sync_errors = {errors},
+        p.deployment_sync_error = {error}
+    RETURN p.id AS id
+    """
+    params = {
+        'project_id': project_id,
+        'status': status,
+        'at': _now_iso(),
+        'by': requested_by,
+        'observed': summary.observed if summary else 0,
+        'releases_created': summary.releases_created if summary else 0,
+        'releases_updated': summary.releases_updated if summary else 0,
+        'events': summary.events_recorded if summary else 0,
+        'errors': len(summary.errors) if summary else 0,
+        'error': error[:_MAX_ERROR_LEN],
+    }
+    attempts = _STATUS_WRITE_RETRIES if retry else 1
+    for attempt in range(attempts):
+        try:
+            await db.execute(query, params, ['id'])
+            return
+        except Exception as exc:  # noqa: BLE001
+            conflict = _is_write_conflict(exc)
+            if retry and conflict and attempt + 1 < attempts:
+                await asyncio.sleep(_STATUS_RETRY_BACKOFF * (attempt + 1))
+                continue
+            if conflict:
+                LOGGER.debug(
+                    'deployment-sync status write for %s lost a concurrent '
+                    'update (status=%s); leaving the newer state in place',
+                    project_id,
+                    status,
+                )
+            else:
+                LOGGER.warning(
+                    'Failed to persist deployment-sync status for project %s',
+                    project_id,
+                    exc_info=True,
+                )
+            return
+
+
+def _opt_str(value: object) -> str | None:
+    text = str(value) if value is not None else ''
+    return text or None
+
+
+def _opt_int(value: object) -> int | None:
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        try:
+            return int(value)
+        except ValueError:
+            return None
+    return None
+
+
+async def read_status(
+    db: graph.Graph, project_id: str
+) -> DeploymentSyncStatus:
+    """Read last-resync state from the ``Project`` node (``idle`` default)."""
+    query: typing.LiteralString = """
+    MATCH (p:Project {{id: {project_id}}})
+    RETURN p.deployment_sync_status AS status,
+           p.deployment_sync_at AS at,
+           p.deployment_sync_by AS requested_by,
+           p.deployment_sync_observed AS observed,
+           p.deployment_sync_releases_created AS releases_created,
+           p.deployment_sync_releases_updated AS releases_updated,
+           p.deployment_sync_events AS events,
+           p.deployment_sync_errors AS errors,
+           p.deployment_sync_error AS error
+    """
+    records = await db.execute(
+        query,
+        {'project_id': project_id},
+        [
+            'status',
+            'at',
+            'requested_by',
+            'observed',
+            'releases_created',
+            'releases_updated',
+            'events',
+            'errors',
+            'error',
+        ],
+    )
+    if not records:
+        return DeploymentSyncStatus()
+    row = records[0]
+    status_raw = graph.parse_agtype(row.get('status'))
+    status: SyncState = 'idle'
+    if status_raw in ('queued', 'running', 'success', 'failed', 'idle'):
+        status = status_raw
+    at_raw = _opt_str(graph.parse_agtype(row.get('at')))
+    last_synced_at: datetime.datetime | None = None
+    if at_raw:
+        try:
+            last_synced_at = datetime.datetime.fromisoformat(at_raw)
+        except ValueError:
+            last_synced_at = None
+    return DeploymentSyncStatus(
+        status=status,
+        last_synced_at=last_synced_at,
+        observed=_opt_int(graph.parse_agtype(row.get('observed'))),
+        releases_created=_opt_int(
+            graph.parse_agtype(row.get('releases_created'))
+        ),
+        releases_updated=_opt_int(
+            graph.parse_agtype(row.get('releases_updated'))
+        ),
+        events_recorded=_opt_int(graph.parse_agtype(row.get('events'))),
+        errors=_opt_int(graph.parse_agtype(row.get('errors'))),
+        error=_opt_str(graph.parse_agtype(row.get('error'))),
+        requested_by=_opt_str(graph.parse_agtype(row.get('requested_by'))),
+    )

--- a/src/imbi_api/deployment_sync/service.py
+++ b/src/imbi_api/deployment_sync/service.py
@@ -103,7 +103,12 @@ async def run_resync(
         raise
 
 
-def _now_iso() -> str:
+def now_iso() -> str:
+    """Current UTC time in the ISO-8601 form stored on the Project node.
+
+    Public so the enqueue endpoint can capture a pre-enqueue timestamp
+    for :func:`set_status`'s ``only_if_before`` guard.
+    """
     return datetime.datetime.now(datetime.UTC).isoformat()
 
 
@@ -121,6 +126,7 @@ async def set_status(
     summary: ResyncSummary | None = None,
     error: str = '',
     retry: bool = True,
+    only_if_before: str | None = None,
 ) -> None:
     """Persist last-resync state on the ``Project`` node (best-effort).
 
@@ -130,9 +136,26 @@ async def set_status(
     project mid-write.  The enqueue endpoint passes ``retry=False`` for
     its optimistic ``queued`` write: dropping that on conflict is
     correct, since the worker's newer ``running`` write must win.
+
+    *only_if_before* skips the write entirely when the stored
+    ``deployment_sync_at`` has already advanced to or past the given
+    ISO-8601 timestamp.  AGE only raises a conflict for truly
+    concurrent transactions, so without this guard an optimistic
+    ``queued`` write that merely executes *after* the worker finished
+    would silently clobber the newer terminal status.
     """
-    query: typing.LiteralString = """
-    MATCH (p:Project {{id: {project_id}}})
+    guard: typing.LiteralString = (
+        ''
+        if only_if_before is None
+        else """
+    WHERE p.deployment_sync_at IS NULL
+       OR p.deployment_sync_at < {only_if_before}"""
+    )
+    query: typing.LiteralString = (
+        """
+    MATCH (p:Project {{id: {project_id}}})"""
+        + guard
+        + """
     SET p.deployment_sync_status = {status},
         p.deployment_sync_at = {at},
         p.deployment_sync_by = {by},
@@ -144,10 +167,11 @@ async def set_status(
         p.deployment_sync_error = {error}
     RETURN p.id AS id
     """
+    )
     params = {
         'project_id': project_id,
         'status': status,
-        'at': _now_iso(),
+        'at': now_iso(),
         'by': requested_by,
         'observed': summary.observed if summary else 0,
         'releases_created': summary.releases_created if summary else 0,
@@ -156,6 +180,8 @@ async def set_status(
         'errors': len(summary.errors) if summary else 0,
         'error': error[:_MAX_ERROR_LEN],
     }
+    if only_if_before is not None:
+        params['only_if_before'] = only_if_before
     attempts = _STATUS_WRITE_RETRIES if retry else 1
     for attempt in range(attempts):
         try:

--- a/src/imbi_api/endpoints/project_deployments.py
+++ b/src/imbi_api/endpoints/project_deployments.py
@@ -599,6 +599,29 @@ def _handler(resolved: ResolvedCapability) -> DeploymentCapability:
     return typing.cast(DeploymentCapability, resolved.capability_cls())
 
 
+def _require_deployment_sync_support(resolved: ResolvedCapability) -> None:
+    """Raise 400 unless the plugin opts into deployment resync.
+
+    Shared by the enqueue endpoint and the worker-side
+    :func:`resync_for_project` so the gate cannot silently diverge.
+    """
+    deployment_capability = resolved.entry.manifest.get_capability(
+        'deployment'
+    )
+    supports_deployment_sync = bool(
+        deployment_capability
+        and deployment_capability.hints.get('supports_deployment_sync')
+    )
+    if not supports_deployment_sync:
+        raise fastapi.HTTPException(
+            status_code=400,
+            detail=(
+                f'Plugin {resolved.plugin_slug!r} does not support '
+                'deployment resync.'
+            ),
+        )
+
+
 def _resolve_credentials(
     ctx: PluginContext, fallback: dict[str, str]
 ) -> dict[str, str]:
@@ -955,21 +978,7 @@ async def resync_for_project(
         source=source,
         best_effort_identity=True,
     )
-    deployment_capability = resolved.entry.manifest.get_capability(
-        'deployment'
-    )
-    supports_deployment_sync = bool(
-        deployment_capability
-        and deployment_capability.hints.get('supports_deployment_sync')
-    )
-    if not supports_deployment_sync:
-        raise fastapi.HTTPException(
-            status_code=400,
-            detail=(
-                f'Plugin {resolved.plugin_slug!r} does not support '
-                'deployment resync.'
-            ),
-        )
+    _require_deployment_sync_support(resolved)
     environments = await _load_resync_environments(db, project_id=project_id)
     if not environments:
         return summary
@@ -1402,35 +1411,29 @@ async def resync_project_deployments(
     when the job was debounced or Valkey is unavailable.
     """
     resolved = await resolve_capability(db, project_id, 'deployment', source)
-    deployment_capability = resolved.entry.manifest.get_capability(
-        'deployment'
-    )
-    supports_deployment_sync = bool(
-        deployment_capability
-        and deployment_capability.hints.get('supports_deployment_sync')
-    )
-    if not supports_deployment_sync:
-        raise fastapi.HTTPException(
-            status_code=400,
-            detail=(
-                f'Plugin {resolved.plugin_slug!r} does not support '
-                'deployment resync.'
-            ),
-        )
+    _require_deployment_sync_support(resolved)
     requested_by = auth.principal_name
+    # Captured before the XADD: every worker write for this job lands
+    # after the enqueue, so guarding the optimistic ``queued`` on this
+    # timestamp keeps it from clobbering a worker that already advanced
+    # (or even finished) the run before this write executes.
+    enqueued_at = deployment_sync_service.now_iso()
     enqueued = await deployment_sync_queue.enqueue_deployment_sync(
         valkey_client, org_slug, project_id, requested_by, limit=limit
     )
     if enqueued:
         # Optimistic, best-effort: if the worker has already flipped the
         # project to ``running``, that newer write must win -- so this
-        # one does not retry the concurrent-update conflict.
+        # one does not retry the concurrent-update conflict and skips
+        # the write entirely once ``deployment_sync_at`` has advanced
+        # past the enqueue time.
         await deployment_sync_service.set_status(
             db,
             project_id,
             status='queued',
             requested_by=requested_by,
             retry=False,
+            only_if_before=enqueued_at,
         )
     return DeploymentResyncEnqueueResponse(enqueued=enqueued)
 

--- a/src/imbi_api/endpoints/project_deployments.py
+++ b/src/imbi_api/endpoints/project_deployments.py
@@ -39,6 +39,8 @@ from imbi_common.plugins.base import (
 )
 
 from imbi_api.auth import permissions
+from imbi_api.deployment_sync import queue as deployment_sync_queue
+from imbi_api.deployment_sync import service as deployment_sync_service
 from imbi_api.endpoints._helpers import (
     lookup_project_links,
     lookup_project_slugs,
@@ -58,6 +60,7 @@ from imbi_api.identity.host_integration import (
 from imbi_api.llm.dependencies import InjectAnthropicClient
 from imbi_api.plugins import call_with_timeout
 from imbi_api.plugins.resolution import ResolvedCapability, resolve_capability
+from imbi_api.scoring import OptionalValkeyClient
 
 LOGGER = logging.getLogger(__name__)
 
@@ -973,13 +976,15 @@ async def resync_for_project(
     handler = _handler(resolved)
 
     async def _fetch(c: PluginContext) -> list[RemoteDeployment]:
-        return await call_with_timeout(
-            handler.list_recent_deployments(
-                c,
-                _resolve_credentials(c, credentials),
-                environments=environments,
-                limit=limit,
-            )
+        # No per-call plugin timeout: a deep backfill (limit=100 across
+        # several environments) legitimately takes minutes of remote API
+        # calls, and every caller is a background worker (the
+        # deployment-sync queue or the maintenance sweep).
+        return await handler.list_recent_deployments(
+            c,
+            _resolve_credentials(c, credentials),
+            environments=environments,
+            limit=limit,
         )
 
     try:
@@ -1353,11 +1358,18 @@ async def trigger_deployment(
     )
 
 
-@project_deployments_router.post('/resync')
+class DeploymentResyncEnqueueResponse(pydantic.BaseModel):
+    """Result of enqueueing a deployment resync."""
+
+    enqueued: bool
+
+
+@project_deployments_router.post('/resync', status_code=202)
 async def resync_project_deployments(
     org_slug: str,
     project_id: str,
     db: graph.Pool,
+    valkey_client: OptionalValkeyClient,
     auth: typing.Annotated[
         permissions.AuthContext,
         fastapi.Depends(
@@ -1366,15 +1378,18 @@ async def resync_project_deployments(
     ],
     source: str | None = None,
     limit: int = fastapi.Query(default=1, ge=1, le=100),
-) -> ResyncSummary:
-    """Backfill Release nodes + DEPLOYED_TO edges from the remote.
+) -> DeploymentResyncEnqueueResponse:
+    """Enqueue a backfill of Release nodes + DEPLOYED_TO edges.
 
-    Asks the project's deployment plugin for the most recent ``limit``
-    deployments per environment, upserts any missing ``Release`` nodes,
-    and dedup-appends ``DeploymentEvent`` rows so the badges advance
-    even when the gateway webhook flow has lapsed.  No ``operations_log``
-    audit row is written -- the ``DEPLOYED_TO`` edge already carries the
-    original creator via ``DeploymentEvent.performed_by``.
+    The worker asks the project's deployment plugin for the most recent
+    ``limit`` deployments per environment, upserts any missing
+    ``Release`` nodes, and dedup-appends ``DeploymentEvent`` rows so the
+    badges advance even when the gateway webhook flow has lapsed.  A
+    deep backfill makes hundreds of remote API calls, so the work runs
+    as a Valkey-stream job; poll ``GET /deployments/sync-status`` for
+    the outcome.  No ``operations_log`` audit row is written -- the
+    ``DEPLOYED_TO`` edge already carries the original creator via
+    ``DeploymentEvent.performed_by``.
 
     ``limit`` defaults to 1 (cheap webhook-lapse catch-up).  Raise it
     (up to 100, the GitHub per-page ceiling) for a deeper backfill that
@@ -1383,16 +1398,58 @@ async def resync_project_deployments(
 
     Surfaces 400 when the project's deployment plugin does not
     advertise ``supports_deployment_sync`` -- callers should hide the
-    button using the plugin manifest flag.
+    button using the plugin manifest flag.  Returns ``enqueued=False``
+    when the job was debounced or Valkey is unavailable.
     """
-    return await resync_for_project(
-        db,
-        org_slug=org_slug,
-        project_id=project_id,
-        auth=auth,
-        source=source,
-        limit=limit,
+    resolved = await resolve_capability(db, project_id, 'deployment', source)
+    deployment_capability = resolved.entry.manifest.get_capability(
+        'deployment'
     )
+    supports_deployment_sync = bool(
+        deployment_capability
+        and deployment_capability.hints.get('supports_deployment_sync')
+    )
+    if not supports_deployment_sync:
+        raise fastapi.HTTPException(
+            status_code=400,
+            detail=(
+                f'Plugin {resolved.plugin_slug!r} does not support '
+                'deployment resync.'
+            ),
+        )
+    requested_by = auth.principal_name
+    enqueued = await deployment_sync_queue.enqueue_deployment_sync(
+        valkey_client, org_slug, project_id, requested_by, limit=limit
+    )
+    if enqueued:
+        # Optimistic, best-effort: if the worker has already flipped the
+        # project to ``running``, that newer write must win -- so this
+        # one does not retry the concurrent-update conflict.
+        await deployment_sync_service.set_status(
+            db,
+            project_id,
+            status='queued',
+            requested_by=requested_by,
+            retry=False,
+        )
+    return DeploymentResyncEnqueueResponse(enqueued=enqueued)
+
+
+@project_deployments_router.get('/sync-status')
+async def get_deployment_sync_status(
+    org_slug: str,
+    project_id: str,
+    db: graph.Pool,
+    _auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('project:deployment:read'),
+        ),
+    ],
+) -> deployment_sync_service.DeploymentSyncStatus:
+    """Return the project's last deployment-resync state."""
+    del org_slug
+    return await deployment_sync_service.read_status(db, project_id)
 
 
 @project_deployments_router.get('/runs/{run_id}')

--- a/src/imbi_api/lifespans.py
+++ b/src/imbi_api/lifespans.py
@@ -15,6 +15,7 @@ from imbi_common.llm import AnthropicClient
 
 from imbi_api import openapi
 from imbi_api.commit_sync import queue as commit_sync_queue
+from imbi_api.deployment_sync import queue as deployment_sync_queue
 from imbi_api.email.client import EmailClient
 from imbi_api.email.templates import TemplateManager
 from imbi_api.identity import sweeper as identity_sweeper
@@ -197,6 +198,43 @@ async def pr_sync_worker_hook() -> abc.AsyncGenerator[None]:
         except Exception:  # noqa: BLE001
             LOGGER.warning(
                 'PR-sync worker task exited with error', exc_info=True
+            )
+
+
+@contextlib.asynccontextmanager
+async def deployment_sync_worker_hook() -> abc.AsyncGenerator[None]:
+    """Run the on-demand deployment-resync consumer loop."""
+    try:
+        client = valkey.get_client()
+    except RuntimeError:
+        LOGGER.warning(
+            'Valkey unavailable; deployment-sync worker not started'
+        )
+        yield None
+        return
+    if _graph is None:
+        LOGGER.warning('Graph not ready; deployment-sync worker not started')
+        yield None
+        return
+    stop = asyncio.Event()
+    LOGGER.info('Deployment-sync worker starting')
+    consumer_task = asyncio.create_task(
+        deployment_sync_queue.consume_deployment_sync(
+            client, _graph, stop=stop
+        )
+    )
+    try:
+        yield None
+    finally:
+        stop.set()
+        consumer_task.cancel()
+        try:
+            await consumer_task
+        except asyncio.CancelledError:
+            pass
+        except Exception:  # noqa: BLE001
+            LOGGER.warning(
+                'Deployment-sync worker task exited with error', exc_info=True
             )
 
 

--- a/tests/endpoints/test_project_deployments.py
+++ b/tests/endpoints/test_project_deployments.py
@@ -1554,7 +1554,12 @@ class ResyncEndpointTestCase(ProjectDeploymentsTestCase):
         self.assertEqual(response.status_code, 202, response.text)
         self.assertTrue(response.json()['enqueued'])
         self.assertEqual(enqueue.await_args.kwargs['limit'], 50)
-        self.assertEqual(set_status.await_args.kwargs['status'], 'queued')
+        kwargs = set_status.await_args.kwargs
+        self.assertEqual(kwargs['status'], 'queued')
+        # The optimistic write is guarded by a pre-enqueue timestamp so
+        # a worker that already finished the job cannot be clobbered.
+        self.assertIsInstance(kwargs['only_if_before'], str)
+        self.assertFalse(kwargs['retry'])
 
     def test_resync_debounced_skips_status(self) -> None:
         with (

--- a/tests/endpoints/test_project_deployments.py
+++ b/tests/endpoints/test_project_deployments.py
@@ -1,5 +1,6 @@
 """Tests for the project deployment plugin endpoints."""
 
+import asyncio
 import datetime
 import json
 import typing
@@ -1150,7 +1151,13 @@ class ProjectDeploymentsTestCase(support.SharedAppTestCase):
 
 
 class ResyncProjectDeploymentsTestCase(ProjectDeploymentsTestCase):
-    """End-to-end coverage for the per-project resync endpoint."""
+    """End-to-end coverage for the background resync flow.
+
+    The endpoint enqueues onto the deployment-sync stream; the worker
+    calls :func:`resync_for_project`, which these tests exercise
+    directly (endpoint behavior is covered by
+    :class:`ResyncEndpointTestCase`).
+    """
 
     def _arm(
         self,
@@ -1246,21 +1253,27 @@ class ResyncProjectDeploymentsTestCase(ProjectDeploymentsTestCase):
             creator_subject=creator_subject,
         )
 
+    def _run_resync(self, limit: int = 1) -> project_deployments.ResyncSummary:
+        return asyncio.run(
+            project_deployments.resync_for_project(
+                self.mock_db,
+                org_slug='myorg',
+                project_id='proj1',
+                auth=self.auth_context,
+                limit=limit,
+            )
+        )
+
     def test_resync_persists_release_and_event_for_sha(self) -> None:
         observed = self._observed()
         self._arm([observed], release_exists=False)
-        with testclient.TestClient(self.test_app) as client:
-            response = client.post(
-                '/organizations/myorg/projects/proj1/deployments/resync'
-            )
-        self.assertEqual(response.status_code, 200, response.text)
-        data = response.json()
-        self.assertEqual(data['projects'], 1)
-        self.assertEqual(data['observed'], 1)
-        self.assertEqual(data['releases_created'], 1)
-        self.assertEqual(data['releases_updated'], 0)
-        self.assertEqual(data['events_recorded'], 1)
-        self.assertEqual(data['errors'], [])
+        summary = self._run_resync()
+        self.assertEqual(summary.projects, 1)
+        self.assertEqual(summary.observed, 1)
+        self.assertEqual(summary.releases_created, 1)
+        self.assertEqual(summary.releases_updated, 0)
+        self.assertEqual(summary.events_recorded, 1)
+        self.assertEqual(summary.errors, [])
         # Sha-style ref produces (tag=None, committish=sha[:7]).
         upsert_call = self.mocks['upsert_release_node'].call_args
         self.assertIsNone(upsert_call.kwargs['tag'])
@@ -1280,14 +1293,9 @@ class ResyncProjectDeploymentsTestCase(ProjectDeploymentsTestCase):
             [self._observed(ref='v1.2.3', sha='deadbeefcafebabe')],
             release_exists=True,
         )
-        with testclient.TestClient(self.test_app) as client:
-            response = client.post(
-                '/organizations/myorg/projects/proj1/deployments/resync'
-            )
-        self.assertEqual(response.status_code, 200, response.text)
-        data = response.json()
-        self.assertEqual(data['releases_created'], 0)
-        self.assertEqual(data['releases_updated'], 1)
+        summary = self._run_resync()
+        self.assertEqual(summary.releases_created, 0)
+        self.assertEqual(summary.releases_updated, 1)
         upsert_call = self.mocks['upsert_release_node'].call_args
         self.assertEqual(upsert_call.kwargs['tag'], 'v1.2.3')
         self.assertEqual(upsert_call.kwargs['committish'], 'deadbee')
@@ -1306,11 +1314,7 @@ class ResyncProjectDeploymentsTestCase(ProjectDeploymentsTestCase):
             ],
             release_exists=False,
         )
-        with testclient.TestClient(self.test_app) as client:
-            response = client.post(
-                '/organizations/myorg/projects/proj1/deployments/resync'
-            )
-        self.assertEqual(response.status_code, 200, response.text)
+        self._run_resync()
         upsert_call = self.mocks['upsert_release_node'].call_args
         self.assertEqual(
             upsert_call.kwargs['notes_markdown'],
@@ -1324,11 +1328,7 @@ class ResyncProjectDeploymentsTestCase(ProjectDeploymentsTestCase):
         # No release body (branch/SHA deploy) keeps the prior behavior:
         # the short deploy description supplies the notes.
         self._arm([self._observed(release_notes=None)], release_exists=False)
-        with testclient.TestClient(self.test_app) as client:
-            response = client.post(
-                '/organizations/myorg/projects/proj1/deployments/resync'
-            )
-        self.assertEqual(response.status_code, 200, response.text)
+        self._run_resync()
         upsert_call = self.mocks['upsert_release_node'].call_args
         self.assertEqual(upsert_call.kwargs['notes_markdown'], 'Bump foo')
 
@@ -1343,11 +1343,7 @@ class ResyncProjectDeploymentsTestCase(ProjectDeploymentsTestCase):
         self.mocks['get_release_notes'] = self._start(
             mock.patch(f'{_MODULE}._get_release_notes', return_value=notes)
         )
-        with testclient.TestClient(self.test_app) as client:
-            response = client.post(
-                '/organizations/myorg/projects/proj1/deployments/resync'
-            )
-        self.assertEqual(response.status_code, 200, response.text)
+        self._run_resync()
         upsert_call = self.mocks['upsert_release_node'].call_args
         # Reconciled onto the existing tag, and notes fetched by that tag.
         self.assertEqual(upsert_call.kwargs['tag'], '3.23.4')
@@ -1363,37 +1359,26 @@ class ResyncProjectDeploymentsTestCase(ProjectDeploymentsTestCase):
             sync=False,
             options={'owner': 'octo', 'repo': 'demo'},
         )
-        with testclient.TestClient(self.test_app) as client:
-            response = client.post(
-                '/organizations/myorg/projects/proj1/deployments/resync'
-            )
-        self.assertEqual(response.status_code, 400)
-        self.assertIn('does not support', response.json()['detail'])
+        with self.assertRaises(fastapi.HTTPException) as cm:
+            self._run_resync()
+        self.assertEqual(cm.exception.status_code, 400)
+        self.assertIn('does not support', str(cm.exception.detail))
 
     def test_resync_no_environments_returns_zero(self) -> None:
         self._arm([], environments=[])
-        with testclient.TestClient(self.test_app) as client:
-            response = client.post(
-                '/organizations/myorg/projects/proj1/deployments/resync'
-            )
-        self.assertEqual(response.status_code, 200, response.text)
-        self.assertEqual(response.json()['observed'], 0)
+        summary = self._run_resync()
+        self.assertEqual(summary.observed, 0)
         self.mocks['upsert_release_node'].assert_not_called()
         self.mocks['append_deployment_event'].assert_not_called()
 
     def test_resync_records_missing_edge_as_error(self) -> None:
         self._arm([self._observed()], edge_status='missing')
-        with testclient.TestClient(self.test_app) as client:
-            response = client.post(
-                '/organizations/myorg/projects/proj1/deployments/resync'
-            )
-        self.assertEqual(response.status_code, 200, response.text)
-        data = response.json()
-        self.assertEqual(len(data['errors']), 1)
+        summary = self._run_resync()
+        self.assertEqual(len(summary.errors), 1)
         self.assertEqual(
-            data['errors'][0]['environment'], 'infrastructure-testing'
+            summary.errors[0].environment, 'infrastructure-testing'
         )
-        self.assertEqual(data['events_recorded'], 0)
+        self.assertEqual(summary.events_recorded, 0)
 
     def test_resync_does_not_write_operations_log_audit(self) -> None:
         """Resync must not poison ``argMax(performed_by, occurred_at)``.
@@ -1406,22 +1391,14 @@ class ResyncProjectDeploymentsTestCase(ProjectDeploymentsTestCase):
         flows still write their own audit rows.
         """
         self._arm([self._observed()])
-        with testclient.TestClient(self.test_app) as client:
-            response = client.post(
-                '/organizations/myorg/projects/proj1/deployments/resync'
-            )
-        self.assertEqual(response.status_code, 200, response.text)
+        self._run_resync()
         ch = self.mocks['clickhouse'].return_value
         ch.insert.assert_not_awaited()
 
     def test_resync_threads_creator_to_performed_by(self) -> None:
         """``observed.creator`` becomes ``DeploymentEvent.performed_by``."""
         self._arm([self._observed(creator='octocat')])
-        with testclient.TestClient(self.test_app) as client:
-            response = client.post(
-                '/organizations/myorg/projects/proj1/deployments/resync'
-            )
-        self.assertEqual(response.status_code, 200, response.text)
+        self._run_resync()
         append_call = self.mocks['append_deployment_event'].call_args
         self.assertEqual(append_call.kwargs['performed_by'], 'octocat')
 
@@ -1445,11 +1422,7 @@ class ResyncProjectDeploymentsTestCase(ProjectDeploymentsTestCase):
                 return_value=_resolver,
             )
         )
-        with testclient.TestClient(self.test_app) as client:
-            response = client.post(
-                '/organizations/myorg/projects/proj1/deployments/resync'
-            )
-        self.assertEqual(response.status_code, 200, response.text)
+        self._run_resync()
         append_call = self.mocks['append_deployment_event'].call_args
         self.assertEqual(
             append_call.kwargs['performed_by'], 'kevin@example.com'
@@ -1474,80 +1447,22 @@ class ResyncProjectDeploymentsTestCase(ProjectDeploymentsTestCase):
                 return_value=_resolver,
             )
         )
-        with testclient.TestClient(self.test_app) as client:
-            response = client.post(
-                '/organizations/myorg/projects/proj1/deployments/resync'
-            )
-        self.assertEqual(response.status_code, 200, response.text)
+        self._run_resync()
         append_call = self.mocks['append_deployment_event'].call_args
         self.assertEqual(append_call.kwargs['performed_by'], 'kevinv')
 
     def test_resync_defaults_limit_to_one(self) -> None:
         """Absent ``limit`` keeps the cheap latest-per-env catch-up."""
         self._arm([self._observed()])
-        with testclient.TestClient(self.test_app) as client:
-            response = client.post(
-                '/organizations/myorg/projects/proj1/deployments/resync'
-            )
-        self.assertEqual(response.status_code, 200, response.text)
+        self._run_resync()
         self.assertEqual(self.mocks['handler'].return_value._last_limit, 1)
 
     def test_resync_threads_limit_to_plugin(self) -> None:
-        """``?limit=N`` reaches ``list_recent_deployments`` for a deeper
+        """``limit`` reaches ``list_recent_deployments`` for a deeper
         backfill that re-resolves historical attribution."""
         self._arm([self._observed()])
-        with testclient.TestClient(self.test_app) as client:
-            response = client.post(
-                '/organizations/myorg/projects/proj1/deployments/resync'
-                '?limit=50'
-            )
-        self.assertEqual(response.status_code, 200, response.text)
+        self._run_resync(limit=50)
         self.assertEqual(self.mocks['handler'].return_value._last_limit, 50)
-
-    def test_resync_rejects_out_of_range_limit(self) -> None:
-        """``limit`` is clamped to the 1..100 GitHub per-page window."""
-        self._arm([self._observed()])
-        with testclient.TestClient(self.test_app) as client:
-            self.assertEqual(
-                client.post(
-                    '/organizations/myorg/projects/proj1/deployments/'
-                    'resync?limit=0'
-                ).status_code,
-                422,
-            )
-            self.assertEqual(
-                client.post(
-                    '/organizations/myorg/projects/proj1/deployments/'
-                    'resync?limit=101'
-                ).status_code,
-                422,
-            )
-
-    def test_resync_requires_write_permission(self) -> None:
-        non_admin = models.User(
-            email='dev@example.com',
-            display_name='Dev',
-            is_active=True,
-            is_admin=False,
-            password_hash=password.hash_password('testpassword123'),
-            created_at=datetime.datetime.now(datetime.UTC),
-        )
-        self.auth_context = permissions.AuthContext(
-            user=non_admin,
-            session_id='test-session',
-            auth_method='jwt',
-            permissions={'project:deployment:read'},
-        )
-
-        async def _ctx() -> permissions.AuthContext:
-            return self.auth_context
-
-        self.test_app.dependency_overrides[permissions.get_current_user] = _ctx
-        with testclient.TestClient(self.test_app) as client:
-            response = client.post(
-                '/organizations/myorg/projects/proj1/deployments/resync'
-            )
-        self.assertEqual(response.status_code, 403)
 
     def test_resync_falls_back_to_app_credentials_without_identity(
         self,
@@ -1577,12 +1492,8 @@ class ResyncProjectDeploymentsTestCase(ProjectDeploymentsTestCase):
             'app_id': '971',
             'private_key': 'PEM',
         }
-        with testclient.TestClient(self.test_app) as client:
-            response = client.post(
-                '/organizations/myorg/projects/proj1/deployments/resync'
-            )
-        self.assertEqual(response.status_code, 200, response.text)
-        self.assertEqual(response.json()['observed'], 1)
+        summary = self._run_resync()
+        self.assertEqual(summary.observed, 1)
 
     def test_resync_503_when_no_service_credentials(self) -> None:
         """No identity connection *and* no service secret is a genuine
@@ -1603,11 +1514,125 @@ class ResyncProjectDeploymentsTestCase(ProjectDeploymentsTestCase):
 
         self.mocks['attach_identity'].side_effect = _identity_required
         self.mocks['decrypt_integration_credentials'].return_value = {}
+        with self.assertRaises(fastapi.HTTPException) as cm:
+            self._run_resync()
+        self.assertEqual(cm.exception.status_code, 503)
+
+
+class ResyncEndpointTestCase(ProjectDeploymentsTestCase):
+    """The resync endpoint validates, enqueues, and returns 202."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        from imbi_api import scoring
+
+        self.test_app.dependency_overrides[scoring._inject_optional_client] = (
+            lambda: mock.AsyncMock()
+        )
+
+    def _post(self, query: str = '') -> typing.Any:
         with testclient.TestClient(self.test_app) as client:
-            response = client.post(
+            return client.post(
                 '/organizations/myorg/projects/proj1/deployments/resync'
+                + query
             )
-        self.assertEqual(response.status_code, 503, response.text)
+
+    def test_resync_enqueues(self) -> None:
+        with (
+            mock.patch.object(
+                project_deployments.deployment_sync_queue,
+                'enqueue_deployment_sync',
+                mock.AsyncMock(return_value=True),
+            ) as enqueue,
+            mock.patch.object(
+                project_deployments.deployment_sync_service,
+                'set_status',
+                mock.AsyncMock(),
+            ) as set_status,
+        ):
+            response = self._post('?limit=50')
+        self.assertEqual(response.status_code, 202, response.text)
+        self.assertTrue(response.json()['enqueued'])
+        self.assertEqual(enqueue.await_args.kwargs['limit'], 50)
+        self.assertEqual(set_status.await_args.kwargs['status'], 'queued')
+
+    def test_resync_debounced_skips_status(self) -> None:
+        with (
+            mock.patch.object(
+                project_deployments.deployment_sync_queue,
+                'enqueue_deployment_sync',
+                mock.AsyncMock(return_value=False),
+            ),
+            mock.patch.object(
+                project_deployments.deployment_sync_service,
+                'set_status',
+                mock.AsyncMock(),
+            ) as set_status,
+        ):
+            response = self._post()
+        self.assertEqual(response.status_code, 202, response.text)
+        self.assertFalse(response.json()['enqueued'])
+        set_status.assert_not_awaited()
+
+    def test_resync_400_when_plugin_opts_out(self) -> None:
+        self.mocks['resolve_capability'].return_value = _make_resolved(
+            _FakeNoSyncDeploymentPlugin,
+            slug='no-sync-deployment',
+            name='No-Sync Deployment',
+            sync=False,
+            options={'owner': 'octo', 'repo': 'demo'},
+        )
+        response = self._post()
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('does not support', response.json()['detail'])
+
+    def test_resync_rejects_out_of_range_limit(self) -> None:
+        """``limit`` is clamped to the 1..100 GitHub per-page window."""
+        self.assertEqual(self._post('?limit=0').status_code, 422)
+        self.assertEqual(self._post('?limit=101').status_code, 422)
+
+    def test_resync_requires_write_permission(self) -> None:
+        non_admin = models.User(
+            email='dev@example.com',
+            display_name='Dev',
+            is_active=True,
+            is_admin=False,
+            password_hash=password.hash_password('testpassword123'),
+            created_at=datetime.datetime.now(datetime.UTC),
+        )
+        self.auth_context = permissions.AuthContext(
+            user=non_admin,
+            session_id='test-session',
+            auth_method='jwt',
+            permissions={'project:deployment:read'},
+        )
+
+        async def _ctx() -> permissions.AuthContext:
+            return self.auth_context
+
+        self.test_app.dependency_overrides[permissions.get_current_user] = _ctx
+        response = self._post()
+        self.assertEqual(response.status_code, 403)
+
+    def test_get_sync_status(self) -> None:
+        from imbi_api.deployment_sync import service as sync_service
+
+        status = sync_service.DeploymentSyncStatus(
+            status='success', observed=3, events_recorded=2
+        )
+        with mock.patch.object(
+            sync_service, 'read_status', mock.AsyncMock(return_value=status)
+        ):
+            with testclient.TestClient(self.test_app) as client:
+                response = client.get(
+                    '/organizations/myorg/projects/proj1/deployments'
+                    '/sync-status'
+                )
+        self.assertEqual(response.status_code, 200, response.text)
+        data = response.json()
+        self.assertEqual(data['status'], 'success')
+        self.assertEqual(data['observed'], 3)
+        self.assertEqual(data['events_recorded'], 2)
 
 
 class FallbackNotesTestCase(unittest.TestCase):

--- a/tests/test_deployment_sync_queue.py
+++ b/tests/test_deployment_sync_queue.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import time
 import unittest
 from unittest import mock
@@ -145,7 +146,10 @@ class ConsumerTests(unittest.IsolatedAsyncioTestCase):
         client = mock.AsyncMock()
         with mock.patch.object(queue, '_process_message', mock.AsyncMock()):
             await queue._handle_entries(
-                client, [(b'1-0', {b'project_id': b'p1'})], mock.AsyncMock()
+                client,
+                [(b'1-0', {b'project_id': b'p1'})],
+                mock.AsyncMock(),
+                'w',
             )
         client.xack.assert_awaited_once()
 
@@ -157,9 +161,56 @@ class ConsumerTests(unittest.IsolatedAsyncioTestCase):
             mock.AsyncMock(side_effect=RuntimeError('boom')),
         ):
             await queue._handle_entries(
-                client, [(b'1-0', {b'project_id': b'p1'})], mock.AsyncMock()
+                client,
+                [(b'1-0', {b'project_id': b'p1'})],
+                mock.AsyncMock(),
+                'w',
             )
         client.xack.assert_not_called()
+
+    async def test_renews_claim_while_processing(self) -> None:
+        # A long-running backfill must keep XCLAIMing its own message
+        # (JUSTID -> no delivery-count bump) so another worker's
+        # stale-reclaim never duplicate-processes an in-flight job.
+        client = mock.AsyncMock()
+
+        async def _slow(db: object, fields: dict[str, str]) -> None:
+            del db, fields
+            await asyncio.sleep(0.05)
+
+        with (
+            mock.patch.object(queue, 'CLAIM_RENEW_SECONDS', 0.01),
+            mock.patch.object(queue, '_process_message', _slow),
+        ):
+            await queue._handle_entries(
+                client,
+                [(b'1-0', {b'project_id': b'p1'})],
+                mock.AsyncMock(),
+                'w',
+            )
+        client.xclaim.assert_awaited()
+        kwargs = client.xclaim.await_args.kwargs
+        self.assertEqual(0, kwargs['min_idle_time'])
+        self.assertEqual([b'1-0'], kwargs['message_ids'])
+        self.assertTrue(kwargs['justid'])
+        client.xack.assert_awaited_once()
+
+    async def test_renewal_stops_after_processing(self) -> None:
+        client = mock.AsyncMock()
+        with (
+            mock.patch.object(queue, 'CLAIM_RENEW_SECONDS', 0.01),
+            mock.patch.object(queue, '_process_message', mock.AsyncMock()),
+        ):
+            await queue._handle_entries(
+                client,
+                [(b'1-0', {b'project_id': b'p1'})],
+                mock.AsyncMock(),
+                'w',
+            )
+            renews = client.xclaim.await_count
+            await asyncio.sleep(0.05)
+        # The renewer was cancelled with the job; no further XCLAIMs.
+        self.assertEqual(renews, client.xclaim.await_count)
 
     async def test_dlq_after_max_deliveries(self) -> None:
         client = mock.AsyncMock()
@@ -188,6 +239,7 @@ class ConsumerTests(unittest.IsolatedAsyncioTestCase):
                     (b'2-0', {b'project_id': b'p2'}),
                 ],
                 mock.AsyncMock(),
+                'w',
             )
         # Pause marker set; message left pending (no ack), not
         # dead-lettered, and the batch stopped before the sibling job.

--- a/tests/test_deployment_sync_queue.py
+++ b/tests/test_deployment_sync_queue.py
@@ -1,0 +1,228 @@
+"""Tests for the deployment-resync queue."""
+
+from __future__ import annotations
+
+import time
+import unittest
+from unittest import mock
+
+from imbi_common.plugins.errors import PluginRateLimited
+
+from imbi_api.deployment_sync import queue
+from imbi_api.deployment_sync.service import DeploymentSyncUnavailable
+
+
+def _summary(**kwargs: int) -> mock.Mock:
+    summary = mock.Mock()
+    summary.observed = kwargs.get('observed', 0)
+    summary.releases_created = kwargs.get('releases_created', 0)
+    summary.releases_updated = kwargs.get('releases_updated', 0)
+    summary.events_recorded = kwargs.get('events_recorded', 0)
+    summary.errors = []
+    return summary
+
+
+class EnqueueTests(unittest.IsolatedAsyncioTestCase):
+    async def test_enqueue_xadds_when_debounce_acquired(self) -> None:
+        client = mock.AsyncMock()
+        client.set = mock.AsyncMock(return_value=True)
+        client.xadd = mock.AsyncMock()
+        result = await queue.enqueue_deployment_sync(
+            client, 'octo', 'p1', 'alice', limit=50
+        )
+        self.assertTrue(result)
+        client.xadd.assert_awaited_once()
+        args, _ = client.xadd.await_args
+        self.assertEqual(args[0], queue.STREAM)
+        self.assertEqual(args[1]['project_id'], 'p1')
+        self.assertEqual(args[1]['org_slug'], 'octo')
+        self.assertEqual(args[1]['requested_by'], 'alice')
+        self.assertEqual(args[1]['limit'], '50')
+
+    async def test_enqueue_skips_when_debounced(self) -> None:
+        client = mock.AsyncMock()
+        client.set = mock.AsyncMock(return_value=None)
+        client.xadd = mock.AsyncMock()
+        result = await queue.enqueue_deployment_sync(client, 'octo', 'p1')
+        self.assertFalse(result)
+        client.xadd.assert_not_called()
+
+    async def test_enqueue_none_client_returns_false(self) -> None:
+        self.assertFalse(
+            await queue.enqueue_deployment_sync(None, 'octo', 'p1')
+        )
+
+
+class ParseLimitTests(unittest.TestCase):
+    def test_parses_and_clamps(self) -> None:
+        self.assertEqual(1, queue._parse_limit(None))
+        self.assertEqual(1, queue._parse_limit(''))
+        self.assertEqual(1, queue._parse_limit('bogus'))
+        self.assertEqual(50, queue._parse_limit('50'))
+        self.assertEqual(1, queue._parse_limit('0'))
+        self.assertEqual(queue.MAX_LIMIT, queue._parse_limit('500'))
+
+
+class ProcessMessageTests(unittest.IsolatedAsyncioTestCase):
+    async def test_success_sets_running_then_success(self) -> None:
+        db = mock.AsyncMock()
+        summary = _summary(observed=3, events_recorded=2)
+        with (
+            mock.patch.object(
+                queue, 'run_resync', mock.AsyncMock(return_value=summary)
+            ) as run,
+            mock.patch.object(queue, 'set_status', mock.AsyncMock()) as ss,
+        ):
+            await queue._process_message(
+                db,
+                {
+                    'project_id': 'p1',
+                    'org_slug': 'octo',
+                    'requested_by': 'a',
+                    'limit': '25',
+                },
+            )
+        run.assert_awaited_once_with(db, 'octo', 'p1', 25)
+        statuses = [c.kwargs['status'] for c in ss.await_args_list]
+        self.assertEqual(['running', 'success'], statuses)
+        success = ss.await_args_list[-1].kwargs
+        self.assertIs(summary, success['summary'])
+
+    async def test_unavailable_marks_failed_without_raising(self) -> None:
+        db = mock.AsyncMock()
+        with (
+            mock.patch.object(
+                queue,
+                'run_resync',
+                mock.AsyncMock(side_effect=DeploymentSyncUnavailable('nope')),
+            ),
+            mock.patch.object(queue, 'set_status', mock.AsyncMock()) as ss,
+        ):
+            await queue._process_message(db, {'project_id': 'p1'})
+        self.assertEqual('failed', ss.await_args_list[-1].kwargs['status'])
+
+    async def test_other_error_marks_failed_and_raises(self) -> None:
+        db = mock.AsyncMock()
+        with (
+            mock.patch.object(
+                queue,
+                'run_resync',
+                mock.AsyncMock(side_effect=RuntimeError('boom')),
+            ),
+            mock.patch.object(queue, 'set_status', mock.AsyncMock()) as ss,
+        ):
+            with self.assertRaises(RuntimeError):
+                await queue._process_message(db, {'project_id': 'p1'})
+        self.assertEqual('failed', ss.await_args_list[-1].kwargs['status'])
+
+    async def test_missing_project_id_is_noop(self) -> None:
+        db = mock.AsyncMock()
+        with mock.patch.object(queue, 'set_status', mock.AsyncMock()) as ss:
+            await queue._process_message(db, {})
+        ss.assert_not_awaited()
+
+    async def test_rate_limited_marks_queued_and_raises(self) -> None:
+        db = mock.AsyncMock()
+        with (
+            mock.patch.object(
+                queue,
+                'run_resync',
+                mock.AsyncMock(
+                    side_effect=PluginRateLimited(retry_at=time.time() + 600)
+                ),
+            ),
+            mock.patch.object(queue, 'set_status', mock.AsyncMock()) as ss,
+        ):
+            with self.assertRaises(PluginRateLimited):
+                await queue._process_message(db, {'project_id': 'p1'})
+        statuses = [c.kwargs['status'] for c in ss.await_args_list]
+        # running -> queued (NOT failed); re-raised for the pause handler.
+        self.assertEqual(['running', 'queued'], statuses)
+
+
+class ConsumerTests(unittest.IsolatedAsyncioTestCase):
+    async def test_xack_on_success(self) -> None:
+        client = mock.AsyncMock()
+        with mock.patch.object(queue, '_process_message', mock.AsyncMock()):
+            await queue._handle_entries(
+                client, [(b'1-0', {b'project_id': b'p1'})], mock.AsyncMock()
+            )
+        client.xack.assert_awaited_once()
+
+    async def test_no_xack_on_exception(self) -> None:
+        client = mock.AsyncMock()
+        with mock.patch.object(
+            queue,
+            '_process_message',
+            mock.AsyncMock(side_effect=RuntimeError('boom')),
+        ):
+            await queue._handle_entries(
+                client, [(b'1-0', {b'project_id': b'p1'})], mock.AsyncMock()
+            )
+        client.xack.assert_not_called()
+
+    async def test_dlq_after_max_deliveries(self) -> None:
+        client = mock.AsyncMock()
+        client.xpending_range = mock.AsyncMock(
+            return_value=[{'times_delivered': queue.MAX_DELIVERIES}]
+        )
+        result = await queue._maybe_dead_letter(
+            client, b'1-0', {'project_id': 'p1'}
+        )
+        self.assertTrue(result)
+        client.xadd.assert_awaited_once()
+        client.xack.assert_awaited_once()
+
+    async def test_rate_limited_pauses_without_ack_or_dlq(self) -> None:
+        client = mock.AsyncMock()
+        retry_at = time.time() + 1800
+        with mock.patch.object(
+            queue,
+            '_process_message',
+            mock.AsyncMock(side_effect=PluginRateLimited(retry_at=retry_at)),
+        ):
+            await queue._handle_entries(
+                client,
+                [
+                    (b'1-0', {b'project_id': b'p1'}),
+                    (b'2-0', {b'project_id': b'p2'}),
+                ],
+                mock.AsyncMock(),
+            )
+        # Pause marker set; message left pending (no ack), not
+        # dead-lettered, and the batch stopped before the sibling job.
+        client.set.assert_awaited_once()
+        self.assertEqual(queue.PAUSE_KEY, client.set.await_args.args[0])
+        client.xack.assert_not_called()
+        client.xadd.assert_not_called()
+
+
+class PauseTests(unittest.IsolatedAsyncioTestCase):
+    async def test_paused_remaining_future_and_past(self) -> None:
+        client = mock.AsyncMock()
+        client.get = mock.AsyncMock(
+            return_value=str(time.time() + 120).encode()
+        )
+        self.assertGreater(await queue._paused_remaining(client), 60)
+        client.get = mock.AsyncMock(return_value=str(time.time() - 5).encode())
+        self.assertEqual(0.0, await queue._paused_remaining(client))
+
+    async def test_paused_remaining_absent_is_zero(self) -> None:
+        client = mock.AsyncMock()
+        client.get = mock.AsyncMock(return_value=None)
+        self.assertEqual(0.0, await queue._paused_remaining(client))
+
+    async def test_consume_loop_honors_pause_and_skips_read(self) -> None:
+        client = mock.AsyncMock()
+        client.get = mock.AsyncMock(
+            return_value=str(time.time() + 300).encode()
+        )
+        stop = mock.Mock()
+        # Paused this tick -> sleep, then stop the loop before any read.
+        stop.is_set = mock.Mock(side_effect=[False, True])
+        with mock.patch.object(queue.asyncio, 'sleep', mock.AsyncMock()):
+            await queue.consume_deployment_sync(
+                client, mock.AsyncMock(), consumer='w', stop=stop
+            )
+        client.xreadgroup.assert_not_called()
+        client.xautoclaim.assert_not_called()

--- a/tests/test_deployment_sync_service.py
+++ b/tests/test_deployment_sync_service.py
@@ -95,6 +95,32 @@ class StatusTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(1, params['errors'])
         self.assertEqual('alice', params['by'])
 
+    async def test_set_status_unguarded_omits_where(self) -> None:
+        db = mock.AsyncMock()
+        await service.set_status(db, 'p1', status='running')
+        query = db.execute.await_args.args[0]
+        self.assertNotIn('WHERE', query)
+
+    async def test_set_status_guard_adds_timestamp_predicate(self) -> None:
+        db = mock.AsyncMock()
+        enqueued_at = service.now_iso()
+        await service.set_status(
+            db,
+            'p1',
+            status='queued',
+            retry=False,
+            only_if_before=enqueued_at,
+        )
+        db.execute.assert_awaited_once()
+        query = db.execute.await_args.args[0]
+        # The guard must land between MATCH and SET so a status that
+        # already advanced past the enqueue time is left untouched.
+        self.assertIn('WHERE p.deployment_sync_at IS NULL', query)
+        self.assertIn('p.deployment_sync_at < {only_if_before}', query)
+        self.assertLess(query.index('WHERE'), query.index('SET'))
+        params = db.execute.await_args.args[1]
+        self.assertEqual(enqueued_at, params['only_if_before'])
+
     async def test_set_status_retries_on_write_conflict(self) -> None:
         db = mock.AsyncMock()
         db.execute.side_effect = [

--- a/tests/test_deployment_sync_service.py
+++ b/tests/test_deployment_sync_service.py
@@ -1,0 +1,164 @@
+"""Tests for the deployment-sync service (run, status)."""
+
+from __future__ import annotations
+
+import unittest
+from unittest import mock
+
+import fastapi
+
+from imbi_api.deployment_sync import service
+
+
+class RunResyncTests(unittest.IsolatedAsyncioTestCase):
+    async def test_invokes_resync_for_project(self) -> None:
+        db = mock.AsyncMock()
+        summary = mock.Mock()
+        resync = mock.AsyncMock(return_value=summary)
+        with mock.patch(
+            'imbi_api.endpoints.project_deployments.resync_for_project',
+            resync,
+        ):
+            result = await service.run_resync(db, 'octo', 'p1', 25)
+        self.assertIs(summary, result)
+        kwargs = resync.await_args.kwargs
+        self.assertEqual('octo', kwargs['org_slug'])
+        self.assertEqual('p1', kwargs['project_id'])
+        self.assertEqual(25, kwargs['limit'])
+        # Synthetic service-account principal, no acting user.
+        self.assertIsNone(kwargs['auth'].user)
+        self.assertEqual(service.REQUESTED_BY, kwargs['auth'].principal_name)
+
+    async def test_unsupported_plugin_raises_unavailable(self) -> None:
+        db = mock.AsyncMock()
+        with mock.patch(
+            'imbi_api.endpoints.project_deployments.resync_for_project',
+            mock.AsyncMock(
+                side_effect=fastapi.HTTPException(
+                    status_code=400, detail='does not support'
+                )
+            ),
+        ):
+            with self.assertRaises(service.DeploymentSyncUnavailable):
+                await service.run_resync(db, 'octo', 'p1', 1)
+
+    async def test_no_capability_raises_unavailable(self) -> None:
+        db = mock.AsyncMock()
+        with mock.patch(
+            'imbi_api.endpoints.project_deployments.resync_for_project',
+            mock.AsyncMock(
+                side_effect=fastapi.HTTPException(
+                    status_code=404, detail='no capability'
+                )
+            ),
+        ):
+            with self.assertRaises(service.DeploymentSyncUnavailable):
+                await service.run_resync(db, 'octo', 'p1', 1)
+
+    async def test_other_http_error_propagates(self) -> None:
+        db = mock.AsyncMock()
+        with mock.patch(
+            'imbi_api.endpoints.project_deployments.resync_for_project',
+            mock.AsyncMock(
+                side_effect=fastapi.HTTPException(
+                    status_code=503, detail='no credentials'
+                )
+            ),
+        ):
+            with self.assertRaises(fastapi.HTTPException):
+                await service.run_resync(db, 'octo', 'p1', 1)
+
+
+class StatusTests(unittest.IsolatedAsyncioTestCase):
+    async def test_set_status_writes_all_fields(self) -> None:
+        db = mock.AsyncMock()
+        summary = mock.Mock()
+        summary.observed = 7
+        summary.releases_created = 2
+        summary.releases_updated = 1
+        summary.events_recorded = 5
+        summary.errors = [mock.Mock()]
+        await service.set_status(
+            db,
+            'p1',
+            status='success',
+            requested_by='alice',
+            summary=summary,
+        )
+        db.execute.assert_awaited_once()
+        params = db.execute.await_args.args[1]
+        self.assertEqual('success', params['status'])
+        self.assertEqual(7, params['observed'])
+        self.assertEqual(2, params['releases_created'])
+        self.assertEqual(1, params['releases_updated'])
+        self.assertEqual(5, params['events'])
+        self.assertEqual(1, params['errors'])
+        self.assertEqual('alice', params['by'])
+
+    async def test_set_status_retries_on_write_conflict(self) -> None:
+        db = mock.AsyncMock()
+        db.execute.side_effect = [
+            Exception('Entity failed to be updated: 3'),
+            [{'id': '"p1"'}],
+        ]
+        with mock.patch.object(service.asyncio, 'sleep'):
+            await service.set_status(db, 'p1', status='running')
+        self.assertEqual(2, db.execute.await_count)
+
+    async def test_set_status_no_retry_drops_conflict(self) -> None:
+        db = mock.AsyncMock()
+        db.execute.side_effect = Exception('Entity failed to be updated: 3')
+        await service.set_status(db, 'p1', status='queued', retry=False)
+        db.execute.assert_awaited_once()
+
+    async def test_set_status_swallows_unrelated_error(self) -> None:
+        db = mock.AsyncMock()
+        db.execute.side_effect = Exception('boom')
+        await service.set_status(db, 'p1', status='running')
+        db.execute.assert_awaited_once()
+
+    async def test_read_status_idle_when_unset(self) -> None:
+        db = mock.AsyncMock()
+        db.execute.return_value = [
+            {
+                'status': None,
+                'at': None,
+                'requested_by': None,
+                'observed': None,
+                'releases_created': None,
+                'releases_updated': None,
+                'events': None,
+                'errors': None,
+                'error': None,
+            }
+        ]
+        status = await service.read_status(db, 'p1')
+        self.assertEqual('idle', status.status)
+        self.assertIsNone(status.last_synced_at)
+        self.assertIsNone(status.observed)
+
+    async def test_read_status_parses_success(self) -> None:
+        db = mock.AsyncMock()
+        db.execute.return_value = [
+            {
+                'status': '"success"',
+                'at': '"2026-07-20T12:00:00+00:00"',
+                'requested_by': '"alice"',
+                'observed': 12,
+                'releases_created': 3,
+                'releases_updated': 2,
+                'events': 9,
+                'errors': 0,
+                'error': '""',
+            }
+        ]
+        status = await service.read_status(db, 'p1')
+        self.assertEqual('success', status.status)
+        self.assertEqual(12, status.observed)
+        self.assertEqual(3, status.releases_created)
+        self.assertEqual(2, status.releases_updated)
+        self.assertEqual(9, status.events_recorded)
+        self.assertEqual(0, status.errors)
+        self.assertEqual('alice', status.requested_by)
+        self.assertIsNotNone(status.last_synced_at)
+        self.assertIsNone(status.error)


### PR DESCRIPTION
## Summary
Move `POST /deployments/resync` from an in-request backfill to a background Valkey-stream job with a polling status endpoint, mirroring the existing commit-sync and pr-sync pattern.

## Problem
The resync endpoint ran the full backfill synchronously inside the request. A deep resync (`limit=100` across several environments) makes hundreds of GitHub Enterprise API calls (per-deployment statuses plus release-tag lookups), which cannot finish inside the 10-second `call_with_timeout` plugin cap — so every deep resync returned 503 "Plugin timed out". Verified in production logs: the fetch starts, ~9.7s of GHE calls follow, then the 503 lands; multiple users hit this across different projects.

## Solution
- New `imbi_api.deployment_sync` package (service + queue) mirroring `commit_sync`/`pr_sync`: an `imbi:deployment-sync` stream with per-project debounce, stale-entry reclaim, DLQ after repeated failures, and the GitHub rate-limit pause; last-run state persisted as `deployment_sync_*` properties on the Project node
- `POST /deployments/resync` validates the capability and `supports_deployment_sync` hint (400/404 fail fast), enqueues, and returns 202 `{enqueued}`; new `GET /deployments/sync-status` reports the outcome for polling
- The worker runs `resync_for_project` with a synthetic service-account principal; identity attach stays best-effort so GitHub App credentials still work headless
- The per-call plugin timeout is removed from the resync fetch — every remaining caller (queue worker, maintenance sweep) is a background worker

## Impact
- Breaking response change for `POST /deployments/resync`: 200 + summary → 202 + `{enqueued}`. The companion imbi-ui PR (AWeber-Imbi/imbi-ui) consumes the new shape; deploy this API first
- Deep resyncs now complete reliably instead of 503ing; results surface via the status endpoint
- One new consumer loop per API process (same lifecycle handling as the commit-sync/pr-sync workers)

## Testing
- Full suite passes: 2429 passed, coverage 85.55% (gate 85%)
- `just lint` clean (pre-commit, basedpyright, mypy)
- New unit tests for the queue (enqueue/debounce, limit parsing, DLQ, rate-limit pause) and service (run/unavailable mapping, status read/write); resync business-logic tests rewired to exercise `resync_for_project` directly plus new enqueue/status endpoint tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)