### PR TITLE
Add user_type_selector to webhook IMPLEMENTED_BY edge

### DIFF
--- a/src/imbi_api/domain/models.py
+++ b/src/imbi_api/domain/models.py
@@ -986,6 +986,14 @@ class WebhookCreate(pydantic.BaseModel):
             '(e.g. /deployment/creator/id) used to resolve the Imbi user.'
         ),
     )
+    user_type_selector: str | None = pydantic.Field(
+        default=None,
+        description=(
+            'JSON Pointer that locates the sender account type (e.g. '
+            "/sender/type). When it resolves to 'Bot' the identity lookup "
+            'is skipped, since bot senders are never Imbi users.'
+        ),
+    )
     identity_integration_slug: str | None = pydantic.Field(
         default=None,
         description=(
@@ -1015,6 +1023,8 @@ class WebhookCreate(pydantic.BaseModel):
             raise ValueError('identifier_selector requires integration_slug')
         if self.user_subject_selector and not self.integration_slug:
             raise ValueError('user_subject_selector requires integration_slug')
+        if self.user_type_selector and not self.integration_slug:
+            raise ValueError('user_type_selector requires integration_slug')
         if self.identity_integration_slug and not self.integration_slug:
             raise ValueError(
                 'identity_integration_slug requires integration_slug'
@@ -1056,6 +1066,14 @@ class WebhookUpdate(pydantic.BaseModel):
             '(e.g. /deployment/creator/id) used to resolve the Imbi user.'
         ),
     )
+    user_type_selector: str | None = pydantic.Field(
+        default=None,
+        description=(
+            'JSON Pointer that locates the sender account type (e.g. '
+            "/sender/type). When it resolves to 'Bot' the identity lookup "
+            'is skipped, since bot senders are never Imbi users.'
+        ),
+    )
     identity_integration_slug: str | None = pydantic.Field(
         default=None,
         description=(
@@ -1085,6 +1103,8 @@ class WebhookUpdate(pydantic.BaseModel):
             raise ValueError('identifier_selector requires integration_slug')
         if self.user_subject_selector and not self.integration_slug:
             raise ValueError('user_subject_selector requires integration_slug')
+        if self.user_type_selector and not self.integration_slug:
+            raise ValueError('user_type_selector requires integration_slug')
         if self.identity_integration_slug and not self.integration_slug:
             raise ValueError(
                 'identity_integration_slug requires integration_slug'
@@ -1118,6 +1138,7 @@ class WebhookResponse(pydantic.BaseModel):
     integration: dict[str, typing.Any] | None = None
     identifier_selector: str | None = None
     user_subject_selector: str | None = None
+    user_type_selector: str | None = None
     identity_integration_slug: str | None = None
     event_type_selector: str | None = None
     rules: list[WebhookRuleResponse] = []
@@ -1167,6 +1188,9 @@ class WebhookResponse(pydantic.BaseModel):
             ),
             user_subject_selector=graph.parse_agtype(
                 record.get('user_subject_selector')
+            ),
+            user_type_selector=graph.parse_agtype(
+                record.get('user_type_selector')
             ),
             identity_integration_slug=graph.parse_agtype(
                 record.get('identity_integration_slug')

--- a/src/imbi_api/endpoints/webhooks.py
+++ b/src/imbi_api/endpoints/webhooks.py
@@ -149,6 +149,7 @@ RETURN w{{.*}} AS webhook,
        tps{{.*}} AS tps,
        impl.identifier_selector AS identifier_selector,
        impl.user_subject_selector AS user_subject_selector,
+       impl.user_type_selector AS user_type_selector,
        impl.identity_integration_slug AS identity_integration_slug,
        impl.event_type_selector AS event_type_selector,
        [x IN all_rules
@@ -169,6 +170,7 @@ _UPDATE_RETURN_TAIL_WITH_TPS: typing.LiteralString = (
     ' RETURN w{{.*}} AS webhook, tps{{.*}} AS tps,'
     ' impl.identifier_selector AS identifier_selector,'
     ' impl.user_subject_selector AS user_subject_selector,'
+    ' impl.user_type_selector AS user_type_selector,'
     ' impl.identity_integration_slug AS identity_integration_slug,'
     ' impl.event_type_selector AS event_type_selector,'
     ' [x IN all_rules'
@@ -188,6 +190,7 @@ _UPDATE_RETURN_TAIL_NO_TPS: typing.LiteralString = (
     ' RETURN w{{.*}} AS webhook, null AS tps,'
     ' null AS identifier_selector,'
     ' null AS user_subject_selector,'
+    ' null AS user_type_selector,'
     ' null AS identity_integration_slug,'
     ' null AS event_type_selector,'
     ' [x IN all_rules'
@@ -279,6 +282,7 @@ async def create_webhook(
             ' CREATE (w)-[:IMPLEMENTED_BY {{'
             'identifier_selector: {identifier_selector},'
             ' user_subject_selector: {user_subject_selector},'
+            ' user_type_selector: {user_type_selector},'
             ' identity_integration_slug: {identity_integration_slug},'
             ' event_type_selector: {event_type_selector}'
             '}}]->(tps)' + rule_clauses + ' RETURN w.id AS id'
@@ -288,6 +292,7 @@ async def create_webhook(
             'tps_slug': data.integration_slug,
             'identifier_selector': data.identifier_selector,
             'user_subject_selector': data.user_subject_selector,
+            'user_type_selector': data.user_type_selector,
             'identity_integration_slug': data.identity_integration_slug,
             'event_type_selector': data.event_type_selector,
         }
@@ -333,6 +338,7 @@ async def create_webhook(
             'tps',
             'identifier_selector',
             'user_subject_selector',
+            'user_type_selector',
             'identity_integration_slug',
             'event_type_selector',
             'rules',
@@ -371,6 +377,7 @@ async def list_webhooks(
            tps{{.*}} AS tps,
            impl.identifier_selector AS identifier_selector,
            impl.user_subject_selector AS user_subject_selector,
+           impl.user_type_selector AS user_type_selector,
            impl.identity_integration_slug AS identity_integration_slug,
            impl.event_type_selector AS event_type_selector,
            [x IN all_rules
@@ -387,6 +394,7 @@ async def list_webhooks(
             'tps',
             'identifier_selector',
             'user_subject_selector',
+            'user_type_selector',
             'identity_integration_slug',
             'event_type_selector',
             'rules',
@@ -416,6 +424,7 @@ async def get_webhook(
             'tps',
             'identifier_selector',
             'user_subject_selector',
+            'user_type_selector',
             'identity_integration_slug',
             'event_type_selector',
             'rules',
@@ -467,6 +476,7 @@ async def patch_webhook(
             'tps',
             'identifier_selector',
             'user_subject_selector',
+            'user_type_selector',
             'identity_integration_slug',
             'event_type_selector',
             'rules',
@@ -501,6 +511,9 @@ async def patch_webhook(
         ),
         'user_subject_selector': graph.parse_agtype(
             existing[0].get('user_subject_selector')
+        ),
+        'user_type_selector': graph.parse_agtype(
+            existing[0].get('user_type_selector')
         ),
         'identity_integration_slug': graph.parse_agtype(
             existing[0].get('identity_integration_slug')
@@ -606,6 +619,7 @@ async def patch_webhook(
             ' SET impl.identifier_selector'
             ' = {identifier_selector},'
             ' impl.user_subject_selector = {user_subject_selector},'
+            ' impl.user_type_selector = {user_type_selector},'
             ' impl.identity_integration_slug = {identity_integration_slug},'
             ' impl.event_type_selector = {event_type_selector}'
             + rule_clauses
@@ -618,6 +632,7 @@ async def patch_webhook(
             **props,
             'identifier_selector': data.identifier_selector,
             'user_subject_selector': data.user_subject_selector,
+            'user_type_selector': data.user_type_selector,
             'identity_integration_slug': data.identity_integration_slug,
             'event_type_selector': data.event_type_selector,
             **rules_params,
@@ -667,6 +682,7 @@ async def patch_webhook(
             'tps',
             'identifier_selector',
             'user_subject_selector',
+            'user_type_selector',
             'identity_integration_slug',
             'event_type_selector',
             'rules',

--- a/tests/endpoints/test_webhooks.py
+++ b/tests/endpoints/test_webhooks.py
@@ -433,6 +433,21 @@ class WebhookEndpointsTestCase(support.SharedAppTestCase):
         data = response.json()
         self.assertEqual(data['user_type_selector'], '/sender/type')
 
+        write_params = [
+            call.args[1]
+            for call in self.mock_db.execute.call_args_list
+            if len(call.args) > 1
+            and isinstance(call.args[1], dict)
+            and 'user_type_selector' in call.args[1]
+        ]
+        self.assertTrue(
+            any(
+                params['user_type_selector'] == '/sender/type'
+                for params in write_params
+            ),
+            'CREATE write must pass user_type_selector to the query',
+        )
+
     def test_create_user_type_selector_without_service(self) -> None:
         """user_type_selector requires a third-party service."""
         response = self.client.post(

--- a/tests/endpoints/test_webhooks.py
+++ b/tests/endpoints/test_webhooks.py
@@ -35,6 +35,7 @@ class _WebhookRecord(typing.TypedDict):
     tps: typing.NotRequired[dict[str, str] | None]
     identifier_selector: typing.NotRequired[str | None]
     user_subject_selector: typing.NotRequired[str | None]
+    user_type_selector: typing.NotRequired[str | None]
     identity_integration_slug: typing.NotRequired[str | None]
     event_type_selector: typing.NotRequired[str | None]
     rules: list[_WebhookRule | None]
@@ -399,6 +400,46 @@ class WebhookEndpointsTestCase(support.SharedAppTestCase):
             json={
                 'name': 'Test',
                 'event_type_selector': 'x-github-event',
+            },
+        )
+        self.assertEqual(response.status_code, 422)
+
+    def test_create_with_user_type_selector(self) -> None:
+        """user_type_selector round-trips through CREATE/GET."""
+        record = copy.deepcopy(self.webhook_record)
+        record['tps'] = {'name': 'GitHub', 'slug': 'github'}
+        record['identifier_selector'] = '/repository/full_name'
+        record['user_type_selector'] = '/sender/type'
+
+        self.mock_db.execute.return_value = [record]
+        with (
+            self._patch_encryption(),
+            mock.patch(
+                'imbi_common.graph.parse_agtype', side_effect=lambda x: x
+            ),
+        ):
+            payload = {
+                'name': 'GitHub Events',
+                'integration_slug': 'github',
+                'identifier_selector': '/repository/full_name',
+                'user_type_selector': '/sender/type',
+            }
+            response = self.client.post(
+                '/organizations/engineering/webhooks/',
+                json=payload,
+            )
+
+        self.assertEqual(response.status_code, 201)
+        data = response.json()
+        self.assertEqual(data['user_type_selector'], '/sender/type')
+
+    def test_create_user_type_selector_without_service(self) -> None:
+        """user_type_selector requires a third-party service."""
+        response = self.client.post(
+            '/organizations/engineering/webhooks/',
+            json={
+                'name': 'Test',
+                'user_type_selector': '/sender/type',
             },
         )
         self.assertEqual(response.status_code, 422)


### PR DESCRIPTION
## Summary

Exposes a new `user_type_selector` field on the webhook `IMPLEMENTED_BY` edge so operators can tell the gateway which payload field carries the sender's account type. When it resolves to `"Bot"` (e.g. GitHub's `/sender/type`), the gateway skips the `/users/by-identity` lookup — bots are never Imbi users, so that lookup only ever 404s and floods the access log.

Companion to:
- imbi-gateway #46 — the consumer that reads `sel.get('user_type_selector')` and short-circuits the lookup.
- imbi-ui `fix/webhook-user-type-selector` — surfaces the field in the webhook admin form/detail.

## Changes

`user_type_selector` mirrors `user_subject_selector` end to end:
- **`domain/models.py`** — added to `WebhookCreate`, `WebhookUpdate`, `WebhookResponse` (+ `from_graph_record` mapping), and the `requires integration_slug` validators.
- **`endpoints/webhooks.py`** — the `CREATE (w)-[:IMPLEMENTED_BY {…}]` clause, the patch `SET`, the `patchable` snapshot, every `RETURN` projection (fetch/list/update-with-tps/update-no-tps → `null AS …`), and all five `db.execute` column lists.

Inert for existing webhooks: the field defaults to null and changes no current behavior until an operator sets it.

## Testing

- `test_create_with_user_type_selector` — round-trips through CREATE/GET.
- `test_create_user_type_selector_without_service` — 422 without an integration.
- Full webhook endpoint suite: 64 passed. `just lint` clean (0 errors; the 7 warnings are pre-existing `parse_scopes` deprecations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)