### PR TITLE
Store current release per environment on DEPLOYED_IN edge

### DIFF
--- a/src/imbi_api/endpoints/releases.py
+++ b/src/imbi_api/endpoints/releases.py
@@ -1141,6 +1141,15 @@ async def append_deployment_event(
                     deployments=updated_list,
                     env=env,
                 )
+                if status == 'success':
+                    await _set_current_release(
+                        db,
+                        org_slug=org_slug,
+                        project_id=project_id,
+                        env_slug=env_slug,
+                        release_id=release_id,
+                        timestamp=refreshed.timestamp,
+                    )
                 return updated_edge, 'updated'
     event = models.DeploymentEvent(
         timestamp=timestamp or datetime.datetime.now(datetime.UTC),
@@ -1152,7 +1161,7 @@ async def append_deployment_event(
     )
     deployments = [*existing, event]
     if existing:
-        appended_edge = await _set_deployments(
+        edge = await _set_deployments(
             db,
             project_id=project_id,
             release_id=release_id,
@@ -1160,17 +1169,26 @@ async def append_deployment_event(
             deployments=deployments,
             env=env,
         )
-        return appended_edge, 'appended'
-    created_edge = await _create_deployments_edge(
-        db,
-        project_id=project_id,
-        release_id=release_id,
-        env_slug=env_slug,
-        org_slug=org_slug,
-        deployments=deployments,
-        env=env,
-    )
-    return created_edge, 'appended'
+    else:
+        edge = await _create_deployments_edge(
+            db,
+            project_id=project_id,
+            release_id=release_id,
+            env_slug=env_slug,
+            org_slug=org_slug,
+            deployments=deployments,
+            env=env,
+        )
+    if status == 'success':
+        await _set_current_release(
+            db,
+            org_slug=org_slug,
+            project_id=project_id,
+            env_slug=env_slug,
+            release_id=release_id,
+            timestamp=event.timestamp,
+        )
+    return edge, 'appended'
 
 
 async def _set_deployments(
@@ -1258,6 +1276,62 @@ async def _create_deployments_edge(
             ),
         )
     return _edge_to_response(env, deployments)
+
+
+async def _set_current_release(
+    db: graph.Graph,
+    *,
+    org_slug: str,
+    project_id: str,
+    env_slug: str,
+    release_id: str,
+    timestamp: datetime.datetime,
+) -> None:
+    """Point the project's ``DEPLOYED_IN`` edge at the current release.
+
+    Records ``release_id`` as ``current_release`` on the
+    ``Project -[:DEPLOYED_IN]-> Environment`` edge so the release
+    currently deployed to an environment can be read as a single
+    edge-property lookup rather than derived from the ``DEPLOYED_TO``
+    deployment history. Called on every ``success`` deployment event.
+
+    The edge is ``MERGE``d: for the common case where the project is
+    already configured to deploy in the environment it reuses the
+    existing edge, and it creates one when a success event targets an
+    environment the project was not yet linked to.
+
+    The pointer only advances when ``timestamp`` is newer than the
+    ``current_release_at`` already stored, so an out-of-order replay (a
+    deep resync backfill returning deployments newest-first, or a
+    delayed webhook) cannot regress it to an older release. Timestamps
+    are normalized to UTC ISO-8601 so the stored string comparison is
+    chronologically correct.
+    """
+    ts = timestamp.astimezone(datetime.UTC).isoformat()
+    query: typing.LiteralString = """
+    MATCH (p:Project {{id: {project_id}}})
+    MATCH (e:Environment {{slug: {env_slug}}})
+          -[:BELONGS_TO]->(:Organization {{slug: {org_slug}}})
+    MERGE (p)-[d:DEPLOYED_IN]->(e)
+    SET d.current_release = CASE
+          WHEN d.current_release_at IS NULL OR d.current_release_at < {ts}
+          THEN {release_id} ELSE d.current_release END,
+        d.current_release_at = CASE
+          WHEN d.current_release_at IS NULL OR d.current_release_at < {ts}
+          THEN {ts} ELSE d.current_release_at END
+    RETURN d.current_release AS current_release
+    """
+    await db.execute(
+        query,
+        {
+            'project_id': project_id,
+            'env_slug': env_slug,
+            'org_slug': org_slug,
+            'release_id': release_id,
+            'ts': ts,
+        },
+        ['current_release'],
+    )
 
 
 @releases_router.post(
@@ -1348,6 +1422,18 @@ async def record_deployment(
                 'deployments': serialized,
             },
             ['deployments'],
+        )
+
+    if data.status == 'success':
+        # A successful deployment makes this release the current one for
+        # the environment; record it on the DEPLOYED_IN edge.
+        await _set_current_release(
+            db,
+            org_slug=org_slug,
+            project_id=project_id,
+            env_slug=env_slug,
+            release_id=release_id,
+            timestamp=event.timestamp,
         )
 
     if data.external_run_id and data.status in {

--- a/src/imbi_api/endpoints/releases.py
+++ b/src/imbi_api/endpoints/releases.py
@@ -1321,7 +1321,7 @@ async def _set_current_release(
           THEN {ts} ELSE d.current_release_at END
     RETURN d.current_release AS current_release
     """
-    await db.execute(
+    rows = await db.execute(
         query,
         {
             'project_id': project_id,
@@ -1332,6 +1332,14 @@ async def _set_current_release(
         },
         ['current_release'],
     )
+    if not rows:
+        LOGGER.warning(
+            'current_release update skipped: project %r or environment '
+            '%r in organization %r no longer exists',
+            project_id,
+            env_slug,
+            org_slug,
+        )
 
 
 @releases_router.post(

--- a/tests/endpoints/test_releases.py
+++ b/tests/endpoints/test_releases.py
@@ -961,6 +961,33 @@ class DeploymentEdgeTestCase(_ReleasesTestBase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(self._current_release_calls(), [])
 
+    def test_record_deployment_current_release_empty_logs_warning(
+        self,
+    ) -> None:
+        self.mock_db.execute.side_effect = [
+            [{'release': _release_row()}],
+            [{'env': self._env(), 'deployments': None}],
+            [{'deployments': None}],  # create edge
+            [],  # current_release write matched nothing
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            with self.assertLogs(
+                'imbi_api.endpoints.releases', level='WARNING'
+            ) as logs:
+                response = self.client.post(
+                    self._url(f'/{RELEASE_ID}/environments/production'),
+                    json={'status': 'success'},
+                )
+        # The deployment write still succeeds; only the pointer is skipped.
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(self._current_release_calls()), 1)
+        self.assertTrue(
+            any('current_release update skipped' in m for m in logs.output)
+        )
+
 
 class AppendDeploymentEventDedupeTestCase(_ReleasesTestBase):
     """Direct coverage for ``append_deployment_event`` dedupe semantics."""

--- a/tests/endpoints/test_releases.py
+++ b/tests/endpoints/test_releases.py
@@ -686,6 +686,7 @@ class DeploymentEdgeTestCase(_ReleasesTestBase):
                 }
             ],
             [{'deployments': None}],
+            [{'current_release': RELEASE_ID}],  # current_release write
         ]
         with mock.patch(
             'imbi_common.graph.parse_agtype',
@@ -777,6 +778,7 @@ class DeploymentEdgeTestCase(_ReleasesTestBase):
                 }
             ],
             [{'deployments': None}],
+            [{'current_release': RELEASE_ID}],  # current_release write
         ]
         with (
             mock.patch(
@@ -901,6 +903,64 @@ class DeploymentEdgeTestCase(_ReleasesTestBase):
         body = response.json()
         self.assertEqual(body['current_status'], 'success')
 
+    def _current_release_calls(self) -> list[typing.Any]:
+        # The current_release write is the only query that MERGEs the
+        # DEPLOYED_IN edge and sets current_release.
+        return [
+            call
+            for call in self.mock_db.execute.await_args_list
+            if 'DEPLOYED_IN' in call.args[0]
+            and 'current_release' in call.args[0]
+        ]
+
+    def test_record_deployment_success_sets_current_release(self) -> None:
+        self.mock_db.execute.side_effect = [
+            [{'release': _release_row()}],
+            [{'env': self._env(), 'deployments': None}],
+            [{'deployments': None}],  # create edge
+            [{'current_release': RELEASE_ID}],  # current_release write
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            response = self.client.post(
+                self._url(f'/{RELEASE_ID}/environments/production'),
+                json={'status': 'success'},
+            )
+        self.assertEqual(response.status_code, 200)
+        calls = self._current_release_calls()
+        self.assertEqual(len(calls), 1)
+        params = calls[0].args[1]
+        self.assertEqual(params['release_id'], RELEASE_ID)
+        self.assertEqual(params['project_id'], PROJECT_ID)
+        self.assertEqual(params['env_slug'], 'production')
+        self.assertEqual(params['org_slug'], ORG)
+        # Timestamp is normalized to UTC so the stored-string comparison
+        # in the newer-only guard is chronologically correct.
+        self.assertTrue(params['ts'].endswith('+00:00'))
+        # The write is guarded so out-of-order replays cannot regress it.
+        self.assertIn('current_release_at', calls[0].args[0])
+
+    def test_record_deployment_non_success_skips_current_release(
+        self,
+    ) -> None:
+        self.mock_db.execute.side_effect = [
+            [{'release': _release_row()}],
+            [{'env': self._env(), 'deployments': None}],
+            [{'deployments': None}],
+        ]
+        with mock.patch(
+            'imbi_common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            response = self.client.post(
+                self._url(f'/{RELEASE_ID}/environments/production'),
+                json={'status': 'in_progress'},
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(self._current_release_calls(), [])
+
 
 class AppendDeploymentEventDedupeTestCase(_ReleasesTestBase):
     """Direct coverage for ``append_deployment_event`` dedupe semantics."""
@@ -927,6 +987,8 @@ class AppendDeploymentEventDedupeTestCase(_ReleasesTestBase):
                 }
             ],
             [{'deployments': None}],  # only consumed by append / set path
+            # only consumed by the current_release write on success writes
+            [{'current_release': RELEASE_ID}],
         ]
         with mock.patch(
             'imbi_common.graph.parse_agtype',
@@ -1044,6 +1106,26 @@ class AppendDeploymentEventDedupeTestCase(_ReleasesTestBase):
         )
         self.assertEqual(outcome, 'updated')
         self.assertEqual(edge.deployments[0].performed_by, 'octocat')
+
+    def _current_release_calls(self) -> list[typing.Any]:
+        return [
+            call
+            for call in self.mock_db.execute.await_args_list
+            if 'DEPLOYED_IN' in call.args[0]
+            and 'current_release' in call.args[0]
+        ]
+
+    def test_success_append_records_current_release(self) -> None:
+        _edge, outcome = self._call([], external_run_id=None, status='success')
+        self.assertEqual(outcome, 'appended')
+        calls = self._current_release_calls()
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0].args[1]['release_id'], RELEASE_ID)
+
+    def test_non_success_append_skips_current_release(self) -> None:
+        _edge, outcome = self._call([], external_run_id=None, status='failed')
+        self.assertEqual(outcome, 'appended')
+        self.assertEqual(self._current_release_calls(), [])
 
     def test_performed_by_match_is_no_op(self) -> None:
         existing = [
@@ -1465,6 +1547,7 @@ class CurrentReleasesHydrationTestCase(_ReleasesTestBase):
             [{'release': _release_row(tag='1.0.0', id='r1')}],
             [{'env': self._env('production'), 'deployments': None}],
             [{'deployments': '[]'}],
+            [{'current_release': 'r1'}],  # current_release write on success
         ]
         with mock.patch(
             'imbi_common.graph.parse_agtype',


### PR DESCRIPTION
## Summary

Records the release currently deployed to an environment on the `Project -[:DEPLOYED_IN]-> Environment` edge on every `success` deployment event, so "current release per environment" can be read as a single edge-property lookup rather than derived from deployment history.

## Problem

Current release is a `(project, environment)` fact, but the `Environment` node is shared org-wide. Today it's derived at query time by walking every `Release -[:DEPLOYED_TO]-> Environment` edge and JSON-scanning each edge's append-only deployment history for the latest event — cost grows with release count × history depth, and there's no stored pointer to query directly (e.g. `MATCH (p:Project)-[d:DEPLOYED_IN]->(e:Environment) WHERE r.id = d.current_release`).

## Solution

Add `_set_current_release()` and call it on `status == 'success'` from **both** deployment-event write paths:

- `append_deployment_event()` — in-product deploy/promote, resync, and release-train hydration (on the `updated` and `appended`/`created` branches; **not** on `noop`, preserving the "no-op does no writes" invariant).
- the `record_deployment` endpoint — the gateway webhook path (separate inline write logic).

The helper `MERGE`s the `DEPLOYED_IN` edge — reusing the existing edge for configured environments, creating it when a success targets an off-config environment — and advances `current_release`/`current_release_at` **only when the incoming event is newer** than what's stored. Timestamps are normalized to UTC ISO-8601 so the stored-string comparison is chronologically correct, making out-of-order replays (deep resync backfill returning newest-first, delayed webhooks) safe.

## Scope / follow-up

- **Reads unchanged:** `list_current_releases` and `_fetch_current_releases` still derive from history, so nothing UI-facing shifts. Switching them to the stored value (the efficiency win) plus a backfill of existing edges is a clean follow-up.
- **Gateway:** no change needed — it already maps and forwards `success` to `record_deployment`.
- Pairs with AWeber-Imbi/imbi-common #189 (`ProjectEnvironmentEdge`). Independent for CI: this change writes/reads via Cypher and does not import the new model, so it does not require an imbi-common release.

## Testing

- `just test tests/endpoints/test_releases.py` — 65 passed
- `just test tests/endpoints/test_project_deployments.py` — 242 passed
- `just lint` — pre-commit + basedpyright (0 errors) + mypy clean

New tests cover: both write paths set `current_release` on success, skip on non-success, timestamp normalized to UTC, and the newer-only guard is wired.

Note: the DB-level `CASE` newer-only guard executes server-side in AGE; the unit tests (mocked graph) assert the query shape and UTC normalization but not the runtime comparison.