### PR TITLE
Relax and log OAuth dynamic client registration

### DIFF
--- a/src/imbi_api/endpoints/auth.py
+++ b/src/imbi_api/endpoints/auth.py
@@ -637,6 +637,31 @@ async def authorize(
     )
 
 
+def _reject_registration(
+    body: models.OAuthClientRegistrationRequest, detail: str
+) -> fastapi.HTTPException:
+    """Log and build the 400 for a rejected client registration.
+
+    A rejected DCR is otherwise invisible in the access log (only the
+    bare ``POST /auth/register 400`` line survives), which makes it very
+    hard to see why a remote MCP client -- e.g. Claude's connector --
+    cannot complete OAuth login. The request carries only public client
+    metadata (no secrets), so logging it is safe.
+    """
+    LOGGER.warning(
+        'Rejecting OAuth client registration (%s): client_name=%r '
+        'redirect_uris=%r grant_types=%r response_types=%r '
+        'token_endpoint_auth_method=%r',
+        detail,
+        body.client_name,
+        body.redirect_uris,
+        body.grant_types,
+        body.response_types,
+        body.token_endpoint_auth_method,
+    )
+    return fastapi.HTTPException(status_code=400, detail=detail)
+
+
 @auth_router.post(
     '/register',
     response_model=models.OAuthClientRegistrationResponse,
@@ -656,29 +681,34 @@ async def register_oauth_client(
             detail='Dynamic client registration is disabled',
         )
     if not body.redirect_uris:
-        raise fastapi.HTTPException(
-            status_code=400, detail='redirect_uris is required'
-        )
+        raise _reject_registration(body, 'redirect_uris is required')
     for uri in body.redirect_uris:
         if not oauth_clients.is_valid_redirect_uri(uri):
-            raise fastapi.HTTPException(
-                status_code=400, detail=f'Invalid redirect_uri: {uri}'
-            )
-    if set(body.grant_types) != {'authorization_code', 'refresh_token'}:
-        raise fastapi.HTTPException(
-            status_code=400,
-            detail='Only authorization_code and refresh_token grants '
+            raise _reject_registration(body, f'Invalid redirect_uri: {uri}')
+    # A public client only needs the authorization-code grant; requesting
+    # refresh_token is optional (RFC 7591 clients need not ask for it, and
+    # many -- including Claude's connector -- register authorization_code
+    # alone). Grants beyond these two (e.g. client_credentials) are for
+    # confidential service accounts, which are provisioned out-of-band
+    # rather than via DCR.
+    if 'authorization_code' not in body.grant_types:
+        raise _reject_registration(
+            body, 'The authorization_code grant type is required'
+        )
+    if set(body.grant_types) - {'authorization_code', 'refresh_token'}:
+        raise _reject_registration(
+            body,
+            'Only the authorization_code and refresh_token grant types '
             'are supported',
         )
-    if body.response_types != ['code']:
-        raise fastapi.HTTPException(
-            status_code=400,
-            detail="Only response_types=['code'] is supported",
+    if set(body.response_types) != {'code'}:
+        raise _reject_registration(
+            body, "Only response_types=['code'] is supported"
         )
     if body.token_endpoint_auth_method != 'none':
-        raise fastapi.HTTPException(
-            status_code=400,
-            detail='Only public clients '
+        raise _reject_registration(
+            body,
+            'Only public clients '
             '(token_endpoint_auth_method=none) are supported',
         )
     client = await oauth_clients.register_client(

--- a/tests/auth/test_oauth_server.py
+++ b/tests/auth/test_oauth_server.py
@@ -184,6 +184,32 @@ class OAuthServerTestCase(support.SharedAppTestCase):
         self.assertEqual(resp.status_code, 400)
         self.mock_db.create.assert_not_called()
 
+    def test_register_accepts_authorization_code_only(self) -> None:
+        # RFC 7591 clients need not request refresh_token. Public MCP
+        # clients (e.g. Claude's connector) may register the
+        # authorization_code grant on its own.
+        self.mock_db.create.return_value = None
+        resp = self.client.post(
+            '/auth/register',
+            json={
+                'redirect_uris': ['https://app.example/cb'],
+                'grant_types': ['authorization_code'],
+            },
+        )
+        self.assertEqual(resp.status_code, 201)
+        self.mock_db.create.assert_awaited_once()
+
+    def test_register_rejects_extra_grant_alongside_supported(self) -> None:
+        resp = self.client.post(
+            '/auth/register',
+            json={
+                'redirect_uris': ['https://app.example/cb'],
+                'grant_types': ['authorization_code', 'client_credentials'],
+            },
+        )
+        self.assertEqual(resp.status_code, 400)
+        self.mock_db.create.assert_not_called()
+
     # -- authorize --------------------------------------------------------
 
     def _authorize(self, **overrides: str) -> object:


### PR DESCRIPTION
## Problem

Claude's remote MCP connector (claude.ai web, pointed at `https://imbi-public.aweber.io/mcp`) cannot complete OAuth login. Production logs show the connector getting all the way through discovery and then failing at registration:

```
POST /mcp                                      -> 401  (challenge)
GET  /.well-known/oauth-protected-resource/mcp -> 200
GET  /.well-known/oauth-authorization-server   -> 200
POST /api/auth/register                        -> 400  <- dies here
```

The `register_oauth_client` handler required `grant_types` to be **exactly** `{authorization_code, refresh_token}`. A spec-compliant public client that registers the `authorization_code` grant on its own (RFC 7591 does not require asking for `refresh_token`) is rejected with `400`. On top of that, the rejection was **invisible** in logs — only the bare `POST /auth/register 400` access-log line survived, so there was no way to see *why* a client was turned away.

## Change

- **Relax grant validation** — require the `authorization_code` grant to be present and treat `refresh_token` as optional. Grants outside those two (e.g. `client_credentials`) are still rejected; those are for confidential service accounts provisioned out-of-band, not via DCR.
- **Compare `response_types` as a set** so `['code']` is matched robustly.
- **Keep DCR public-only** — `token_endpoint_auth_method` must still be `none` (DCR issues no client secret here). The authorization-server metadata legitimately advertises `client_secret_post`/`client_credentials` because the AS supports confidential service-account clients through a separate, out-of-band path.
- **Log every rejection** with the offending reason and the (secret-free) client metadata, so a future connector failure is diagnosable at a glance.
- Tests for `authorization_code`-only registration and for rejecting an unsupported grant alongside a supported one.

## Testing

- `uv run ruff check` / `ruff format --check` — clean
- `uv run mypy` / `basedpyright` on the changed file — clean
- `uv run pytest tests/auth/test_oauth_server.py` — 22 passed (includes the two new cases)

## Notes / follow-ups (out of scope here)

- The new rejection log will confirm, on the next connector attempt, the exact field if any residual mismatch remains.
- Separately observed in prod, worth their own fixes: `POST /api/auth/token/refresh` intermittently returns `500`, and a client is hitting `/api/mcp` (should be `/mcp`) and getting `404`.

---
*Opened by Claude on behalf of @artemk.*
