### PR TITLE
Advertise public-only token endpoint auth for DCR

### DIFF
--- a/src/imbi_api/endpoints/oauth_metadata.py
+++ b/src/imbi_api/endpoints/oauth_metadata.py
@@ -44,9 +44,13 @@ async def authorization_server_metadata(
             'client_credentials',
         ],
         'code_challenge_methods_supported': ['S256'],
-        'token_endpoint_auth_methods_supported': [
-            'none',
-            'client_secret_post',
-        ],
+        # Dynamic client registration only provisions public clients, so
+        # advertise ``none`` alone. Advertising ``client_secret_post`` led
+        # spec-compliant clients (e.g. Claude's connector) to self-register
+        # as confidential clients, which /auth/register then rejected --
+        # breaking OAuth login. Confidential service accounts do authenticate
+        # at the token endpoint with a secret, but they are provisioned
+        # out-of-band and do not rely on this discovery document.
+        'token_endpoint_auth_methods_supported': ['none'],
         'scopes_supported': ['imbi'],
     }

--- a/tests/auth/test_oauth_server.py
+++ b/tests/auth/test_oauth_server.py
@@ -72,6 +72,11 @@ class OAuthServerTestCase(support.SharedAppTestCase):
         )
         self.assertEqual(body['code_challenge_methods_supported'], ['S256'])
         self.assertIn('authorization_code', body['grant_types_supported'])
+        # DCR is public-only; advertising client_secret_post would lure
+        # clients into confidential registration that /auth/register rejects.
+        self.assertEqual(
+            body['token_endpoint_auth_methods_supported'], ['none']
+        )
 
     def test_metadata_reflects_trusted_request_host(self) -> None:
         """Issuer/endpoints name the trusted host the client reached.


### PR DESCRIPTION
## Problem

After the DCR grant-type relaxation (#485) shipped in 2.16.0, Claude's connector got past registration's grant checks but still failed OAuth login with "An unknown error occurred during authentication." The new DCR rejection log (added in #485) captured exactly why:

```
WARNING imbi_api.endpoints.auth: Rejecting OAuth client registration
(Only public clients (token_endpoint_auth_method=none) are supported):
client_name='Claude'
redirect_uris=['https://claude.ai/api/mcp/auth_callback']
grant_types=['authorization_code', 'refresh_token']
response_types=['code']
token_endpoint_auth_method='client_secret_post'
```

The connector registers as a **confidential** client (`client_secret_post`). It does so because the authorization-server metadata advertises `token_endpoint_auth_methods_supported: ["none", "client_secret_post"]` — but `/auth/register` only provisions **public** clients, so it rejects `client_secret_post` with `400`. imbi advertises a capability its DCR refuses.

## Change

Advertise `token_endpoint_auth_methods_supported: ["none"]` only. A spec-compliant client (Claude) then registers as a public client and uses the `authorization_code` + PKCE flow that imbi fully supports end to end.

- Confidential **service accounts** still authenticate at the token endpoint with a secret — they're provisioned out-of-band and don't use this discovery document, so they're unaffected.
- Test asserts the advertised auth methods.

## Testing

- `ruff check` / `ruff format --check` — clean
- `mypy` / `basedpyright` on the changed file — clean
- `pytest tests/auth/test_oauth_server.py` — 22 passed

## Follow-up (out of scope)

If Imbi wants to support confidential MCP clients as a first-class thing, the larger alternative is to make DCR issue/store/validate a `client_secret` (and keep advertising `client_secret_post`). This PR takes the minimal path: keep DCR public-only and stop advertising what it won't accept.

---
*Opened by Claude on behalf of @artemk.*
